### PR TITLE
Issue 11-2: Add read-only holder and case drilldowns

### DIFF
--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import sqlite3
+
+from assettrack.assets import get_asset_table_columns
+
+
+def _parse_utc_timestamp(value: object) -> datetime | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def list_holders_in_custody(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            h.id AS holder_id,
+            h.name AS holder_name,
+            COUNT(*) AS asset_count
+        FROM assets a
+        JOIN holders h
+          ON h.id = a.current_holder_id
+        WHERE a.location_type = 'IN_CUSTODY'
+          AND a.current_holder_id IS NOT NULL
+        GROUP BY h.id, h.name
+        ORDER BY asset_count DESC, h.name ASC, h.id ASC;
+        """
+    ).fetchall()
+
+    return [
+        {
+            "holder_id": int(row["holder_id"]),
+            "holder_name": str(row["holder_name"]),
+            "asset_count": int(row["asset_count"] or 0),
+        }
+        for row in rows
+    ]
+
+
+def get_holder_custody_detail(
+    conn: sqlite3.Connection,
+    holder_id: int,
+    *,
+    now_utc: datetime | None = None,
+) -> dict | None:
+    holder_row = conn.execute(
+        """
+        SELECT id, name
+        FROM holders
+        WHERE id = ?;
+        """,
+        (holder_id,),
+    ).fetchone()
+    if holder_row is None:
+        return None
+
+    asset_columns = get_asset_table_columns(conn)
+    equipment_expr = "a.equipment_type" if "equipment_type" in asset_columns else "NULL"
+    manufacturer_expr = "a.manufacturer" if "manufacturer" in asset_columns else "NULL"
+    model_expr = "a.model" if "model" in asset_columns else "NULL"
+
+    asset_rows = conn.execute(
+        f"""
+        SELECT
+            a.asset_tag,
+            {equipment_expr} AS equipment_type,
+            {manufacturer_expr} AS manufacturer,
+            {model_expr} AS model
+        FROM assets a
+        WHERE a.location_type = 'IN_CUSTODY'
+          AND a.current_holder_id = ?
+        ORDER BY a.asset_tag ASC, a.id ASC;
+        """,
+        (holder_id,),
+    ).fetchall()
+
+    assets = [
+        {
+            "asset_tag": str(row["asset_tag"]),
+            "equipment_type": row["equipment_type"],
+            "manufacturer": row["manufacturer"],
+            "model": row["model"],
+            "days_out": None,
+            "last_issued_date": None,
+        }
+        for row in asset_rows
+    ]
+
+    if not assets:
+        return {
+            "holder_id": int(holder_row["id"]),
+            "holder_name": str(holder_row["name"]),
+            "assets": [],
+        }
+
+    current_utc = (now_utc or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    asset_tags = [asset["asset_tag"] for asset in assets]
+    placeholders = ", ".join("?" for _ in asset_tags)
+    event_rows = conn.execute(
+        f"""
+        SELECT id, asset_tag, event_date
+        FROM asset_events
+        WHERE event_type = 'STOCK_OUT'
+          AND asset_tag IN ({placeholders})
+        ORDER BY asset_tag ASC, id ASC;
+        """,
+        tuple(asset_tags),
+    ).fetchall()
+
+    latest_stock_out: dict[str, dict] = {}
+    for row in event_rows:
+        asset_tag = str(row["asset_tag"] or "")
+        parsed = _parse_utc_timestamp(row["event_date"])
+        if parsed is None:
+            continue
+
+        event_id = int(row["id"])
+        previous = latest_stock_out.get(asset_tag)
+        if previous is None or parsed > previous["ts"] or (parsed == previous["ts"] and event_id > previous["id"]):
+            latest_stock_out[asset_tag] = {
+                "ts": parsed,
+                "id": event_id,
+                "event_date": str(row["event_date"]),
+            }
+
+    for asset in assets:
+        stock_out = latest_stock_out.get(asset["asset_tag"])
+        if stock_out is None:
+            continue
+        days_out = int((current_utc - stock_out["ts"]).total_seconds() // 86400)
+        asset["days_out"] = max(0, days_out)
+        asset["last_issued_date"] = stock_out["event_date"]
+
+    return {
+        "holder_id": int(holder_row["id"]),
+        "holder_name": str(holder_row["name"]),
+        "assets": assets,
+    }
+
+
+def list_case_summaries(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            s.case_name,
+            COUNT(*) AS total_slots,
+            COUNT(DISTINCT so.slot_id) AS occupied_slots
+        FROM slots s
+        LEFT JOIN slot_occupancy so
+          ON so.slot_id = s.id
+        GROUP BY s.case_name
+        ORDER BY occupied_slots DESC, s.case_name ASC;
+        """
+    ).fetchall()
+
+    results: list[dict] = []
+    for row in rows:
+        total_slots = int(row["total_slots"] or 0)
+        occupied_slots = int(row["occupied_slots"] or 0)
+        empty_slots = max(0, total_slots - occupied_slots)
+        utilization_percent = int((occupied_slots * 100.0 / total_slots) + 0.5) if total_slots > 0 else 0
+        results.append(
+            {
+                "case_name": str(row["case_name"]),
+                "total_slots": total_slots,
+                "occupied_slots": occupied_slots,
+                "empty_slots": empty_slots,
+                "utilization_percent": utilization_percent,
+            }
+        )
+    return results
+
+
+def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | None:
+    exists_row = conn.execute(
+        """
+        SELECT 1
+        FROM slots
+        WHERE case_name = ?
+        LIMIT 1;
+        """,
+        (case_name,),
+    ).fetchone()
+    if exists_row is None:
+        return None
+
+    slot_rows = conn.execute(
+        """
+        SELECT
+            s.id AS slot_id,
+            s.slot_position,
+            a.asset_tag
+        FROM slots s
+        LEFT JOIN (
+            SELECT so.slot_id, so.asset_id
+            FROM slot_occupancy so
+            JOIN (
+                SELECT slot_id, MIN(id) AS min_occupancy_id
+                FROM slot_occupancy
+                GROUP BY slot_id
+            ) pick
+              ON pick.min_occupancy_id = so.id
+        ) chosen
+          ON chosen.slot_id = s.id
+        LEFT JOIN assets a
+          ON a.id = chosen.asset_id
+        WHERE s.case_name = ?
+        ORDER BY s.slot_position ASC, s.id ASC;
+        """,
+        (case_name,),
+    ).fetchall()
+
+    return {
+        "case_name": case_name,
+        "slots": [
+            {
+                "slot_id": int(row["slot_id"]),
+                "slot_position": int(row["slot_position"]),
+                "asset_tag": row["asset_tag"],
+            }
+            for row in slot_rows
+        ],
+    }

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -22,11 +22,17 @@ import time
 from typing import Optional
 from datetime import datetime, timezone
 
