### PR TITLE
Issue 8-1: add holders model and selection UI

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -1,3 +1,4 @@
+# file: assettrack/db.py
 import sqlite3
 from pathlib import Path
 
@@ -59,5 +60,33 @@ def _create_schema(conn: sqlite3.Connection):
     """
     CREATE INDEX IF NOT EXISTS idx_slots_current_asset_tag
         ON slots(current_asset_tag);
+    """
+    )
+
+    cursor.execute(
+    """
+    CREATE TABLE IF NOT EXISTS holders (
+        id INTEGER PRIMARY KEY,
+        holder_type TEXT NOT NULL,
+        name TEXT NOT NULL,
+        identifier TEXT NULL,
+        contact_info TEXT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    );
+    """
+    )
+
+    cursor.execute(
+    """
+    CREATE INDEX IF NOT EXISTS idx_holders_name
+        ON holders(name);
+    """
+    )
+
+    cursor.execute(
+    """
+    CREATE INDEX IF NOT EXISTS idx_holders_identifier
+        ON holders(identifier);
     """
     )

--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -1,0 +1,55 @@
+# file: assettrack/holders.py
+from __future__ import annotations
+
+from assettrack.db import get_connection
+
+
+def search_holders(query: str, limit: int = 20) -> list[dict]:
+    q = (query or "").strip()
+    if not q:
+        return []
+
+    if limit <= 0:
+        raise ValueError("limit must be > 0")
+
+    pattern = f"%{q}%"
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT * FROM holders
+            WHERE name LIKE ? OR identifier LIKE ?
+            ORDER BY name ASC, id ASC
+            LIMIT ?;
+            """,
+            (pattern, pattern, limit),
+        )
+        rows = cursor.fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_holder(holder_id: int) -> dict | None:
+    if holder_id is None:
+        return None
+
+    try:
+        normalized_id = int(holder_id)
+    except (TypeError, ValueError):
+        return None
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            SELECT * FROM holders
+            WHERE id = ?;
+            """,
+            (normalized_id,),
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -21,6 +21,7 @@ from assettrack.ingest.committer import BatchCommitError, commit_batch
 from assettrack.ingest.validator import validate_rows
 from assettrack.intake.scan import Scan
 from assettrack.intake.to_ingest import scan_to_ingest_row
+from assettrack.holders import get_holder, search_holders
 
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
@@ -126,6 +127,17 @@ def wants_json() -> bool:
     return (request.args.get("json") or "").strip() == "1"
 
 
+def _selected_holder_from_session() -> Optional[dict]:
+    holder_id = session.get("holder_id")
+    if holder_id is None:
+        return None
+
+    holder = get_holder(holder_id)
+    if holder is None:
+        session.pop("holder_id", None)
+    return holder
+
+
 # Routes
 
 @app.route("/", methods=["GET", "POST"])
@@ -149,6 +161,7 @@ def intake():
 
         if action == "clear":
             SCAN_QUEUE.clear()
+            session.pop("holder_id", None)
             touch_session()
         else:
             raw = request.form.get("scan_text", "")
@@ -209,6 +222,7 @@ def preview():
         valid=is_valid,
         validation=validation,
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+        selected_holder=_selected_holder_from_session(),
     )
 
 
@@ -235,6 +249,7 @@ def preview_discard():
 
     discarded = len(SCAN_QUEUE)
     SCAN_QUEUE.clear()
+    session.pop("holder_id", None)
 
     # Reset UI defaults back to laptop (same invariant as intake()).
     session["equipment_type"] = "laptop"
@@ -306,6 +321,7 @@ def preview_commit():
 
     # Clear queue ONLY after commit succeeds.
     SCAN_QUEUE.clear()
+    session.pop("holder_id", None)
     touch_session()
 
     if wants_json():
@@ -319,6 +335,60 @@ def preview_commit():
 def lock():
     set_authed(False)
     return redirect("/")
