### PR TITLE
Issue 8-6: fix return flow wiring and operator UX

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -705,6 +705,9 @@ def intake():
         submitted_code = request.form.get("access_code")
         if auth_ok(submitted_code):
             set_authed(True)
+        return_to = (request.form.get("return_to") or "").strip()
+        if return_to.startswith("/"):
+            return redirect(return_to)
         return redirect("/")
 
     # Determine auth state and enforce timeout for authed sessions.
@@ -728,6 +731,9 @@ def intake():
 
                 existing = {s.asset_tag for s in SCAN_QUEUE}
                 if record.asset_tag in existing:
+                    return_to = (request.form.get("return_to") or "").strip()
+                    if return_to.startswith("/"):
+                        return redirect(return_to)
                     return redirect("/")
 
                 SCAN_QUEUE.append(record)
@@ -735,6 +741,9 @@ def intake():
                 session["equipment_type"] = "laptop"
                 touch_session()
 
+        return_to = (request.form.get("return_to") or "").strip()
+        if return_to.startswith("/"):
+            return redirect(return_to)
         return redirect("/")
 
     # View model for template.
@@ -1066,7 +1075,7 @@ def return_preview():
     return render_template(
         "return_preview.html",
         queued_count=len(asset_tags),
-        assets=state["assets"],
+        preview_rows=state["assets"],
         ready_count=state["ready_count"],
         blocking_issues=state["blocking_issues"],
     )
@@ -1116,7 +1125,7 @@ def return_commit():
         return {"ok": True, "committed": committed_count, "error": None}
 
     flash(f"Returned {committed_count} assets.", "success")
-    return redirect(url_for("intake"))
+    return redirect(url_for("return_queue"))
 
 @app.get("/lock")
 def lock():

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -1,10 +1,10 @@
-<!-- assettrack/intake/templates/return_preview.html -->
+<!-- file: assettrack/intake/templates/return_preview.html -->
 <!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Return Assets Preview</title>
+    <title>Return Assets — Preview</title>
     <style>
       body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
       .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 1100px; }
@@ -19,21 +19,12 @@
       .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
       .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
       .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
-      ul { margin: 0.5rem 0 0 1.25rem; }
       a { text-decoration: none; }
     </style>
   </head>
   <body>
-    <h1>Return Assets Preview / Confirm</h1>
-    <p><a href="/return">← Back to Return Assets</a></p>
-
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}
-        {% for category, message in messages %}
-          <div class="flash {{ category|e }}">{{ message }}</div>
-        {% endfor %}
-      {% endif %}
-    {% endwith %}
+    <h1>Return Assets — Preview / Confirm</h1>
+    <p><a href="/return">← Back to Return Queue</a></p>
 
     <div class="card">
       <h2>Validation Summary</h2>
@@ -49,48 +40,55 @@
           <span class="pill good">ready</span>
         {% endif %}
       </p>
+
       {% if blocking_issues %}
-        <p><strong>Conflicts must be resolved before returning assets.</strong></p>
-        <ul>
+        <div role="list" style="margin: 0.5rem 0 0 1.25rem;">
           {% for issue in blocking_issues %}
-            <li>{{ issue }}</li>
+            <div role="listitem">• {{ issue }}</div>
           {% endfor %}
-        </ul>
+        </div>
       {% endif %}
     </div>
 
     <div class="card">
-      <h2>Per-Asset Diff</h2>
-      {% if assets %}
+      <h2>Per-Asset Preview</h2>
+
+      {% if preview_rows %}
         <table>
           <thead>
             <tr>
-              <th style="width: 170px;">Scanned Tag</th>
-              <th style="width: 190px;">Canonical Tag</th>
-              <th style="width: 180px;">Location Type</th>
-              <th style="width: 220px;">Current Holder</th>
-              <th style="width: 220px;">Destination Slot</th>
-              <th style="width: 180px;">Slot Occupancy</th>
-              <th>Checks</th>
+              <th>Asset</th>
+              <th>Current State</th>
+              <th>After Return</th>
+              <th>Status</th>
             </tr>
           </thead>
           <tbody>
-            {% for row in assets %}
+            {% for row in preview_rows %}
               <tr>
-                <td><code>{{ row["scanned_tag"] }}</code></td>
-                <td><code>{{ row["canonical_tag"] or "n/a" }}</code></td>
-                <td><code>{{ row["before_location_type"] }}</code> → <code>{{ row["after_location_type"] }}</code></td>
-                <td><code>{{ row["before_holder"] }}</code> → <code>{{ row["after_holder"] }}</code></td>
-                <td><code>{{ row["destination_slot"] }}</code></td>
-                <td><code>{{ row["before_slot_occupancy"] }}</code> → <code>{{ row["after_slot_occupancy"] }}</code></td>
+                <td><code>{{ row.canonical_tag or row.scanned_tag }}</code></td>
+
                 <td>
