### PR TITLE
Issue 9-6: fix return batch title test

### DIFF
--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -69,7 +69,7 @@ class ReturnBatchTests(unittest.TestCase):
 
         preview_render = self.client.get("/return/preview")
         self.assertEqual(preview_render.status_code, 200)
-        self.assertIn(b"Return Assets Preview / Confirm", preview_render.data)
+        self.assertIn("Return Assets — Preview / Confirm".encode("utf-8"), preview_render.data)
 
         unreviewed = self.client.post("/return/commit?json=1")
         self.assertEqual(unreviewed.status_code, 400)


### PR DESCRIPTION
## Summary
Fixes a pre-existing failing return-batch test by aligning the assertion with the rendered page heading.

## Related Issue
Closes #9-6

## Changes
- Updated `tests/test_return_batch.py` to assert the UTF-8 encoded H1 title string.

## Verification checklist
- [x] `python3 -m unittest tests/test_return_batch.py`

## Notes
No functional behavior changes. This is a test expectation alignment only.