-from flask import Flask, flash, redirect, render_template, request, session, url_for
+from flask import Flask, abort, flash, redirect, render_template, request, session, url_for
 
 from assettrack.assets import get_asset_table_columns
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import get_connection
+from assettrack.drilldowns import (
+    get_case_slot_detail,
+    get_holder_custody_detail,
+    list_case_summaries,
+    list_holders_in_custody,
+)
 from assettrack.ingest.validator import validate_rows
 from assettrack.ingest.committer import BatchCommitError, commit_batch
 from assettrack.intake.scan import Scan
@@ -1683,6 +1689,68 @@ def dashboard():
         "dashboard.html",
         dashboard=dashboard_data,
         custody_days_threshold=threshold_days,
+    )
+
+
+@app.get("/dashboard/holders")
+def dashboard_holders():
+    conn = get_connection()
+    try:
+        holders = list_holders_in_custody(conn)
+    finally:
+        conn.close()
+
+    return render_template(
+        "dashboard_holders.html",
+        holders=holders,
+    )
+
+
+@app.get("/dashboard/holders/<int:holder_id>")
+def dashboard_holder_detail(holder_id: int):
+    conn = get_connection()
+    try:
+        detail = get_holder_custody_detail(conn, holder_id)
+    finally:
+        conn.close()
+
+    if detail is None:
+        abort(404)
+
+    return render_template(
+        "dashboard_holder_detail.html",
+        holder=detail,
+    )
+
+
+@app.get("/dashboard/cases")
+def dashboard_cases():
+    conn = get_connection()
+    try:
+        cases = list_case_summaries(conn)
+    finally:
+        conn.close()
+
+    return render_template(
+        "dashboard_cases.html",
+        cases=cases,
+    )
+
+
+@app.get("/dashboard/cases/<case_name>")
+def dashboard_case_detail(case_name: str):
+    conn = get_connection()
+    try:
+        detail = get_case_slot_detail(conn, case_name)
+    finally:
+        conn.close()
+
+    if detail is None:
+        abort(404)
+
+    return render_template(
+        "dashboard_case_detail.html",
+        case_detail=detail,
     )
 
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -97,6 +97,8 @@
       <nav class="actions" aria-label="Quick actions">
         <a class="chip" href="/issue/preview">Issue (Checkout)</a>
         <a class="chip" href="/return">Return (Check-in)</a>
