### PR TITLE
Issue 2-2: add append-only audit event writer

### DIFF
--- a/assettrack/audit.py
+++ b/assettrack/audit.py
@@ -1,0 +1,43 @@
+import json
+import sqlite3
+from typing import Optional
+
+
+def record_event(
+    conn: sqlite3.Connection,
+    asset_tag: str,
+    event_type: str,
+    event_date: str,
+    actor: Optional[str] = None,
+    notes: Optional[str] = None,
+    payload: Optional[dict] = None,
+):
+    """
+    Append an audit event for an asset.
+    This function is append-only and does not enforce business rules.
+    """
+    cursor = conn.cursor()
+
+    cursor.execute(
+        """
+        INSERT INTO asset_events (
+            asset_tag,
+            event_type,
+            event_date,
+            actor,
+            notes,
+            payload
+        )
+        VALUES (?, ?, ?, ?, ?, ?);
+        """,
+        (
+            asset_tag,
+            event_type,
+            event_date,
+            actor,
+            notes,
+            json.dumps(payload) if payload is not None else None,
+        ),
+    )
+
+    conn.commit()


### PR DESCRIPTION
## Summary
Introduces a minimal, append-only audit writer for AssetTrack so asset events can be recorded consistently without coupling to CRUD, UI, or legacy scripts.

## Related Issue
Closes #8 

## Changes
- Added `assettrack/audit.py` with `record_event(...)` to insert rows into `asset_events`
- Uses parameterized SQL only
- Supports optional `actor`, `notes`, and JSON-serialized `payload`

## Verification checklist
- [x] `python3 -m compileall .` passes
- [x] REPL smoke test confirms `record_event(...)` inserts without error

## Notes
This is intentionally rules-light and append-only; state/transition rules and CRUD hooks come in later Milestone 2 issues.
