### PR TITLE
Issue 5-4: require explicit confirmation before add; allow discard

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -223,6 +223,28 @@ def preview_validate():
         "result": result,
     }
 
+@app.post("/preview/discard")
+def preview_discard():
+    # Enforce auth and inactivity timeout for discard requests.
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        if wants_json():
+            return {"ok": False, "discarded": 0, "error": "Locked"}, 401
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    discarded = len(SCAN_QUEUE)
+    SCAN_QUEUE.clear()
+
+    # Reset UI defaults back to laptop (same invariant as intake()).
+    session["equipment_type"] = "laptop"
+    touch_session()
+
+    if wants_json():
+        return {"ok": True, "discarded": discarded}
+
+    flash("Batch discarded.", "success")
+    return redirect(url_for("intake"))
 
 @app.post("/preview/commit")
 def preview_commit():
@@ -234,6 +256,18 @@ def preview_commit():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    # Require deliberate confirmation before adding to the database.
+    confirmed = (request.form.get("confirm_reviewed") or "").strip().lower() in {"on", "true", "1", "yes"}
+    if not confirmed:
+        if wants_json():
+            return {
+                "ok": False,
+                "committed": 0,
+                "error": "Please confirm you reviewed the batch before adding it.",
+            }, 400
+        flash("Please confirm you reviewed the batch before adding it.", "error")
+        return redirect(url_for("preview"))
+    
     parsed_rows = build_parsed_rows_from_queue()
 
     # Validate first (commit boundary: reviewed + valid only).

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -56,7 +56,17 @@
       </p>
 
       <form method="post" action="/preview/commit" style="margin-top: 10px;">
-        <button type="submit">Add to database</button>
+        <label style="display:block; margin-bottom: 10px;">
+          <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed">
+          I reviewed this batch and want to add it to the database.
+        </label>
+
+        <button id="add_btn" type="submit" disabled>Add to database</button>
+      </form>
+
+      <form method="post" action="/preview/discard" style="margin-top: 10px;"
+            onsubmit="return confirm('Discard this batch? This clears the queue.');">
+        <button type="submit">Discard batch</button>
       </form>
 
       <p style="margin-top: 10px;">
@@ -110,5 +120,15 @@
       <h2>Validation result</h2>
       <pre>{{ validation | tojson(indent=2) }}</pre>
     </div>
+
+    <script>
+      const cb = document.getElementById('confirm_reviewed');
+      const btn = document.getElementById('add_btn');
+      if (cb && btn) {
+        const sync = () => { btn.disabled = !cb.checked; };
+        cb.addEventListener('change', sync);
+        sync();
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
Add an explicit confirmation step before adding a batch to the database, and provide a clear discard option.

## Related Issue
Closes #43 

## Changes
- Require operator confirmation before “Add to database”
- Disable add action until confirmation is checked
- Add “Discard batch” flow that clears the queue and resets defaults
- Keep all ingest, validation, and DB logic unchanged

## Verification
- [x] Preview blocks add without confirmation
- [x] Add succeeds only after confirmation
- [x] Discard clears queue and returns to intake
- [x] `python3 -m compileall .` passes