### PR TITLE
Issue 21-2: centralize holder persistence via create_holder helper

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2177,14 +2177,15 @@ def holders_create():
     name = (request.form.get("name") or "").strip()
     form = {"name": name}
 
-    if not name:
+    try:
+        created = create_holder(name)
+    except ValueError:
         return render_template(
             "holder_new.html",
             form=form,
             error_message="Name is required.",
         )
 
-    created = create_holder(name)
     flash(f"Created holder: {created['name']}", "success")
     return redirect(url_for("holders_search"))
 


### PR DESCRIPTION
## Summary
Centralize holder creation persistence to ensure all inserts flow through a single helper and route handlers remain thin.

## Related Issue
Closes #141 

## Changes
- Enforce `create_holder(...)` as the single canonical insert location.
- Remove duplicated validation logic from `POST /holders/new`.
- Ensure route handler contains no inline SQL.
- Confirm timestamps (`created_at`, `updated_at`) are set within helper.

## Verification checklist
- [x] No `INSERT INTO holders` in any route handler
- [x] `POST /holders/new` calls `create_holder(...)`
- [x] Full test suite green
- [x] `PYTHONPATH=. pytest -q` → 44 passed

## Notes
- Scope limited to persistence centralization.
- No schema changes.
- No duplication checks added.