### PR TITLE
Issue 21-0: add holder creation viability gate test

### DIFF
--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+
+
+class HolderCreationViabilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+        with self.client.session_transaction() as session:
+            session["authed"] = True
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def test_get_holders_new_route_exists(self) -> None:
+        response = self.client.get("/holders/new")
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_holders_new_persists_holder(self) -> None:
+        holder_name = "Viability Gate Holder"
+        self.client.post(
+            "/holders/new",
+            data={"name": holder_name},
+        )
+
+        row = self.conn.execute(
+            "SELECT id, name FROM holders WHERE name = ?;",
+            (holder_name,),
+        ).fetchone()
+        self.assertIsNotNone(row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add a failing viability-gate test that proves holder creation is not implemented in the runtime app.

## Related Issue
Closes #21-0

## Changes
- Added tests asserting `/holders/new` exists and that POSTing a holder persists to the database.

## Verification checklist
- [x] `PYTHONPATH=. pytest -q tests/test_holder_creation_viability.py` (2 failing as expected)
- [x] `PYTHONPATH=. pytest -q` (41 passed, 2 failed)

## Notes
These failures are intentional and define the baseline for implementing holder creation in Issue 21-1.