+        <a class="chip" href="/dashboard/holders">Holder Drilldown</a>
+        <a class="chip" href="/dashboard/cases">Case Drilldown</a>
         <a class="chip secondary" href="/">Intake</a>
         <a class="chip secondary" href="/dashboard">Dashboard</a>
       </nav>

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -1,0 +1,59 @@
+<!-- file: assettrack/intake/templates/dashboard_case_detail.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Case Detail</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 0; color: #12202f; background: #f7f9fc; }
+      a { color: #134e8a; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
+      .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+      .chip { display: inline-flex; align-items: center; padding: 0.4rem 0.6rem; border-radius: 999px; background: #eef3fb; border: 1px solid #d7deea; font-weight: 600; }
+      .card { background: #fff; border: 1px solid #d7deea; border-radius: 10px; padding: 1rem; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 0.55rem 0.6rem; border-bottom: 1px solid #e8edf6; }
+      th { background: #eef3fb; }
+      tr:last-child td { border-bottom: 0; }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <h1>Case Detail: {{ case_detail.case_name }}</h1>
+      <nav class="actions" aria-label="Dashboard navigation">
+        <a class="chip" href="/dashboard">Back to Dashboard</a>
+        <a class="chip" href="/dashboard/cases">Back to Cases</a>
+      </nav>
+
+      <section class="card">
+        <h2>Slot Layout</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Slot Position</th>
+                <th>Asset Tag</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in case_detail.slots %}
+                <tr>
+                  <td>{{ row.slot_position }}</td>
+                  <td class="mono">{{ row.asset_tag if row.asset_tag else "Empty" }}</td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="2">None</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -1,0 +1,64 @@
+<!-- file: assettrack/intake/templates/dashboard_cases.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dashboard Cases</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 0; color: #12202f; background: #f7f9fc; }
+      a { color: #134e8a; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
+      .card { background: #fff; border: 1px solid #d7deea; border-radius: 10px; padding: 1rem; }
+      .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+      .chip { display: inline-flex; align-items: center; padding: 0.4rem 0.6rem; border-radius: 999px; background: #eef3fb; border: 1px solid #d7deea; font-weight: 600; }
+      .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 0.55rem 0.6rem; border-bottom: 1px solid #e8edf6; }
+      th { background: #eef3fb; }
+      tr:last-child td { border-bottom: 0; }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <h1>Case Accountability</h1>
+      <nav class="actions" aria-label="Dashboard navigation">
+        <a class="chip" href="/dashboard">Back to Dashboard</a>
+        <a class="chip" href="/dashboard/holders">Holder View</a>
+      </nav>
+
+      <section class="card">
+        <h2>Case Summary</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Case Name</th>
+                <th>Total Slots</th>
+                <th>Occupied Slots</th>
+                <th>Empty Slots</th>
+                <th>Utilization %</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in cases %}
+                <tr>
+                  <td><a href="/dashboard/cases/{{ row.case_name }}">{{ row.case_name }}</a></td>
+                  <td>{{ row.total_slots }}</td>
+                  <td>{{ row.occupied_slots }}</td>
+                  <td>{{ row.empty_slots }}</td>
+                  <td>{{ row.utilization_percent }}%</td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="5">None</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -1,0 +1,67 @@
+<!-- file: assettrack/intake/templates/dashboard_holder_detail.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Holder Detail</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 0; color: #12202f; background: #f7f9fc; }
+      a { color: #134e8a; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
+      .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+      .chip { display: inline-flex; align-items: center; padding: 0.4rem 0.6rem; border-radius: 999px; background: #eef3fb; border: 1px solid #d7deea; font-weight: 600; }
+      .card { background: #fff; border: 1px solid #d7deea; border-radius: 10px; padding: 1rem; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 0.55rem 0.6rem; border-bottom: 1px solid #e8edf6; }
+      th { background: #eef3fb; }
+      tr:last-child td { border-bottom: 0; }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <h1>Holder Detail: {{ holder.holder_name }}</h1>
+      <nav class="actions" aria-label="Dashboard navigation">
+        <a class="chip" href="/dashboard">Back to Dashboard</a>
+        <a class="chip" href="/dashboard/holders">Back to Holders</a>
+      </nav>
+
+      <section class="card">
+        <h2>Current Custody Assets</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Asset Tag</th>
+                <th>Equipment Type</th>
+                <th>Manufacturer</th>
+                <th>Model</th>
+                <th>Days Out</th>
+                <th>Last Issued Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in holder.assets %}
+                <tr>
+                  <td class="mono">{{ row.asset_tag }}</td>
+                  <td>{{ row.equipment_type or "" }}</td>
+                  <td>{{ row.manufacturer or "" }}</td>
+                  <td>{{ row.model or "" }}</td>
+                  <td>{{ row.days_out if row.days_out is not none else "Unknown" }}</td>
+                  <td>{{ row.last_issued_date if row.last_issued_date else "Unknown" }}</td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="6">None</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -1,0 +1,58 @@
+<!-- file: assettrack/intake/templates/dashboard_holders.html -->
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Dashboard Holders</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Arial, sans-serif; margin: 0; color: #12202f; background: #f7f9fc; }
+      a { color: #134e8a; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      .page { max-width: 1100px; margin: 0 auto; padding: 1.25rem; }
+      .card { background: #fff; border: 1px solid #d7deea; border-radius: 10px; padding: 1rem; }
+      .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+      .chip { display: inline-flex; align-items: center; padding: 0.4rem 0.6rem; border-radius: 999px; background: #eef3fb; border: 1px solid #d7deea; font-weight: 600; }
+      .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { text-align: left; padding: 0.55rem 0.6rem; border-bottom: 1px solid #e8edf6; }
+      th { background: #eef3fb; }
+      tr:last-child td { border-bottom: 0; }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <h1>Holder Accountability</h1>
+      <nav class="actions" aria-label="Dashboard navigation">
+        <a class="chip" href="/dashboard">Back to Dashboard</a>
+        <a class="chip" href="/dashboard/cases">Case View</a>
+      </nav>
+
+      <section class="card">
+        <h2>Holders in Custody</h2>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>Holder Name</th>
+                <th>Asset Count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in holders %}
+                <tr>
+                  <td><a href="/dashboard/holders/{{ row.holder_id }}">{{ row.holder_name }}</a></td>
+                  <td>{{ row.asset_count }}</td>
+                </tr>
+              {% else %}
+                <tr>
+                  <td colspan="2">None</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </body>
+</html>

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.drilldowns import (
+    get_holder_custody_detail,
+    list_case_summaries,
+    list_holders_in_custody,
+)
+from assettrack.intake import app as intake_app
+
+
+@pytest.fixture
+def app_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS assets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            asset_tag TEXT NOT NULL UNIQUE,
+            equipment_type TEXT NULL,
+            manufacturer TEXT NULL,
+            model TEXT NULL,
+            location_type TEXT NULL,
+            current_holder_id INTEGER NULL,
+            home_slot_id INTEGER NULL
+        );
+        """
+    )
+    conn.commit()
+    intake_app.app.testing = True
+    client = intake_app.app.test_client()
+    yield conn, client
+    conn.close()
+
+
+def _insert_holder(conn, holder_id: int, name: str) -> None:
+    now = "2026-01-01T00:00:00Z"
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (?, 'PERSON', ?, NULL, NULL, ?, ?);
+        """,
+        (holder_id, name, now, now),
+    )
+
+
+def _insert_asset(
+    conn,
+    asset_tag: str,
+    *,
+    location_type: str,
+    holder_id: int | None = None,
+    equipment_type: str | None = None,
+    manufacturer: str | None = None,
+    model: str | None = None,
+    home_slot_id: int | None = None,
+) -> int:
+    cursor = conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            equipment_type,
+            manufacturer,
+            model,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+        """,
+        (asset_tag, equipment_type, manufacturer, model, location_type, holder_id, home_slot_id),
+    )
+    return int(cursor.lastrowid)
+
+
+def _insert_stock_out(conn, asset_tag: str, event_date: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (?, 'STOCK_OUT', ?, 'tester', NULL, NULL, NULL);
+        """,
+        (asset_tag, event_date),
+    )
+
+
+def _insert_slot(conn, slot_id: int, case_name: str, slot_position: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (?, ?, ?, NULL);
+        """,
+        (slot_id, case_name, slot_position),
+    )
+
+
+def test_dashboard_holders_route_returns_200_and_is_read_only(app_client) -> None:
+    conn, client = app_client
+    _insert_holder(conn, 1, "Alpha")
+    _insert_asset(conn, "AT-1", location_type="IN_CUSTODY", holder_id=1)
+    conn.commit()
+
+    counts_before = (
+        conn.execute("SELECT COUNT(*) AS c FROM assets;").fetchone()["c"],
+        conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()["c"],
+        conn.execute("SELECT COUNT(*) AS c FROM slot_occupancy;").fetchone()["c"],
+    )
+
+    response = client.get("/dashboard/holders")
+    assert response.status_code == 200
+    assert b"Holders in Custody" in response.data
+
+    counts_after = (
+        conn.execute("SELECT COUNT(*) AS c FROM assets;").fetchone()["c"],
+        conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()["c"],
+        conn.execute("SELECT COUNT(*) AS c FROM slot_occupancy;").fetchone()["c"],
+    )
+    assert counts_before == counts_after
+
+
+def test_dashboard_holder_detail_404_when_holder_missing(app_client) -> None:
+    _, client = app_client
+    response = client.get("/dashboard/holders/999")
+    assert response.status_code == 404
+
+
+def test_dashboard_holder_detail_200_none_when_no_assets(app_client) -> None:
+    conn, client = app_client
+    _insert_holder(conn, 1, "No Custody")
+    conn.commit()
+
+    response = client.get("/dashboard/holders/1")
+    assert response.status_code == 200
+    assert b"None" in response.data
+
+
+def test_dashboard_cases_route_200_and_missing_case_404(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 10, "CASE-A", 1)
+    conn.commit()
+
+    cases_response = client.get("/dashboard/cases")
+    assert cases_response.status_code == 200
+    assert b"Case Summary" in cases_response.data
+
+    missing_response = client.get("/dashboard/cases/CASE-MISSING")
+    assert missing_response.status_code == 404
+
+
+def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 10, "CASE-A", 1)
+    _insert_slot(conn, 11, "CASE-A", 2)
+    asset_id = _insert_asset(conn, "AT-SLOTTED", location_type="STORAGE")
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (10, ?, '2026-01-01T00:00:00Z');
+        """,
+        (asset_id,),
+    )
+    conn.commit()
+
+    response = client.get("/dashboard/cases/CASE-A")
+    assert response.status_code == 200
+    assert b"Slot Position" in response.data
+    assert b">1<" in response.data
+    assert b">2<" in response.data
+    assert b"AT-SLOTTED" in response.data
+    assert b"Empty" in response.data
+
+
+def test_holders_and_cases_deterministic_ordering(app_client) -> None:
+    conn, _ = app_client
+    _insert_holder(conn, 1, "Bravo")
+    _insert_holder(conn, 2, "Alpha")
+    _insert_asset(conn, "A-1", location_type="IN_CUSTODY", holder_id=1)
+    _insert_asset(conn, "A-2", location_type="IN_CUSTODY", holder_id=2)
+
+    _insert_slot(conn, 10, "CASE-B", 1)
+    _insert_slot(conn, 11, "CASE-A", 1)
+    asset_id = _insert_asset(conn, "SLOT-1", location_type="STORAGE")
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (10, ?, '2026-01-01T00:00:00Z');
+        """,
+        (asset_id,),
+    )
+    conn.commit()
+
+    holders = list_holders_in_custody(conn)
+    assert [row["holder_name"] for row in holders] == ["Alpha", "Bravo"]
+
+    cases = list_case_summaries(conn)
+    assert [row["case_name"] for row in cases] == ["CASE-B", "CASE-A"]
+
+
+def test_holder_detail_uses_most_recent_stock_out_and_unknown_when_missing(app_client) -> None:
+    conn, _ = app_client
+    _insert_holder(conn, 1, "Holder")
+    _insert_asset(
+        conn,
+        "AT-RECENT",
+        location_type="IN_CUSTODY",
+        holder_id=1,
+        equipment_type="laptop",
+        manufacturer="Dell",
+        model="XPS",
+    )
+    _insert_asset(
+        conn,
+        "AT-UNKNOWN",
+        location_type="IN_CUSTODY",
+        holder_id=1,
+        equipment_type="tablet",
+    )
+    _insert_stock_out(conn, "AT-RECENT", "2026-01-01T00:00:00Z")
+    _insert_stock_out(conn, "AT-RECENT", "2026-02-01T00:00:00Z")
+    conn.commit()
+
+    detail = get_holder_custody_detail(
+        conn,
+        1,
+        now_utc=datetime(2026, 2, 20, 0, 0, 0, tzinfo=timezone.utc),
+    )
+    assert detail is not None
+
+    rows = {row["asset_tag"]: row for row in detail["assets"]}
+    assert rows["AT-RECENT"]["last_issued_date"] == "2026-02-01T00:00:00Z"
+    assert rows["AT-RECENT"]["days_out"] == 19
+    assert rows["AT-UNKNOWN"]["last_issued_date"] is None
+    assert rows["AT-UNKNOWN"]["days_out"] is None
+


### PR DESCRIPTION
## Summary

Adds read-only dashboard drilldowns for holder and case accountability views.  
Expands visibility without introducing any mutation capability.

## Related Issue

Closes #84 

## Changes

- Added drilldown routes:
  - `/dashboard/holders`
  - `/dashboard/holders/<int:holder_id>`
  - `/dashboard/cases`
  - `/dashboard/cases/<case_name>`
- Added helper module `assettrack/drilldowns.py`
- Added templates for holder summary/detail and case summary/detail
- Deterministic ordering across all queries
- Strict read-only enforcement (GET only)
- 404 behavior for invalid holder/case
- Added drilldown tests (`tests/test_dashboard_drilldowns.py`)

## Verification Checklist

- [x] Holder summary renders correctly
- [x] Holder detail enforces 404 vs empty behavior
- [x] Case summary renders correctly
- [x] Case detail slot grid renders correctly
- [x] No mutation exposure
- [x] Deterministic ordering enforced
- [x] Tests passing locally (40 passed)
- [x] CI green

## Notes

Custody state derives strictly from `assets.location_type`.  
Slot occupancy derives strictly from `slots` + `slot_occupancy`.