### PR TITLE
Issue 13-4: Add non-blocking Trivy scan step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,12 @@ jobs:
       - name: Compile all Python files
         run: |
           python -m compileall .
+      
+      - name: Trivy scan (non-blocking)
+        uses: aquasecurity/trivy-action@0.28.0
+        continue-on-error: true
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: table
+          severity: CRITICAL,HIGH,MEDIUM,LOW


### PR DESCRIPTION
### Summary

Add a non-blocking Trivy scan step to CI for visibility while keeping the existing CI baseline unchanged.

### Related Issue

Closes #90 

### Changes

-   Added Trivy filesystem scan step to GitHub Actions workflow
    
-   Kept compile-only CI behavior intact (no new gates)
    

### Verification

-   CI workflow still runs `pip install -r requirements.txt` and `python -m compileall .`
    
-   Trivy step reports findings but does not fail builds