### PR TITLE
Issue 11-1: Add read-only dashboard command view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ ENV/
 # IDE/editor settings
 .vscode/
 .idea/
+.local/
 
 # Local database & JSON configs
 inventory.db

--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import sqlite3
+
+
+def get_custody_days_threshold(raw_value: object, default: int = 30) -> int:
+    if raw_value is None:
+        return default
+
+    try:
+        threshold = int(str(raw_value).strip())
+    except (TypeError, ValueError):
+        return default
+
+    return max(0, threshold)
+
+
+def _parse_utc_timestamp(value: object) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _inventory_summary(conn: sqlite3.Connection) -> dict:
+    row = conn.execute(
+        """
+        SELECT
+            COUNT(*) AS total_assets,
+            SUM(CASE WHEN COALESCE(a.location_type, '') <> 'DISPOSED' THEN 1 ELSE 0 END) AS active_assets,
+            SUM(CASE WHEN a.location_type = 'DISPOSED' THEN 1 ELSE 0 END) AS disposed_assets,
+            SUM(CASE WHEN a.location_type = 'STORAGE' THEN 1 ELSE 0 END) AS in_storage_assets,
+            SUM(CASE WHEN a.location_type = 'IN_CUSTODY' THEN 1 ELSE 0 END) AS in_custody_assets,
+            SUM(
+                CASE
+                    WHEN a.location_type = 'STORAGE'
+                     AND (
+                        a.home_slot_id IS NULL
+                        OR NOT EXISTS (
+                            SELECT 1
+                            FROM slot_occupancy so
+                            WHERE so.asset_id = a.id
+                        )
+                     )
+                    THEN 1 ELSE 0
+                END
+            ) AS unslotted_assets
+        FROM assets a;
+        """
+    ).fetchone()
+
+    return {
+        "total_assets": int(row["total_assets"] or 0),
+        "active_assets": int(row["active_assets"] or 0),
+        "disposed_assets": int(row["disposed_assets"] or 0),
+        "in_storage_assets": int(row["in_storage_assets"] or 0),
+        "in_custody_assets": int(row["in_custody_assets"] or 0),
+        "unslotted_assets": int(row["unslotted_assets"] or 0),
+    }
+
+
+def _slot_summary(conn: sqlite3.Connection) -> dict:
+    total_row = conn.execute("SELECT COUNT(*) AS total_slots FROM slots;").fetchone()
+    occupied_row = conn.execute(
+        """
+        SELECT COUNT(DISTINCT slot_id) AS occupied_slots
+        FROM slot_occupancy;
+        """
+    ).fetchone()
+
+    total_slots = int(total_row["total_slots"] or 0)
+    occupied_slots = int(occupied_row["occupied_slots"] or 0)
+    empty_slots = max(0, total_slots - occupied_slots)
+    utilization_percent = int((occupied_slots * 100.0 / total_slots) + 0.5) if total_slots > 0 else 0
+
+    return {
+        "total_slots": total_slots,
+        "occupied_slots": occupied_slots,
+        "empty_slots": empty_slots,
+        "utilization_percent": utilization_percent,
+    }
+
+
+def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            a.current_holder_id AS holder_id,
+            COALESCE(NULLIF(TRIM(h.name), ''), 'ID ' || a.current_holder_id) AS holder_name,
+            COUNT(*) AS asset_count
+        FROM assets a
+        LEFT JOIN holders h
+          ON h.id = a.current_holder_id
+        WHERE a.location_type = 'IN_CUSTODY'
+          AND a.current_holder_id IS NOT NULL
+        GROUP BY a.current_holder_id, COALESCE(NULLIF(TRIM(h.name), ''), 'ID ' || a.current_holder_id)
+        ORDER BY asset_count DESC, holder_name ASC, a.current_holder_id ASC
+        LIMIT ?;
+        """,
+        (limit,),
+    ).fetchall()
+
+    return [
+        {
+            "holder_id": int(row["holder_id"]),
+            "holder_name": str(row["holder_name"]),
+            "asset_count": int(row["asset_count"] or 0),
+        }
+        for row in rows
+    ]
+
+
+def _custody_summary(conn: sqlite3.Connection) -> dict:
+    unique_holders_row = conn.execute(
+        """
+        SELECT COUNT(DISTINCT current_holder_id) AS unique_holders
+        FROM assets
+        WHERE location_type = 'IN_CUSTODY'
+          AND current_holder_id IS NOT NULL;
+        """
+    ).fetchone()
+
+    top_holders = _top_custody_holders(conn, limit=1)
+    top_holder = top_holders[0] if top_holders else None
+
+    return {
+        "unique_holders": int(unique_holders_row["unique_holders"] or 0),
+        "top_holder": top_holder,
+    }
+
+
+def _unslotted_assets(conn: sqlite3.Connection, limit: int | None = None) -> list[str]:
+    sql = """
+        SELECT a.asset_tag
+        FROM assets a
+        WHERE a.location_type = 'STORAGE'
+          AND (
+            a.home_slot_id IS NULL
+            OR NOT EXISTS (
+                SELECT 1
+                FROM slot_occupancy so
+                WHERE so.asset_id = a.id
+            )
+          )
+        ORDER BY a.asset_tag ASC, a.id ASC
+    """
+    params: tuple[object, ...] = ()
+    if limit is not None:
+        sql += " LIMIT ?"
+        params = (limit,)
+    sql += ";"
+
+    rows = conn.execute(sql, params).fetchall()
+    return [str(row["asset_tag"]) for row in rows]
+
+
+def _slot_conflict_count(conn: sqlite3.Connection) -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS conflict_slot_count
+        FROM (
+            SELECT so.slot_id
+            FROM slot_occupancy so
+            GROUP BY so.slot_id
+            HAVING COUNT(*) > 1
+        ) conflicts;
+        """
+    ).fetchone()
+    return int(row["conflict_slot_count"] or 0)
+
+
+def _slot_conflicts_preview(conn: sqlite3.Connection, limit: int) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            c.slot_id,
+            s.case_name,
+            s.slot_position
+        FROM (
+            SELECT so.slot_id
+            FROM slot_occupancy so
+            GROUP BY so.slot_id
+            HAVING COUNT(*) > 1
+        ) c
+        LEFT JOIN slots s ON s.id = c.slot_id
+        ORDER BY COALESCE(s.case_name, '') ASC, s.slot_position ASC, c.slot_id ASC
+        LIMIT ?;
+        """,
+        (limit,),
+    ).fetchall()
+
+    return [
+        {
+            "slot_id": int(row["slot_id"]),
+            "case_name": str(row["case_name"] or ""),
+            "slot_position": row["slot_position"],
+        }
+        for row in rows
+    ]
+
+
+def _in_custody_days_out(conn: sqlite3.Connection, *, now_utc: datetime) -> list[dict]:
+    asset_rows = conn.execute(
+        """
+        SELECT id, asset_tag
+        FROM assets
+        WHERE location_type = 'IN_CUSTODY'
+        ORDER BY asset_tag ASC, id ASC;
+        """
+    ).fetchall()
+    if not asset_rows:
+        return []
+
+    asset_tags = [str(row["asset_tag"]) for row in asset_rows]
+    placeholders = ", ".join("?" for _ in asset_tags)
+    event_rows = conn.execute(
+        f"""
+        SELECT asset_tag, event_date, id
+        FROM asset_events
+        WHERE event_type = 'STOCK_OUT'
+          AND asset_tag IN ({placeholders})
+        ORDER BY asset_tag ASC, id ASC;
+        """,
+        tuple(asset_tags),
+    ).fetchall()
+
+    latest_stock_out_by_tag: dict[str, datetime] = {}
+    for row in event_rows:
+        asset_tag = str(row["asset_tag"] or "")
+        parsed = _parse_utc_timestamp(row["event_date"])
+        if parsed is None:
+            continue
+        previous = latest_stock_out_by_tag.get(asset_tag)
+        if previous is None or parsed > previous:
+            latest_stock_out_by_tag[asset_tag] = parsed
+
+    rows_with_days: list[dict] = []
+    for row in asset_rows:
+        asset_tag = str(row["asset_tag"] or "")
+        stock_out_ts = latest_stock_out_by_tag.get(asset_tag)
+        if stock_out_ts is None:
+            continue
+
+        days_out = int((now_utc - stock_out_ts).total_seconds() // 86400)
+        rows_with_days.append(
+            {
+                "asset_tag": asset_tag,
+                "days_out": max(0, days_out),
+            }
+        )
+
+    rows_with_days.sort(key=lambda item: (-item["days_out"], item["asset_tag"]))
+    return rows_with_days
+
+
+def _exceptions_summary(
+    *,
+    unslotted_assets: list[str],
+    slot_conflict_count: int,
+    in_custody_days_out: list[dict],
+    custody_days_threshold: int,
+) -> dict:
+    in_custody_over_threshold = sum(1 for row in in_custody_days_out if row["days_out"] > custody_days_threshold)
+    return {
+        "unslotted_assets": len(unslotted_assets),
+        "slot_conflicts": slot_conflict_count,
+        "in_custody_over_threshold": in_custody_over_threshold,
+    }
+
+
+def _case_utilization_preview(conn: sqlite3.Connection, limit: int) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            s.case_name,
+            COUNT(*) AS total_slots,
+            COUNT(DISTINCT so.slot_id) AS occupied_slots
+        FROM slots s
+        LEFT JOIN slot_occupancy so
+          ON so.slot_id = s.id
+        GROUP BY s.case_name
+        ORDER BY occupied_slots DESC, s.case_name ASC
+        LIMIT ?;
+        """,
+        (limit,),
+    ).fetchall()
+
+    results: list[dict] = []
+    for row in rows:
+        total_slots = int(row["total_slots"] or 0)
+        occupied_slots = int(row["occupied_slots"] or 0)
+        utilization_percent = int((occupied_slots * 100.0 / total_slots) + 0.5) if total_slots > 0 else 0
+        results.append(
+            {
+                "case_name": str(row["case_name"] or ""),
+                "total_slots": total_slots,
+                "occupied_slots": occupied_slots,
+                "utilization_percent": utilization_percent,
+            }
+        )
+    return results
+
+
+def build_dashboard_data(
+    conn: sqlite3.Connection,
+    *,
+    custody_days_threshold: int,
+    now_utc: datetime | None = None,
+) -> dict:
+    current_utc = (now_utc or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    inventory_summary = _inventory_summary(conn)
+    slot_summary = _slot_summary(conn)
+    custody_summary = _custody_summary(conn)
+
+    unslotted_assets = _unslotted_assets(conn)
+    in_custody_days_out = _in_custody_days_out(conn, now_utc=current_utc)
+    slot_conflict_count = _slot_conflict_count(conn)
+
+    exceptions_summary = _exceptions_summary(
+        unslotted_assets=unslotted_assets,
+        slot_conflict_count=slot_conflict_count,
+        in_custody_days_out=in_custody_days_out,
+        custody_days_threshold=custody_days_threshold,
+    )
+
+    return {
+        "summary": {
+            "inventory": inventory_summary,
+            "slots": slot_summary,
+            "custody": custody_summary,
+            "exceptions": exceptions_summary,
+        },
+        "snapshots": {
+            "top_custody_holders": _top_custody_holders(conn, limit=5),
+            "case_utilization": _case_utilization_preview(conn, limit=5),
+            "exceptions": {
+                "unslotted_assets": _unslotted_assets(conn, limit=10),
+                "in_custody_over_threshold": [
+                    row for row in in_custody_days_out if row["days_out"] > custody_days_threshold
+                ][:10],
+                "slot_conflicts": _slot_conflicts_preview(conn, limit=10),
+            },
+        },
+    }

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from flask import Flask, flash, redirect, render_template, request, session, url_for
 
 from assettrack.assets import get_asset_table_columns
+from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import get_connection
 from assettrack.ingest.validator import validate_rows
 from assettrack.ingest.committer import BatchCommitError, commit_batch
@@ -1574,6 +1575,29 @@ def intake():
         timeout_seconds=timeout_seconds,
         last_seen_age_seconds=last_seen_age_seconds,
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+    )
+
+
+@app.get("/dashboard")
+def dashboard():
+    threshold_days = get_custody_days_threshold(
+        os.getenv("ASSETTRACK_CUSTODY_DAYS_THRESHOLD"),
+        default=30,
+    )
+
+    conn = get_connection()
+    try:
+        dashboard_data = build_dashboard_data(
+            conn,
+            custody_days_threshold=threshold_days,
+        )
+    finally:
+        conn.close()
+
+    return render_template(
+        "dashboard.html",
+        dashboard=dashboard_data,
+        custody_days_threshold=threshold_days,
     )
 
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -1,0 +1,323 @@
+<!-- file: assettrack/intake/templates/dashboard.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AssetTrack Dashboard</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 0; color: #12202f; background: #f7f9fc; }
+      h1, h2, h3 { margin: 0 0 0.5rem 0; }
+      a { color: #134e8a; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+
+      .page { max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
+      .muted { color: #5b6878; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+      .topbar { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 0.75rem; }
+      .subtitle { margin: 0; }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin: 0.75rem 0 1rem 0;
+      }
+      .chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.4rem 0.6rem;
+        border-radius: 999px;
+        background: #eef3fb;
+        border: 1px solid #d7deea;
+        font-weight: 600;
+        font-size: 0.95rem;
+        white-space: nowrap;
+      }
+      .chip.secondary { background: #fff; }
+
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: 1rem; }
+      .card { background: #fff; border: 1px solid #d7deea; border-radius: 10px; padding: 1rem; }
+      .metric { margin: 0.35rem 0; }
+      .section { margin-top: 1rem; }
+
+      .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 0.55rem 0.6rem; border-bottom: 1px solid #e8edf6; }
+      th { background: #eef3fb; }
+      tr:last-child td { border-bottom: 0; }
+
+      /* Collapsible sections (no JS) */
+      details.collapsible {
+        background: #fff;
+        border: 1px solid #d7deea;
+        border-radius: 10px;
+        overflow: hidden;
+        margin-top: 0.75rem;
+      }
+      details.collapsible summary {
+        cursor: pointer;
+        list-style: none;
+        padding: 0.8rem 1rem;
+        background: #f3f7ff;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        font-weight: 700;
+      }
+      details.collapsible summary::-webkit-details-marker { display: none; }
+      .summary-hint { font-weight: 500; font-size: 0.9rem; color: #5b6878; }
+      .collapsible-body { padding: 0.75rem 1rem 1rem 1rem; }
+      .collapsible-body .table-wrap { margin-top: 0.25rem; }
+
+      /* Visual hierarchy helpers */
+      .section-title { margin-top: 1.25rem; }
+      .accent {
+        height: 3px;
+        width: 64px;
+        background: #134e8a;
+        border-radius: 999px;
+        margin: 0.35rem 0 0.75rem 0;
+      }
+
+      @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="topbar">
+        <h1>Dashboard Summary Metrics</h1>
+        <p class="muted subtitle">Operational + Accountability Command View</p>
+      </div>
+
+      <!-- Quick actions: safe navigation (wiring/redirect happens with auth in Issue 11-3) -->
+      <nav class="actions" aria-label="Quick actions">
+        <a class="chip" href="/issue/preview">Issue (Checkout)</a>
+        <a class="chip" href="/return">Return (Check-in)</a>
+        <a class="chip secondary" href="/">Intake</a>
+        <a class="chip secondary" href="/dashboard">Dashboard</a>
+      </nav>
+
+      <div class="grid">
+        <section class="card">
+          <h2>Inventory Summary</h2>
+          <div class="accent"></div>
+          <p class="metric">Total Assets: <strong>{{ dashboard.summary.inventory.total_assets }}</strong></p>
+          <p class="metric">Active Assets: <strong>{{ dashboard.summary.inventory.active_assets }}</strong></p>
+          <p class="metric">Disposed Assets: <strong>{{ dashboard.summary.inventory.disposed_assets }}</strong></p>
+          <p class="metric">In Storage: <strong>{{ dashboard.summary.inventory.in_storage_assets }}</strong></p>
+          <p class="metric">In Custody: <strong>{{ dashboard.summary.inventory.in_custody_assets }}</strong></p>
+          <p class="metric">Unslotted (Storage): <strong>{{ dashboard.summary.inventory.unslotted_assets }}</strong></p>
+        </section>
+
+        <section class="card">
+          <h2>Slot Summary</h2>
+          <div class="accent"></div>
+          <p class="metric">Total Slots: <strong>{{ dashboard.summary.slots.total_slots }}</strong></p>
+          <p class="metric">Occupied Slots: <strong>{{ dashboard.summary.slots.occupied_slots }}</strong></p>
+          <p class="metric">Empty Slots: <strong>{{ dashboard.summary.slots.empty_slots }}</strong></p>
+          <p class="metric">Utilization %: <strong>{{ dashboard.summary.slots.utilization_percent }}%</strong></p>
+        </section>
+
+        <section class="card">
+          <h2>Custody Summary</h2>
+          <div class="accent"></div>
+          <p class="metric">Unique Holders: <strong>{{ dashboard.summary.custody.unique_holders }}</strong></p>
+          <p class="metric">
+            Top Holder:
+            {% if dashboard.summary.custody.top_holder %}
+              <strong>{{ dashboard.summary.custody.top_holder.holder_name }} ({{ dashboard.summary.custody.top_holder.asset_count }})</strong>
+            {% else %}
+              <strong>None</strong>
+            {% endif %}
+          </p>
+        </section>
+
+        <section class="card">
+          <h2>Exceptions Summary</h2>
+          <div class="accent"></div>
+          <p class="metric">Unslotted Assets: <strong>{{ dashboard.summary.exceptions.unslotted_assets }}</strong></p>
+          <p class="metric">Slot Conflicts: <strong>{{ dashboard.summary.exceptions.slot_conflicts }}</strong></p>
+          <p class="metric">In Custody &gt; {{ custody_days_threshold }} Days: <strong>{{ dashboard.summary.exceptions.in_custody_over_threshold }}</strong></p>
+        </section>
+      </div>
+
+      <h2 class="section-title">Snapshots</h2>
+      <p class="muted">Collapsed by default to keep the command view clean. Expand only when needed.</p>
+
+      <!-- Top Custody Holders -->
+      <details class="collapsible">
+        <summary>
+          <span>Top Custody Holders (Top 5)</span>
+          <span class="summary-hint">click to expand</span>
+        </summary>
+        <div class="collapsible-body">
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Holder Name</th>
+                  <th>Count In Custody</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in dashboard.snapshots.top_custody_holders %}
+                  <tr>
+                    <td>{{ row.holder_name }}</td>
+                    <td>{{ row.asset_count }}</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td colspan="2">None</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </details>
+
+      <!-- Case Utilization -->
+      <details class="collapsible">
+        <summary>
+          <span>Case Utilization (Top 5 by Occupied Slots)</span>
+          <span class="summary-hint">click to expand</span>
+        </summary>
+        <div class="collapsible-body">
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Case Name</th>
+                  <th>Occupied / Total</th>
+                  <th>Utilization %</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in dashboard.snapshots.case_utilization %}
+                  <tr>
+                    <td>{{ row.case_name }}</td>
+                    <td>{{ row.occupied_slots }} / {{ row.total_slots }}</td>
+                    <td>{{ row.utilization_percent }}%</td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td colspan="3">None</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </details>
+
+      <!-- Exceptions Preview -->
+      <details class="collapsible">
+        <summary>
+          <span>Exceptions Preview</span>
+          <span class="summary-hint">click to expand</span>
+        </summary>
+        <div class="collapsible-body">
+
+          <details class="collapsible">
+            <summary>
+              <span>Unslotted Assets (Top 10)</span>
+              <span class="summary-hint">click to expand</span>
+            </summary>
+            <div class="collapsible-body">
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Asset Tag</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for asset_tag in dashboard.snapshots.exceptions.unslotted_assets %}
+                      <tr>
+                        <td class="mono">{{ asset_tag }}</td>
+                      </tr>
+                    {% else %}
+                      <tr>
+                        <td>None</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </details>
+
+          <details class="collapsible">
+            <summary>
+              <span>In Custody &gt; {{ custody_days_threshold }} Days (Top 10)</span>
+              <span class="summary-hint">click to expand</span>
+            </summary>
+            <div class="collapsible-body">
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Asset Tag</th>
+                      <th>Days Out</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in dashboard.snapshots.exceptions.in_custody_over_threshold %}
+                      <tr>
+                        <td class="mono">{{ row.asset_tag }}</td>
+                        <td>{{ row.days_out }}</td>
+                      </tr>
+                    {% else %}
+                      <tr>
+                        <td colspan="2">None</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </details>
+
+          <details class="collapsible">
+            <summary>
+              <span>Slot Conflicts (Top 10)</span>
+              <span class="summary-hint">click to expand</span>
+            </summary>
+            <div class="collapsible-body">
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Slot ID</th>
+                      <th>Case Name</th>
+                      <th>Slot Position</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in dashboard.snapshots.exceptions.slot_conflicts %}
+                      <tr>
+                        <td>{{ row.slot_id }}</td>
+                        <td>{{ row.case_name or "None" }}</td>
+                        <td>{{ row.slot_position if row.slot_position is not none else "None" }}</td>
+                      </tr>
+                    {% else %}
+                      <tr>
+                        <td colspan="3">None</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </details>
+
+        </div>
+      </details>
+
+    </div>
+  </body>
+</html>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.dashboard import build_dashboard_data
+from assettrack.intake import app as intake_app
+
+
+class DashboardTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        self.conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE,
+                serial_number TEXT NULL,
+                manufacturer TEXT NULL,
+                equipment_type TEXT NOT NULL,
+                building TEXT NULL,
+                room TEXT NULL,
+                model TEXT NULL,
+                model_code TEXT NULL,
+                notes TEXT NULL,
+                building_room TEXT NULL,
+                custody_state TEXT NOT NULL,
+                accountability_status TEXT NOT NULL,
+                condition TEXT NOT NULL,
+                created_date TEXT NOT NULL,
+                updated_date TEXT NULL,
+                location_type TEXT NULL,
+                current_holder_id INTEGER NULL,
+                home_slot_id INTEGER NULL
+            );
+            """
+        )
+        self.conn.commit()
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_holder(self, holder_id: int, name: str) -> None:
+        now = "2026-01-01T00:00:00Z"
+        self.conn.execute(
+            """
+            INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+            VALUES (?, 'PERSON', ?, NULL, NULL, ?, ?);
+            """,
+            (holder_id, name, now, now),
+        )
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        location_type: str,
+        home_slot_id: int | None = None,
+        current_holder_id: int | None = None,
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                manufacturer,
+                equipment_type,
+                building,
+                room,
+                building_room,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                updated_date,
+                location_type,
+                current_holder_id,
+                home_slot_id
+            )
+            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '100', 'HQ/100', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?);
+            """,
+            (asset_tag, f"SN-{asset_tag}", location_type, current_holder_id, home_slot_id),
+        )
+        return int(cursor.lastrowid)
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, NULL);
+            """,
+            (slot_id, case_name, slot_position),
+        )
+
+    def _insert_stock_out(self, asset_tag: str, event_date: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES (?, 'STOCK_OUT', ?, 'tester', NULL, NULL, NULL);
+            """,
+            (asset_tag, event_date),
+        )
+
+    def _replace_slot_occupancy_without_unique_constraints(self) -> None:
+        self.conn.execute("DROP TABLE slot_occupancy;")
+        self.conn.execute(
+            """
+            CREATE TABLE slot_occupancy (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                slot_id INTEGER NOT NULL,
+                asset_id INTEGER NOT NULL,
+                assigned_at TEXT NOT NULL
+            );
+            """
+        )
+        self.conn.commit()
+
+    def test_dashboard_route_smoke_renders_summary_sections(self) -> None:
+        self._insert_holder(1, "Alex Holder")
+        self._insert_slot(10, "CASE-A", 1)
+        storage_asset_id = self._insert_asset("AT-STORED", location_type="STORAGE", home_slot_id=10)
+        self._insert_asset("AT-UNSLOT", location_type="STORAGE", home_slot_id=None)
+        self._insert_asset("AT-CUST", location_type="IN_CUSTODY", current_holder_id=1)
+        self._insert_asset("AT-DISP", location_type="DISPOSED")
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (10, ?, '2026-01-01T00:00:00Z');
+            """,
+            (storage_asset_id,),
+        )
+        self._insert_stock_out("AT-CUST", "2025-12-01T00:00:00Z")
+        self.conn.commit()
+
+        response = self.client.get("/dashboard")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Dashboard Summary Metrics", response.data)
+        self.assertIn(b"Inventory Summary", response.data)
+        self.assertIn(b"Slot Summary", response.data)
+        self.assertIn(b"Custody Summary", response.data)
+        self.assertIn(b"Exceptions Summary", response.data)
+        self.assertIn(b"Top Custody Holders", response.data)
+        self.assertIn(b"Case Utilization", response.data)
+        self.assertIn(b"Exceptions Preview", response.data)
+
+    def test_dashboard_metrics_use_distinct_and_most_recent_stock_out(self) -> None:
+        self._replace_slot_occupancy_without_unique_constraints()
+        self._insert_holder(1, "Alpha")
+        self._insert_holder(2, "Bravo")
+
+        self._insert_slot(1, "CASE-X", 1)
+        self._insert_slot(2, "CASE-X", 2)
+
+        asset_old = self._insert_asset("AT-OLD", location_type="IN_CUSTODY", current_holder_id=1)
+        asset_recent = self._insert_asset("AT-RECENT", location_type="IN_CUSTODY", current_holder_id=1)
+        asset_noevent = self._insert_asset("AT-NOEVENT", location_type="IN_CUSTODY", current_holder_id=2)
+        asset_storage = self._insert_asset("AT-STORAGE", location_type="STORAGE", home_slot_id=2)
+
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES
+                (1, ?, '2026-01-01T00:00:00Z'),
+                (1, ?, '2026-01-02T00:00:00Z'),
+                (2, ?, '2026-01-03T00:00:00Z');
+            """,
+            (asset_old, asset_recent, asset_storage),
+        )
+
+        self._insert_stock_out("AT-OLD", "2026-01-01T00:00:00Z")
+        self._insert_stock_out("AT-RECENT", "2026-01-01T00:00:00Z")
+        self._insert_stock_out("AT-RECENT", "2026-02-10T00:00:00Z")
+        self.conn.commit()
+
+        data = build_dashboard_data(
+            self.conn,
+            custody_days_threshold=30,
+            now_utc=datetime(2026, 2, 20, 0, 0, 0, tzinfo=timezone.utc),
+        )
+
+        self.assertEqual(data["summary"]["slots"]["occupied_slots"], 2)
+        self.assertEqual(data["summary"]["exceptions"]["slot_conflicts"], 1)
+        self.assertEqual(data["summary"]["exceptions"]["in_custody_over_threshold"], 1)
+
+        overdue_rows = data["snapshots"]["exceptions"]["in_custody_over_threshold"]
+        self.assertEqual(len(overdue_rows), 1)
+        self.assertEqual(overdue_rows[0]["asset_tag"], "AT-OLD")
+        self.assertEqual(overdue_rows[0]["days_out"], 50)
+


