### PR TITLE
Issue 8-4: implement Return Assets batch to home slot

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -139,3 +139,10 @@ def _create_schema(conn: sqlite3.Connection):
             ADD COLUMN current_holder_id INTEGER NULL;
             """
             )
+        if not _column_exists(conn, "assets", "home_slot_id"):
+            cursor.execute(
+            """
+            ALTER TABLE assets
+            ADD COLUMN home_slot_id INTEGER NULL REFERENCES slots(id);
+            """
+            )

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -292,6 +292,120 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
         "holder_label": holder_label,
     }
 
+
+def _build_return_preview_state(asset_tags: list[str]) -> dict:
+    assets: list[dict] = []
+    unknown_tags: list[str] = []
+    not_in_custody: list[str] = []
+    no_home_slot: list[str] = []
+    occupied_home_slot: list[str] = []
+    blocking_issues: list[str] = []
+
+    if not asset_tags:
+        blocking_issues.append("Queue is empty. Scan assets before returning.")
+        return {"assets": assets, "ready_count": 0, "blocking_issues": blocking_issues}
+
+    def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
+        t = (scan_tag or "").strip()
+        if not t:
+            return None
+
+        rows = conn.execute(
+            """
+            SELECT asset_tag, location_type, home_slot_id
+            FROM assets
+            WHERE UPPER(asset_tag) = UPPER(?)
+               OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
+            LIMIT 2;
+            """,
+            (t, t),
+        ).fetchall()
+
+        if not rows:
+            return None
+
+        if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
+            raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
+
+        return dict(rows[0])
+
+    conn = get_connection()
+    try:
+        asset_columns = get_asset_table_columns(conn)
+        required_columns = {"location_type", "current_holder_id", "home_slot_id"}
+        missing_columns = sorted(required_columns - asset_columns)
+        if missing_columns:
+            blocking_issues.append(f"Assets table missing columns: {', '.join(missing_columns)}")
+            return {"assets": assets, "ready_count": 0, "blocking_issues": blocking_issues}
+
+        for scan_tag in asset_tags:
+            row: dict = {
+                "scanned_tag": scan_tag,
+                "canonical_tag": None,
+                "home_slot": "unknown",
+                "ready": False,
+                "asset_issues": [],
+            }
+
+            asset_row = _canon_asset_row_for_scan_tag(conn, scan_tag)
+            if not asset_row:
+                row["asset_issues"].append("Unknown asset tag")
+                unknown_tags.append(scan_tag)
+                assets.append(row)
+                continue
+
+            canon_tag = str(asset_row["asset_tag"])
+            row["canonical_tag"] = canon_tag
+
+            location_type = str(asset_row["location_type"] or "").strip().upper()
+            if location_type != "IN_CUSTODY":
+                row["asset_issues"].append("Asset is not in IN_CUSTODY")
+                not_in_custody.append(canon_tag)
+
+            home_slot_id = asset_row["home_slot_id"]
+            if home_slot_id is None:
+                row["asset_issues"].append("Asset has no home slot")
+                no_home_slot.append(canon_tag)
+                assets.append(row)
+                continue
+
+            slot = conn.execute(
+                """
+                SELECT id, case_name, slot_position, current_asset_tag
+                FROM slots
+                WHERE id = ?;
+                """,
+                (home_slot_id,),
+            ).fetchone()
+            if not slot:
+                row["asset_issues"].append("Home slot not found")
+                no_home_slot.append(canon_tag)
+                assets.append(row)
+                continue
+
+            row["home_slot"] = f"{slot['case_name']} / {slot['slot_position']}"
+            if slot["current_asset_tag"] is not None:
+                row["asset_issues"].append(f"Home slot occupied by {slot['current_asset_tag']}")
+                occupied_home_slot.append(canon_tag)
+
+            row["ready"] = not row["asset_issues"]
+            assets.append(row)
+    finally:
+        conn.close()
+
+    if unknown_tags:
+        blocking_issues.append(f"Unknown asset_tag(s): {', '.join(unknown_tags)}")
+    if not_in_custody:
+        blocking_issues.append(f"Not in IN_CUSTODY: {', '.join(not_in_custody)}")
+    if no_home_slot:
+        blocking_issues.append(f"Missing home slot: {', '.join(no_home_slot)}")
+    if occupied_home_slot:
+        blocking_issues.append(f"Home slot occupied: {', '.join(occupied_home_slot)}")
+
+    ready_count = sum(1 for row in assets if row["ready"])
+    return {"assets": assets, "ready_count": ready_count, "blocking_issues": blocking_issues}
+
+
 def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to stock out")
@@ -425,6 +539,143 @@ def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
                 )
 
             return len(canon_tags)
+    finally:
+        conn.close()
+
+
+def _stock_in_batch(asset_tags: list[str]) -> int:
+    if not asset_tags:
+        raise ValueError("No assets in the queue to return")
+
+    def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
+        t = (scan_tag or "").strip()
+        if not t:
+            return None
+
+        rows = conn.execute(
+            """
+            SELECT asset_tag, location_type, home_slot_id
+            FROM assets
+            WHERE UPPER(asset_tag) = UPPER(?)
+               OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
+            LIMIT 2;
+            """,
+            (t, t),
+        ).fetchall()
+
+        if not rows:
+            return None
+
+        if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
+            raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
+
+        return dict(rows[0])
+
+    conn = get_connection()
+    try:
+        with conn:
+            asset_columns = get_asset_table_columns(conn)
+            required_columns = {"location_type", "current_holder_id", "home_slot_id"}
+            missing_columns = sorted(required_columns - asset_columns)
+            if missing_columns:
+                raise ValueError(f"Assets table missing columns: {', '.join(missing_columns)}")
+
+            unknown_tags: list[str] = []
+            not_in_custody: list[str] = []
+            no_home_slot: list[str] = []
+            occupied_home_slot: list[str] = []
+            validated_rows: list[dict] = []
+
+            for scan_tag in asset_tags:
+                asset_row = _canon_asset_row_for_scan_tag(conn, scan_tag)
+                if not asset_row:
+                    unknown_tags.append(scan_tag)
+                    continue
+
+                canon_tag = str(asset_row["asset_tag"])
+
+                location_type = str(asset_row["location_type"] or "").strip().upper()
+                if location_type != "IN_CUSTODY":
+                    not_in_custody.append(canon_tag)
+
+                home_slot_id = asset_row["home_slot_id"]
+                if home_slot_id is None:
+                    no_home_slot.append(canon_tag)
+                    continue
+
+                slot = conn.execute(
+                    """
+                    SELECT id, case_name, slot_position, current_asset_tag
+                    FROM slots
+                    WHERE id = ?;
+                    """,
+                    (home_slot_id,),
+                ).fetchone()
+                if not slot:
+                    no_home_slot.append(canon_tag)
+                    continue
+
+                if slot["current_asset_tag"] is not None:
+                    occupied_home_slot.append(canon_tag)
+
+                validated_rows.append({"asset_tag": canon_tag, "home_slot_id": int(slot["id"])})
+
+            if unknown_tags or not_in_custody or no_home_slot or occupied_home_slot:
+                parts: list[str] = []
+                if unknown_tags:
+                    parts.append(f"Unknown asset_tag(s): {', '.join(unknown_tags)}")
+                if not_in_custody:
+                    parts.append(f"Not in IN_CUSTODY: {', '.join(not_in_custody)}")
+                if no_home_slot:
+                    parts.append(f"Missing home slot: {', '.join(no_home_slot)}")
+                if occupied_home_slot:
+                    parts.append(f"Home slot occupied: {', '.join(occupied_home_slot)}")
+                raise ValueError("; ".join(parts))
+
+            now_iso = datetime.now(timezone.utc).isoformat()
+
+            for row in validated_rows:
+                canon_tag = row["asset_tag"]
+                home_slot_id = row["home_slot_id"]
+
+                conn.execute(
+                    """
+                    UPDATE assets
+                    SET location_type = ?, current_holder_id = NULL
+                    WHERE UPPER(asset_tag) = UPPER(?)
+                       OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?);
+                    """,
+                    ("STORAGE", canon_tag, canon_tag),
+                )
+
+                cursor = conn.execute(
+                    """
+                    UPDATE slots
+                    SET current_asset_tag = ?
+                    WHERE id = ? AND current_asset_tag IS NULL;
+                    """,
+                    (canon_tag, home_slot_id),
+                )
+                if cursor.rowcount != 1:
+                    raise ValueError(f"Home slot became occupied for {canon_tag}")
+
+                conn.execute(
+                    """
+                    INSERT INTO asset_events (
+                        asset_tag,
+                        event_type,
+                        event_date,
+                        actor,
+                        notes,
+                        payload,
+                        holder_id
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?);
+                    """,
+                    (canon_tag, "STOCK_IN", now_iso, "system", None, None, None),
+                )
+
+            return len(validated_rows)
     finally:
         conn.close()
 
@@ -752,6 +1003,73 @@ def issue_commit():
         return {"ok": True, "committed": committed_count, "error": None}
 
     flash(f"Issued {committed_count} assets.", "success")
+    return redirect(url_for("intake"))
+
+
+@app.get("/return")
+def return_queue():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "Locked"}, 401
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    asset_tags = _queue_asset_tags()
+    state = _build_return_preview_state(asset_tags)
+
+    if wants_json():
+        return {
+            "ok": len(state["blocking_issues"]) == 0,
+            "committed": 0,
+            "error": "; ".join(state["blocking_issues"]) if state["blocking_issues"] else None,
+            "queued": asset_tags,
+            "ready_count": state["ready_count"],
+            "items": state["assets"],
+        }
+
+    return render_template(
+        "return_queue.html",
+        queued_count=len(asset_tags),
+        assets=state["assets"],
+        ready_count=state["ready_count"],
+        blocking_issues=state["blocking_issues"],
+    )
+
+
+@app.post("/return/commit")
+def return_commit():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "Locked"}, 401
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    asset_tags = _queue_asset_tags()
+    state = _build_return_preview_state(asset_tags)
+    if state["blocking_issues"]:
+        message = "; ".join(state["blocking_issues"])
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": message}, 400
+        flash(f"Return failed: {message}", "error")
+        return redirect(url_for("return_queue"))
+
+    try:
+        committed_count = _stock_in_batch(asset_tags)
+    except ValueError as e:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": str(e)}, 400
+        flash(f"Return failed: {e}", "error")
+        return redirect(url_for("return_queue"))
+
+    SCAN_QUEUE.clear()
+    touch_session()
+
+    if wants_json():
+        return {"ok": True, "committed": committed_count, "error": None}
+
+    flash(f"Returned {committed_count} assets.", "success")
     return redirect(url_for("intake"))
 
 @app.get("/lock")

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -61,6 +61,7 @@
     <div class="card">
       <p><strong>How to use:</strong> click the box once, then scan. The scanner “types” and hits Enter.</p>
       <p><a href="/preview" target="_blank">Preview batch</a></p>
+      <p><a href="/return" target="_blank">Return Assets</a></p>
 
       {% if auth_enabled and not authed %}
         <form method="post">

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -1,0 +1,108 @@
+<!-- assettrack/intake/templates/return_queue.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Return Assets</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 1100px; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 1100px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; border-bottom: 1px solid #eee; padding: 0.5rem; vertical-align: top; }
+      th { background: #fafafa; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; }
+      .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
+      .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
+      .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      ul { margin: 0.5rem 0 0 1.25rem; }
+      a { text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <h1>Return Assets</h1>
+    <p><a href="/">← Back to intake</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <div class="card">
+      <h2>Validation Summary</h2>
+      <p>
+        <strong>Queued assets:</strong> {{ queued_count }}
+        &nbsp;|&nbsp;
+        <strong>Ready:</strong> {{ ready_count }}
+        &nbsp;|&nbsp;
+        <strong>Status:</strong>
+        {% if blocking_issues %}
+          <span class="pill bad">blocked</span>
+        {% else %}
+          <span class="pill good">ready</span>
+        {% endif %}
+      </p>
+      {% if blocking_issues %}
+        <ul>
+          {% for issue in blocking_issues %}
+            <li>{{ issue }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+
+    <div class="card">
+      <h2>Queued Assets</h2>
+      {% if assets %}
+        <table>
+          <thead>
+            <tr>
+              <th style="width: 170px;">Scanned Tag</th>
+              <th style="width: 190px;">Canonical Tag</th>
+              <th style="width: 210px;">Home Slot</th>
+              <th>Checks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in assets %}
+              <tr>
+                <td><code>{{ row["scanned_tag"] }}</code></td>
+                <td><code>{{ row["canonical_tag"] or "n/a" }}</code></td>
+                <td><code>{{ row["home_slot"] }}</code></td>
+                <td>
+                  {% if row["asset_issues"] %}
+                    <span class="pill bad">blocked</span>
+                    <ul>
+                      {% for issue in row["asset_issues"] %}
+                        <li>{{ issue }}</li>
+                      {% endfor %}
+                    </ul>
+                  {% else %}
+                    <span class="pill good">ready</span>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p>No assets queued.</p>
+      {% endif %}
+    </div>
+
+    <div class="card">
+      <h2>Commit</h2>
+      <form method="post" action="/return/commit">
+        <button type="submit">Return assets</button>
+      </form>
+      <p style="margin-top: 10px;">JSON API: <code>/return/commit?json=1</code> (POST)</p>
+    </div>
+  </body>
+</html>

--- a/assettrack/slots.py
+++ b/assettrack/slots.py
@@ -58,6 +58,7 @@ def assign_asset_to_slot(case_name: str, slot_position: int, asset_tag: str) -> 
     conn = get_connection()
     try:
         with conn:
+            destination_slot_id: int | None = None
             existing_slot = conn.execute(
                 """
                 SELECT * FROM slots
