### PR TITLE
Issue 9-3: admin force vacate tool

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -287,6 +287,88 @@ def _build_admin_slot_move_source_view(conn, slot_id: int) -> Optional[dict]:
     }
 
 
+def _build_admin_force_vacate_view(conn, slot_id: int) -> Optional[dict]:
+    slot_row = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE id = ?;
+        """,
+        (slot_id,),
+    ).fetchone()
+    if not slot_row:
+        return None
+
+    occupancy_row = conn.execute(
+        """
+        SELECT
+            so.asset_id,
+            a.asset_tag,
+            a.manufacturer,
+            a.model,
+            a.serial_number,
+            a.location_type,
+            a.home_slot_id,
+            a.building_room
+        FROM slot_occupancy so
+        JOIN assets a ON a.id = so.asset_id
+        WHERE so.slot_id = ?
+        LIMIT 1;
+        """,
+        (slot_id,),
+    ).fetchone()
+
+    occupied = occupancy_row is not None
+    asset_view: Optional[dict] = None
+    if occupancy_row:
+        asset_view = {
+            "asset_id": int(occupancy_row["asset_id"]),
+            "asset_tag": str(occupancy_row["asset_tag"] or ""),
+            "manufacturer": str(occupancy_row["manufacturer"] or ""),
+            "model": str(occupancy_row["model"] or ""),
+            "serial": str(occupancy_row["serial_number"] or ""),
+            "location_type": str(occupancy_row["location_type"] or ""),
+            "home_slot_id": occupancy_row["home_slot_id"],
+            "building_room": str(occupancy_row["building_room"] or ""),
+        }
+    else:
+        legacy_asset_tag = str(slot_row["current_asset_tag"] or "").strip()
+        if legacy_asset_tag:
+            occupied = True
+            legacy_asset = _find_asset_for_scan_tag(conn, legacy_asset_tag)
+            if legacy_asset:
+                asset_view = {
+                    "asset_id": int(legacy_asset["id"]),
+                    "asset_tag": str(legacy_asset.get("asset_tag") or legacy_asset_tag),
+                    "manufacturer": str(legacy_asset.get("manufacturer") or ""),
+                    "model": str(legacy_asset.get("model") or ""),
+                    "serial": str(legacy_asset.get("serial_number") or ""),
+                    "location_type": str(legacy_asset.get("location_type") or ""),
+                    "home_slot_id": legacy_asset.get("home_slot_id"),
+                    "building_room": str(legacy_asset.get("building_room") or ""),
+                }
+            else:
+                asset_view = {
+                    "asset_id": None,
+                    "asset_tag": legacy_asset_tag,
+                    "manufacturer": "",
+                    "model": "",
+                    "serial": "",
+                    "location_type": "",
+                    "home_slot_id": None,
+                    "building_room": "",
+                }
+
+    return {
+        "slot_id": int(slot_row["id"]),
+        "case_name": str(slot_row["case_name"] or ""),
+        "slot_position": int(slot_row["slot_position"]),
+        "occupied": occupied,
+        "current_asset_tag": str(slot_row["current_asset_tag"] or ""),
+        "asset": asset_view,
+    }
+
+
 def _selected_holder_from_session() -> Optional[dict]:
     holder_id = session.get("holder_id")
     if holder_id is None:
@@ -1886,6 +1968,251 @@ def admin_slot_move():
         case_number=case_number,
         slot_number=slot_number,
         notes=notes,
+    )
+
+
+@app.route("/admin/force-vacate", methods=["GET", "POST"])
+def admin_force_vacate():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    slot_id_raw = (request.args.get("slot_id") or request.form.get("slot_id") or "").strip()
+    slot_id: Optional[int] = None
+    slot_view: Optional[dict] = None
+    reason = ""
+    notes = ""
+    confirmed = False
+
+    if slot_id_raw:
+        try:
+            slot_id = int(slot_id_raw)
+        except ValueError:
+            flash("slot_id must be an integer.", "error")
+
+    conn = get_connection()
+    try:
+        if slot_id is not None:
+            slot_view = _build_admin_force_vacate_view(conn, slot_id)
+            if slot_view is None and request.method == "GET":
+                flash("Slot not found.", "error")
+        elif request.method == "GET":
+            flash("slot_id is required.", "error")
+
+        if request.method == "POST":
+            reason = (request.form.get("reason") or "").strip()
+            notes = (request.form.get("notes") or "").strip()
+            confirmed = (request.form.get("confirm_empty") or "").strip().lower() in {"on", "true", "1", "yes"}
+
+            if slot_id is None:
+                flash("slot_id is required.", "error")
+            if slot_view is None:
+                flash("Slot not found.", "error")
+            if slot_view and not slot_view.get("occupied"):
+                flash("Cannot force vacate an empty slot.", "error")
+
+            asset_for_view = (slot_view or {}).get("asset") if slot_view else None
+            if asset_for_view and str(asset_for_view.get("location_type") or "").strip().upper() == "IN_CUSTODY":
+                flash("Cannot force vacate: occupied asset is IN_CUSTODY.", "error")
+            if not reason:
+                flash("Reason is required.", "error")
+            if not confirmed:
+                flash("You must confirm physical verification before force vacate.", "error")
+
+            if (
+                slot_id is None
+                or slot_view is None
+                or not slot_view.get("occupied")
+                or not reason
+                or not confirmed
+                or (asset_for_view and str(asset_for_view.get("location_type") or "").strip().upper() == "IN_CUSTODY")
+            ):
+                return render_template(
+                    "admin_force_vacate.html",
+                    slot=slot_view,
+                    slot_id=slot_id_raw,
+                    reason=reason,
+                    notes=notes,
+                    confirmed=confirmed,
+                )
+
+            try:
+                conn.execute("BEGIN;")
+
+                locked = conn.execute(
+                    """
+                    SELECT
+                        s.id AS slot_id,
+                        s.case_name,
+                        s.slot_position,
+                        s.current_asset_tag,
+                        so.asset_id AS occupancy_asset_id,
+                        a.asset_tag AS occ_asset_tag,
+                        a.manufacturer AS occ_manufacturer,
+                        a.model AS occ_model,
+                        a.serial_number AS occ_serial,
+                        a.location_type AS occ_location_type,
+                        a.building_room AS occ_building_room
+                    FROM slots s
+                    LEFT JOIN slot_occupancy so ON so.slot_id = s.id
+                    LEFT JOIN assets a ON a.id = so.asset_id
+                    WHERE s.id = ?
+                    LIMIT 1;
+                    """,
+                    (slot_id,),
+                ).fetchone()
+
+                if not locked:
+                    raise ValueError("Slot not found.")
+
+                legacy_asset_tag = str(locked["current_asset_tag"] or "").strip()
+                occupied = locked["occupancy_asset_id"] is not None or bool(legacy_asset_tag)
+                if not occupied:
+                    raise ValueError("Cannot force vacate an empty slot.")
+
+                asset_id: Optional[int] = None
+                asset_tag = ""
+                asset_manufacturer = ""
+                asset_model = ""
+                asset_serial = ""
+                asset_location_type = ""
+                asset_building_room = ""
+
+                if locked["occupancy_asset_id"] is not None:
+                    asset_id = int(locked["occupancy_asset_id"])
+                    asset_tag = str(locked["occ_asset_tag"] or "")
+                    asset_manufacturer = str(locked["occ_manufacturer"] or "")
+                    asset_model = str(locked["occ_model"] or "")
+                    asset_serial = str(locked["occ_serial"] or "")
+                    asset_location_type = str(locked["occ_location_type"] or "").strip().upper()
+                    asset_building_room = str(locked["occ_building_room"] or "")
+                elif legacy_asset_tag:
+                    legacy_asset = _find_asset_for_scan_tag(conn, legacy_asset_tag)
+                    if legacy_asset:
+                        asset_id = int(legacy_asset["id"])
+                        asset_tag = str(legacy_asset.get("asset_tag") or legacy_asset_tag)
+                        asset_manufacturer = str(legacy_asset.get("manufacturer") or "")
+                        asset_model = str(legacy_asset.get("model") or "")
+                        asset_serial = str(legacy_asset.get("serial_number") or "")
+                        asset_location_type = str(legacy_asset.get("location_type") or "").strip().upper()
+                        asset_building_room = str(legacy_asset.get("building_room") or "")
+                    else:
+                        raise ValueError("Occupied asset record not found.")
+
+                if asset_location_type == "IN_CUSTODY":
+                    raise ValueError("Cannot force vacate: occupied asset is IN_CUSTODY.")
+
+                conn.execute(
+                    """
+                    DELETE FROM slot_occupancy
+                    WHERE slot_id = ?;
+                    """,
+                    (slot_id,),
+                )
+
+                conn.execute(
+                    """
+                    UPDATE slots
+                    SET current_asset_tag = NULL
+                    WHERE id = ?;
+                    """,
+                    (slot_id,),
+                )
+
+                now_iso = datetime.now(timezone.utc).isoformat()
+                if asset_id is not None:
+                    asset_columns = get_asset_table_columns(conn)
+                    update_clauses: list[str] = []
+                    update_values: list[object] = []
+                    if "home_slot_id" in asset_columns:
+                        update_clauses.append("home_slot_id = NULL")
+                    if "location_type" in asset_columns:
+                        update_clauses.append("location_type = ?")
+                        update_values.append("STORAGE")
+                    if "updated_date" in asset_columns:
+                        update_clauses.append("updated_date = ?")
+                        update_values.append(now_iso)
+                    if update_clauses:
+                        update_values.append(asset_id)
+                        conn.execute(
+                            f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+                            tuple(update_values),
+                        )
+
+                payload = {
+                    "slot": {
+                        "slot_id": int(locked["slot_id"]),
+                        "building_room": asset_building_room,
+                        "case_number": str(locked["case_name"] or ""),
+                        "slot_number": int(locked["slot_position"]),
+                    },
+                    "asset": {
+                        "asset_id": asset_id,
+                        "asset_tag": asset_tag,
+                        "building_room": asset_building_room,
+                        "manufacturer": asset_manufacturer,
+                        "model": asset_model,
+                        "serial": asset_serial,
+                    },
+                    "reason": reason,
+                    "notes": notes or None,
+                }
+                conn.execute(
+                    """
+                    INSERT INTO asset_events (
+                        asset_tag,
+                        event_type,
+                        event_date,
+                        actor,
+                        notes,
+                        payload,
+                        holder_id
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?);
+                    """,
+                    (
+                        asset_tag,
+                        "FORCE_VACATE",
+                        now_iso,
+                        "admin",
+                        reason,
+                        json.dumps(payload),
+                        None,
+                    ),
+                )
+
+                conn.commit()
+            except ValueError as e:
+                conn.rollback()
+                flash(str(e), "error")
+                slot_view = _build_admin_force_vacate_view(conn, slot_id)
+                return render_template(
+                    "admin_force_vacate.html",
+                    slot=slot_view,
+                    slot_id=slot_id,
+                    reason=reason,
+                    notes=notes,
+                    confirmed=confirmed,
+                )
+            except Exception:
+                conn.rollback()
+                raise
+
+            flash(
+                f"Force vacated slot {locked['case_name']} slot {locked['slot_position']} for asset {asset_tag}.",
+                "success",
+            )
+            return redirect(url_for("admin_force_vacate", slot_id=slot_id))
+    finally:
+        conn.close()
+
+    return render_template(
+        "admin_force_vacate.html",
+        slot=slot_view,
+        slot_id=slot_id,
+        reason=reason,
+        notes=notes,
+        confirmed=confirmed,
     )
 
 

--- a/assettrack/intake/templates/admin_force_vacate.html
+++ b/assettrack/intake/templates/admin_force_vacate.html
@@ -1,0 +1,107 @@
+<!-- assettrack/intake/templates/admin_force_vacate.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Force Vacate Slot</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 980px; }
+      .row { margin: 0.75rem 0; }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+      input[type="text"], textarea { width: 100%; max-width: 720px; padding: 0.6rem; font-size: 1rem; }
+      textarea { min-height: 120px; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 980px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      .warn { color: #8a1f11; font-weight: 700; }
+      .muted { color: #555; }
+      .check { display: flex; align-items: center; gap: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Admin: Force Vacate Slot</h1>
+    <p><a href="/">&larr; Back to intake</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    <div class="card">
+      <h2>Slot Detail</h2>
+      {% if slot %}
+        <div class="grid">
+          <div><strong>slot_id:</strong> <code>{{ slot.slot_id }}</code></div>
+          <div><strong>occupied:</strong> <code>{{ "yes" if slot.occupied else "no" }}</code></div>
+          <div><strong>case_number:</strong> <code>{{ slot.case_name }}</code></div>
+          <div><strong>slot_number:</strong> <code>{{ slot.slot_position }}</code></div>
+          <div><strong>building/room:</strong> {{ slot.asset.building_room if slot.asset and slot.asset.building_room is defined else "" }}</div>
+          <div><strong>legacy marker:</strong> <code>{{ slot.current_asset_tag or "" }}</code></div>
+        </div>
+      {% else %}
+        <p class="muted">Provide <code>slot_id</code> in query, e.g. <code>/admin/force-vacate?slot_id=1</code>.</p>
+      {% endif %}
+    </div>
+
+    {% if slot and slot.asset %}
+      <div class="card">
+        <h2>Occupied Asset</h2>
+        <div class="grid">
+          <div><strong>asset_tag:</strong> <code>{{ slot.asset.asset_tag }}</code></div>
+          <div><strong>location_type:</strong> <code>{{ slot.asset.location_type }}</code></div>
+          <div><strong>manufacturer:</strong> {{ slot.asset.manufacturer }}</div>
+          <div><strong>model:</strong> {{ slot.asset.model }}</div>
+          <div><strong>serial:</strong> {{ slot.asset.serial }}</div>
+          <div><strong>home_slot_id:</strong> {{ slot.asset.home_slot_id if slot.asset.home_slot_id is not none else "none" }}</div>
+        </div>
+      </div>
+    {% endif %}
+
+    {% if slot %}
+      <div class="card">
+        <h2>Force Vacate Confirmation</h2>
+        <p class="warn">Use only when you physically verified the slot is empty and database state is wrong.</p>
+
+        <form method="post" action="/admin/force-vacate">
+          <input type="hidden" name="slot_id" value="{{ slot.slot_id }}" />
+
+          <div class="row">
+            <label for="reason"><strong>Reason</strong> (required)</label><br />
+            <textarea
+              id="reason"
+              name="reason"
+              placeholder="Describe why this forced vacate is needed"
+              required
+            >{{ reason or '' }}</textarea>
+          </div>
+
+          <div class="row">
+            <label for="notes"><strong>Notes</strong> (optional)</label><br />
+            <input
+              type="text"
+              id="notes"
+              name="notes"
+              value="{{ notes or '' }}"
+              placeholder="Optional extra context"
+              autocomplete="off"
+            />
+          </div>
+
+          <div class="row check">
+            <input type="checkbox" id="confirm_empty" name="confirm_empty" {% if confirmed %}checked{% endif %} />
+            <label for="confirm_empty"><strong>I physically verified this slot is empty.</strong></label>
+          </div>
+
+          <button type="submit">Force Vacate Slot</button>
+        </form>
+      </div>
+    {% endif %}
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Adds an admin-only “Force Vacate Slot” escape hatch to reconcile DB occupancy with physical reality.  
Requires explicit reason + physical verification confirmation and writes an audit event.

## Related Issue

Closes #79 

## Changes

- Added `/admin/force-vacate` (GET renders slot + asset detail and confirmation form; POST validates and executes force vacate)
- Hard-stop validation:
  - Slot must exist and be occupied
  - Blocks if occupied asset is `IN_CUSTODY`
  - Reason required
  - Confirmation checkbox required
- Atomic transaction:
  - Remove `slot_occupancy` for the slot
  - Clear legacy `slots.current_asset_tag`
  - Set `assets.home_slot_id = NULL` (and keep `location_type = STORAGE`)
  - Write `FORCE_VACATE` event with reason + payload

## Verification Checklist

- [x] Cannot vacate an empty slot
- [x] Blocks if asset is `IN_CUSTODY`
- [x] Blocks if reason missing
- [x] Blocks if checkbox not checked
- [x] Happy path clears slot + unslots asset + writes `FORCE_VACATE` event
- [x] Works in Docker + persisted SQLite

## Notes

Intentional “hard” admin tool: requires reason + explicit confirmation and preserves audit trail.