### PR TITLE
Issue 12-2: ignore superseded events in derived reads

### DIFF
--- a/assettrack/audit.py
+++ b/assettrack/audit.py
@@ -1,6 +1,19 @@
+# file: assettrack/audit.py
+
 import json
 import sqlite3
 from typing import Optional
+
+
+# Canonical filter for "active" (non-superseded) events.
+# Any event whose id appears as a supersedes_event_id is no longer active.
+ACTIVE_EVENTS_WHERE = """
+id NOT IN (
+    SELECT supersedes_event_id
+    FROM asset_events
+    WHERE supersedes_event_id IS NOT NULL
+)
+"""
 
 
 def record_event(
@@ -11,10 +24,17 @@ def record_event(
     actor: Optional[str] = None,
     notes: Optional[str] = None,
     payload: Optional[dict] = None,
+    supersedes_event_id: Optional[int] = None,
+    correction_reason: Optional[str] = None,
 ):
     """
     Append an audit event for an asset.
+
     This function is append-only and does not enforce business rules.
+
+    If supersedes_event_id is provided:
+        - correction_reason must also be provided (DB-level CHECK enforces this).
+        - The new event formally supersedes a prior event.
     """
     cursor = conn.cursor()
 
@@ -26,9 +46,11 @@ def record_event(
             event_date,
             actor,
             notes,
-            payload
+            payload,
+            supersedes_event_id,
+            correction_reason
         )
-        VALUES (?, ?, ?, ?, ?, ?);
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?);
         """,
         (
             asset_tag,
@@ -37,5 +59,7 @@ def record_event(
             actor,
             notes,
             json.dumps(payload) if payload is not None else None,
+            supersedes_event_id,
+            correction_reason,
         ),
     )

--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from assettrack.audit import ACTIVE_EVENTS_WHERE
+
 from datetime import datetime, timezone
 import sqlite3
 
@@ -228,7 +230,8 @@ def _in_custody_days_out(conn: sqlite3.Connection, *, now_utc: datetime) -> list
         SELECT asset_tag, event_date, id
         FROM asset_events
         WHERE event_type = 'STOCK_OUT'
-          AND asset_tag IN ({placeholders})
+        AND {ACTIVE_EVENTS_WHERE}
+        AND asset_tag IN ({placeholders})
         ORDER BY asset_tag ASC, id ASC;
         """,
         tuple(asset_tags),

--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -1,9 +1,11 @@
+# file: assettrack/drilldowns.py
 from __future__ import annotations
 
 from datetime import datetime, timezone
 import sqlite3
 
 from assettrack.assets import get_asset_table_columns
+from assettrack.audit import ACTIVE_EVENTS_WHERE
 
 
 def _parse_utc_timestamp(value: object) -> datetime | None:
@@ -108,11 +110,14 @@ def get_holder_custody_detail(
     current_utc = (now_utc or datetime.now(timezone.utc)).astimezone(timezone.utc)
     asset_tags = [asset["asset_tag"] for asset in assets]
     placeholders = ", ".join("?" for _ in asset_tags)
+
+    # Important: ignore superseded events (Issue 12-2)
     event_rows = conn.execute(
         f"""
         SELECT id, asset_tag, event_date
         FROM asset_events
         WHERE event_type = 'STOCK_OUT'
+          AND {ACTIVE_EVENTS_WHERE}
           AND asset_tag IN ({placeholders})
         ORDER BY asset_tag ASC, id ASC;
         """,


### PR DESCRIPTION
## Summary

Updates derived read queries to ignore superseded events, so corrected rows don’t influence “current state” calculations.

This keeps audit history intact while ensuring dashboards/drilldowns reflect the active (non-superseded) ledger.

## Related Issue

Closes #86 

## Changes

- Added a canonical `ACTIVE_EVENTS_WHERE` filter for non-superseded events
- Updated dashboard custody “days out” event reads to exclude superseded events
- Updated holder drilldown “last issued” event reads to exclude superseded events
- Extended `record_event()` to optionally include `supersedes_event_id` and `correction_reason` (no behavior change for existing callers)

## Verification Checklist

- [x] All tests passing (27/27)
- [x] No changes to mutation behavior
- [x] Derived reads are deterministic and exclude superseded events

## Notes

This PR only updates read/query logic. Correction creation endpoints/UI come in later issues.