### PR DESCRIPTION
## Summary

Adds a read-only operational dashboard at `GET /dashboard` providing deterministic summary metrics and snapshot views.

The dashboard serves as the system command view and does not mutate state.

---

## Related Issue

Closes #83 

---

## Changes

### Backend
- Added `assettrack/dashboard.py` query layer
- Added public `GET /dashboard` route
- Implemented:
  - Inventory summary metrics
  - Slot summary metrics (DISTINCT slot occupancy)
  - Custody summary (unique holders + deterministic top holder)
  - Exceptions summary (unslotted, slot conflicts, custody > threshold days)
- Implemented snapshot views (Top 5 / Top 10)
- Deterministic ordering with explicit tie-breakers
- Custody age derived from most recent `STOCK_OUT`
- Assets missing `STOCK_OUT` excluded from age metric
- Fail-closed behavior on DB errors

### UI
- Card-based layout with command-first design
- Collapsible snapshot sections (no JS)
- Quick action navigation (Issue / Return / Intake / Dashboard)
- Reduced visual noise below the fold

### Tests
- Route smoke test for `/dashboard`
- Focused metric logic tests:
  - DISTINCT slot occupancy
  - Slot conflict detection
  - Most recent STOCK_OUT selection
  - Missing STOCK_OUT exclusion
- All tests passing (CI green)

---

## Verification Checklist

- [x] `/dashboard` renders successfully
- [x] Summary counters reflect SQLite data
- [x] Snapshot tables respect top-N limits
- [x] Deterministic ordering enforced
- [x] No state mutations introduced
- [x] Tests added and passing
- [x] CI green

---

## Notes

Dashboard is public in this issue.  
Mutation endpoints will be gated in Issue 11-3.