### PR TITLE
Issue 10-2: implement atomic asset replacement swap workflow

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -356,6 +356,140 @@ def _build_admin_retire_asset_view(conn, scan_tag: str) -> tuple[Optional[dict],
     return view, errors
 
 
+def _resolve_replacement_target_slot(
+    conn: sqlite3.Connection,
+    *,
+    failed_asset_id: int,
+    failed_asset_tag: str,
+    failed_home_slot_id: Optional[int],
+) -> tuple[int, dict]:
+    occupancy_slot = conn.execute(
+        """
+        SELECT s.id, s.case_name, s.slot_position, s.current_asset_tag
+        FROM slot_occupancy so
+        JOIN slots s ON s.id = so.slot_id
+        WHERE so.asset_id = ?
+        LIMIT 1;
+        """,
+        (failed_asset_id,),
+    ).fetchone()
+    if occupancy_slot:
+        return int(occupancy_slot["id"]), dict(occupancy_slot)
+
+    if failed_home_slot_id is None:
+        raise ValueError("Asset has no slot. Assign a slot first.")
+
+    home_slot = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (failed_home_slot_id,),
+    ).fetchone()
+    if not home_slot:
+        raise ValueError("Target slot does not exist.")
+
+    return int(home_slot["id"]), dict(home_slot)
+
+
+def _validate_swap_target_slot_integrity(
+    conn: sqlite3.Connection,
+    *,
+    target_slot_id: int,
+    failed_asset_id: int,
+    failed_asset_tag: str,
+) -> None:
+    occupied = conn.execute(
+        """
+        SELECT asset_id
+        FROM slot_occupancy
+        WHERE slot_id = ?
+        LIMIT 1;
+        """,
+        (target_slot_id,),
+    ).fetchone()
+    if occupied and int(occupied["asset_id"]) != failed_asset_id:
+        raise ValueError("Target slot is occupied by another asset.")
+
+    slot_row = conn.execute(
+        """
+        SELECT current_asset_tag
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (target_slot_id,),
+    ).fetchone()
+    if not slot_row:
+        raise ValueError("Target slot does not exist.")
+
+    marker = str(slot_row["current_asset_tag"] or "").strip()
+    if marker:
+        is_failed_asset_marker = marker.upper() == failed_asset_tag.upper() or marker.upper() == failed_asset_tag.upper().replace("-", "")
+        if not is_failed_asset_marker:
+            raise ValueError("Target slot is occupied by another asset.")
+
+
+def _build_admin_replace_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
+    asset = _find_asset_for_scan_tag(conn, scan_tag)
+    if not asset:
+        return None, ["asset_tag not found"]
+
+    location_type = _normalize_location_type(asset.get("location_type"))
+    errors: list[str] = []
+    if _is_terminal_location_type(location_type):
+        errors.append("Asset is already retired/disposed.")
+    if location_type not in {"STORAGE", "IN_CUSTODY"}:
+        errors.append("Asset must be in STORAGE or IN_CUSTODY to replace.")
+
+    holder_label = "None"
+    holder_id = asset.get("current_holder_id")
+    if holder_id is not None:
+        holder = conn.execute(
+            """
+            SELECT id, name, identifier
+            FROM holders
+            WHERE id = ?;
+            """,
+            (holder_id,),
+        ).fetchone()
+        if holder:
+            identifier = str(holder["identifier"] or "").strip()
+            holder_label = f"{holder['name']} ({identifier})" if identifier else str(holder["name"])
+        else:
+            holder_label = f"ID {holder_id}"
+
+    target_slot_id = None
+    target_slot = None
+    try:
+        target_slot_id, target_slot = _resolve_replacement_target_slot(
+            conn,
+            failed_asset_id=int(asset["id"]),
+            failed_asset_tag=str(asset["asset_tag"]),
+            failed_home_slot_id=asset.get("home_slot_id"),
+        )
+    except ValueError as e:
+        errors.append(str(e))
+
+    view = {
+        "id": int(asset["id"]),
+        "asset_tag": str(asset.get("asset_tag") or ""),
+        "location_type": location_type,
+        "serial_number": str(asset.get("serial_number") or ""),
+        "manufacturer": str(asset.get("manufacturer") or ""),
+        "model": str(asset.get("model") or ""),
+        "building_room": str(asset.get("building_room") or ""),
+        "current_holder": holder_label,
+        "current_holder_id": holder_id,
+        "home_slot_id": asset.get("home_slot_id"),
+        "target_slot_id": target_slot_id,
+        "target_slot": target_slot,
+    }
+    return view, errors
+
+
 def _build_admin_force_vacate_view(conn, slot_id: int) -> Optional[dict]:
     slot_row = conn.execute(
         """
@@ -2080,6 +2214,221 @@ def admin_retire_asset():
         "admin_retire_asset.html",
         form=form_state,
         asset=asset_view,
+        error_message=error_message,
+        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+    )
+
+
+@app.route("/admin/assets/replace", methods=["GET", "POST"])
+def admin_replace_asset():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    form_state = {
+        "failed_asset_tag": "",
+        "failure_type": "",
+        "failure_notes": "",
+        "replacement_asset_tag": "",
+        "replacement_serial_number": "",
+        "replacement_manufacturer": "",
+        "replacement_equipment_type": "laptop",
+        "replacement_model": "",
+        "replacement_model_code": "",
+        "replacement_notes": "",
+        "confirm_retire": False,
+        "confirm_slot": False,
+    }
+    failed_asset_view: Optional[dict] = None
+    error_message: Optional[str] = None
+
+    if request.method == "POST":
+        action = (request.form.get("action") or "lookup").strip().lower()
+        form_state = {
+            "failed_asset_tag": (request.form.get("failed_asset_tag") or "").strip().upper(),
+            "failure_type": (request.form.get("failure_type") or "").strip().upper(),
+            "failure_notes": (request.form.get("failure_notes") or "").strip(),
+            "replacement_asset_tag": (request.form.get("replacement_asset_tag") or "").strip().upper(),
+            "replacement_serial_number": (request.form.get("replacement_serial_number") or "").strip(),
+            "replacement_manufacturer": (request.form.get("replacement_manufacturer") or "").strip(),
+            "replacement_equipment_type": (request.form.get("replacement_equipment_type") or "").strip() or "laptop",
+            "replacement_model": (request.form.get("replacement_model") or "").strip(),
+            "replacement_model_code": (request.form.get("replacement_model_code") or "").strip(),
+            "replacement_notes": (request.form.get("replacement_notes") or "").strip(),
+            "confirm_retire": _is_truthy(request.form.get("confirm_retire")),
+            "confirm_slot": _is_truthy(request.form.get("confirm_slot")),
+        }
+
+        conn = get_connection()
+        try:
+            failed_asset_view, blocking_errors = _build_admin_replace_asset_view(conn, form_state["failed_asset_tag"])
+            if action == "lookup":
+                if not form_state["failed_asset_tag"]:
+                    error_message = "failed asset_tag is required."
+                elif blocking_errors:
+                    error_message = "; ".join(blocking_errors)
+            elif action == "replace":
+                errors: list[str] = []
+                if not form_state["failed_asset_tag"]:
+                    errors.append("failed asset_tag is required.")
+                if not form_state["failure_type"]:
+                    errors.append("failure_type is required.")
+                elif form_state["failure_type"] not in RETIRE_FAILURE_TYPES:
+                    errors.append(
+                        f"failure_type must be one of: {', '.join(sorted(RETIRE_FAILURE_TYPES))}."
+                    )
+                if not form_state["failure_notes"]:
+                    errors.append("failure notes are required.")
+                if not form_state["replacement_asset_tag"]:
+                    errors.append("replacement asset_tag is required.")
+                if not form_state["replacement_serial_number"]:
+                    errors.append("replacement serial_number is required.")
+                if not form_state["replacement_manufacturer"]:
+                    errors.append("replacement manufacturer is required.")
+                if not form_state["replacement_equipment_type"]:
+                    errors.append("replacement equipment_type is required.")
+                if not form_state["confirm_retire"]:
+                    errors.append("You must confirm the failed asset is being retired.")
+                if not form_state["confirm_slot"]:
+                    errors.append("You must confirm the replacement will go into the target slot.")
+                if blocking_errors:
+                    errors.extend(blocking_errors)
+                if errors:
+                    error_message = "; ".join(errors)
+                    return render_template(
+                        "admin_replace_asset.html",
+                        form=form_state,
+                        failed_asset=failed_asset_view,
+                        error_message=error_message,
+                        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                    )
+
+                try:
+                    conn.execute("BEGIN;")
+                    locked_failed = conn.execute(
+                        """
+                        SELECT id, asset_tag, location_type, current_holder_id, home_slot_id
+                        FROM assets
+                        WHERE id = ?
+                        LIMIT 1;
+                        """,
+                        (int(failed_asset_view["id"]),),
+                    ).fetchone()
+                    if not locked_failed:
+                        raise ValueError("failed asset_tag not found.")
+
+                    locked_location = _normalize_location_type(locked_failed["location_type"])
+                    if _is_terminal_location_type(locked_location):
+                        raise ValueError("Failed asset is already retired/disposed.")
+                    if locked_location not in {"STORAGE", "IN_CUSTODY"}:
+                        raise ValueError("Failed asset must be in STORAGE or IN_CUSTODY.")
+
+                    target_slot_id, target_slot = _resolve_replacement_target_slot(
+                        conn,
+                        failed_asset_id=int(locked_failed["id"]),
+                        failed_asset_tag=str(locked_failed["asset_tag"]),
+                        failed_home_slot_id=locked_failed["home_slot_id"],
+                    )
+
+                    replacement_tag_exists = conn.execute(
+                        """
+                        SELECT 1
+                        FROM assets
+                        WHERE UPPER(asset_tag) = UPPER(?)
+                        LIMIT 1;
+                        """,
+                        (form_state["replacement_asset_tag"],),
+                    ).fetchone()
+                    if replacement_tag_exists:
+                        raise ValueError("replacement asset_tag already exists.")
+
+                    replacement_serial_exists = conn.execute(
+                        """
+                        SELECT 1
+                        FROM assets
+                        WHERE TRIM(COALESCE(serial_number, '')) <> ''
+                          AND UPPER(serial_number) = UPPER(?)
+                        LIMIT 1;
+                        """,
+                        (form_state["replacement_serial_number"],),
+                    ).fetchone()
+                    if replacement_serial_exists:
+                        raise ValueError("replacement serial_number already exists.")
+
+                    _validate_swap_target_slot_integrity(
+                        conn,
+                        target_slot_id=target_slot_id,
+                        failed_asset_id=int(locked_failed["id"]),
+                        failed_asset_tag=str(locked_failed["asset_tag"]),
+                    )
+
+                    _retire_admin_asset_in_tx(
+                        conn,
+                        asset_id=int(locked_failed["id"]),
+                        asset_tag=str(locked_failed["asset_tag"]),
+                        failure_type=form_state["failure_type"],
+                        notes=form_state["failure_notes"],
+                        actor="admin",
+                    )
+
+                    _create_admin_asset_in_tx(
+                        conn,
+                        asset_tag=form_state["replacement_asset_tag"],
+                        actor="admin",
+                        equipment_type=form_state["replacement_equipment_type"],
+                        serial_number=form_state["replacement_serial_number"],
+                        manufacturer=form_state["replacement_manufacturer"],
+                        building=str(failed_asset_view.get("building_room") or "").split("/", 1)[0],
+                        room=str(failed_asset_view.get("building_room") or "").split("/", 1)[1]
+                        if "/" in str(failed_asset_view.get("building_room") or "")
+                        else "",
+                        model=form_state["replacement_model"] or None,
+                        model_code=form_state["replacement_model_code"] or None,
+                        notes=form_state["replacement_notes"] or None,
+                        assign_case_number=str(target_slot["case_name"]),
+                        assign_slot_number=int(target_slot["slot_position"]),
+                    )
+
+                    conn.commit()
+                except ValueError as e:
+                    conn.rollback()
+                    error_message = str(e)
+                    return render_template(
+                        "admin_replace_asset.html",
+                        form=form_state,
+                        failed_asset=failed_asset_view,
+                        error_message=error_message,
+                        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                    )
+                except sqlite3.IntegrityError as e:
+                    conn.rollback()
+                    error_message = f"replace failed: {e}"
+                    return render_template(
+                        "admin_replace_asset.html",
+                        form=form_state,
+                        failed_asset=failed_asset_view,
+                        error_message=error_message,
+                        failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                    )
+                except Exception:
+                    conn.rollback()
+                    raise
+
+                flash(
+                    f"Replaced {form_state['failed_asset_tag']} with {form_state['replacement_asset_tag']} "
+                    f"in case {target_slot['case_name']} slot {target_slot['slot_position']}.",
+                    "success",
+                )
+                return redirect(url_for("admin_replace_asset"))
+            else:
+                error_message = "Unknown action."
+        finally:
+            conn.close()
+
+    return render_template(
+        "admin_replace_asset.html",
+        form=form_state,
+        failed_asset=failed_asset_view,
         error_message=error_message,
         failure_type_options=sorted(RETIRE_FAILURE_TYPES),
     )

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -1,0 +1,149 @@
+<!-- assettrack/intake/templates/admin_replace_asset.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Admin Replace Asset</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 2rem; }
+      .card { margin-top: 1rem; padding: 1rem; border: 1px solid #ddd; border-radius: 10px; max-width: 980px; }
+      .row { margin: 0.75rem 0; }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+      input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
+      textarea { min-height: 100px; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; margin-right: 0.35rem; }
+      .flash { padding: 0.75rem 1rem; border-radius: 10px; margin: 0.75rem 0; max-width: 980px; }
+      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
+      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
+      .check { display: flex; align-items: center; gap: 0.5rem; }
+      .warn { color: #8a1f11; font-weight: 700; }
+    </style>
+  </head>
+  <body>
+    <h1>Admin: Replace Failed Asset</h1>
+    <p><a href="/">&larr; Back to intake</a></p>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, message in messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
+
+    {% if error_message %}
+      <div class="flash error">{{ error_message }}</div>
+    {% endif %}
+
+    <div class="card">
+      <h2>1) Lookup Failed Asset</h2>
+      <form method="post" action="/admin/assets/replace">
+        <input type="hidden" name="action" value="lookup" />
+        <div class="row">
+          <label for="failed_asset_tag"><strong>failed asset_tag</strong> (required)</label><br />
+          <input type="text" id="failed_asset_tag" name="failed_asset_tag" value="{{ form.failed_asset_tag or '' }}" required autofocus />
+        </div>
+        <button type="submit">Lookup Asset</button>
+      </form>
+    </div>
+
+    {% if failed_asset %}
+      <div class="card">
+        <h2>2) Failed Asset + Target Slot</h2>
+        <div class="grid">
+          <div><strong>asset_tag:</strong> <code>{{ failed_asset.asset_tag }}</code></div>
+          <div><strong>location_type:</strong> <code>{{ failed_asset.location_type }}</code></div>
+          <div><strong>manufacturer:</strong> {{ failed_asset.manufacturer or "" }}</div>
+          <div><strong>model:</strong> {{ failed_asset.model or "" }}</div>
+          <div><strong>serial_number:</strong> {{ failed_asset.serial_number or "" }}</div>
+          <div><strong>current_holder:</strong> {{ failed_asset.current_holder }}</div>
+          <div><strong>building/room:</strong> {{ failed_asset.building_room or "" }}</div>
+          <div><strong>home_slot_id:</strong> {{ failed_asset.home_slot_id if failed_asset.home_slot_id is not none else "none" }}</div>
+          <div><strong>target_slot_id:</strong> <code>{{ failed_asset.target_slot_id if failed_asset.target_slot_id is not none else "none" }}</code></div>
+          <div>
+            <strong>target case/slot:</strong>
+            {% if failed_asset.target_slot %}
+              <code>{{ failed_asset.target_slot.case_name }} / {{ failed_asset.target_slot.slot_position }}</code>
+            {% else %}
+              none
+            {% endif %}
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <h2>3) Replacement + Failure Details</h2>
+        <p class="warn">This is one atomic operation: retire failed asset, create replacement, assign replacement to target slot.</p>
+        <form method="post" action="/admin/assets/replace">
+          <input type="hidden" name="action" value="replace" />
+          <input type="hidden" name="failed_asset_tag" value="{{ failed_asset.asset_tag }}" />
+
+          <div class="row">
+            <label for="failure_type"><strong>failure_type</strong> (required)</label><br />
+            <select id="failure_type" name="failure_type" required>
+              <option value="">-- select failure type --</option>
+              {% for option in failure_type_options %}
+                <option value="{{ option }}" {% if form.failure_type == option %}selected{% endif %}>{{ option }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="row">
+            <label for="failure_notes"><strong>failure notes</strong> (required)</label><br />
+            <textarea id="failure_notes" name="failure_notes" required>{{ form.failure_notes or '' }}</textarea>
+          </div>
+
+          <h3>Replacement Asset</h3>
+          <div class="grid">
+            <div class="row">
+              <label for="replacement_asset_tag"><strong>asset_tag</strong> (required)</label><br />
+              <input type="text" id="replacement_asset_tag" name="replacement_asset_tag" value="{{ form.replacement_asset_tag or '' }}" required />
+            </div>
+            <div class="row">
+              <label for="replacement_serial_number"><strong>serial_number</strong> (required)</label><br />
+              <input type="text" id="replacement_serial_number" name="replacement_serial_number" value="{{ form.replacement_serial_number or '' }}" required />
+            </div>
+            <div class="row">
+              <label for="replacement_manufacturer"><strong>manufacturer</strong> (required)</label><br />
+              <input type="text" id="replacement_manufacturer" name="replacement_manufacturer" value="{{ form.replacement_manufacturer or '' }}" required />
+            </div>
+            <div class="row">
+              <label for="replacement_equipment_type"><strong>equipment_type</strong> (required)</label><br />
+              <input type="text" id="replacement_equipment_type" name="replacement_equipment_type" value="{{ form.replacement_equipment_type or 'laptop' }}" required />
+            </div>
+            <div class="row">
+              <label for="replacement_model"><strong>model</strong> (optional)</label><br />
+              <input type="text" id="replacement_model" name="replacement_model" value="{{ form.replacement_model or '' }}" />
+            </div>
+            <div class="row">
+              <label for="replacement_model_code"><strong>model_code</strong> (optional)</label><br />
+              <input type="text" id="replacement_model_code" name="replacement_model_code" value="{{ form.replacement_model_code or '' }}" />
+            </div>
+            <div class="row">
+              <label for="replacement_notes"><strong>notes</strong> (optional)</label><br />
+              <input type="text" id="replacement_notes" name="replacement_notes" value="{{ form.replacement_notes or '' }}" />
+            </div>
+          </div>
+
+          <div class="row check">
+            <input type="checkbox" id="confirm_retire" name="confirm_retire" value="yes" {% if form.confirm_retire %}checked{% endif %} />
+            <label for="confirm_retire"><strong>I confirm the failed asset is being retired.</strong></label>
+          </div>
+
+          <div class="row check">
+            <input type="checkbox" id="confirm_slot" name="confirm_slot" value="yes" {% if form.confirm_slot %}checked{% endif %} />
+            <label for="confirm_slot">
+              <strong>
+                I confirm the replacement laptop is going into Case {{ failed_asset.target_slot.case_name if failed_asset.target_slot else "?" }}
+                Slot {{ failed_asset.target_slot.slot_position if failed_asset.target_slot else "?" }}.
+              </strong>
+            </label>
+          </div>
+
+          <button type="submit">Replace Asset</button>
+        </form>
+      </div>
+    {% endif %}
+  </body>
+</html>

--- a/tests/test_admin_replace_asset.py
+++ b/tests/test_admin_replace_asset.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+
+
+class AdminReplaceAssetTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE,
+                serial_number TEXT NULL,
+                manufacturer TEXT NULL,
+                model TEXT NULL,
+                model_code TEXT NULL,
+                notes TEXT NULL,
+                building_room TEXT NULL,
+                equipment_type TEXT NOT NULL,
+                custody_state TEXT NULL,
+                accountability_status TEXT NULL,
+                condition TEXT NULL,
+                created_date TEXT NULL,
+                updated_date TEXT NULL,
+                location_type TEXT NULL,
+                current_holder_id INTEGER NULL,
+                home_slot_id INTEGER NULL
+            );
+            """
+        )
+        self.conn.commit()
+
+        self.orig_passcode = intake_app.INTAKE_PASSCODE
+        intake_app.INTAKE_PASSCODE = "test-admin-code"
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+
+    def tearDown(self) -> None:
+        intake_app.INTAKE_PASSCODE = self.orig_passcode
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _set_admin_session(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess["authed"] = True
+            sess["last_seen"] = intake_app.now_seconds()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int, current_asset_tag: str | None = None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            (slot_id, case_name, slot_position, current_asset_tag),
+        )
+        self.conn.commit()
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        serial_number: str,
+        location_type: str,
+        holder_id: int | None = None,
+        home_slot_id: int | None = None,
+        building_room: str = "HQ/100",
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                manufacturer,
+                model,
+                model_code,
+                notes,
+                building_room,
+                equipment_type,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                updated_date,
+                location_type,
+                current_holder_id,
+                home_slot_id
+            )
+            VALUES (
+                ?, ?, 'Dell', 'Latitude', 'LAT', NULL, ?, 'laptop',
+                'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z',
+                ?, ?, ?
+            );
+            """,
+            (asset_tag, serial_number, building_room, location_type, holder_id, home_slot_id),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def _assign_slot(self, slot_id: int, asset_id: int, asset_tag: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, '2026-02-01T00:00:00Z');
+            """,
+            (slot_id, asset_id),
+        )
+        self.conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", (asset_tag, slot_id))
+        self.conn.commit()
+
+    def test_get_replace_route_admin_only(self) -> None:
+        blocked = self.client.get("/admin/assets/replace")
+        self.assertEqual(blocked.status_code, 302)
+        self.assertTrue((blocked.headers.get("Location") or "").endswith("/"))
+
+        self._set_admin_session()
+        allowed = self.client.get("/admin/assets/replace")
+        self.assertEqual(allowed.status_code, 200)
+        self.assertIn(b"Admin: Replace Failed Asset", allowed.data)
+
+    def test_swap_from_storage_success(self) -> None:
+        self._set_admin_session()
+        self._insert_slot(10, "CASE-A", 1, None)
+        failed_id = self._insert_asset(
+            "FAIL-100",
+            serial_number="SER-FAIL-100",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=10,
+        )
+        self._assign_slot(10, failed_id, "FAIL-100")
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-100",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Power rail damage.",
+                "replacement_asset_tag": "NEW-100",
+                "replacement_serial_number": "SER-NEW-100",
+                "replacement_manufacturer": "Lenovo",
+                "replacement_equipment_type": "laptop",
+                "replacement_model": "T14",
+                "replacement_model_code": "G5",
+                "replacement_notes": "swap replacement",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Replaced FAIL-100 with NEW-100", response.data)
+
+        failed = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id FROM assets WHERE id = ?;",
+            (failed_id,),
+        ).fetchone()
+        self.assertEqual(failed["location_type"], "DISPOSED")
+        self.assertIsNone(failed["current_holder_id"])
+        self.assertIsNone(failed["home_slot_id"])
+
+        replacement = self.conn.execute(
+            """
+            SELECT id, location_type, current_holder_id, home_slot_id
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            ("NEW-100",),
+        ).fetchone()
+        self.assertIsNotNone(replacement)
+        self.assertEqual(replacement["location_type"], "STORAGE")
+        self.assertIsNone(replacement["current_holder_id"])
+        self.assertEqual(replacement["home_slot_id"], 10)
+
+        slot_occ = self.conn.execute(
+            "SELECT asset_id FROM slot_occupancy WHERE slot_id = 10;",
+        ).fetchone()
+        self.assertEqual(slot_occ["asset_id"], replacement["id"])
+        slot = self.conn.execute("SELECT current_asset_tag FROM slots WHERE id = 10;").fetchone()
+        self.assertEqual(slot["current_asset_tag"], "NEW-100")
+
+        failed_event = self.conn.execute(
+            """
+            SELECT event_type
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("FAIL-100",),
+        ).fetchone()
+        self.assertEqual(failed_event["event_type"], "ASSET_RETIRED")
+
+        replacement_events = self.conn.execute(
+            """
+            SELECT event_type
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id ASC;
+            """,
+            ("NEW-100",),
+        ).fetchall()
+        self.assertEqual([row["event_type"] for row in replacement_events], ["ASSET_CREATED", "SLOT_ASSIGN"])
+
+    def test_swap_from_in_custody_success(self) -> None:
+        self._set_admin_session()
+        self._insert_slot(11, "CASE-B", 2, None)
+        failed_id = self._insert_asset(
+            "FAIL-200",
+            serial_number="SER-FAIL-200",
+            location_type="IN_CUSTODY",
+            holder_id=99,
+            home_slot_id=11,
+        )
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-200",
+                "failure_type": "LOST",
+                "failure_notes": "Lost in field operations.",
+                "replacement_asset_tag": "NEW-200",
+                "replacement_serial_number": "SER-NEW-200",
+                "replacement_manufacturer": "HP",
+                "replacement_equipment_type": "laptop",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        failed = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id FROM assets WHERE id = ?;",
+            (failed_id,),
+        ).fetchone()
+        self.assertEqual(failed["location_type"], "DISPOSED")
+        self.assertIsNone(failed["current_holder_id"])
+        self.assertIsNone(failed["home_slot_id"])
+
+        replacement = self.conn.execute(
+            "SELECT location_type, home_slot_id FROM assets WHERE asset_tag = ?;",
+            ("NEW-200",),
+        ).fetchone()
+        self.assertEqual(replacement["location_type"], "STORAGE")
+        self.assertEqual(replacement["home_slot_id"], 11)
+
+        retired_event = self.conn.execute(
+            """
+            SELECT event_type, holder_id
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("FAIL-200",),
+        ).fetchone()
+        self.assertEqual(retired_event["event_type"], "ASSET_RETIRED_IN_FIELD")
+        self.assertEqual(retired_event["holder_id"], 99)
+
+    def test_missing_target_slot_is_blocked(self) -> None:
+        self._set_admin_session()
+        self._insert_asset(
+            "FAIL-300",
+            serial_number="SER-FAIL-300",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-300",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Broken.",
+                "replacement_asset_tag": "NEW-300",
+                "replacement_serial_number": "SER-NEW-300",
+                "replacement_manufacturer": "Lenovo",
+                "replacement_equipment_type": "laptop",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset has no slot. Assign a slot first.", response.data)
+
+        replacement = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = 'NEW-300';").fetchone()
+        self.assertIsNone(replacement)
+
+    def test_target_slot_occupied_by_other_asset_is_blocked_with_no_partial_updates(self) -> None:
+        self._set_admin_session()
+        self._insert_slot(12, "CASE-C", 3, None)
+        failed_id = self._insert_asset(
+            "FAIL-400",
+            serial_number="SER-FAIL-400",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=12,
+        )
+        other_id = self._insert_asset(
+            "OTHER-400",
+            serial_number="SER-OTHER-400",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=12,
+        )
+        self._assign_slot(12, other_id, "OTHER-400")
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-400",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Broken.",
+                "replacement_asset_tag": "NEW-400",
+                "replacement_serial_number": "SER-NEW-400",
+                "replacement_manufacturer": "Lenovo",
+                "replacement_equipment_type": "laptop",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Target slot is occupied by another asset.", response.data)
+
+        failed = self.conn.execute(
+            "SELECT location_type, home_slot_id FROM assets WHERE id = ?;",
+            (failed_id,),
+        ).fetchone()
+        self.assertEqual(failed["location_type"], "STORAGE")
+        self.assertEqual(failed["home_slot_id"], 12)
+        replacement = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = 'NEW-400';").fetchone()
+        self.assertIsNone(replacement)
+
+    def test_duplicate_replacement_identifiers_are_blocked(self) -> None:
+        self._set_admin_session()
+        self._insert_slot(13, "CASE-D", 4, None)
+        failed_id = self._insert_asset(
+            "FAIL-500",
+            serial_number="SER-FAIL-500",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=13,
+        )
+        self._assign_slot(13, failed_id, "FAIL-500")
+        self._insert_asset(
+            "EXISTING-TAG",
+            serial_number="SER-EXISTING",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=None,
+        )
+
+        duplicate_tag = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-500",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Broken.",
+                "replacement_asset_tag": "EXISTING-TAG",
+                "replacement_serial_number": "SER-NEW-500",
+                "replacement_manufacturer": "Lenovo",
+                "replacement_equipment_type": "laptop",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+        )
+        self.assertEqual(duplicate_tag.status_code, 200)
+        self.assertIn(b"replacement asset_tag already exists.", duplicate_tag.data)
+
+        duplicate_serial = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-500",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Broken.",
+                "replacement_asset_tag": "NEW-500",
+                "replacement_serial_number": "SER-EXISTING",
+                "replacement_manufacturer": "Lenovo",
+                "replacement_equipment_type": "laptop",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+        )
+        self.assertEqual(duplicate_serial.status_code, 200)
+        self.assertIn(b"replacement serial_number already exists.", duplicate_serial.data)
+
+        failed = self.conn.execute(
+            "SELECT location_type, home_slot_id FROM assets WHERE asset_tag = 'FAIL-500';",
+        ).fetchone()
+        self.assertEqual(failed["location_type"], "STORAGE")
+        self.assertEqual(failed["home_slot_id"], 13)
+        replacement = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = 'NEW-500';").fetchone()
+        self.assertIsNone(replacement)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements atomic asset replacement (swap) workflow. Retires a failed asset (from STORAGE or IN_CUSTODY) and creates/assigns a replacement into the same slot within a single transaction. Slot remains the anchor; asset identity changes.

