### PR TITLE
Issue 11-3: Add Basic Auth guard for mutation routes (fail-closed)

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -11,6 +11,10 @@ Feynman-brief:
 
 from __future__ import annotations
 
+import base64
+import binascii
+from functools import wraps
+import hmac
 import json
 import os
 import sqlite3
@@ -42,6 +46,7 @@ INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", "300
 TERMINAL_LOCATION_TYPE = "DISPOSED"
 TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
+ADMIN_AUTH_REALM = "AssetTrack Admin"
 
 
 # Helpers
@@ -575,6 +580,86 @@ def _build_admin_force_vacate_view(conn, slot_id: int) -> Optional[dict]:
 
 def _is_truthy(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_admin_users(raw_value: str | None) -> list[tuple[str, str]]:
+    if raw_value is None:
+        raise ValueError("ASSETTRACK_ADMIN_USERS is not configured")
+
+    raw = raw_value.strip()
+    if not raw:
+        raise ValueError("ASSETTRACK_ADMIN_USERS is empty")
+
+    if any(ch.isspace() for ch in raw):
+        raise ValueError("ASSETTRACK_ADMIN_USERS must not contain whitespace")
+
+    users: list[tuple[str, str]] = []
+    seen_usernames: set[str] = set()
+    for entry in raw.split(","):
+        if not entry:
+            raise ValueError("ASSETTRACK_ADMIN_USERS has empty entry")
+        if entry.count(":") != 1:
+            raise ValueError("ASSETTRACK_ADMIN_USERS entry must be username:password")
+
+        username, password = entry.split(":", 1)
+        if not username or not password:
+            raise ValueError("ASSETTRACK_ADMIN_USERS entry must include username and password")
+        if username in seen_usernames:
+            raise ValueError("ASSETTRACK_ADMIN_USERS has duplicate usernames")
+
+        seen_usernames.add(username)
+        users.append((username, password))
+
+    if not users:
+        raise ValueError("ASSETTRACK_ADMIN_USERS must include at least one user")
+    return users
+
+
+def _unauthorized_response():
+    response = {"ok": False, "error": "Unauthorized"}
+    headers = {"WWW-Authenticate": f'Basic realm="{ADMIN_AUTH_REALM}"'}
+    return response, 401, headers
+
+
+def require_admin(view_func):
+    @wraps(view_func)
+    def wrapped(*args, **kwargs):
+        raw_admin_users = os.getenv("ASSETTRACK_ADMIN_USERS")
+        try:
+            configured_users = _parse_admin_users(raw_admin_users)
+        except ValueError:
+            return {"ok": False, "error": "Admin authentication is not configured"}, 503
+
+        auth_header = request.headers.get("Authorization")
+        if not auth_header:
+            return _unauthorized_response()
+
+        scheme, _, encoded_credentials = auth_header.partition(" ")
+        if scheme.lower() != "basic" or not encoded_credentials:
+            return _unauthorized_response()
+
+        try:
+            decoded = base64.b64decode(encoded_credentials, validate=True).decode("utf-8")
+        except (ValueError, binascii.Error, UnicodeDecodeError):
+            return _unauthorized_response()
+
+        if ":" not in decoded:
+            return _unauthorized_response()
+
+        provided_username, provided_password = decoded.split(":", 1)
+
+        is_authorized = False
+        for configured_username, configured_password in configured_users:
+            username_match = hmac.compare_digest(provided_username, configured_username)
+            password_match = hmac.compare_digest(provided_password, configured_password)
+            is_authorized = is_authorized or (username_match and password_match)
+
+        if not is_authorized:
+            return _unauthorized_response()
+
+        return view_func(*args, **kwargs)
+
+    return wrapped
 
 
 def _create_admin_asset_in_tx(
@@ -1635,6 +1720,7 @@ def preview_validate():
     }
 
 @app.post("/preview/mode")
+@require_admin
 def preview_mode():
     authed = enforce_inactivity_timeout()
     if auth_enabled() and not authed:
@@ -1652,6 +1738,7 @@ def preview_mode():
     return redirect(url_for("preview"))
 
 @app.post("/preview/discard")
+@require_admin
 def preview_discard():
     # Enforce auth and inactivity timeout for discard requests.
     authed = enforce_inactivity_timeout()
@@ -1676,6 +1763,7 @@ def preview_discard():
     return redirect(url_for("intake"))
 
 @app.post("/preview/commit")
+@require_admin
 def preview_commit():
     # Enforce auth and inactivity timeout for commit requests.
     authed = enforce_inactivity_timeout()
@@ -1781,6 +1869,7 @@ def preview_commit():
 
 
 @app.get("/issue/preview")
+@require_admin
 def issue_preview():
     stock_out_mode = bool(session.get("stock_out_mode"))
     if not stock_out_mode:
@@ -1803,6 +1892,7 @@ def issue_preview():
 
 
 @app.post("/issue/commit")
+@require_admin
 def issue_commit():
     authed = enforce_inactivity_timeout()
     if auth_enabled() and not authed:
@@ -1914,6 +2004,7 @@ def return_preview():
 
 
 @app.post("/return/commit")
+@require_admin
 def return_commit():
     authed = enforce_inactivity_timeout()
     if auth_enabled() and not authed:
@@ -1960,6 +2051,7 @@ def return_commit():
     return redirect(url_for("return_queue"))
 
 @app.get("/lock")
+@require_admin
 def lock():
     set_authed(False)
     return redirect("/")
@@ -2018,6 +2110,7 @@ def holders_clear():
 
 
 @app.route("/admin/assets/new", methods=["GET", "POST"])
+@require_admin
 def admin_new_asset():
     guard_result = _require_admin_for_route()
     if guard_result:
@@ -2128,6 +2221,7 @@ def admin_new_asset():
 
 
 @app.route("/admin/assets/retire", methods=["GET", "POST"])
+@require_admin
 def admin_retire_asset():
     guard_result = _require_admin_for_route()
     if guard_result:
@@ -2244,6 +2338,7 @@ def admin_retire_asset():
 
 
 @app.route("/admin/assets/replace", methods=["GET", "POST"])
+@require_admin
 def admin_replace_asset():
     guard_result = _require_admin_for_route()
     if guard_result:
@@ -2459,6 +2554,7 @@ def admin_replace_asset():
 
 
 @app.post("/admin/assets/create")
+@require_admin
 def admin_create_asset():
     guard_result = _require_admin_for_api()
     if guard_result:
@@ -2560,6 +2656,7 @@ def admin_create_asset():
 
 
 @app.route("/admin/assign-slot", methods=["GET", "POST"])
+@require_admin
 def admin_assign_slot():
     guard_result = _require_admin_for_route()
     if guard_result:
@@ -2819,6 +2916,7 @@ def admin_assign_slot():
 
 
 @app.route("/admin/slot-move", methods=["GET", "POST"])
+@require_admin
 def admin_slot_move():
     guard_result = _require_admin_for_route()
     if guard_result:
@@ -3113,6 +3211,7 @@ def admin_slot_move():
 
 
 @app.route("/admin/force-vacate", methods=["GET", "POST"])
+@require_admin
 def admin_force_vacate():
     guard_result = _require_admin_for_route()
     if guard_result:

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -41,11 +43,17 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.conn.commit()
 
         self.orig_passcode = intake_app.INTAKE_PASSCODE
+        self.orig_admin_users = os.environ.get("ASSETTRACK_ADMIN_USERS")
+        os.environ["ASSETTRACK_ADMIN_USERS"] = "admin:test-pass"
         intake_app.INTAKE_PASSCODE = "test-admin-code"
         intake_app.app.testing = True
         self.client = intake_app.app.test_client()
 
     def tearDown(self) -> None:
+        if self.orig_admin_users is None:
+            os.environ.pop("ASSETTRACK_ADMIN_USERS", None)
+        else:
+            os.environ["ASSETTRACK_ADMIN_USERS"] = self.orig_admin_users
         intake_app.INTAKE_PASSCODE = self.orig_passcode
         self.conn.close()
         self.temp_dir.cleanup()
@@ -92,13 +100,17 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.conn.commit()
         return int(cursor.lastrowid)
 
+    def _admin_headers(self) -> dict[str, str]:
+        token = base64.b64encode(b"admin:test-pass").decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
     def test_get_admin_new_asset_route_blocks_non_admin_and_allows_admin(self) -> None:
-        blocked = self.client.get("/admin/assets/new")
+        blocked = self.client.get("/admin/assets/new", headers=self._admin_headers())
         self.assertEqual(blocked.status_code, 302)
         self.assertTrue((blocked.headers.get("Location") or "").endswith("/"))
 
         self._set_admin_session()
-        allowed = self.client.get("/admin/assets/new")
+        allowed = self.client.get("/admin/assets/new", headers=self._admin_headers())
         self.assertEqual(allowed.status_code, 200)
         self.assertIn(b"Admin: Add Asset", allowed.data)
 
@@ -106,6 +118,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self._set_admin_session()
         response = self.client.post(
             "/admin/assets/new",
+            headers=self._admin_headers(),
             data={
                 "asset_tag": "AT-500",
                 "serial_number": "SER-500",
@@ -137,6 +150,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         duplicate = self.client.post(
             "/admin/assets/new",
+            headers=self._admin_headers(),
             data={
                 "asset_tag": "AT-501",
                 "serial_number": "SER-500",
@@ -157,6 +171,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/new",
+            headers=self._admin_headers(),
             data={
                 "asset_tag": "AT-600",
                 "serial_number": "SER-600",
@@ -206,6 +221,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/new",
+            headers=self._admin_headers(),
             data={
                 "asset_tag": "AT-701",
                 "serial_number": "SER-DUP",
@@ -241,6 +257,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/new",
+            headers=self._admin_headers(),
             data={
                 "asset_tag": "AT-801",
                 "serial_number": "SER-801",

--- a/tests/test_admin_create_asset.py
+++ b/tests/test_admin_create_asset.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -32,10 +34,16 @@ class AdminCreateAssetTests(unittest.TestCase):
             """
         )
         self.conn.commit()
+        self.orig_admin_users = os.environ.get("ASSETTRACK_ADMIN_USERS")
+        os.environ["ASSETTRACK_ADMIN_USERS"] = "admin:test-pass"
         intake_app.app.testing = True
         self.client = intake_app.app.test_client()
 
     def tearDown(self) -> None:
+        if self.orig_admin_users is None:
+            os.environ.pop("ASSETTRACK_ADMIN_USERS", None)
+        else:
+            os.environ["ASSETTRACK_ADMIN_USERS"] = self.orig_admin_users
         self.conn.close()
         self.temp_dir.cleanup()
 
@@ -69,9 +77,14 @@ class AdminCreateAssetTests(unittest.TestCase):
         )
         self.conn.commit()
 
+    def _admin_headers(self) -> dict[str, str]:
+        token = base64.b64encode(b"admin:test-pass").decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
     def test_create_asset_unslotted_success(self) -> None:
         response = self.client.post(
             "/admin/assets/create",
+            headers=self._admin_headers(),
             json={
                 "asset_tag": "AT-100",
                 "actor": "admin-user",
@@ -118,6 +131,7 @@ class AdminCreateAssetTests(unittest.TestCase):
     def test_create_asset_allows_missing_equipment_type(self) -> None:
         response = self.client.post(
             "/admin/assets/create",
+            headers=self._admin_headers(),
             json={
                 "asset_tag": "AT-101",
                 "actor": "admin-user",
@@ -151,6 +165,7 @@ class AdminCreateAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/create",
+            headers=self._admin_headers(),
             json={
                 "asset_tag": "AT-200",
                 "actor": "admin-user",
@@ -208,6 +223,7 @@ class AdminCreateAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/create",
+            headers=self._admin_headers(),
             json={
                 "asset_tag": "AT-DUP",
                 "actor": "admin-user",
@@ -225,6 +241,7 @@ class AdminCreateAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/create",
+            headers=self._admin_headers(),
             json={
                 "asset_tag": "AT-300",
                 "actor": "admin-user",

--- a/tests/test_admin_replace_asset.py
+++ b/tests/test_admin_replace_asset.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -39,11 +41,17 @@ class AdminReplaceAssetTests(unittest.TestCase):
         self.conn.commit()
 
         self.orig_passcode = intake_app.INTAKE_PASSCODE
+        self.orig_admin_users = os.environ.get("ASSETTRACK_ADMIN_USERS")
+        os.environ["ASSETTRACK_ADMIN_USERS"] = "admin:test-pass"
         intake_app.INTAKE_PASSCODE = "test-admin-code"
         intake_app.app.testing = True
         self.client = intake_app.app.test_client()
 
     def tearDown(self) -> None:
+        if self.orig_admin_users is None:
+            os.environ.pop("ASSETTRACK_ADMIN_USERS", None)
+        else:
+            os.environ["ASSETTRACK_ADMIN_USERS"] = self.orig_admin_users
         intake_app.INTAKE_PASSCODE = self.orig_passcode
         self.conn.close()
         self.temp_dir.cleanup()
@@ -115,13 +123,17 @@ class AdminReplaceAssetTests(unittest.TestCase):
         self.conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", (asset_tag, slot_id))
         self.conn.commit()
 
+    def _admin_headers(self) -> dict[str, str]:
+        token = base64.b64encode(b"admin:test-pass").decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
     def test_get_replace_route_admin_only(self) -> None:
-        blocked = self.client.get("/admin/assets/replace")
+        blocked = self.client.get("/admin/assets/replace", headers=self._admin_headers())
         self.assertEqual(blocked.status_code, 302)
         self.assertTrue((blocked.headers.get("Location") or "").endswith("/"))
 
         self._set_admin_session()
-        allowed = self.client.get("/admin/assets/replace")
+        allowed = self.client.get("/admin/assets/replace", headers=self._admin_headers())
         self.assertEqual(allowed.status_code, 200)
         self.assertIn(b"Admin: Replace Failed Asset", allowed.data)
 
@@ -139,6 +151,7 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/replace",
+            headers=self._admin_headers(),
             data={
                 "action": "replace",
                 "failed_asset_tag": "FAIL-100",
@@ -223,6 +236,7 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/replace",
+            headers=self._admin_headers(),
             data={
                 "action": "replace",
                 "failed_asset_tag": "FAIL-200",
@@ -279,6 +293,7 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/replace",
+            headers=self._admin_headers(),
             data={
                 "action": "replace",
                 "failed_asset_tag": "FAIL-300",
@@ -319,6 +334,7 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/replace",
+            headers=self._admin_headers(),
             data={
                 "action": "replace",
                 "failed_asset_tag": "FAIL-400",
@@ -365,6 +381,7 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         duplicate_tag = self.client.post(
             "/admin/assets/replace",
+            headers=self._admin_headers(),
             data={
                 "action": "replace",
                 "failed_asset_tag": "FAIL-500",
@@ -383,6 +400,7 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         duplicate_serial = self.client.post(
             "/admin/assets/replace",
+            headers=self._admin_headers(),
             data={
                 "action": "replace",
                 "failed_asset_tag": "FAIL-500",

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import base64
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -32,6 +34,8 @@ class AdminRetireAssetTests(unittest.TestCase):
         self.conn.commit()
 
         self.orig_passcode = intake_app.INTAKE_PASSCODE
+        self.orig_admin_users = os.environ.get("ASSETTRACK_ADMIN_USERS")
+        os.environ["ASSETTRACK_ADMIN_USERS"] = "admin:test-pass"
         intake_app.INTAKE_PASSCODE = "test-admin-code"
         intake_app.app.testing = True
         intake_app.SCAN_QUEUE.clear()
@@ -39,6 +43,10 @@ class AdminRetireAssetTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         intake_app.SCAN_QUEUE.clear()
+        if self.orig_admin_users is None:
+            os.environ.pop("ASSETTRACK_ADMIN_USERS", None)
+        else:
+            os.environ["ASSETTRACK_ADMIN_USERS"] = self.orig_admin_users
         intake_app.INTAKE_PASSCODE = self.orig_passcode
         self.conn.close()
         self.temp_dir.cleanup()
@@ -85,13 +93,17 @@ class AdminRetireAssetTests(unittest.TestCase):
         self.conn.commit()
         return int(cursor.lastrowid)
 
+    def _admin_headers(self) -> dict[str, str]:
+        token = base64.b64encode(b"admin:test-pass").decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
     def test_get_retire_route_admin_only(self) -> None:
-        blocked = self.client.get("/admin/assets/retire")
+        blocked = self.client.get("/admin/assets/retire", headers=self._admin_headers())
         self.assertEqual(blocked.status_code, 302)
         self.assertTrue((blocked.headers.get("Location") or "").endswith("/"))
 
         self._set_admin_session()
-        allowed = self.client.get("/admin/assets/retire")
+        allowed = self.client.get("/admin/assets/retire", headers=self._admin_headers())
         self.assertEqual(allowed.status_code, 200)
         self.assertIn(b"Admin: Retire Asset", allowed.data)
 
@@ -110,6 +122,7 @@ class AdminRetireAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assets/retire",
+            headers=self._admin_headers(),
             data={
                 "action": "retire",
                 "asset_tag": "RET-100",
@@ -158,6 +171,7 @@ class AdminRetireAssetTests(unittest.TestCase):
 
         missing_confirm = self.client.post(
             "/admin/assets/retire",
+            headers=self._admin_headers(),
             data={
                 "action": "retire",
                 "asset_tag": "RET-200",
@@ -171,6 +185,7 @@ class AdminRetireAssetTests(unittest.TestCase):
 
         ok = self.client.post(
             "/admin/assets/retire",
+            headers=self._admin_headers(),
             data={
                 "action": "retire",
                 "asset_tag": "RET-200",
@@ -223,6 +238,7 @@ class AdminRetireAssetTests(unittest.TestCase):
 
         response = self.client.post(
             "/admin/assign-slot",
+            headers=self._admin_headers(),
             data={
                 "action": "lookup",
                 "asset_tag": "RET-400",

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+
+
+def _basic_auth_header(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS assets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            asset_tag TEXT NOT NULL UNIQUE,
+            location_type TEXT NULL,
+            current_holder_id INTEGER NULL,
+            home_slot_id INTEGER NULL
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(intake_app, "INTAKE_PASSCODE", None)
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def test_mutation_route_missing_env_returns_503(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ASSETTRACK_ADMIN_USERS", raising=False)
+    response = client_with_temp_db.post("/preview/discard")
+    assert response.status_code == 503
+
+
+def test_mutation_route_empty_env_returns_503(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSETTRACK_ADMIN_USERS", "")
+    response = client_with_temp_db.post("/preview/discard")
+    assert response.status_code == 503
+
+
+def test_mutation_route_malformed_env_returns_503(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSETTRACK_ADMIN_USERS", "admin-without-password")
+    response = client_with_temp_db.post("/preview/discard")
+    assert response.status_code == 503
+
+
+def test_mutation_route_without_authorization_returns_401(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSETTRACK_ADMIN_USERS", "admin:secret")
+    response = client_with_temp_db.post("/preview/discard")
+    assert response.status_code == 401
+    assert response.headers.get("WWW-Authenticate") == 'Basic realm="AssetTrack Admin"'
+
+
+def test_mutation_route_with_invalid_credentials_returns_401(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSETTRACK_ADMIN_USERS", "admin:secret")
+    response = client_with_temp_db.post(
+        "/preview/discard",
+        headers=_basic_auth_header("admin", "wrong"),
+    )
+    assert response.status_code == 401
+    assert response.headers.get("WWW-Authenticate") == 'Basic realm="AssetTrack Admin"'
+
+
+def test_mutation_route_with_valid_credentials_returns_200(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSETTRACK_ADMIN_USERS", "admin:secret")
+    response = client_with_temp_db.get(
+        "/admin/assets/new",
+        headers=_basic_auth_header("admin", "secret"),
+    )
+    assert response.status_code == 200
+
+
+def test_dashboard_route_remains_public(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ASSETTRACK_ADMIN_USERS", raising=False)
+    response = client_with_temp_db.get("/dashboard")
+    assert response.status_code == 200
+

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -1,6 +1,8 @@
 # file: tests/test_return_batch.py
 from __future__ import annotations
 
+import base64
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -26,11 +28,17 @@ class ReturnBatchTests(unittest.TestCase):
             """
         )
         self.conn.commit()
+        self.orig_admin_users = os.environ.get("ASSETTRACK_ADMIN_USERS")
+        os.environ["ASSETTRACK_ADMIN_USERS"] = "admin:test-pass"
         self.client = intake_app.app.test_client()
         intake_app.app.testing = True
         intake_app.SCAN_QUEUE.clear()
 
     def tearDown(self) -> None:
+        if self.orig_admin_users is None:
+            os.environ.pop("ASSETTRACK_ADMIN_USERS", None)
+        else:
+            os.environ["ASSETTRACK_ADMIN_USERS"] = self.orig_admin_users
         intake_app.SCAN_QUEUE.clear()
         self.conn.close()
         self.temp_dir.cleanup()
@@ -55,6 +63,10 @@ class ReturnBatchTests(unittest.TestCase):
         )
         self.conn.commit()
 
+    def _admin_headers(self) -> dict[str, str]:
+        token = base64.b64encode(b"admin:test-pass").decode("ascii")
+        return {"Authorization": f"Basic {token}"}
+
     def test_return_preview_and_commit_gating(self) -> None:
         self._insert_slot(10, "A", 1, None)
         self._insert_slot(20, "B", 2, None)
@@ -71,7 +83,7 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(preview_render.status_code, 200)
         self.assertIn("Return Assets — Preview / Confirm".encode("utf-8"), preview_render.data)
 
-        unreviewed = self.client.post("/return/commit?json=1")
+        unreviewed = self.client.post("/return/commit?json=1", headers=self._admin_headers())
         self.assertEqual(unreviewed.status_code, 400)
         self.assertFalse(unreviewed.json["ok"])
         self.assertEqual(unreviewed.json["committed"], 0)
@@ -84,7 +96,11 @@ class ReturnBatchTests(unittest.TestCase):
         intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-VALID", equipment_type="laptop"))
         intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="UNKNOWN", equipment_type="laptop"))
 
-        blocked = self.client.post("/return/commit?json=1", data={"confirm_reviewed": "on"})
+        blocked = self.client.post(
+            "/return/commit?json=1",
+            headers=self._admin_headers(),
+            data={"confirm_reviewed": "on"},
+        )
         self.assertEqual(blocked.status_code, 400)
         self.assertFalse(blocked.json["ok"])
         self.assertEqual(blocked.json["committed"], 0)
@@ -104,7 +120,11 @@ class ReturnBatchTests(unittest.TestCase):
         intake_app.SCAN_QUEUE.clear()
         intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-OK", equipment_type="laptop"))
 
-        success = self.client.post("/return/commit?json=1", data={"confirm_reviewed": "on"})
+        success = self.client.post(
+            "/return/commit?json=1",
+            headers=self._admin_headers(),
+            data={"confirm_reviewed": "on"},
+        )
         self.assertEqual(success.status_code, 200)
         self.assertTrue(success.json["ok"])
         self.assertEqual(success.json["committed"], 1)


### PR DESCRIPTION
## Summary

Adds HTTP Basic Auth protection to all mutation-capable routes.  
Implements strict, fail-closed access control for admin and commit endpoints while keeping read-only views public.

## Related Issue

Closes #110 

## Changes

- Added reusable `@require_admin` decorator in `assettrack/intake/app.py`
- Strict parser for `ASSETTRACK_ADMIN_USERS`
- Fail-closed behavior:
  - 503 when env missing/empty/malformed
  - 401 when missing/invalid credentials
  - Includes `WWW-Authenticate` header
- Protected routes:
  - All `/admin/*`
  - `/issue/preview`
  - `/issue/commit`
  - `/return/commit`
  - `/preview/commit`
  - `/preview/mode`
  - `/preview/discard`
  - `/lock`
- Left public:
  - `/`
  - `/dashboard`
  - `/return`
  - `/preview`
  - `/holders`
- Added auth tests (`tests/test_basic_auth_guard.py`)
- Updated mutation-route tests to include valid Basic Auth headers

## Verification Checklist

- [x] `/dashboard` remains public
- [x] `/admin/*` returns 503 when auth not configured
- [x] `/admin/*` returns 401 without credentials
- [x] `/admin/*` returns 200 with valid credentials
- [x] Mutation routes protected
- [x] Tests passing locally (33 passed)
- [x] CI green

## Notes

Environment configuration example:
ASSETTRACK_ADMIN_USERS="user1:strongpass,user2:anotherstrongpass"


Fail-closed behavior prevents accidental open admin access.