### PR TITLE
Issue 9-1: admin assign slot tool

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -1,4 +1,4 @@
-# file: assettrack/db.py
+# assettrack/db.py
 import sqlite3
 from pathlib import Path
 
@@ -98,6 +98,33 @@ def _create_schema(conn: sqlite3.Connection):
 
     cursor.execute(
     """
+    CREATE TABLE IF NOT EXISTS slot_occupancy (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        slot_id INTEGER NOT NULL REFERENCES slots(id),
+        asset_id INTEGER NOT NULL REFERENCES assets(id),
+        assigned_at TEXT NOT NULL,
+        UNIQUE(slot_id),
+        UNIQUE(asset_id)
+    );
+    """
+    )
+
+    cursor.execute(
+    """
+    CREATE INDEX IF NOT EXISTS idx_slot_occupancy_slot_id
+        ON slot_occupancy(slot_id);
+    """
+    )
+
+    cursor.execute(
+    """
+    CREATE INDEX IF NOT EXISTS idx_slot_occupancy_asset_id
+        ON slot_occupancy(asset_id);
+    """
+    )
+
+    cursor.execute(
+    """
     CREATE TABLE IF NOT EXISTS holders (
         id INTEGER PRIMARY KEY,
         holder_type TEXT NOT NULL,
@@ -146,3 +173,19 @@ def _create_schema(conn: sqlite3.Connection):
             ADD COLUMN home_slot_id INTEGER NULL REFERENCES slots(id);
             """
             )