-                  {% if row["asset_issues"] %}
+                  Location: {{ row.before_location_type }}<br />
+                  Holder: {{ row.before_holder if row.before_holder != "null" else "—" }}<br />
+                  Home Slot: {{ row.destination_slot if row.destination_slot != "unknown" else "—" }}
+                </td>
+
+                <td>
+                  Location: {{ row.after_location_type }}<br />
+                  Holder: —<br />
+                  Slot: {{ row.destination_slot if row.destination_slot != "unknown" else "—" }}
+                </td>
+
+                <td>
+                  {% if row.asset_issues %}
                     <span class="pill bad">blocked</span>
-                    <ul>
-                      {% for issue in row["asset_issues"] %}
-                        <li>{{ issue }}</li>
+
+                    <div role="list" style="margin: 0.5rem 0 0 1rem;">
+                      {% for issue in row.asset_issues %}
+                        <div role="listitem">• {{ issue }}</div>
                       {% endfor %}
-                    </ul>
+                    </div>
                   {% else %}
                     <span class="pill good">ready</span>
                   {% endif %}
@@ -105,29 +103,22 @@
     </div>
 
     <div class="card">
-      <h2>Confirm Commit</h2>
-      <form method="post" action="/return/commit">
-        <label style="display:block; margin-bottom: 10px;">
-          <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
-          I reviewed this batch and want to return these assets.
-        </label>
-        <button id="return_btn" type="submit" {% if blocking_issues %}disabled{% endif %}>Return assets</button>
-      </form>
-      {% if blocking_issues %}
-        <p style="margin-top: 10px;">Commit is disabled until all blocking issues are resolved.</p>
-      {% endif %}
-      <p style="margin-top: 10px;">JSON API: <code>/return/commit?json=1</code> (POST)</p>
-    </div>
+      <h2>Confirm Return</h2>
 
-    <script>
-      const cb = document.getElementById('confirm_reviewed');
-      const btn = document.getElementById('return_btn');
-      const blocked = {{ (blocking_issues|length > 0)|tojson }};
-      if (cb && btn) {
-        const sync = () => { btn.disabled = blocked || !cb.checked; };
-        cb.addEventListener('change', sync);
-        sync();
-      }
-    </script>
+      {% if not blocking_issues %}
+        <form method="post" action="/return/commit">
+          <label>
+            <input type="checkbox" name="confirm_reviewed" value="1" required />
+            I have reviewed the changes and confirm this return batch.
+          </label>
+          <br /><br />
+          <button type="submit">Commit Return</button>
+        </form>
+      {% else %}
+        <p class="flash error">
+          Conflicts must be resolved before committing this batch.
+        </p>
+      {% endif %}
+    </div>
   </body>
 </html>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -1,4 +1,4 @@
-<!-- assettrack/intake/templates/return_queue.html -->
+<!-- file: assettrack/intake/templates/return_queue.html -->
 <!doctype html>
 <html lang="en">
   <head>
@@ -21,6 +21,7 @@
       .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
       ul { margin: 0.5rem 0 0 1.25rem; }
       a { text-decoration: none; }
+      input[type="text"] { padding: 0.6rem; font-size: 1rem; width: 420px; }
     </style>
   </head>
   <body>
@@ -34,6 +35,26 @@
         {% endfor %}
       {% endif %}
     {% endwith %}
+
+    <div class="card">
+      <h2>Scan returns</h2>
+      <p>Click the box once, then scan. The scanner "types" and hits Enter.</p>
+
+      <form method="post" action="/" style="margin-top: 10px;">
+        <input type="hidden" name="return_to" value="/return" />
+        <input
+          type="text"
+          name="scan_text"
+          placeholder="Scan here..."
+          autofocus
+        />
+        <button type="submit">Submit</button>
+      </form>
+
+      <form method="post" action="/queue/clear" style="margin-top: 10px;">
+        <button type="submit" onclick="return confirm('Clear the queue?');">Clear queue</button>
+      </form>
+    </div>
 
     <div class="card">
       <h2>Validation Summary</h2>
@@ -50,11 +71,11 @@
         {% endif %}
       </p>
       {% if blocking_issues %}
-        <ul>
+        <div role="list" style="margin: 0.5rem 0 0 1.25rem;">
           {% for issue in blocking_issues %}
-            <li>{{ issue }}</li>
+            <div role="listitem">• <span>{{ issue }}</span></div>
           {% endfor %}
-        </ul>
+        </div>
       {% endif %}
     </div>
 


### PR DESCRIPTION
## Summary
Fix return flow wiring and operator UX issues. Ensure scans stay on `/return`, preview renders correct asset data, confirm gate aligns with server logic, and successful returns redirect back to `/return`.

## Related Issue
Closes #8-6

## Changes
- Honor `return_to` in intake POST to prevent redirect back to `/`
- Fix `/return/preview` template wiring (`preview_rows`)
- Align preview table keys with `_build_return_preview_state`
- Fix confirm checkbox name (`confirm_reviewed`)
- Redirect successful return commits back to `/return`

## Verification checklist
- [ ] Scan on `/return` stays on `/return`
- [ ] Preview page shows correct per-asset state
- [ ] Confirm gate blocks when unchecked
- [ ] Successful return logs `STOCK_IN`
- [ ] Asset moves to `STORAGE` and slot is re-occupied

## Notes
Backlog: reduce page hopping and consider single-page/modal preview flow for operators.