### PR TITLE
Issue 2-4: state transition minimal

### DIFF
--- a/assettrack/transitions.py
+++ b/assettrack/transitions.py
@@ -1,8 +1,33 @@
 # assettrack/transitions.py
 
-def transition_asset_state(conn, asset_tag, *, new_state, actor=None, notes=None):
+from __future__ import annotations
+
+from assettrack.audit import record_event
+from assettrack.assets import update_asset
+
+
+def transition_custody_state(
+    conn,
+    asset_tag: str,
+    *,
+    new_state: str,
+    actor: str | None = None,
+    notes: str | None = None,
+) -> None:
     """
-    Single choke point for asset state transitions.
-    Applies the update and records audit together.
+    Choke point for custody_state transitions.
+    Updates the asset and records an audit event together.
     """
-    raise NotImplementedError("State transition not implemented yet")
+
+    # 1) Apply the state change using the existing, sanitized update path
+    update_asset(conn, asset_tag, custody_state=new_state)
+
+    # 2) Record the audit event (append-only)
+    record_event(
+        conn,
+        asset_tag=asset_tag,
+        event_type="custody_state_changed",
+        actor=actor,
+        notes=notes,
+        payload={"custody_state": new_state},
+    )


### PR DESCRIPTION
## Summary
Introduce a dedicated transition “choke point” for custody state changes so updates and audit logging happen together.

## Related Issue
Closes #10 

## Changes
- Add `assettrack/transitions.py`
- Implement `transition_custody_state(...)` to:
  - update `custody_state` via existing sanitized update path
  - write an append-only audit event (`custody_state_changed`) with optional actor/notes and payload

## Verification checklist
- [ ] `python3 -m compileall .`

## Notes
- This is intentionally minimal (custody_state only) to establish the enforced transition pattern before expanding to other state changes.