+
+    if _table_exists(conn, "assets"):
+        cursor.execute(
+        """
+        INSERT OR IGNORE INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        SELECT s.id, a.id, '1970-01-01T00:00:00Z'
+        FROM slots s
+        JOIN assets a
+          ON UPPER(a.asset_tag) = UPPER(s.current_asset_tag)
+          OR REPLACE(UPPER(a.asset_tag), '-', '') = UPPER(s.current_asset_tag)
+        WHERE s.current_asset_tag IS NOT NULL
+          AND TRIM(s.current_asset_tag) <> '';
+        """
+        )
+
+    conn.commit()

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -11,6 +11,7 @@ Feynman-brief:
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from typing import Optional
@@ -130,6 +131,116 @@ def wants_json() -> bool:
       /preview/commit?json=1 (POST)
     """
     return (request.args.get("json") or "").strip() == "1"
+
+
+def _require_admin_for_route():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    if auth_enabled():
+        touch_session()
+    return None
+
+
+def _find_asset_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
+    t = (scan_tag or "").strip()
+    if not t:
+        return None
+
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM assets
+        WHERE UPPER(asset_tag) = UPPER(?)
+           OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
+        LIMIT 2;
+        """,
+        (t, t),
+    ).fetchall()
+
+    if not rows:
+        return None
+
+    if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
+        raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
+
+    return dict(rows[0])
+
+
+def _asset_current_slot(conn, asset_id: int, asset_tag: str) -> Optional[dict]:
+    occupancy_row = conn.execute(
+        """
+        SELECT s.id AS slot_id, s.case_name, s.slot_position
+        FROM slot_occupancy so
+        JOIN slots s ON s.id = so.slot_id
+        WHERE so.asset_id = ?
+        LIMIT 1;
+        """,
+        (asset_id,),
+    ).fetchone()
+    if occupancy_row:
+        return dict(occupancy_row)
+
+    legacy_row = conn.execute(
+        """
+        SELECT id AS slot_id, case_name, slot_position
+        FROM slots
+        WHERE UPPER(current_asset_tag) = UPPER(?)
+           OR REPLACE(UPPER(current_asset_tag), '-', '') = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_tag, asset_tag),
+    ).fetchone()
+    return dict(legacy_row) if legacy_row else None
+
+
+def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
+    errors: list[str] = []
+    asset = _find_asset_for_scan_tag(conn, scan_tag)
+    if not asset:
+        return None, ["asset_tag not found"]
+
+    holder_label = "None"
+    holder_id = asset.get("current_holder_id")
+    if holder_id is not None:
+        holder = conn.execute(
+            """
+            SELECT id, name, identifier
+            FROM holders
+            WHERE id = ?;
+            """,
+            (holder_id,),
+        ).fetchone()
+        if holder:
+            identifier = (holder["identifier"] or "").strip()
+            holder_label = f"{holder['name']} ({identifier})" if identifier else str(holder["name"])
+        else:
+            holder_label = f"ID {holder_id}"
+
+    location_type = str(asset.get("location_type") or "").strip().upper()
+    if location_type != "STORAGE":
+        errors.append("Asset must be location_type=STORAGE.")
+    if location_type == "IN_CUSTODY":
+        errors.append("Asset is IN_CUSTODY and cannot be assigned to a slot.")
+
+    current_slot = _asset_current_slot(conn, int(asset["id"]), str(asset["asset_tag"]))
+    if current_slot:
+        errors.append("Asset is already slotted.")
+
+    view = {
+        "id": int(asset["id"]),
+        "asset_tag": str(asset.get("asset_tag") or ""),
+        "manufacturer": str(asset.get("manufacturer") or ""),
+        "model": str(asset.get("model") or ""),
+        "serial": str(asset.get("serial_number") or ""),
+        "location_type": str(asset.get("location_type") or ""),
+        "current_holder": holder_label,
+        "current_slot": current_slot,
+        "home_slot_id": asset.get("home_slot_id"),
+    }
+    return view, errors
 
 
 def _selected_holder_from_session() -> Optional[dict]:
@@ -1183,6 +1294,263 @@ def holders_clear():
     touch_session()
     flash("Cleared holder selection.", "success")
     return redirect(url_for("holders_search"))
+
+
+@app.route("/admin/assign-slot", methods=["GET", "POST"])
+def admin_assign_slot():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    asset_tag = ""
+    building_room = ""
+    case_number = ""
+    slot_number = ""
+    notes = ""
+    asset_view: Optional[dict] = None
+
+    if request.method == "POST":
+        action = (request.form.get("action") or "lookup").strip().lower()
+        asset_tag = (request.form.get("asset_tag") or "").strip()
+        building_room = (request.form.get("building_room") or "").strip()
+        case_number = (request.form.get("case_number") or "").strip().upper()
+        slot_number = (request.form.get("slot_number") or "").strip()
+        notes = (request.form.get("notes") or "").strip()
+
+        conn = get_connection()
+        try:
+            asset_view, blocking_errors = _build_admin_assign_asset_view(conn, asset_tag)
+
+            if action == "lookup":
+                if not asset_tag:
+                    flash("asset_tag is required.", "error")
+                elif blocking_errors:
+                    for msg in blocking_errors:
+                        flash(msg, "error")
+                else:
+                    flash(f"Asset {asset_view['asset_tag']} is eligible for slot assignment.", "success")
+            elif action == "assign":
+                if not asset_tag:
+                    flash("asset_tag is required.", "error")
+                if not building_room:
+                    flash("building/room is required.", "error")
+                if not case_number:
+                    flash("case_number is required.", "error")
+                if not slot_number:
+                    flash("slot_number is required.", "error")
+
+                if not asset_tag or not building_room or not case_number or not slot_number:
+                    return render_template(
+                        "admin_assign_slot.html",
+                        asset_tag=asset_tag,
+                        building_room=building_room,
+                        case_number=case_number,
+                        slot_number=slot_number,
+                        notes=notes,
+                        asset=asset_view,
+                    )
+
+                if blocking_errors:
+                    for msg in blocking_errors:
+                        flash(msg, "error")
+                    return render_template(
+                        "admin_assign_slot.html",
+                        asset_tag=asset_tag,
+                        building_room=building_room,
+                        case_number=case_number,
+                        slot_number=slot_number,
+                        notes=notes,
+                        asset=asset_view,
+                    )
+
+                try:
+                    slot_position = int(slot_number)
+                except ValueError:
+                    flash("slot_number must be an integer.", "error")
+                    return render_template(
+                        "admin_assign_slot.html",
+                        asset_tag=asset_tag,
+                        building_room=building_room,
+                        case_number=case_number,
+                        slot_number=slot_number,
+                        notes=notes,
+                        asset=asset_view,
+                    )
+
+                try:
+                    conn.execute("BEGIN;")
+
+                    asset_row = _find_asset_for_scan_tag(conn, asset_tag)
+                    if not asset_row:
+                        raise ValueError("asset_tag not found")
+
+                    location_type = str(asset_row.get("location_type") or "").strip().upper()
+                    if location_type != "STORAGE":
+                        raise ValueError("Asset must be location_type=STORAGE.")
+                    if location_type == "IN_CUSTODY":
+                        raise ValueError("Asset is IN_CUSTODY and cannot be assigned to a slot.")
+
+                    occupied_by_asset = conn.execute(
+                        """
+                        SELECT 1
+                        FROM slot_occupancy
+                        WHERE asset_id = ?
+                        LIMIT 1;
+                        """,
+                        (asset_row["id"],),
+                    ).fetchone()
+                    legacy_occupied_by_asset = conn.execute(
+                        """
+                        SELECT 1
+                        FROM slots
+                        WHERE UPPER(current_asset_tag) = UPPER(?)
+                           OR REPLACE(UPPER(current_asset_tag), '-', '') = UPPER(?)
+                        LIMIT 1;
+                        """,
+                        (asset_row["asset_tag"], asset_row["asset_tag"]),
+                    ).fetchone()
+                    if occupied_by_asset or legacy_occupied_by_asset:
+                        raise ValueError("Asset is already slotted.")
+
+                    slot = conn.execute(
+                        """
+                        SELECT id, case_name, slot_position, current_asset_tag
+                        FROM slots
+                        WHERE UPPER(case_name) = UPPER(?)
+                          AND slot_position = ?
+                        LIMIT 1;
+                        """,
+                        (case_number, slot_position),
+                    ).fetchone()
+                    if not slot:
+                        raise ValueError("Selected slot does not exist.")
+
+                    occupied_by_slot = conn.execute(
+                        """
+                        SELECT 1
+                        FROM slot_occupancy
+                        WHERE slot_id = ?
+                        LIMIT 1;
+                        """,
+                        (slot["id"],),
+                    ).fetchone()
+                    if occupied_by_slot:
+                        raise ValueError("Selected slot is already occupied.")
+                    legacy_slot_occupied = str(slot["current_asset_tag"] or "").strip()
+                    if legacy_slot_occupied:
+                        raise ValueError("Selected slot is already occupied.")
+
+                    now_iso = datetime.now(timezone.utc).isoformat()
+
+                    conn.execute(
+                        """
+                        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                        VALUES (?, ?, ?);
+                        """,
+                        (slot["id"], asset_row["id"], now_iso),
+                    )
+
+                    conn.execute(
+                        """
+                        UPDATE slots
+                        SET current_asset_tag = ?
+                        WHERE id = ?;
+                        """,
+                        (asset_row["asset_tag"], slot["id"]),
+                    )
+
+                    asset_columns = get_asset_table_columns(conn)
+                    update_clauses: list[str] = []
+                    update_values: list[object] = []
+                    if "home_slot_id" in asset_columns:
+                        update_clauses.append("home_slot_id = ?")
+                        update_values.append(slot["id"])
+                    if "building_room" in asset_columns:
+                        update_clauses.append("building_room = ?")
+                        update_values.append(building_room)
+                    if "case_number" in asset_columns:
+                        update_clauses.append("case_number = ?")
+                        update_values.append(case_number)
+                    if "slot_number" in asset_columns:
+                        update_clauses.append("slot_number = ?")
+                        update_values.append(str(slot_position))
+                    if "updated_date" in asset_columns:
+                        update_clauses.append("updated_date = ?")
+                        update_values.append(now_iso)
+                    if update_clauses:
+                        update_values.append(asset_row["id"])
+                        conn.execute(
+                            f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+                            tuple(update_values),
+                        )
+
+                    payload = {
+                        "slot_id": int(slot["id"]),
+                        "building_room": building_room,
+                        "case_number": str(slot["case_name"]),
+                        "slot_number": int(slot["slot_position"]),
+                    }
+                    conn.execute(
+                        """
+                        INSERT INTO asset_events (
+                            asset_tag,
+                            event_type,
+                            event_date,
+                            actor,
+                            notes,
+                            payload,
+                            holder_id
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?);
+                        """,
+                        (
+                            str(asset_row["asset_tag"]),
+                            "SLOT_ASSIGN",
+                            now_iso,
+                            "admin",
+                            notes or None,
+                            json.dumps(payload),
+                            None,
+                        ),
+                    )
+
+                    conn.commit()
+                except ValueError as e:
+                    conn.rollback()
+                    flash(str(e), "error")
+                    asset_view, _ = _build_admin_assign_asset_view(conn, asset_tag)
+                    return render_template(
+                        "admin_assign_slot.html",
+                        asset_tag=asset_tag,
+                        building_room=building_room,
+                        case_number=case_number,
+                        slot_number=slot_number,
+                        notes=notes,
+                        asset=asset_view,
+                    )
+                except Exception:
+                    conn.rollback()
+                    raise
+
+                flash(
+                    f"Assigned asset {asset_row['asset_tag']} to {slot['case_name']} slot {slot['slot_position']}.",
+                    "success",
+                )
+                return redirect(url_for("admin_assign_slot"))
+            else:
+                flash("Unknown action.", "error")
+        finally:
+            conn.close()
+
+    return render_template(
+        "admin_assign_slot.html",
+        asset_tag=asset_tag,
+        building_room=building_room,
+        case_number=case_number,
+        slot_number=slot_number,
+        notes=notes,
+        asset=asset_view,
+    )
 
 
 if __name__ == "__main__":

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -1,0 +1,139 @@
+<!-- assettrack/intake/templates/admin_assign_slot.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Assign Slot</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 980px; }
+      .row { margin: 0.75rem 0; }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+      input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; margin-right: 0.35rem; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 980px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      .muted { color: #555; }
+    </style>
+  </head>
+  <body>
+    <h1>Admin: Assign Slot to Unslotted Asset</h1>
+    <p><a href="/">&larr; Back to intake</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <div class="card">
+      <h2>1) Scan or Enter Asset Tag</h2>
+      <p class="muted">Scanner-first flow: scan into asset_tag and submit lookup.</p>
+      <form method="post" action="/admin/assign-slot">
+        <input type="hidden" name="action" value="lookup" />
+        <div class="row">
+          <label for="asset_tag"><strong>asset_tag</strong></label><br />
+          <input
+            type="text"
+            id="asset_tag"
+            name="asset_tag"
+            value="{{ asset_tag or '' }}"
+            placeholder="Scan asset tag"
+            autocomplete="off"
+            autofocus
+          />
+        </div>
+        <button type="submit">Lookup Asset</button>
+      </form>
+    </div>
+
+    {% if asset %}
+      <div class="card">
+        <h2>2) Asset Details</h2>
+        <div class="grid">
+          <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
+          <div><strong>manufacturer:</strong> {{ asset.manufacturer or "" }}</div>
+          <div><strong>model:</strong> {{ asset.model or "" }}</div>
+          <div><strong>serial:</strong> {{ asset.serial or "" }}</div>
+          <div><strong>location_type:</strong> <code>{{ asset.location_type or "" }}</code></div>
+          <div><strong>current_holder:</strong> {{ asset.current_holder }}</div>
+          <div>
+            <strong>current slot:</strong>
+            {% if asset.current_slot %}
+              <code>{{ asset.current_slot.case_name }} / {{ asset.current_slot.slot_position }} (id {{ asset.current_slot.slot_id }})</code>
+            {% else %}
+              none
+            {% endif %}
+          </div>
+          <div><strong>home_slot_id:</strong> {{ asset.home_slot_id if asset.home_slot_id is not none else "none" }}</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>3) Assign Slot</h2>
+        <form method="post" action="/admin/assign-slot">
+          <input type="hidden" name="action" value="assign" />
+          <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
+
+          <div class="row">
+            <label for="building_room"><strong>building/room</strong> (required)</label><br />
+            <input
+              type="text"
+              id="building_room"
+              name="building_room"
+              value="{{ building_room or '' }}"
+              placeholder="e.g. BQ26-101"
+              autocomplete="off"
+              required
+            />
+          </div>
+
+          <div class="row">
+            <label for="case_number"><strong>case_number</strong> (required)</label><br />
+            <input
+              type="text"
+              id="case_number"
+              name="case_number"
+              value="{{ case_number or '' }}"
+              placeholder="e.g. CASE-01"
+              autocomplete="off"
+              required
+            />
+          </div>
+
+          <div class="row">
+            <label for="slot_number"><strong>slot_number</strong> (required)</label><br />
+            <input
+              type="text"
+              id="slot_number"
+              name="slot_number"
+              value="{{ slot_number or '' }}"
+              placeholder="e.g. 2"
+              autocomplete="off"
+              required
+            />
+          </div>
+
+          <div class="row">
+            <label for="notes"><strong>notes</strong> (optional)</label><br />
+            <input
+              type="text"
+              id="notes"
+              name="notes"
+              value="{{ notes or '' }}"
+              placeholder="Optional assignment note"
+              autocomplete="off"
+            />
+          </div>
+
+          <button type="submit">Assign Slot</button>
+        </form>
+      </div>
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Adds an admin-only tool to assign a slot to an existing unslotted asset (STORAGE only).  
Supports scanner-first workflow with hard-stop validation and atomic commit behavior.

## Related Issue

Closes #77 

## Changes

- Added `/admin/assign-slot` (GET + POST)
- Scanner-first asset lookup by `asset_tag`
- Hard-stop validation:
  - Unknown asset
  - Asset not `STORAGE`
  - Asset `IN_CUSTODY`
  - Asset already slotted
  - Slot does not exist
  - Slot already occupied
- Atomic transaction:
  - Create `slot_occupancy`
  - Set `assets.home_slot_id`
  - Sync legacy `slots.current_asset_tag`
  - Write `SLOT_ASSIGN` event with payload
- Flask-rendered admin template (`admin_assign_slot.html`)

## Verification Checklist

- [x] Unknown `asset_tag` blocked
- [x] `IN_CUSTODY` asset blocked
- [x] Already slotted asset blocked
- [x] Missing slot blocked
- [x] Occupied slot blocked
- [x] Happy path creates `slot_occupancy`
- [x] `home_slot_id` updated
- [x] `SLOT_ASSIGN` event written
- [x] Works in Docker + persisted SQLite

## Notes

Admin-only route.  
Scanner-friendly flow.  
Maintains referential integrity and atomicity.