### PR TITLE
Issue 9-4: admin asset create API

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import time
 from typing import Optional
 from datetime import datetime, timezone
@@ -138,6 +139,16 @@ def _require_admin_for_route():
     if auth_enabled() and not authed:
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
+
+    if auth_enabled():
+        touch_session()
+    return None
+
+
+def _require_admin_for_api():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        return {"ok": False, "error": "Locked"}, 401
 
     if auth_enabled():
         touch_session()
@@ -1420,6 +1431,194 @@ def holders_clear():
     touch_session()
     flash("Cleared holder selection.", "success")
     return redirect(url_for("holders_search"))
+
+
+@app.post("/admin/assets/create")
+def admin_create_asset():
+    guard_result = _require_admin_for_api()
+    if guard_result:
+        return guard_result
+
+    raw_data = request.get_json(silent=True)
+    if not isinstance(raw_data, dict):
+        raw_data = request.form.to_dict()
+
+    asset_tag = str(raw_data.get("asset_tag") or "").strip().upper()
+    actor = str(raw_data.get("actor") or "").strip()
+    equipment_type_raw = str(raw_data.get("equipment_type") or "").strip()
+    notes_raw = str(raw_data.get("notes") or "").strip()
+    home_slot_raw = raw_data.get("home_slot_id")
+
+    equipment_type = equipment_type_raw or None
+    notes = notes_raw or None
+
+    errors: list[str] = []
+    if not asset_tag:
+        errors.append("asset_tag is required.")
+    if not actor:
+        errors.append("actor is required.")
+
+    home_slot_id: Optional[int] = None
+    if home_slot_raw is not None and str(home_slot_raw).strip() != "":
+        try:
+            home_slot_id = int(str(home_slot_raw).strip())
+        except ValueError:
+            errors.append("home_slot_id must be an integer.")
+
+    if errors:
+        return {"ok": False, "error": "; ".join(errors)}, 400
+
+    conn = get_connection()
+    try:
+        try:
+            conn.execute("BEGIN;")
+
+            existing_asset = conn.execute(
+                """
+                SELECT 1
+                FROM assets
+                WHERE UPPER(asset_tag) = UPPER(?)
+                LIMIT 1;
+                """,
+                (asset_tag,),
+            ).fetchone()
+            if existing_asset:
+                raise ValueError("asset_tag already exists.")
+
+            slot_row = None
+            if home_slot_id is not None:
+                slot_row = conn.execute(
+                    """
+                    SELECT id, current_asset_tag
+                    FROM slots
+                    WHERE id = ?
+                    LIMIT 1;
+                    """,
+                    (home_slot_id,),
+                ).fetchone()
+                if slot_row is None:
+                    raise ValueError("home_slot_id does not reference an existing slot.")
+
+                occupied_row = conn.execute(
+                    """
+                    SELECT 1
+                    FROM slot_occupancy
+                    WHERE slot_id = ?
+                    LIMIT 1;
+                    """,
+                    (home_slot_id,),
+                ).fetchone()
+                if occupied_row:
+                    raise ValueError("Selected home slot is already occupied.")
+
+                if str(slot_row["current_asset_tag"] or "").strip():
+                    raise ValueError("Selected home slot is already occupied.")
+
+            now_iso = datetime.now(timezone.utc).isoformat()
+            created_date = now_iso.split("T", 1)[0]
+
+            asset_columns = get_asset_table_columns(conn)
+            insert_values: dict[str, object] = {
+                "asset_tag": asset_tag,
+            }
+
+            if "equipment_type" in asset_columns:
+                insert_values["equipment_type"] = equipment_type if equipment_type is not None else ""
+            if "custody_state" in asset_columns and "custody_state" not in insert_values:
+                insert_values["custody_state"] = "in_stock"
+            if "accountability_status" in asset_columns and "accountability_status" not in insert_values:
+                insert_values["accountability_status"] = "accountable"
+            if "condition" in asset_columns and "condition" not in insert_values:
+                insert_values["condition"] = "serviceable"
+            if "retired" in asset_columns and "retired" not in insert_values:
+                insert_values["retired"] = 0
+            if "created_date" in asset_columns and "created_date" not in insert_values:
+                insert_values["created_date"] = created_date
+            if "updated_date" in asset_columns and "updated_date" not in insert_values:
+                insert_values["updated_date"] = now_iso
+            if "location_type" in asset_columns:
+                insert_values["location_type"] = "STORAGE"
+            if "current_holder_id" in asset_columns:
+                insert_values["current_holder_id"] = None
+            if "home_slot_id" in asset_columns:
+                insert_values["home_slot_id"] = home_slot_id
+
+            column_names = list(insert_values.keys())
+            placeholders = ", ".join("?" for _ in column_names)
+            cursor = conn.execute(
+                f"INSERT INTO assets ({', '.join(column_names)}) VALUES ({placeholders});",
+                tuple(insert_values[col] for col in column_names),
+            )
+            asset_id = int(cursor.lastrowid)
+
+            if home_slot_id is not None:
+                conn.execute(
+                    """
+                    INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                    VALUES (?, ?, ?);
+                    """,
+                    (home_slot_id, asset_id, now_iso),
+                )
+                conn.execute(
+                    """
+                    UPDATE slots
+                    SET current_asset_tag = ?
+                    WHERE id = ?;
+                    """,
+                    (asset_tag, home_slot_id),
+                )
+
+            payload: dict[str, object] = {}
+            if home_slot_id is not None:
+                payload["slot_id"] = home_slot_id
+            if equipment_type:
+                payload["equipment_type"] = equipment_type
+
+            conn.execute(
+                """
+                INSERT INTO asset_events (
+                    asset_tag,
+                    event_type,
+                    event_date,
+                    actor,
+                    notes,
+                    payload,
+                    holder_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?);
+                """,
+                (
+                    asset_tag,
+                    "ASSET_CREATED",
+                    now_iso,
+                    actor,
+                    notes,
+                    json.dumps(payload) if payload else None,
+                    None,
+                ),
+            )
+
+            conn.commit()
+        except ValueError as e:
+            conn.rollback()
+            return {"ok": False, "error": str(e)}, 400
+        except sqlite3.IntegrityError as e:
+            conn.rollback()
+            return {"ok": False, "error": f"create failed: {e}"}, 400
+        except Exception:
+            conn.rollback()
+            raise
+    finally:
+        conn.close()
+
+    return {
+        "ok": True,
+        "asset_tag": asset_tag,
+        "location_type": "STORAGE",
+        "current_holder_id": None,
+        "home_slot_id": home_slot_id,
+        "event_type": "ASSET_CREATED",
+    }
 
 
 @app.route("/admin/assign-slot", methods=["GET", "POST"])

