### PR TITLE
Issue 21-1: add holder create routes with validation and persistence

### DIFF
--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -1,6 +1,8 @@
 # file: assettrack/holders.py
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from assettrack.db import get_connection
 
 
@@ -51,5 +53,40 @@ def get_holder(holder_id: int) -> dict | None:
         )
         row = cursor.fetchone()
         return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def create_holder(
+    name: str,
+    *,
+    holder_type: str = "PERSON",
+    identifier: str | None = None,
+    contact_info: str | None = None,
+) -> dict:
+    normalized_name = (name or "").strip()
+    if not normalized_name:
+        raise ValueError("name is required")
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            INSERT INTO holders (holder_type, name, identifier, contact_info, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?);
+            """,
+            (holder_type, normalized_name, identifier, contact_info, now_iso, now_iso),
+        )
+        conn.commit()
+        created_id = int(cursor.lastrowid)
+        row = conn.execute(
+            """
+            SELECT * FROM holders
+            WHERE id = ?;
+            """,
+            (created_id,),
+        ).fetchone()
+        return dict(row)
     finally:
         conn.close()

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -37,7 +37,7 @@ from assettrack.ingest.validator import validate_rows
 from assettrack.ingest.committer import BatchCommitError, commit_batch
 from assettrack.intake.scan import Scan
 from assettrack.intake.to_ingest import scan_to_ingest_row
-from assettrack.holders import get_holder, search_holders
+from assettrack.holders import create_holder, get_holder, search_holders
 from assettrack.slots import vacate_slot_by_asset_tag_in_tx
 from assettrack.audit import record_event
 
@@ -2151,6 +2151,43 @@ def holders_search():
         results=results,
         selected_holder=_selected_holder_from_session(),
     )
+
+
+@app.get("/holders/new")
+def holders_new():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    return render_template(
+        "holder_new.html",
+        form={"name": ""},
+        error_message=None,
+    )
+
+
+@app.post("/holders/new")
+def holders_create():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    name = (request.form.get("name") or "").strip()
+    form = {"name": name}
+
+    if not name:
+        return render_template(
+            "holder_new.html",
+            form=form,
+            error_message="Name is required.",
+        )
+
+    created = create_holder(name)
+    flash(f"Created holder: {created['name']}", "success")
+    return redirect(url_for("holders_search"))
+
 
 @app.post("/holders/select")
 def holders_select():

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -1,0 +1,38 @@
+<!-- file: assettrack/intake/templates/holder_new.html -->
+{% extends "base.html" %}
+
+{% block title %}AssetTrack New Holder{% endblock %}
+{% block page_heading %}Create Holder{% endblock %}
+
+{% block extra_head %}
+  <style>
+    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p><a href="{{ url_for('holders_search') }}">&larr; Back to holders</a></p>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>New Holder</h2>
+    <form method="post" action="{{ url_for('holders_create') }}">
+      <div class="row">
+        <label for="name"><strong>Name</strong> (required)</label><br />
+        <input type="text" id="name" name="name" value="{{ form.name or '' }}" required autofocus />
+      </div>
+      <button type="submit">Create Holder</button>
+    </form>
+  </div>
+{% endblock %}

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -25,19 +25,33 @@ class HolderCreationViabilityTests(unittest.TestCase):
     def test_get_holders_new_route_exists(self) -> None:
         response = self.client.get("/holders/new")
         self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Create Holder", response.data)
 
     def test_post_holders_new_persists_holder(self) -> None:
         holder_name = "Viability Gate Holder"
-        self.client.post(
+        response = self.client.post(
             "/holders/new",
             data={"name": holder_name},
         )
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue(response.headers["Location"].endswith("/holders"))
 
         row = self.conn.execute(
             "SELECT id, name FROM holders WHERE name = ?;",
             (holder_name,),
         ).fetchone()
         self.assertIsNotNone(row)
+
+    def test_post_holders_new_rejects_blank_name(self) -> None:
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "   "},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Name is required.", response.data)
+
+        count = self.conn.execute("SELECT COUNT(*) AS c FROM holders;").fetchone()["c"]
+        self.assertEqual(count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Add holder creation capability with minimal GET/POST routes, validation, and a simple create form.

## Related Issue
Closes #140 

## Changes
- Add `GET /holders/new` form route.
- Add `POST /holders/new` create route with trimmed required-name validation.
- Add minimal holder insert helper in holders persistence module.
- Add `holder_new.html` template for create flow.
- Expand viability tests to cover GET + POST success/failure paths.

## Verification checklist
- [x] `PYTHONPATH=. pytest -q` (44 passed)

## Notes
- Keeps scope limited to holder creation (no identity/roles/dup checks).