### PR TITLE
Issue 4-5: add preview validation using ingest rules (no commit)

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from flask import Flask, request, render_template_string, session, redirect
 from assettrack.intake.to_ingest import scan_to_ingest_row
 from assettrack.intake.scan import Scan
+from assettrack.ingest.validator import validate_rows
 import os
 
 app = Flask(__name__)
@@ -146,6 +147,21 @@ def intake():
 def preview():
     rows = [scan_to_ingest_row(s) for s in SCAN_QUEUE]
     return {"count": len(rows), "rows": rows}
+
+@app.get("/preview/validate")
+def preview_validate():
+    parsed_rows = [
+        {"row_number": idx + 1, "data": scan_to_ingest_row(s)}
+        for idx, s in enumerate(SCAN_QUEUE)
+    ]
+
+    result = validate_rows(parsed_rows)
+
+    return {
+        "row_count": len(parsed_rows),
+        "valid": bool(result.get("valid")) if isinstance(result, dict) else False,
+        "result": result,
+    }
 
 @app.get("/lock")
 def lock():

--- a/assettrack/intake/to_ingest.py
+++ b/assettrack/intake/to_ingest.py
@@ -7,31 +7,31 @@ Feynman-brief:
 - Ingest expects a dict shaped like a CSV row
 - This adapter keeps those worlds decoupled
 """
-
 from __future__ import annotations
-
-from datetime import datetime
-
+from datetime import timezone
 from assettrack.intake.scan import Scan
 
 
-def scan_to_ingest_row(scan: Scan) -> dict[str, object]:
+def scan_to_ingest_row(scan: Scan) -> dict:
     """
-    Produce an ingest-compatible row dict.
+    Convert an intake Scan into the ingest-row shape.
 
-    Notes:
-    - We keep fields explicit, even if some are None for now.
-    - Timestamp is ISO-8601 so it matches CSV-like expectations.
+    This is preview-only. We do not commit anything here.
+    We only fill what intake actually knows today and leave the rest blank.
     """
+    scanned_at = scan.scanned_at
+    if scanned_at.tzinfo is None:
+        scanned_at = scanned_at.replace(tzinfo=timezone.utc)
+
     return {
         "asset_tag": scan.asset_tag,
-        "timestamp": scan.scanned_at.replace(tzinfo=None).isoformat(timespec="seconds"),
-        "operator_id": scan.operator_id,
-        # Fields we don't have yet (future UI inputs / workflow):
-        "event_type": None,
-        "issued_to_name": None,
-        "building_room": None,
-        "case_number": None,
-        "slot_number": None,
-        "notes": None,
+        "timestamp": scanned_at.isoformat(),
+        "event_type": "",         # intake does not know yet
+        "issued_to_name": "",     # intake does not know yet
+        "operator_id": scan.operator_id or "",
+        "case_number": "",        # intake does not know yet
+        "slot_number": "",        # intake does not know yet
+        "building_room": "",      # optional, safe default
+        "notes": "",              # optional, safe default
+        "row_number": None,       # ingest validator may accept None
     }


### PR DESCRIPTION
## Summary
Add preview-only validation for intake scans using existing ingest validation logic.

## Related Issue
Closes #42 

## Changes
- Wired intake preview rows into ingest validator
- Exposed preview validation endpoint with pass/fail and errors
- Kept behavior read-only with no commit side effects

## Verification
- [ ] Preview validation runs without errors
- [ ] Missing fields are reported clearly
- [ ] No ingest commit occurs