### PR TITLE
Issue 4-4: wire intake scans to ingest preview

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -9,14 +9,16 @@ Feynman-brief:
 """
 
 from __future__ import annotations
-from flask import Flask, request, render_template_string
-
+from flask import Flask, request, render_template_string, session, redirect
+from assettrack.intake.to_ingest import scan_to_ingest_row
+from assettrack.intake.scan import Scan
 import os
 
 app = Flask(__name__)
+app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
 
 # In-memory only: wiped on restart (by design for Issue 4-1).
-SCAN_QUEUE: list[str] = []
+SCAN_QUEUE: list[Scan] = []
 
 def sanitize_scan(raw: str) -> str:
     """
@@ -54,9 +56,13 @@ PAGE = """
   </head>
   <body>
     <h1>AssetTrack Intake</h1>
+    {% if auth_enabled and authed %}
+      <p><a href="/lock">Lock</a></p>
+    {% endif %}
 
     <div class="card">
       <p><strong>How to use:</strong> click the box once, then scan. The scanner “types” and hits Enter.</p>
+      <p><a href="/preview" target="_blank">Preview ingest rows (JSON)</a></p>
 
       {% if auth_enabled and not authed %}
         <form method="post">
@@ -87,7 +93,7 @@ PAGE = """
       <h2>Queue ({{ queue_len }})</h2>
       <ul>
         {% for s in queue %}
-          <li><code>{{ s }}</code></li>
+          <li><code>{{ s.asset_tag }}</code></li>
         {% endfor %}
       </ul>
     </div>
@@ -99,12 +105,21 @@ PAGE = """
 @app.route("/", methods=["GET", "POST"])
 def intake():
     latest = ""
-    authed = True
 
-    if INTAKE_PASSCODE:
+    # If no passcode is set, auth is disabled.
+    if not INTAKE_PASSCODE:
+        authed = True
+    else:
+        authed = bool(session.get("authed", False))
+
+    # Handle unlock attempt
+    if request.method == "POST" and INTAKE_PASSCODE and "access_code" in request.form:
         submitted_code = request.form.get("access_code")
-        authed = auth_ok(submitted_code)
+        if auth_ok(submitted_code):
+            session["authed"] = True
+        return redirect("/")
 
+    # Handle scan / clear
     if request.method == "POST" and authed:
         action = request.form.get("action", "scan")
 
@@ -114,8 +129,9 @@ def intake():
             raw = request.form.get("scan_text", "")
             scan = sanitize_scan(raw)
             if scan:
-                SCAN_QUEUE.append(scan)
-                latest = scan
+                record = Scan.now(asset_tag=scan)
+                SCAN_QUEUE.append(record)
+                latest = record.asset_tag
 
     return render_template_string(
         PAGE,
@@ -126,6 +142,15 @@ def intake():
         auth_enabled=bool(INTAKE_PASSCODE),
     )
 
+@app.route("/preview", methods=["GET"])
+def preview():
+    rows = [scan_to_ingest_row(s) for s in SCAN_QUEUE]
+    return {"count": len(rows), "rows": rows}
+
+@app.get("/lock")
+def lock():
+    session.pop("authed", None)
+    return redirect("/")
 
 if __name__ == "__main__":
     # Local dev run (container wiring comes later).

--- a/assettrack/intake/scan.py
+++ b/assettrack/intake/scan.py
@@ -1,0 +1,26 @@
+# file: assettrack/intake/scan.py
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass(frozen=True)
+class Scan:
+    """
+    A single intake scan event.
+
+    Why this exists:
+    - intake collects "raw-ish" scan events (queue of Scan objects)
+    - to_ingest.py adapts Scan -> ingest-shaped dict (preview-only for now)
+    """
+
+    asset_tag: str
+    scanned_at: datetime
+    operator_id: str | None = None
+
+    @staticmethod
+    def now(asset_tag: str, operator_id: str | None = None) -> "Scan":
+        """Convenience constructor for "scan happened right now"."""
+        return Scan(asset_tag=asset_tag, scanned_at=datetime.now(timezone.utc), operator_id=operator_id)

--- a/assettrack/intake/to_ingest.py
+++ b/assettrack/intake/to_ingest.py
@@ -1,0 +1,37 @@
+# assettrack/intake/to_ingest.py
+"""
+Translate intake Scan objects into the row shape the ingest pipeline expects.
+
+Feynman-brief:
+- Intake captures "what was scanned"
+- Ingest expects a dict shaped like a CSV row
+- This adapter keeps those worlds decoupled
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from assettrack.intake.scan import Scan
+
+
+def scan_to_ingest_row(scan: Scan) -> dict[str, object]:
+    """
+    Produce an ingest-compatible row dict.
+
+    Notes:
+    - We keep fields explicit, even if some are None for now.
+    - Timestamp is ISO-8601 so it matches CSV-like expectations.
+    """
+    return {
+        "asset_tag": scan.asset_tag,
+        "timestamp": scan.scanned_at.replace(tzinfo=None).isoformat(timespec="seconds"),
+        "operator_id": scan.operator_id,
+        # Fields we don't have yet (future UI inputs / workflow):
+        "event_type": None,
+        "issued_to_name": None,
+        "building_room": None,
+        "case_number": None,
+        "slot_number": None,
+        "notes": None,
+    }


### PR DESCRIPTION
## Summary
Wire intake scans into ingest-shaped rows and expose a preview-only endpoint.

## Related Issue
Closes #48 

## Changes
- Added Scan model for intake events
- Added adapter to map scans to ingest-compatible rows
- Added /preview endpoint (JSON only, no commit)
- Switched intake auth to session-based unlock
- Added explicit lock/logout route

## Verification
- [ ] Intake unlock persists across scans
- [ ] Scans appear in UI queue
- [ ] /preview returns ingest-shaped JSON
- [ ] No ingest commit occurs