### PR TITLE
Issue 5-3: store equipment_type per scan and default to laptop

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -108,16 +108,10 @@ def build_parsed_rows_from_queue() -> list[dict]:
       [{"row_number": 1, "data": {...}}, ...]
     Also inject session equipment_type for SCAN rows missing it.
     """
-    equipment_type = (session.get("equipment_type") or "").strip()
-
     rows: list[dict] = []
+
     for idx, s in enumerate(SCAN_QUEUE):
         data = scan_to_ingest_row(s)
-
-        # Make preview reflect the operator's selected type
-        if data.get("event_type") == "SCAN" and not str(data.get("equipment_type") or "").strip():
-            data["equipment_type"] = equipment_type
-
         rows.append({"row_number": idx + 1, "data": data})
 
     return rows
@@ -160,7 +154,8 @@ def intake():
             raw = request.form.get("scan_text", "")
             scan = sanitize_scan(raw)
             if scan:
-                record = Scan.now(asset_tag=scan)
+                equipment_type = (request.form.get("equipment_type") or session.get("equipment_type") or "laptop").strip() or "laptop"
+                record = Scan.now(asset_tag=scan, equipment_type=equipment_type)
 
                 existing = {s.asset_tag for s in SCAN_QUEUE}
                 if record.asset_tag in existing:
@@ -168,6 +163,7 @@ def intake():
 
                 SCAN_QUEUE.append(record)
                 latest = record.asset_tag
+                session["equipment_type"] = "laptop"
                 touch_session()
 
         return redirect("/")
@@ -180,6 +176,8 @@ def intake():
     if authed and last_seen_age_seconds is None:
         last_seen_age_seconds = 0
 
+    if not SCAN_QUEUE:
+        session["equipment_type"] = "laptop"
     return render_template(
         "index.html",
         latest=latest,
@@ -189,7 +187,7 @@ def intake():
         auth_enabled=auth_enabled(),
         timeout_seconds=timeout_seconds,
         last_seen_age_seconds=last_seen_age_seconds,
-        equipment_type=(session.get("equipment_type") or "").strip(),
+        equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
     )
 
 
@@ -203,13 +201,14 @@ def preview():
         rows = [r["data"] for r in parsed_rows]
         return {"count": len(rows), "valid": is_valid, "result": validation, "rows": rows}
 
+
     return render_template(
         "preview.html",
         row_count=len(parsed_rows),
         parsed_rows=parsed_rows,
         valid=is_valid,
         validation=validation,
-        equipment_type=(session.get("equipment_type") or "").strip(),
+        equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
     )
 
 

--- a/assettrack/intake/scan.py
+++ b/assettrack/intake/scan.py
@@ -12,15 +12,27 @@ class Scan:
     A single intake scan event.
 
     Why this exists:
-    - intake collects "raw-ish" scan events (queue of Scan objects)
-    - to_ingest.py adapts Scan -> ingest-shaped dict (preview-only for now)
+    - intake collects scan events (queue of Scan objects)
+    - to_ingest.py adapts Scan -> ingest-shaped dict
+    - equipment_type is stored per scan so later edits don't rewrite history
     """
 
     asset_tag: str
     scanned_at: datetime
+    equipment_type: str = "laptop"
     operator_id: str | None = None
 
     @staticmethod
-    def now(asset_tag: str, operator_id: str | None = None) -> "Scan":
-        """Convenience constructor for "scan happened right now"."""
-        return Scan(asset_tag=asset_tag, scanned_at=datetime.now(timezone.utc), operator_id=operator_id)
+    def now(
+        asset_tag: str,
+        operator_id: str | None = None,
+        equipment_type: str = "laptop",
+    ) -> "Scan":
+        """Convenience constructor for 'scan happened right now'."""
+        equipment_type = (equipment_type or "").strip() or "laptop"
+        return Scan(
+            asset_tag=asset_tag,
+            scanned_at=datetime.now(timezone.utc),
+            operator_id=operator_id,
+            equipment_type=equipment_type,
+        )

--- a/assettrack/intake/to_ingest.py
+++ b/assettrack/intake/to_ingest.py
@@ -25,6 +25,7 @@ def scan_to_ingest_row(scan: Scan) -> dict:
         scanned_at = scanned_at.replace(tzinfo=timezone.utc)
 
     operator_id = (scan.operator_id or DEFAULT_OPERATOR_ID or "").strip()
+    equipment_type = (getattr(scan, "equipment_type", "") or "").strip() or "laptop"
 
     return {
         "asset_tag": (scan.asset_tag or "").strip().upper(),
@@ -37,5 +38,5 @@ def scan_to_ingest_row(scan: Scan) -> dict:
         "building_room": "",    # optional
         "notes": "",            # optional
         "row_number": None,     # preview convenience
-        "equipment_type": "",   # may be required later for create; leaving blank for now
+        "equipment_type": equipment_type,
     }


### PR DESCRIPTION
## Summary
Make equipment_type accurate per scan item and keep the intake UI defaulting to laptops.

## Related Issue
Closes #20 

## Changes
- Stored equipment_type on each Scan at intake time (no retroactive overwrite)
- Updated preview/build to rely on per-scan values instead of session injection
- Defaulted equipment_type to "laptop" and snapped the input back to laptop when appropriate

## Verification
- [x] Scan one item as laptop, switch equipment_type, scan another item
- [x] Preview shows the correct equipment_type per row (no rewrites)
- [x] Add to database preserves each item’s equipment_type
- [x] Intake page defaults back to laptop for the next scan flow

## Notes
This is a workflow improvement for the common laptop case while still supporting mixed equipment types in the same batch.