### PR TITLE
Issue 21-3: add Add Holder link on holders page

### DIFF
--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -24,6 +24,7 @@
   {% endwith %}
 
   <div class="card">
+    <p><a href="{{ url_for('holders_new') }}">Add Holder</a></p>
     <form method="get" action="{{ url_for('holders_search') }}">
       <label for="q"><strong>Search by name or identifier</strong></label><br />
       <input


### PR DESCRIPTION
## Summary
Expose holder creation from the existing /holders UI by adding an “Add Holder” entrypoint.

## Related Issue
Closes #142 

## Changes
- Add “Add Holder” link to `/holders` template pointing to `GET /holders/new`.
- Keep UI minimal and consistent with existing templates.

## Verification checklist
- [x] `PYTHONPATH=. pytest -q` → 44 passed

## Notes
- No backend changes required (routes already exist).
- No optional fields added (kept scope minimal).