### PR TITLE
Issue 7-4: add slot move helpers

### DIFF
--- a/assettrack/slots.py
+++ b/assettrack/slots.py
@@ -140,6 +140,31 @@ def vacate_slot(case_name: str, slot_position: int, reason: Optional[str] = None
         conn.close()
 
 
+def vacate_slot_by_asset_tag(asset_tag: str, reason: Optional[str] = None) -> None:
+    normalized_tag = (asset_tag or "").strip()
+    if not normalized_tag:
+        raise ValueError("asset_tag is required")
+
+    if reason is not None:
+        _ = reason  # reserved for future audit trail
+
+    conn = get_connection()
+    try:
+        with conn:
+            cursor = conn.execute(
+                """
+                UPDATE slots
+                SET current_asset_tag = NULL
+                WHERE current_asset_tag = ?;
+                """,
+                (normalized_tag,),
+            )
+            if cursor.rowcount == 0:
+                raise ValueError(f"Asset {normalized_tag} is not assigned to any slot")
+    finally:
+        conn.close()
+
+
 def list_slots_for_case(case_name: str) -> list[dict]:
     normalized_case = (case_name or "").strip()
     if not normalized_case:
@@ -193,5 +218,120 @@ def initialize_case_slots(case_name: str, slot_count: int) -> None:
                 """,
                 rows,
             )
+    finally:
+        conn.close()
+
+
+def move_asset_to_slot(
+    asset_tag: str,
+    to_case_name: str,
+    to_slot_position: int,
+    reason: Optional[str] = None,
+) -> None:
+    normalized_tag = (asset_tag or "").strip()
+    normalized_case = (to_case_name or "").strip()
+    if not normalized_tag:
+        raise ValueError("asset_tag is required")
+    if not normalized_case:
+        raise ValueError("case_name is required")
+
+    if reason is not None:
+        _ = reason  # reserved for future audit trail
+
+    conn = get_connection()
+    try:
+        with conn:
+            current = conn.execute(
+                """
+                SELECT case_name, slot_position, current_asset_tag
+                FROM slots
+                WHERE current_asset_tag = ?;
+                """,
+                (normalized_tag,),
+            ).fetchone()
+            if not current:
+                raise ValueError(f"Asset {normalized_tag} is not assigned to any slot")
+
+            destination = conn.execute(
+                """
+                SELECT current_asset_tag
+                FROM slots
+                WHERE case_name = ? AND slot_position = ?;
+                """,
+                (normalized_case, to_slot_position),
+            ).fetchone()
+            if destination and destination["current_asset_tag"] and destination["current_asset_tag"] != normalized_tag:
+                raise ValueError(
+                    f"Slot {normalized_case} {to_slot_position} already occupied by {destination['current_asset_tag']}"
+                )
+
+            conn.execute(
+                """
+                UPDATE slots
+                SET current_asset_tag = NULL
+                WHERE current_asset_tag = ?;
+                """,
+                (normalized_tag,),
+            )
+
+            if destination:
+                conn.execute(
+                    """
+                    UPDATE slots
+                    SET current_asset_tag = ?
+                    WHERE case_name = ? AND slot_position = ?;
+                    """,
+                    (normalized_tag, normalized_case, to_slot_position),
+                )
+            else:
+                conn.execute(
+                    """
+                    INSERT INTO slots (case_name, slot_position, current_asset_tag)
+                    VALUES (?, ?, ?);
+                    """,
+                    (normalized_case, to_slot_position, normalized_tag),
+                )
+    finally:
+        conn.close()
+
+
+def is_asset_slotted(asset_tag: str) -> bool:
+    normalized_tag = (asset_tag or "").strip()
+    if not normalized_tag:
+        return False
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT 1 FROM slots
+            WHERE current_asset_tag = ?
+            LIMIT 1;
+            """,
+            (normalized_tag,),
+        )
+        return cursor.fetchone() is not None
+    finally:
+        conn.close()
+
+
+def is_slot_empty(case_name: str, slot_position: int) -> bool:
+    normalized_case = (case_name or "").strip()
+    if not normalized_case:
+        return False
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT current_asset_tag FROM slots
+            WHERE case_name = ? AND slot_position = ?;
+            """,
+            (normalized_case, slot_position),
+        )
+        row = cursor.fetchone()
+        if not row:
+            return False
+        return row["current_asset_tag"] is None
     finally:
         conn.close()


### PR DESCRIPTION
## Summary

Adds slot movement and convenience helpers to support custody workflows.

This extends slot integrity logic with atomic move operations and occupancy checks. No schema or UI changes.

## Related Issue

Closes #71 

## Changes

- Added to `assettrack/slots.py`:
  - `vacate_slot_by_asset_tag`
  - `move_asset_to_slot`
  - `is_asset_slotted`
  - `is_slot_empty`
- Enforced hard stops:
  - Prevent moving unslotted assets
  - Prevent moving into occupied slots
- All multi-step operations run in a single atomic SQLite transaction

## Verification Checklist

- [x] `python3 -m compileall .` passes
- [x] Asset move vacates original slot and assigns destination slot
- [x] Moving unslotted asset raises `ValueError`
- [x] Moving into occupied slot raises `ValueError`
- [x] No schema changes
- [x] No UI changes

## Notes

Completes the core slot integrity layer required for upcoming Stock-In / Stock-Out operational wiring.