@@ -93,6 +94,8 @@ def assign_asset_to_slot(case_name: str, slot_position: int, asset_tag: str) -> 
                     )
 
                 if current_tag == normalized_tag:
+                    destination_slot_id = int(existing_slot["id"])
+                    _set_asset_home_slot_in_tx(conn, normalized_tag, destination_slot_id)
                     return
 
                 conn.execute(
@@ -103,14 +106,18 @@ def assign_asset_to_slot(case_name: str, slot_position: int, asset_tag: str) -> 
                     """,
                     (normalized_tag, normalized_case, slot_position),
                 )
+                destination_slot_id = int(existing_slot["id"])
             else:
-                conn.execute(
+                cursor = conn.execute(
                     """
                     INSERT INTO slots (case_name, slot_position, current_asset_tag)
                     VALUES (?, ?, ?);
                     """,
                     (normalized_case, slot_position, normalized_tag),
                 )
+                destination_slot_id = int(cursor.lastrowid)
+
+            _set_asset_home_slot_in_tx(conn, normalized_tag, destination_slot_id)
     finally:
         conn.close()
 
@@ -265,6 +272,7 @@ def move_asset_to_slot(
     conn = get_connection()
     try:
         with conn:
+            destination_slot_id: int | None = None
             current = conn.execute(
                 """
                 SELECT case_name, slot_position, current_asset_tag
@@ -278,7 +286,7 @@ def move_asset_to_slot(
 
             destination = conn.execute(
                 """
-                SELECT current_asset_tag
+                SELECT id, current_asset_tag
                 FROM slots
                 WHERE case_name = ? AND slot_position = ?;
                 """,
@@ -307,16 +315,40 @@ def move_asset_to_slot(
                     """,
                     (normalized_tag, normalized_case, to_slot_position),
                 )
+                destination_slot_id = int(destination["id"])
             else:
-                conn.execute(
+                cursor = conn.execute(
                     """
                     INSERT INTO slots (case_name, slot_position, current_asset_tag)
                     VALUES (?, ?, ?);
                     """,
                     (normalized_case, to_slot_position, normalized_tag),
                 )
+                destination_slot_id = int(cursor.lastrowid)
+
+            _set_asset_home_slot_in_tx(conn, normalized_tag, destination_slot_id)
     finally:
         conn.close()
+
+
+def _set_asset_home_slot_in_tx(conn: sqlite3.Connection, asset_tag: str, slot_id: Optional[int]) -> None:
+    if slot_id is None:
+        return
+
+    row = conn.execute("PRAGMA table_info(assets);").fetchall()
+    asset_columns = {r[1] for r in row}
+    if "home_slot_id" not in asset_columns:
+        return
+
+    conn.execute(
+        """
+        UPDATE assets
+        SET home_slot_id = ?
+        WHERE UPPER(asset_tag) = UPPER(?)
+           OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?);
+        """,
+        (slot_id, asset_tag, asset_tag),
+    )
 
 
 def is_asset_slotted(asset_tag: str) -> bool:

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -1,0 +1,128 @@
+# file: tests/test_return_batch.py
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+
+
+class ReturnBatchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE,
+                location_type TEXT NULL,
+                current_holder_id INTEGER NULL,
+                home_slot_id INTEGER NULL
+            );
+            """
+        )
+        self.conn.commit()
+        self.client = intake_app.app.test_client()
+        intake_app.app.testing = True
+        intake_app.SCAN_QUEUE.clear()
+
+    def tearDown(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_asset(self, asset_tag: str, *, location_type: str, holder_id: int | None, home_slot_id: int) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO assets (asset_tag, location_type, current_holder_id, home_slot_id)
+            VALUES (?, ?, ?, ?);
+            """,
+            (asset_tag, location_type, holder_id, home_slot_id),
+        )
+        self.conn.commit()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int, current_asset_tag: str | None = None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            (slot_id, case_name, slot_position, current_asset_tag),
+        )
+        self.conn.commit()
+
+    def test_return_routes_block_and_commit(self) -> None:
+        self._insert_slot(10, "A", 1, None)
+        self._insert_slot(20, "B", 2, None)
+        self._insert_asset("TAG-VALID", location_type="IN_CUSTODY", holder_id=5, home_slot_id=10)
+        self._insert_asset("TAG-OK", location_type="IN_CUSTODY", holder_id=9, home_slot_id=20)
+
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-VALID", equipment_type="laptop"))
+
+        render = self.client.get("/return")
+        self.assertEqual(render.status_code, 200)
+        self.assertIn(b"Return Assets", render.data)
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-VALID", equipment_type="laptop"))
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="UNKNOWN", equipment_type="laptop"))
+
+        blocked = self.client.post("/return/commit?json=1")
+        self.assertEqual(blocked.status_code, 400)
+        self.assertFalse(blocked.json["ok"])
+        self.assertEqual(blocked.json["committed"], 0)
+
+        valid_asset = self.conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
+            ("TAG-VALID",),
+        ).fetchone()
+        self.assertEqual(valid_asset["location_type"], "IN_CUSTODY")
+        self.assertEqual(valid_asset["current_holder_id"], 5)
+        slot_after_block = self.conn.execute(
+            "SELECT current_asset_tag FROM slots WHERE id = ?;",
+            (10,),
+        ).fetchone()
+        self.assertIsNone(slot_after_block["current_asset_tag"])
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-OK", equipment_type="laptop"))
+
+        success = self.client.post("/return/commit?json=1")
+        self.assertEqual(success.status_code, 200)
+        self.assertTrue(success.json["ok"])
+        self.assertEqual(success.json["committed"], 1)
+        self.assertEqual(success.json["error"], None)
+        self.assertEqual(len(intake_app.SCAN_QUEUE), 0)
+
+        asset_after = self.conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
+            ("TAG-OK",),
+        ).fetchone()
+        self.assertEqual(asset_after["location_type"], "STORAGE")
+        self.assertIsNone(asset_after["current_holder_id"])
+
+        slot_after = self.conn.execute(
+            "SELECT current_asset_tag FROM slots WHERE id = ?;",
+            (20,),
+        ).fetchone()
+        self.assertEqual(slot_after["current_asset_tag"], "TAG-OK")
+
+        event_row = self.conn.execute(
+            """
+            SELECT event_type FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("TAG-OK",),
+        ).fetchone()
+        self.assertIsNotNone(event_row)
+        self.assertEqual(event_row["event_type"], "STOCK_IN")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the scanner-first **Return Assets** batch workflow.

Adds atomic IN_CUSTODY → STORAGE transitions using the asset’s home slot, with strict hard-stop validation and no partial commits.

This PR does not include preview/confirm gating (reserved for Issue 8-5).

---

## Related Issue

Closes #75 

---

## Changes

- Added `assets.home_slot_id` (schema migration if missing)
- Automatically maintains `home_slot_id` during slot assignment/move
- Implemented `_build_return_preview_state` for return validation
- Implemented `_stock_in_batch` atomic return commit logic
- Added GET `/return` queue + validation screen
- Added POST `/return/commit` with hard-stop enforcement
- Added `return_queue.html` template
- Added deterministic test: `test_return_batch.py`
- Preserved existing event model (`STOCK_IN`)
- Preserved existing queue model and `?json=1` response format

---

## Verification Checklist

- [x] `python -m compileall .` passes
- [x] unittest suite passes
- [x] `/return` renders 200
- [x] `/return/commit?json=1` blocks invalid items (400, no partial state)
- [x] `/return/commit?json=1` succeeds valid items (200, atomic commit)

---

## Notes

- No preview/confirm gating added (Issue 8-5)
- No conflict-resolution tooling added
- No reporting/dashboard changes
- No schema changes beyond `home_slot_id`