### PR TITLE
Issue 10-1: add atomic retire asset workflow with terminal DISPOSED s…

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -38,6 +38,9 @@ SCAN_QUEUE: list[Scan] = []
 
 INTAKE_PASSCODE = os.getenv("ASSETTRACK_INTAKE_CODE")
 INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", "300"))  # default 5 min
+TERMINAL_LOCATION_TYPE = "DISPOSED"
+TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
+RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
 
 
 # Helpers
@@ -132,6 +135,14 @@ def wants_json() -> bool:
       /preview/commit?json=1 (POST)
     """
     return (request.args.get("json") or "").strip() == "1"
+
+
+def _normalize_location_type(value: object) -> str:
+    return str(value or "").strip().upper()
+
+
+def _is_terminal_location_type(value: object) -> bool:
+    return _normalize_location_type(value) in TERMINAL_LOCATION_TYPES
 
 
 def _require_admin_for_route():
@@ -230,7 +241,9 @@ def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict],
         else:
             holder_label = f"ID {holder_id}"
 
-    location_type = str(asset.get("location_type") or "").strip().upper()
+    location_type = _normalize_location_type(asset.get("location_type"))
+    if _is_terminal_location_type(location_type):
+        errors.append("Asset is retired/disposed and cannot be assigned to a slot.")
     if location_type != "STORAGE":
         errors.append("Asset must be location_type=STORAGE.")
     if location_type == "IN_CUSTODY":
@@ -296,6 +309,51 @@ def _build_admin_slot_move_source_view(conn, slot_id: int) -> Optional[dict]:
         "occupied": occupied,
         "asset": asset_view,
     }
+
+
+def _build_admin_retire_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
+    asset = _find_asset_for_scan_tag(conn, scan_tag)
+    if not asset:
+        return None, ["asset_tag not found"]
+
+    location_type = _normalize_location_type(asset.get("location_type"))
+    errors: list[str] = []
+    if _is_terminal_location_type(location_type):
+        errors.append("Asset is already retired/disposed.")
+    if location_type not in {"STORAGE", "IN_CUSTODY"}:
+        errors.append("Asset must be in STORAGE or IN_CUSTODY to retire.")
+
+    holder_label = "None"
+    holder_id = asset.get("current_holder_id")
+    if holder_id is not None:
+        holder = conn.execute(
+            """
+            SELECT id, name, identifier
+            FROM holders
+            WHERE id = ?;
+            """,
+            (holder_id,),
+        ).fetchone()
+        if holder:
+            identifier = str(holder["identifier"] or "").strip()
+            holder_label = f"{holder['name']} ({identifier})" if identifier else str(holder["name"])
+        else:
+            holder_label = f"ID {holder_id}"
+
+    current_slot = _asset_current_slot(conn, int(asset["id"]), str(asset["asset_tag"]))
+    view = {
+        "id": int(asset["id"]),
+        "asset_tag": str(asset.get("asset_tag") or ""),
+        "location_type": location_type,
+        "serial_number": str(asset.get("serial_number") or ""),
+        "manufacturer": str(asset.get("manufacturer") or ""),
+        "model": str(asset.get("model") or ""),
+        "current_holder": holder_label,
+        "current_holder_id": holder_id,
+        "home_slot_id": asset.get("home_slot_id"),
+        "current_slot": current_slot,
+    }
+    return view, errors
 
 
 def _build_admin_force_vacate_view(conn, slot_id: int) -> Optional[dict]:
@@ -611,6 +669,121 @@ def _create_admin_asset_in_tx(
     }
 
 
+def _retire_admin_asset_in_tx(
+    conn: sqlite3.Connection,
+    *,
+    asset_id: int,
+    asset_tag: str,
+    failure_type: str,
+    notes: str,
+    actor: str,
+) -> dict:
+    locked_row = conn.execute(
+        """
+        SELECT id, asset_tag, location_type, current_holder_id, home_slot_id
+        FROM assets
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (asset_id,),
+    ).fetchone()
+    if not locked_row:
+        raise ValueError("asset_tag not found")
+
+    origin_location = _normalize_location_type(locked_row["location_type"])
+    if _is_terminal_location_type(origin_location):
+        raise ValueError("Asset is already retired/disposed.")
+    if origin_location not in {"STORAGE", "IN_CUSTODY"}:
+        raise ValueError("Asset must be in STORAGE or IN_CUSTODY to retire.")
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    event_type = "ASSET_RETIRED_IN_FIELD" if origin_location == "IN_CUSTODY" else "ASSET_RETIRED"
+
+    occupied_slots = conn.execute(
+        """
+        SELECT slot_id
+        FROM slot_occupancy
+        WHERE asset_id = ?;
+        """,
+        (asset_id,),
+    ).fetchall()
+    cleared_slot_ids = [int(row["slot_id"]) for row in occupied_slots]
+
+    conn.execute(
+        """
+        DELETE FROM slot_occupancy
+        WHERE asset_id = ?;
+        """,
+        (asset_id,),
+    )
+    conn.execute(
+        """
+        UPDATE slots
+        SET current_asset_tag = NULL
+        WHERE UPPER(current_asset_tag) = UPPER(?)
+           OR REPLACE(UPPER(current_asset_tag), '-', '') = UPPER(?);
+        """,
+        (asset_tag, asset_tag),
+    )
+
+    asset_columns = get_asset_table_columns(conn)
+    update_clauses = [
+        "location_type = ?",
+        "current_holder_id = NULL",
+        "home_slot_id = NULL",
+    ]
+    update_values: list[object] = [TERMINAL_LOCATION_TYPE]
+    if "updated_date" in asset_columns:
+        update_clauses.append("updated_date = ?")
+        update_values.append(now_iso)
+
+    update_values.append(asset_id)
+    conn.execute(
+        f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+        tuple(update_values),
+    )
+
+    payload = {
+        "failure_type": failure_type,
+        "notes": notes,
+        "from_location_type": origin_location,
+        "to_location_type": TERMINAL_LOCATION_TYPE,
+        "cleared_slot_ids": cleared_slot_ids,
+        "previous_holder_id": locked_row["current_holder_id"],
+        "previous_home_slot_id": locked_row["home_slot_id"],
+    }
+    conn.execute(
+        """
+        INSERT INTO asset_events (
+            asset_tag,
+            event_type,
+            event_date,
+            actor,
+            notes,
+            payload,
+            holder_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            str(locked_row["asset_tag"]),
+            event_type,
+            now_iso,
+            actor,
+            notes,
+            json.dumps(payload),
+            locked_row["current_holder_id"],
+        ),
+    )
+
+    return {
+        "asset_tag": str(locked_row["asset_tag"]),
+        "event_type": event_type,
+        "from_location_type": origin_location,
+        "to_location_type": TERMINAL_LOCATION_TYPE,
+    }
+
+
 def _selected_holder_from_session() -> Optional[dict]:
     holder_id = session.get("holder_id")
     if holder_id is None:
@@ -640,6 +813,7 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
     assets: list[dict] = []
     unknown_tags: list[str] = []
     not_storage: list[str] = []
+    retired_assets: list[str] = []
     not_slotted: list[str] = []
     blocking_issues: list[str] = []
 
@@ -736,6 +910,9 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
 
             before_location = str(asset_row["location_type"] or "").strip().upper()
             row["before_location_type"] = before_location or "UNKNOWN"
+            if _is_terminal_location_type(before_location):
+                row["asset_issues"].append("Asset is retired/disposed")
+                retired_assets.append(canon_tag)
 
             before_holder_id = asset_row["current_holder_id"]
             row["before_holder"] = "null" if before_holder_id is None else str(before_holder_id)
@@ -760,6 +937,8 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
         blocking_issues.append(f"Unknown asset_tag(s): {', '.join(unknown_tags)}")
     if not_storage:
         blocking_issues.append(f"Not in STORAGE: {', '.join(not_storage)}")
+    if retired_assets:
+        blocking_issues.append(f"Retired/disposed: {', '.join(retired_assets)}")
     if not_slotted:
         blocking_issues.append(f"Not currently slotted: {', '.join(not_slotted)}")
 
@@ -776,6 +955,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
     assets: list[dict] = []
     unknown_tags: list[str] = []
     not_in_custody: list[str] = []
+    retired_assets: list[str] = []
     no_home_slot: list[str] = []
     occupied_home_slot: list[str] = []
     blocking_issues: list[str] = []
@@ -844,6 +1024,9 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
 
             location_type = str(asset_row["location_type"] or "").strip().upper()
             row["before_location_type"] = location_type or "UNKNOWN"
+            if _is_terminal_location_type(location_type):
+                row["asset_issues"].append("Asset is retired/disposed")
+                retired_assets.append(canon_tag)
             if location_type != "IN_CUSTODY":
                 row["asset_issues"].append("Asset is not in IN_CUSTODY")
                 not_in_custody.append(canon_tag)
@@ -891,6 +1074,8 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
         blocking_issues.append(f"Unknown asset_tag(s): {', '.join(unknown_tags)}")
     if not_in_custody:
         blocking_issues.append(f"Not in IN_CUSTODY: {', '.join(not_in_custody)}")
+    if retired_assets:
+        blocking_issues.append(f"Retired/disposed: {', '.join(retired_assets)}")
     if no_home_slot:
         blocking_issues.append(f"Missing home slot: {', '.join(no_home_slot)}")
     if occupied_home_slot:
@@ -969,6 +1154,7 @@ def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
 
             unknown_tags: list[str] = []
             not_storage: list[str] = []
+            retired_assets: list[str] = []
             not_slotted: list[str] = []
 
             # Map scan tags -> canonical DB tags (so we update/vacate consistently)
@@ -984,18 +1170,22 @@ def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
                 canon_tags.append(canon_tag)
 
                 location_type = str(asset_row["location_type"] or "").strip().upper()
+                if _is_terminal_location_type(location_type):
+                    retired_assets.append(canon_tag)
                 if location_type != "STORAGE":
                     not_storage.append(canon_tag)
 
                 if not _is_slotted(conn, canon_tag):
                     not_slotted.append(canon_tag)
 
-            if unknown_tags or not_storage or not_slotted:
+            if unknown_tags or not_storage or retired_assets or not_slotted:
                 parts: list[str] = []
                 if unknown_tags:
                     parts.append(f"Unknown asset_tag(s): {', '.join(unknown_tags)}")
                 if not_storage:
                     parts.append(f"Not in STORAGE: {', '.join(not_storage)}")
+                if retired_assets:
+                    parts.append(f"Retired/disposed: {', '.join(retired_assets)}")
                 if not_slotted:
                     parts.append(f"Not currently slotted: {', '.join(not_slotted)}")
                 raise ValueError("; ".join(parts))
@@ -1076,6 +1266,7 @@ def _stock_in_batch(asset_tags: list[str]) -> int:
 
             unknown_tags: list[str] = []
             not_in_custody: list[str] = []
+            retired_assets: list[str] = []
             no_home_slot: list[str] = []
             occupied_home_slot: list[str] = []
             validated_rows: list[dict] = []
@@ -1089,6 +1280,8 @@ def _stock_in_batch(asset_tags: list[str]) -> int:
                 canon_tag = str(asset_row["asset_tag"])
 
                 location_type = str(asset_row["location_type"] or "").strip().upper()
+                if _is_terminal_location_type(location_type):
+                    retired_assets.append(canon_tag)
                 if location_type != "IN_CUSTODY":
                     not_in_custody.append(canon_tag)
 
@@ -1114,12 +1307,14 @@ def _stock_in_batch(asset_tags: list[str]) -> int:
 
                 validated_rows.append({"asset_tag": canon_tag, "home_slot_id": int(slot["id"])})
 
-            if unknown_tags or not_in_custody or no_home_slot or occupied_home_slot:
+            if unknown_tags or not_in_custody or retired_assets or no_home_slot or occupied_home_slot:
                 parts: list[str] = []
                 if unknown_tags:
                     parts.append(f"Unknown asset_tag(s): {', '.join(unknown_tags)}")
                 if not_in_custody:
                     parts.append(f"Not in IN_CUSTODY: {', '.join(not_in_custody)}")
+                if retired_assets:
+                    parts.append(f"Retired/disposed: {', '.join(retired_assets)}")
                 if no_home_slot:
                     parts.append(f"Missing home slot: {', '.join(no_home_slot)}")
                 if occupied_home_slot:
@@ -1774,6 +1969,122 @@ def admin_new_asset():
     return render_template("admin_new_asset.html", form=form_state, error_message=error_message)
 
 
+@app.route("/admin/assets/retire", methods=["GET", "POST"])
+def admin_retire_asset():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    form_state = {
+        "asset_tag": "",
+        "failure_type": "",
+        "notes": "",
+        "confirm_physical": False,
+        "confirm_in_field": False,
+    }
+    asset_view: Optional[dict] = None
+    error_message: Optional[str] = None
+
+    if request.method == "POST":
+        action = (request.form.get("action") or "lookup").strip().lower()
+        form_state = {
+            "asset_tag": (request.form.get("asset_tag") or "").strip().upper(),
+            "failure_type": (request.form.get("failure_type") or "").strip().upper(),
+            "notes": (request.form.get("notes") or "").strip(),
+            "confirm_physical": _is_truthy(request.form.get("confirm_physical")),
+            "confirm_in_field": _is_truthy(request.form.get("confirm_in_field")),
+        }
+
+        conn = get_connection()
+        try:
+            asset_view, blocking_errors = _build_admin_retire_asset_view(conn, form_state["asset_tag"])
+            if action == "lookup":
+                if not form_state["asset_tag"]:
+                    error_message = "asset_tag is required."
+                elif blocking_errors:
+                    error_message = "; ".join(blocking_errors)
+            elif action == "retire":
+                errors: list[str] = []
+                if not form_state["asset_tag"]:
+                    errors.append("asset_tag is required.")
+                if not form_state["failure_type"]:
+                    errors.append("failure_type is required.")
+                elif form_state["failure_type"] not in RETIRE_FAILURE_TYPES:
+                    errors.append(
+                        f"failure_type must be one of: {', '.join(sorted(RETIRE_FAILURE_TYPES))}."
+                    )
+                if not form_state["notes"]:
+                    errors.append("notes is required.")
+                if not form_state["confirm_physical"]:
+                    errors.append("You must confirm physical reality before retiring.")
+                if asset_view and asset_view["location_type"] == "IN_CUSTODY" and not form_state["confirm_in_field"]:
+                    errors.append("You must confirm the in-custody asset is not recoverable.")
+                if blocking_errors:
+                    errors.extend(blocking_errors)
+                if errors:
+                    error_message = "; ".join(errors)
+                    return render_template(
+                        "admin_retire_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                    )
+
+                try:
+                    conn.execute("BEGIN;")
+                    result = _retire_admin_asset_in_tx(
+                        conn,
+                        asset_id=int(asset_view["id"]),
+                        asset_tag=str(asset_view["asset_tag"]),
+                        failure_type=form_state["failure_type"],
+                        notes=form_state["notes"],
+                        actor="admin",
+                    )
+                    conn.commit()
+                except ValueError as e:
+                    conn.rollback()
+                    error_message = str(e)
+                    return render_template(
+                        "admin_retire_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                    )
+                except sqlite3.IntegrityError as e:
+                    conn.rollback()
+                    error_message = f"retire failed: {e}"
+                    return render_template(
+                        "admin_retire_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                    )
+                except Exception:
+                    conn.rollback()
+                    raise
+
+                flash(
+                    f"Retired asset {result['asset_tag']} with status {result['to_location_type']}.",
+                    "success",
+                )
+                return redirect(url_for("admin_retire_asset"))
+            else:
+                error_message = "Unknown action."
+        finally:
+            conn.close()
+
+    return render_template(
+        "admin_retire_asset.html",
+        form=form_state,
+        asset=asset_view,
+        error_message=error_message,
+        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+    )
+
+
 @app.post("/admin/assets/create")
 def admin_create_asset():
     guard_result = _require_admin_for_api()
@@ -1963,7 +2274,9 @@ def admin_assign_slot():
                     if not asset_row:
                         raise ValueError("asset_tag not found")
 
-                    location_type = str(asset_row.get("location_type") or "").strip().upper()
+                    location_type = _normalize_location_type(asset_row.get("location_type"))
+                    if _is_terminal_location_type(location_type):
+                        raise ValueError("Asset is retired/disposed and cannot be assigned to a slot.")
                     if location_type != "STORAGE":
                         raise ValueError("Asset must be location_type=STORAGE.")
                     if location_type == "IN_CUSTODY":
@@ -2239,7 +2552,9 @@ def admin_slot_move():
 
                 asset_id = int(source_slot_locked["asset_id"])
                 asset_tag = str(source_slot_locked["asset_tag"] or "")
-                location_type = str(source_slot_locked["location_type"] or "").strip().upper()
+                location_type = _normalize_location_type(source_slot_locked["location_type"])
+                if _is_terminal_location_type(location_type):
+                    raise ValueError("Asset is retired/disposed and cannot be moved.")
                 if location_type != "STORAGE":
                     raise ValueError("Asset must be location_type=STORAGE.")
                 if location_type == "IN_CUSTODY":
@@ -2465,8 +2780,10 @@ def admin_force_vacate():
                 flash("Cannot force vacate an empty slot.", "error")
 
             asset_for_view = (slot_view or {}).get("asset") if slot_view else None
-            if asset_for_view and str(asset_for_view.get("location_type") or "").strip().upper() == "IN_CUSTODY":
+            if asset_for_view and _normalize_location_type(asset_for_view.get("location_type")) == "IN_CUSTODY":
                 flash("Cannot force vacate: occupied asset is IN_CUSTODY.", "error")
+            if asset_for_view and _is_terminal_location_type(asset_for_view.get("location_type")):
+                flash("Cannot force vacate: occupied asset is retired/disposed.", "error")
             if not reason:
                 flash("Reason is required.", "error")
             if not confirmed:
@@ -2478,7 +2795,8 @@ def admin_force_vacate():
                 or not slot_view.get("occupied")
                 or not reason
                 or not confirmed
-                or (asset_for_view and str(asset_for_view.get("location_type") or "").strip().upper() == "IN_CUSTODY")
+                or (asset_for_view and _normalize_location_type(asset_for_view.get("location_type")) == "IN_CUSTODY")
+                or (asset_for_view and _is_terminal_location_type(asset_for_view.get("location_type")))
             ):
                 return render_template(
                     "admin_force_vacate.html",
@@ -2552,6 +2870,8 @@ def admin_force_vacate():
                     else:
                         raise ValueError("Occupied asset record not found.")
 
+                if _is_terminal_location_type(asset_location_type):
+                    raise ValueError("Cannot force vacate: occupied asset is retired/disposed.")
                 if asset_location_type == "IN_CUSTODY":
                     raise ValueError("Cannot force vacate: occupied asset is IN_CUSTODY.")
 

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -1,0 +1,113 @@
+<!-- assettrack/intake/templates/admin_retire_asset.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Retire Asset</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 980px; }
+      .row { margin: 0.75rem 0; }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+      input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
+      textarea { min-height: 120px; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; margin-right: 0.35rem; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 980px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      .warn { color: #8a1f11; font-weight: 700; }
+      .check { display: flex; align-items: center; gap: 0.5rem; }
+    </style>
+  </head>
+  <body>
+    <h1>Admin: Retire Asset</h1>
+    <p><a href="/">&larr; Back to intake</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    {% if error_message %}
+      <div class="flash error">{{ error_message }}</div>
+    {% endif %}
+
+    <div class="card">
+      <h2>1) Lookup Asset</h2>
+      <form method="post" action="/admin/assets/retire">
+        <input type="hidden" name="action" value="lookup" />
+        <div class="row">
+          <label for="asset_tag"><strong>asset_tag</strong> (required)</label><br />
+          <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" required autofocus />
+        </div>
+        <button type="submit">Lookup Asset</button>
+      </form>
+    </div>
+
+    {% if asset %}
+      <div class="card">
+        <h2>2) Current Asset State</h2>
+        <div class="grid">
+          <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
+          <div><strong>location_type:</strong> <code>{{ asset.location_type }}</code></div>
+          <div><strong>manufacturer:</strong> {{ asset.manufacturer or "" }}</div>
+          <div><strong>model:</strong> {{ asset.model or "" }}</div>
+          <div><strong>serial_number:</strong> {{ asset.serial_number or "" }}</div>
+          <div><strong>current_holder:</strong> {{ asset.current_holder }}</div>
+          <div>
+            <strong>current slot:</strong>
+            {% if asset.current_slot %}
+              <code>{{ asset.current_slot.case_name }} / {{ asset.current_slot.slot_position }} (id {{ asset.current_slot.slot_id }})</code>
+            {% else %}
+              none
+            {% endif %}
+          </div>
+          <div><strong>home_slot_id:</strong> {{ asset.home_slot_id if asset.home_slot_id is not none else "none" }}</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>3) Retire Asset</h2>
+        <p class="warn">Retirement is terminal. This action marks the asset as DISPOSED.</p>
+        <form method="post" action="/admin/assets/retire">
+          <input type="hidden" name="action" value="retire" />
+          <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
+
+          <div class="row">
+            <label for="failure_type"><strong>failure_type</strong> (required)</label><br />
+            <select id="failure_type" name="failure_type" required>
+              <option value="">-- select failure type --</option>
+              {% for option in failure_type_options %}
+                <option value="{{ option }}" {% if form.failure_type == option %}selected{% endif %}>{{ option }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="row">
+            <label for="notes"><strong>notes</strong> (required)</label><br />
+            <textarea id="notes" name="notes" required>{{ form.notes or '' }}</textarea>
+          </div>
+
+          <div class="row check">
+            <input type="checkbox" id="confirm_physical" name="confirm_physical" value="yes" {% if form.confirm_physical %}checked{% endif %} />
+            <label for="confirm_physical"><strong>I confirm this reflects physical reality.</strong></label>
+          </div>
+
+          {% if asset.location_type == "IN_CUSTODY" %}
+            <div class="row check">
+              <input type="checkbox" id="confirm_in_field" name="confirm_in_field" value="yes" {% if form.confirm_in_field %}checked{% endif %} />
+              <label for="confirm_in_field"><strong>I confirm the asset is not recoverable / no longer returning.</strong></label>
+            </div>
+          {% endif %}
+
+          <button type="submit">Retire Asset</button>
+        </form>
+      </div>
+    {% endif %}
+  </body>
+</html>

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+
+
+class AdminRetireAssetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE,
+                serial_number TEXT NULL,
+                manufacturer TEXT NULL,
+                model TEXT NULL,
+                location_type TEXT NULL,
+                current_holder_id INTEGER NULL,
+                home_slot_id INTEGER NULL,
+                updated_date TEXT NULL
+            );
+            """
+        )
+        self.conn.commit()
+
+        self.orig_passcode = intake_app.INTAKE_PASSCODE
+        intake_app.INTAKE_PASSCODE = "test-admin-code"
+        intake_app.app.testing = True
+        intake_app.SCAN_QUEUE.clear()
+        self.client = intake_app.app.test_client()
+
+    def tearDown(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.INTAKE_PASSCODE = self.orig_passcode
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _set_admin_session(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess["authed"] = True
+            sess["last_seen"] = intake_app.now_seconds()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int, current_asset_tag: str | None = None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            (slot_id, case_name, slot_position, current_asset_tag),
+        )
+        self.conn.commit()
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        location_type: str,
+        holder_id: int | None = None,
+        home_slot_id: int | None = None,
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                manufacturer,
+                model,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                updated_date
+            )
+            VALUES (?, 'SERIAL', 'Vendor', 'Model-X', ?, ?, ?, NULL);
+            """,
+            (asset_tag, location_type, holder_id, home_slot_id),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def test_get_retire_route_admin_only(self) -> None:
+        blocked = self.client.get("/admin/assets/retire")
+        self.assertEqual(blocked.status_code, 302)
+        self.assertTrue((blocked.headers.get("Location") or "").endswith("/"))
+
+        self._set_admin_session()
+        allowed = self.client.get("/admin/assets/retire")
+        self.assertEqual(allowed.status_code, 200)
+        self.assertIn(b"Admin: Retire Asset", allowed.data)
+
+    def test_retire_from_storage_is_atomic_and_logs_event(self) -> None:
+        self._set_admin_session()
+        asset_id = self._insert_asset("RET-100", location_type="STORAGE", holder_id=None, home_slot_id=10)
+        self._insert_slot(10, "CASE-A", 1, current_asset_tag="RET-100")
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (10, ?, '2026-02-01T00:00:00Z');
+            """,
+            (asset_id,),
+        )
+        self.conn.commit()
+
+        response = self.client.post(
+            "/admin/assets/retire",
+            data={
+                "action": "retire",
+                "asset_tag": "RET-100",
+                "failure_type": "HARDWARE",
+                "notes": "Motherboard failure confirmed.",
+                "confirm_physical": "yes",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Retired asset RET-100 with status DISPOSED.", response.data)
+
+        asset = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id FROM assets WHERE id = ?;",
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset["location_type"], "DISPOSED")
+        self.assertIsNone(asset["current_holder_id"])
+        self.assertIsNone(asset["home_slot_id"])
+
+        occ = self.conn.execute("SELECT 1 FROM slot_occupancy WHERE asset_id = ?;", (asset_id,)).fetchone()
+        self.assertIsNone(occ)
+        slot = self.conn.execute("SELECT current_asset_tag FROM slots WHERE id = 10;").fetchone()
+        self.assertIsNone(slot["current_asset_tag"])
+
+        event = self.conn.execute(
+            """
+            SELECT event_type, actor, notes, payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("RET-100",),
+        ).fetchone()
+        self.assertEqual(event["event_type"], "ASSET_RETIRED")
+        self.assertEqual(event["actor"], "admin")
+        self.assertEqual(event["notes"], "Motherboard failure confirmed.")
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["failure_type"], "HARDWARE")
+        self.assertEqual(payload["to_location_type"], "DISPOSED")
+
+    def test_retire_from_in_custody_requires_extra_confirmation(self) -> None:
+        self._set_admin_session()
+        self._insert_asset("RET-200", location_type="IN_CUSTODY", holder_id=51, home_slot_id=None)
+
+        missing_confirm = self.client.post(
+            "/admin/assets/retire",
+            data={
+                "action": "retire",
+                "asset_tag": "RET-200",
+                "failure_type": "LOST",
+                "notes": "Lost during field operations.",
+                "confirm_physical": "yes",
+            },
+        )
+        self.assertEqual(missing_confirm.status_code, 200)
+        self.assertIn(b"not recoverable", missing_confirm.data)
+
+        ok = self.client.post(
+            "/admin/assets/retire",
+            data={
+                "action": "retire",
+                "asset_tag": "RET-200",
+                "failure_type": "LOST",
+                "notes": "Lost during field operations.",
+                "confirm_physical": "yes",
+                "confirm_in_field": "yes",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(ok.status_code, 200)
+        self.assertIn(b"Retired asset RET-200 with status DISPOSED.", ok.data)
+
+        asset = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id FROM assets WHERE asset_tag = ?;",
+            ("RET-200",),
+        ).fetchone()
+        self.assertEqual(asset["location_type"], "DISPOSED")
+        self.assertIsNone(asset["current_holder_id"])
+        self.assertIsNone(asset["home_slot_id"])
+
+        event = self.conn.execute(
+            """
+            SELECT event_type, payload, holder_id
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("RET-200",),
+        ).fetchone()
+        self.assertEqual(event["event_type"], "ASSET_RETIRED_IN_FIELD")
+        self.assertEqual(event["holder_id"], 51)
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["failure_type"], "LOST")
+
+    def test_retired_assets_are_blocked_from_stock_out_and_stock_in(self) -> None:
+        self._insert_asset("RET-300", location_type="DISPOSED", holder_id=None, home_slot_id=20)
+        self._insert_slot(20, "CASE-B", 2, current_asset_tag=None)
+
+        with self.assertRaisesRegex(ValueError, "Retired/disposed"):
+            intake_app._stock_out_batch(["RET-300"], holder_id=4)
+
+        with self.assertRaisesRegex(ValueError, "Retired/disposed"):
+            intake_app._stock_in_batch(["RET-300"])
+
+    def test_admin_assign_slot_refuses_retired_asset(self) -> None:
+        self._set_admin_session()
+        self._insert_asset("RET-400", location_type="DISPOSED", holder_id=None, home_slot_id=None)
+
+        response = self.client.post(
+            "/admin/assign-slot",
+            data={
+                "action": "lookup",
+                "asset_tag": "RET-400",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"retired/disposed", response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements atomic asset retirement workflow with terminal DISPOSED state, supporting retirement from both STORAGE and IN_CUSTODY. Enforces required failure_type and notes, clears custody and slot relationships, and blocks retired assets from operational flows.

## Related Issue
Closes #81 

## Changes
- Added admin retire route and template (`/admin/assets/retire`)
- Introduced terminal DISPOSED state
- Clears current_holder_id on retire
- Removes slot_occupancy if present
- Clears home_slot_id
- Writes ASSET_RETIRED or ASSET_RETIRED_IN_FIELD event (with failure_type + notes)
- Blocks retired assets from Stock-Out and Stock-In
- Added test coverage for:
  - Retirement from STORAGE
  - Retirement from IN_CUSTODY
  - Required field enforcement
  - Operational blocking of retired assets

## Verification
- [x] Retire from STORAGE works
- [x] Retire from IN_CUSTODY works
- [x] failure_type required
- [x] notes required
- [x] Slot and custody cleared atomically
- [x] Correct event written
- [x] Retired assets blocked from Stock-Out
- [x] Retired assets blocked from Stock-In
- [x] All tests passing (18/18)
- [x] Docker runtime verified

## Notes
Retirement is a terminal state. Replacement/swap workflow deferred to Issue 10-2.