### PR TITLE
Issue 21-4: test holder create search and select flow

### DIFF
--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -53,6 +53,38 @@ class HolderCreationViabilityTests(unittest.TestCase):
         count = self.conn.execute("SELECT COUNT(*) AS c FROM holders;").fetchone()["c"]
         self.assertEqual(count, 0)
 
+    def test_create_search_and_select_holder_workflow(self) -> None:
+        holder_name = "ZZ Test Holder 21-4"
+
+        create_response = self.client.post(
+            "/holders/new",
+            data={"name": holder_name},
+        )
+        self.assertEqual(create_response.status_code, 302)
+        self.assertTrue(create_response.headers["Location"].endswith("/holders"))
+
+        holder_row = self.conn.execute(
+            "SELECT id, name FROM holders WHERE name = ?;",
+            (holder_name,),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        search_response = self.client.get(
+            "/holders",
+            query_string={"q": holder_name},
+        )
+        self.assertEqual(search_response.status_code, 200)
+        self.assertIn(holder_name.encode("utf-8"), search_response.data)
+
+        select_response = self.client.post(
+            "/holders/select",
+            data={"holder_id": str(holder_id)},
+            follow_redirects=True,
+        )
+        self.assertEqual(select_response.status_code, 200)
+        self.assertIn(f"Selected holder: {holder_name}".encode("utf-8"), select_response.data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Add runtime test coverage to lock in the holder create → search → select workflow and prevent regressions.

## Related Issue
Closes #143 

## Changes
- Add deterministic test proving:
  - POST `/holders/new` creates holder (302)
  - `/holders?q=` surfaces holder in results (200 + name present)
  - POST `/holders/select` selects holder and flashes success

## Verification checklist
- [x] `PYTHONPATH=. pytest -q` → 45 passed

## Notes
- Uses DB lookup to resolve holder_id deterministically (avoids HTML parsing fragility).