### PR TITLE
Issue 8-5: add Return Assets preview/confirm gating

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -312,7 +312,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
 
         rows = conn.execute(
             """
-            SELECT asset_tag, location_type, home_slot_id
+            SELECT asset_tag, location_type, current_holder_id, home_slot_id
             FROM assets
             WHERE UPPER(asset_tag) = UPPER(?)
                OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
@@ -342,7 +342,13 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
             row: dict = {
                 "scanned_tag": scan_tag,
                 "canonical_tag": None,
-                "home_slot": "unknown",
+                "before_location_type": "UNKNOWN",
+                "after_location_type": "STORAGE",
+                "before_holder": "null",
+                "after_holder": "null",
+                "destination_slot": "unknown",
+                "before_slot_occupancy": "empty",
+                "after_slot_occupancy": "occupied",
                 "ready": False,
                 "asset_issues": [],
             }
@@ -358,9 +364,17 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
             row["canonical_tag"] = canon_tag
 
             location_type = str(asset_row["location_type"] or "").strip().upper()
+            row["before_location_type"] = location_type or "UNKNOWN"
             if location_type != "IN_CUSTODY":
                 row["asset_issues"].append("Asset is not in IN_CUSTODY")
                 not_in_custody.append(canon_tag)
+
+            current_holder_id = asset_row["current_holder_id"]
+            if current_holder_id is not None:
+                holder = get_holder(current_holder_id)
+                row["before_holder"] = (
+                    holder["name"] if holder is not None else f"holder_id {current_holder_id}"
+                )
 
             home_slot_id = asset_row["home_slot_id"]
             if home_slot_id is None:
@@ -383,10 +397,11 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
                 assets.append(row)
                 continue
 
-            row["home_slot"] = f"{slot['case_name']} / {slot['slot_position']}"
+            row["destination_slot"] = f"{slot['case_name']} / {slot['slot_position']}"
             if slot["current_asset_tag"] is not None:
                 row["asset_issues"].append(f"Home slot occupied by {slot['current_asset_tag']}")
                 occupied_home_slot.append(canon_tag)
+                row["before_slot_occupancy"] = "occupied"
 
             row["ready"] = not row["asset_issues"]
             assets.append(row)
@@ -1031,6 +1046,26 @@ def return_queue():
     return render_template(
         "return_queue.html",
         queued_count=len(asset_tags),
+        ready_count=state["ready_count"],
+        blocking_issues=state["blocking_issues"],
+    )
+
+
+@app.get("/return/preview")
+def return_preview():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "Locked"}, 401
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    asset_tags = _queue_asset_tags()
+    state = _build_return_preview_state(asset_tags)
+
+    return render_template(
+        "return_preview.html",
+        queued_count=len(asset_tags),
         assets=state["assets"],
         ready_count=state["ready_count"],
         blocking_issues=state["blocking_issues"],
@@ -1046,6 +1081,17 @@ def return_commit():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    confirmed = (request.form.get("confirm_reviewed") or "").strip().lower() in {"on", "true", "1", "yes"}
+    if not confirmed:
+        if wants_json():
+            return {
+                "ok": False,
+                "committed": 0,
+                "error": "Please confirm you reviewed the batch before returning assets.",
+            }, 400
+        flash("Please confirm you reviewed the batch before returning assets.", "error")
+        return redirect(url_for("return_preview"))
+
     asset_tags = _queue_asset_tags()
     state = _build_return_preview_state(asset_tags)
     if state["blocking_issues"]:
@@ -1053,7 +1099,7 @@ def return_commit():
         if wants_json():
             return {"ok": False, "committed": 0, "error": message}, 400
         flash(f"Return failed: {message}", "error")
-        return redirect(url_for("return_queue"))
+        return redirect(url_for("return_preview"))
 
     try:
         committed_count = _stock_in_batch(asset_tags)
@@ -1061,7 +1107,7 @@ def return_commit():
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400
         flash(f"Return failed: {e}", "error")
-        return redirect(url_for("return_queue"))
+        return redirect(url_for("return_preview"))
 
     SCAN_QUEUE.clear()
     touch_session()

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -1,0 +1,133 @@
+<!-- assettrack/intake/templates/return_preview.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Return Assets Preview</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 1100px; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 1100px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; border-bottom: 1px solid #eee; padding: 0.5rem; vertical-align: top; }
+      th { background: #fafafa; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; }
+      .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
+      .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
+      .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      ul { margin: 0.5rem 0 0 1.25rem; }
+      a { text-decoration: none; }
+    </style>
+  </head>
+  <body>
+    <h1>Return Assets Preview / Confirm</h1>
+    <p><a href="/return">← Back to Return Assets</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <div class="card">
+      <h2>Validation Summary</h2>
+      <p>
+        <strong>Queued assets:</strong> {{ queued_count }}
+        &nbsp;|&nbsp;
+        <strong>Ready:</strong> {{ ready_count }}
+        &nbsp;|&nbsp;
+        <strong>Status:</strong>
+        {% if blocking_issues %}
+          <span class="pill bad">blocked</span>
+        {% else %}
+          <span class="pill good">ready</span>
+        {% endif %}
+      </p>
+      {% if blocking_issues %}
+        <p><strong>Conflicts must be resolved before returning assets.</strong></p>
+        <ul>
+          {% for issue in blocking_issues %}
+            <li>{{ issue }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+
+    <div class="card">
+      <h2>Per-Asset Diff</h2>
+      {% if assets %}
+        <table>
+          <thead>
+            <tr>
+              <th style="width: 170px;">Scanned Tag</th>
+              <th style="width: 190px;">Canonical Tag</th>
+              <th style="width: 180px;">Location Type</th>
+              <th style="width: 220px;">Current Holder</th>
+              <th style="width: 220px;">Destination Slot</th>
+              <th style="width: 180px;">Slot Occupancy</th>
+              <th>Checks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in assets %}
+              <tr>
+                <td><code>{{ row["scanned_tag"] }}</code></td>
+                <td><code>{{ row["canonical_tag"] or "n/a" }}</code></td>
+                <td><code>{{ row["before_location_type"] }}</code> → <code>{{ row["after_location_type"] }}</code></td>
+                <td><code>{{ row["before_holder"] }}</code> → <code>{{ row["after_holder"] }}</code></td>
+                <td><code>{{ row["destination_slot"] }}</code></td>
+                <td><code>{{ row["before_slot_occupancy"] }}</code> → <code>{{ row["after_slot_occupancy"] }}</code></td>
+                <td>
+                  {% if row["asset_issues"] %}
+                    <span class="pill bad">blocked</span>
+                    <ul>
+                      {% for issue in row["asset_issues"] %}
+                        <li>{{ issue }}</li>
+                      {% endfor %}
+                    </ul>
+                  {% else %}
+                    <span class="pill good">ready</span>
+                  {% endif %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p>No assets queued.</p>
+      {% endif %}
+    </div>
+
+    <div class="card">
+      <h2>Confirm Commit</h2>
+      <form method="post" action="/return/commit">
+        <label style="display:block; margin-bottom: 10px;">
+          <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
+          I reviewed this batch and want to return these assets.
+        </label>
+        <button id="return_btn" type="submit" {% if blocking_issues %}disabled{% endif %}>Return assets</button>
+      </form>
+      {% if blocking_issues %}
+        <p style="margin-top: 10px;">Commit is disabled until all blocking issues are resolved.</p>
+      {% endif %}
+      <p style="margin-top: 10px;">JSON API: <code>/return/commit?json=1</code> (POST)</p>
+    </div>
+
+    <script>
+      const cb = document.getElementById('confirm_reviewed');
+      const btn = document.getElementById('return_btn');
+      const blocked = {{ (blocking_issues|length > 0)|tojson }};
+      if (cb && btn) {
+        const sync = () => { btn.disabled = blocked || !cb.checked; };
+        cb.addEventListener('change', sync);
+        sync();
+      }
+    </script>
+  </body>
+</html>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -59,50 +59,8 @@
     </div>
 
     <div class="card">
-      <h2>Queued Assets</h2>
-      {% if assets %}
-        <table>
-          <thead>
-            <tr>
-              <th style="width: 170px;">Scanned Tag</th>
-              <th style="width: 190px;">Canonical Tag</th>
-              <th style="width: 210px;">Home Slot</th>
-              <th>Checks</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for row in assets %}
-              <tr>
-                <td><code>{{ row["scanned_tag"] }}</code></td>
-                <td><code>{{ row["canonical_tag"] or "n/a" }}</code></td>
-                <td><code>{{ row["home_slot"] }}</code></td>
-                <td>
-                  {% if row["asset_issues"] %}
-                    <span class="pill bad">blocked</span>
-                    <ul>
-                      {% for issue in row["asset_issues"] %}
-                        <li>{{ issue }}</li>
-                      {% endfor %}
-                    </ul>
-                  {% else %}
-                    <span class="pill good">ready</span>
-                  {% endif %}
-                </td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      {% else %}
-        <p>No assets queued.</p>
-      {% endif %}
-    </div>
-
-    <div class="card">
-      <h2>Commit</h2>
-      <form method="post" action="/return/commit">
-        <button type="submit">Return assets</button>
-      </form>
-      <p style="margin-top: 10px;">JSON API: <code>/return/commit?json=1</code> (POST)</p>
+      <h2>Next Step</h2>
+      <p><a href="/return/preview"><strong>Open Return Assets Preview / Confirm</strong></a></p>
     </div>
   </body>
 </html>

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -55,7 +55,7 @@ class ReturnBatchTests(unittest.TestCase):
         )
         self.conn.commit()
 
-    def test_return_routes_block_and_commit(self) -> None:
+    def test_return_preview_and_commit_gating(self) -> None:
         self._insert_slot(10, "A", 1, None)
         self._insert_slot(20, "B", 2, None)
         self._insert_asset("TAG-VALID", location_type="IN_CUSTODY", holder_id=5, home_slot_id=10)
@@ -67,11 +67,24 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(render.status_code, 200)
         self.assertIn(b"Return Assets", render.data)
 
+        preview_render = self.client.get("/return/preview")
+        self.assertEqual(preview_render.status_code, 200)
+        self.assertIn(b"Return Assets Preview / Confirm", preview_render.data)
+
+        unreviewed = self.client.post("/return/commit?json=1")
+        self.assertEqual(unreviewed.status_code, 400)
+        self.assertFalse(unreviewed.json["ok"])
+        self.assertEqual(unreviewed.json["committed"], 0)
+        self.assertEqual(
+            unreviewed.json["error"],
+            "Please confirm you reviewed the batch before returning assets.",
+        )
+
         intake_app.SCAN_QUEUE.clear()
         intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-VALID", equipment_type="laptop"))
         intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="UNKNOWN", equipment_type="laptop"))
 
-        blocked = self.client.post("/return/commit?json=1")
+        blocked = self.client.post("/return/commit?json=1", data={"confirm_reviewed": "on"})
         self.assertEqual(blocked.status_code, 400)
         self.assertFalse(blocked.json["ok"])
         self.assertEqual(blocked.json["committed"], 0)
@@ -91,7 +104,7 @@ class ReturnBatchTests(unittest.TestCase):
         intake_app.SCAN_QUEUE.clear()
         intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-OK", equipment_type="laptop"))
 
-        success = self.client.post("/return/commit?json=1")
+        success = self.client.post("/return/commit?json=1", data={"confirm_reviewed": "on"})
         self.assertEqual(success.status_code, 200)
         self.assertTrue(success.json["ok"])
         self.assertEqual(success.json["committed"], 1)


### PR DESCRIPTION
## Summary

Adds a dedicated **Return Assets Preview / Confirm** flow.

Introduces per-asset before→after diffs and requires explicit reviewed confirmation before commit. Reuses existing validation and preserves atomic return logic.

## Related Issue

Closes #76 

## Changes

- Extended `_build_return_preview_state` to include preview diff fields
- Added GET `/return/preview`
- Added reviewed checkbox gate to POST `/return/commit`
- Added `return_preview.html`
- Updated `/return` to link to preview and removed direct commit UI
- Extended deterministic return tests

## Verification Checklist

- [x] `python -m compileall .` passes
- [x] unittest suite passes
- [x] `/return/preview` renders 200
- [x] `/return/commit?json=1` blocks without reviewed checkbox
- [x] `/return/commit?json=1` blocks when validation fails
- [x] `/return/commit?json=1` succeeds when valid + confirmed

## Notes

- No schema changes
- No changes to `_stock_in_batch`
- Validation rules reused, not duplicated