--- a/tests/test_admin_create_asset.py
+++ b/tests/test_admin_create_asset.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+
+
+class AdminCreateAssetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE,
+                equipment_type TEXT NOT NULL,
+                custody_state TEXT NOT NULL,
+                accountability_status TEXT NOT NULL,
+                condition TEXT NOT NULL,
+                created_date TEXT NOT NULL,
+                updated_date TEXT NULL,
+                location_type TEXT NULL,
+                current_holder_id INTEGER NULL,
+                home_slot_id INTEGER NULL
+            );
+            """
+        )
+        self.conn.commit()
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_slot(self, slot_id: int, *, current_asset_tag: str | None = None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, 'CASE-A', ?, ?);
+            """,
+            (slot_id, slot_id, current_asset_tag),
+        )
+        self.conn.commit()
+
+    def _insert_asset(self, asset_tag: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                equipment_type,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                location_type,
+                current_holder_id,
+                home_slot_id
+            )
+            VALUES (?, 'laptop', 'in_stock', 'accountable', 'serviceable', '2026-01-01', 'STORAGE', NULL, NULL);
+            """,
+            (asset_tag,),
+        )
+        self.conn.commit()
+
+    def test_create_asset_unslotted_success(self) -> None:
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-100",
+                "actor": "admin-user",
+                "equipment_type": "laptop",
+                "notes": "initial load",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json["ok"])
+
+        asset_row = self.conn.execute(
+            """
+            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id, equipment_type
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            ("AT-100",),
+        ).fetchone()
+        self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["location_type"], "STORAGE")
+        self.assertIsNone(asset_row["current_holder_id"])
+        self.assertIsNone(asset_row["home_slot_id"])
+        self.assertEqual(asset_row["equipment_type"], "laptop")
+
+        occ = self.conn.execute("SELECT 1 FROM slot_occupancy WHERE asset_id = ?;", (asset_row["id"],)).fetchone()
+        self.assertIsNone(occ)
+
+        event = self.conn.execute(
+            """
+            SELECT event_type, actor, notes, payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("AT-100",),
+        ).fetchone()
+        self.assertIsNotNone(event)
+        self.assertEqual(event["event_type"], "ASSET_CREATED")
+        self.assertEqual(event["actor"], "admin-user")
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["equipment_type"], "laptop")
+
+    def test_create_asset_allows_missing_equipment_type(self) -> None:
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-101",
+                "actor": "admin-user",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json["ok"])
+
+        asset_row = self.conn.execute(
+            "SELECT equipment_type FROM assets WHERE asset_tag = ?;",
+            ("AT-101",),
+        ).fetchone()
+        self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["equipment_type"], "")
+
+        event = self.conn.execute(
+            """
+            SELECT payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("AT-101",),
+        ).fetchone()
+        self.assertIsNotNone(event)
+        self.assertIsNone(event["payload"])
+
+    def test_create_asset_with_home_slot_success(self) -> None:
+        self._insert_slot(11)
+
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-200",
+                "actor": "admin-user",
+                "equipment_type": "tablet",
+                "home_slot_id": 11,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json["ok"])
+        self.assertEqual(response.json["home_slot_id"], 11)
+
+        asset_row = self.conn.execute(
+            """
+            SELECT id, home_slot_id, location_type, current_holder_id
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            ("AT-200",),
+        ).fetchone()
+        self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["home_slot_id"], 11)
+        self.assertEqual(asset_row["location_type"], "STORAGE")
+        self.assertIsNone(asset_row["current_holder_id"])
+
+        occ = self.conn.execute(
+            """
+            SELECT slot_id
+            FROM slot_occupancy
+            WHERE asset_id = ?;
+            """,
+            (asset_row["id"],),
+        ).fetchone()
+        self.assertIsNotNone(occ)
+        self.assertEqual(occ["slot_id"], 11)
+
+        slot = self.conn.execute("SELECT current_asset_tag FROM slots WHERE id = ?;", (11,)).fetchone()
+        self.assertEqual(slot["current_asset_tag"], "AT-200")
+
+        event = self.conn.execute(
+            """
+            SELECT payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("AT-200",),
+        ).fetchone()
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["slot_id"], 11)
+        self.assertEqual(payload["equipment_type"], "tablet")
+
+    def test_duplicate_asset_tag_rejected(self) -> None:
+        self._insert_asset("AT-DUP")
+
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-DUP",
+                "actor": "admin-user",
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json["ok"])
+        self.assertIn("already exists", response.json["error"])
+
+        count = self.conn.execute("SELECT COUNT(*) AS c FROM assets WHERE asset_tag = ?;", ("AT-DUP",)).fetchone()
+        self.assertEqual(count["c"], 1)
+
+    def test_occupied_home_slot_rejected_and_rolls_back(self) -> None:
+        self._insert_slot(22, current_asset_tag="EXISTING-ASSET")
+
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-300",
+                "actor": "admin-user",
+                "home_slot_id": 22,
+            },
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(response.json["ok"])
+        self.assertIn("occupied", response.json["error"].lower())
+
+        created = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = ?;", ("AT-300",)).fetchone()
+        self.assertIsNone(created)
+
+        event = self.conn.execute(
+            "SELECT 1 FROM asset_events WHERE asset_tag = ? AND event_type = 'ASSET_CREATED';",
+            ("AT-300",),
+        ).fetchone()
+        self.assertIsNone(event)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds an admin-only JSON endpoint to create assets atomically, with optional immediate slot assignment.

## Related Issue
Closes #80 

## Changes
- Added `POST /admin/assets/create` (admin-auth JSON route).
- Enforced unique `asset_tag` validation.
- Initialized new assets in `STORAGE` with no holder.
- Implemented optional slot assignment with hard-stop empty-slot validation (checks `slot_occupancy` and legacy marker).
- Logged `ASSET_CREATED` event with contextual payload.
- Wrapped creation + slot assignment + event logging in a single explicit transaction.
- Added unit tests covering success and rollback scenarios.

## Verification checklist
- [x] `python3 -m unittest tests.test_admin_create_asset`
- [x] `python3 -m compileall .`
- [ ] Manual curl success case (unslotted)
- [ ] Manual curl slot assignment case

## Notes
`python3 -m unittest discover -s tests` reports a pre-existing unrelated failure in `test_return_batch.py` (template title mismatch). No new test regressions introduced by this change.