+
+
+@app.get("/holders")
+def holders_search():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    query = (request.args.get("q") or "").strip()
+    results = search_holders(query) if query else []
+
+    return render_template(
+        "holders_search.html",
+        query=query,
+        results=results,
+        selected_holder=_selected_holder_from_session(),
+    )
+
+
+@app.post("/holders/select")
+def holders_select():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    holder_id_raw = (request.form.get("holder_id") or "").strip()
+    if not holder_id_raw:
+        flash("Select a holder first.", "error")
+        return redirect(url_for("holders_search"))
+
+    holder = get_holder(holder_id_raw)
+    if holder is None:
+        flash("Selected holder not found.", "error")
+        return redirect(url_for("holders_search"))
+
+    session["holder_id"] = holder["id"]
+    touch_session()
+    flash(f"Selected holder: {holder['name']}", "success")
+    return redirect(url_for("holders_search"))
+
+
+@app.post("/holders/clear")
+def holders_clear():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    session.pop("holder_id", None)
+    touch_session()
+    flash("Cleared holder selection.", "success")
+    return redirect(url_for("holders_search"))
 
 
 if __name__ == "__main__":

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -1,0 +1,101 @@
+<!-- file: assettrack/intake/templates/holders_search.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AssetTrack Holders</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 980px; }
+      .row { margin: 0.75rem 0; }
+      input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; margin-left: 0.25rem; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; border-bottom: 1px solid #eee; padding: 0.5rem; vertical-align: top; }
+      th { background: #fafafa; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 980px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+    </style>
+  </head>
+  <body>
+    <h1>Holders</h1>
+    <p><a href="/preview">← Back to preview</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <div class="card">
+      <form method="get" action="/holders">
+        <label for="q"><strong>Search by name or identifier</strong></label><br />
+        <input
+          type="text"
+          id="q"
+          name="q"
+          placeholder="e.g. Jane Doe or ID123"
+          value="{{ query or '' }}"
+          autocomplete="off"
+        />
+        <button type="submit">Search</button>
+      </form>
+    </div>
+
+    <div class="card">
+      <h2>Selected Holder</h2>
+      {% if selected_holder %}
+        <p>
+          <strong>Type:</strong> {{ selected_holder["holder_type"] }}<br />
+          <strong>Name:</strong> {{ selected_holder["name"] }}<br />
+          <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}
+        </p>
+        <form method="post" action="/holders/clear">
+          <button type="submit">Clear selection</button>
+        </form>
+      {% else %}
+        <p>No holder selected.</p>
+      {% endif %}
+    </div>
+
+    <div class="card">
+      <h2>Results</h2>
+      {% if results %}
+        <table>
+          <thead>
+            <tr>
+              <th style="width: 120px;">Type</th>
+              <th style="width: 220px;">Name</th>
+              <th style="width: 180px;">Identifier</th>
+              <th>Contact</th>
+              <th style="width: 120px;">Select</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for h in results %}
+              <tr>
+                <td>{{ h["holder_type"] }}</td>
+                <td>{{ h["name"] }}</td>
+                <td><code>{{ h["identifier"] or "" }}</code></td>
+                <td>{{ h["contact_info"] or "" }}</td>
+                <td>
+                  <form method="post" action="/holders/select">
+                    <input type="hidden" name="holder_id" value="{{ h['id'] }}" />
+                    <button type="submit">Select</button>
+                  </form>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p>No results.</p>
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -75,6 +75,20 @@
     </div>
 
     <div class="card">
+      <h2>Stock-Out Holder</h2>
+      {% if selected_holder %}
+        <p>
+          <strong>Type:</strong> {{ selected_holder["holder_type"] }}<br />
+          <strong>Name:</strong> {{ selected_holder["name"] }}<br />
+          <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}
+        </p>
+      {% else %}
+        <p>No holder selected.</p>
+      {% endif %}
+      <p><a href="/holders">Search/select holder</a></p>
+    </div>
+
+    <div class="card">
       <h2>Rows</h2>
       <table>
         <thead>

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -1,0 +1,64 @@
+# file: tests/test_holders.py
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.holders import get_holder, search_holders
+
+
+class HoldersTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_holder(
+        self,
+        holder_type: str,
+        name: str,
+        identifier: str | None = None,
+        contact_info: str | None = None,
+    ) -> int:
+        now = datetime.now(timezone.utc).isoformat()
+        cursor = self.conn.execute(
+            """
+            INSERT INTO holders (
+                holder_type, name, identifier, contact_info, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?);
+            """,
+            (holder_type, name, identifier, contact_info, now, now),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def test_holders_insert_and_get(self) -> None:
+        holder_id = self._insert_holder(
+            holder_type="Person",
+            name="Jane Doe",
+            identifier="ID-123",
+            contact_info="jane@example.org",
+        )
+        holder = get_holder(holder_id)
+        self.assertIsNotNone(holder)
+        self.assertEqual(holder["name"], "Jane Doe")
+        self.assertEqual(holder["identifier"], "ID-123")
+
+    def test_search_holders_by_name_and_identifier(self) -> None:
+        self._insert_holder("Person", "Alpha User", "A-001", None)
+        self._insert_holder("Organization", "Bravo Org", "BR-77", "contact@bravo.org")
+
+        by_name = search_holders("Alpha")
+        self.assertEqual(len(by_name), 1)
+        self.assertEqual(by_name[0]["name"], "Alpha User")
+
+        by_identifier = search_holders("BR-77")
+        self.assertEqual(len(by_identifier), 1)
+        self.assertEqual(by_identifier[0]["name"], "Bravo Org")


### PR DESCRIPTION
## Summary
Adds the holders model and a minimal server-rendered search/select flow to support upcoming custody operations.

## Related Issue
Closes #72 

## Changes
- Added `holders` table and supporting indexes to schema bootstrap.
- Added `assettrack/holders.py` helper module (search + get).
- Added `/holders` search route with select/clear actions.
- Persisted selected holder in session alongside pending batch.
- Updated preview page to display selected holder.
- Added basic unittest coverage for holders insert/get and search.

## Verification checklist
- [ ] python3 -m compileall .
- [ ] python3 -m unittest discover -s tests -p "test_*.py" -v
- [ ] Run app locally and confirm:
  - Search/select holder works.
  - Selected holder displays on preview.
  - Holder clears on discard and commit.
  - Works under Docker with persisted DB.

## Notes
- No refactors.
- No custody state changes yet (Stock-Out/Stock-In handled in 8-2+).
- Minimal UI only; no holder creation screen added.