## Related Issue
Closes #82 

## Changes
- Added admin-only `/admin/assets/replace` (GET/POST)
- Deterministic target slot resolution:
  - occupancy first
  - fallback to home_slot_id
  - hard-stop if none
- Enforced slot integrity (target must be empty or occupied-by-failed-asset only)
- Atomic transaction:
  - Retire failed asset (DISPOSED, clear holder, remove occupancy, clear home_slot_id)
  - Create replacement asset (STORAGE + metadata)
  - Assign replacement to target slot (slot_occupancy + home_slot_id)
- Wrote required events:
  - ASSET_RETIRED / ASSET_RETIRED_IN_FIELD
  - ASSET_CREATED
  - SLOT_ASSIGN
- Added tests covering:
  - Swap from STORAGE
  - Swap from IN_CUSTODY
  - Missing target slot
  - Slot conflict
  - Duplicate replacement identifiers
  - Atomic rollback on failure

## Verification
- [x] Swap from STORAGE validated (manual + tests)
- [x] Swap from IN_CUSTODY validated (manual + tests)
- [x] Missing-slot assets hard-stop with operator guidance
- [x] Slot conflicts enforced
- [x] Atomic behavior confirmed (no partial updates)
- [x] All tests passing (24/24)
- [x] Docker-compatible

## Notes
Replacement summary event deferred. Admin authentication gate tracked separately.