### PR TITLE
Issue 15-2: admin user management UI

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -37,7 +37,17 @@ from assettrack.auth import current_user, require_login, require_role
 from assettrack.holders import create_holder, get_holder, search_holders
 from assettrack.slots import vacate_slot_by_asset_tag_in_tx
 from assettrack.audit import record_event
-from assettrack.users import count_users, create_user, get_user_by_username, verify_password
+from assettrack.users import (
+    count_users,
+    create_user,
+    get_user_by_id,
+    get_user_by_username,
+    list_users,
+    reset_user_password,
+    set_user_active,
+    set_user_role,
+    verify_password,
+)
 
 
 app = Flask(__name__)
@@ -2147,6 +2157,90 @@ def holders_clear():
     touch_session()
     flash("Cleared holder selection.", "success")
     return redirect(url_for("holders_search"))
+
+
+@app.get("/admin/users")
+@require_login
+@require_role("admin")
+def admin_users():
+    users = list_users()
+    return render_template("admin_users.html", users=users)
+
+
+@app.post("/admin/users/create")
+@require_login
+@require_role("admin")
+def admin_users_create():
+    username = (request.form.get("username") or "").strip()
+    password = request.form.get("password") or ""
+    role = (request.form.get("role") or "").strip().lower()
+    active = True if request.form.get("active") is None else _is_truthy(request.form.get("active"))
+
+    try:
+        create_user(username=username, password=password, role=role, active=active)
+    except ValueError as e:
+        flash(str(e), "error")
+    except sqlite3.IntegrityError:
+        flash("Username already exists.", "error")
+    else:
+        flash(f"Created user: {username}", "success")
+
+    return redirect(url_for("admin_users"))
+
+
+@app.post("/admin/users/<int:user_id>/toggle-active")
+@require_login
+@require_role("admin")
+def admin_users_toggle_active(user_id: int):
+    target = get_user_by_id(user_id)
+    if target is None:
+        flash("User not found.", "error")
+        return redirect(url_for("admin_users"))
+
+    requested = request.form.get("active")
+    next_active = (not bool(int(target.get("active") or 0))) if requested is None else _is_truthy(requested)
+
+    try:
+        updated = set_user_active(user_id, next_active)
+    except ValueError as e:
+        flash(str(e), "error")
+    else:
+        state = "enabled" if int(updated.get("active") or 0) == 1 else "disabled"
+        flash(f"User {updated['username']} is now {state}.", "success")
+
+    return redirect(url_for("admin_users"))
+
+
+@app.post("/admin/users/<int:user_id>/reset-password")
+@require_login
+@require_role("admin")
+def admin_users_reset_password(user_id: int):
+    new_password = request.form.get("new_password") or ""
+
+    try:
+        updated = reset_user_password(user_id, new_password)
+    except ValueError as e:
+        flash(str(e), "error")
+    else:
+        flash(f"Password reset for {updated['username']}.", "success")
+
+    return redirect(url_for("admin_users"))
+
+
+@app.post("/admin/users/<int:user_id>/set-role")
+@require_login
+@require_role("admin")
+def admin_users_set_role(user_id: int):
+    role = (request.form.get("role") or "").strip().lower()
+
+    try:
+        updated = set_user_role(user_id, role)
+    except ValueError as e:
+        flash(str(e), "error")
+    else:
+        flash(f"Updated role for {updated['username']} to {updated['role']}.", "success")
+
+    return redirect(url_for("admin_users"))
 
 
 @app.route("/admin/assets/new", methods=["GET", "POST"])

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -1,0 +1,98 @@
+<!-- file: assettrack/intake/templates/admin_users.html -->
+{% extends "base.html" %}
+
+{% block title %}Admin Users{% endblock %}
+{% block page_heading %}Admin: Users{% endblock %}
+
+{% block extra_head %}
+  <style>
+    input[type="text"], input[type="password"], select { width: 100%; max-width: 320px; padding: 0.45rem; font-size: 0.95rem; }
+    .inline-form { display: inline-block; margin: 0.15rem 0.35rem 0.15rem 0; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card">
+    <h2>Create User</h2>
+    <form method="post" action="{{ url_for('admin_users_create') }}">
+      <div class="row">
+        <label for="username"><strong>Username</strong></label><br />
+        <input type="text" id="username" name="username" required />
+      </div>
+      <div class="row">
+        <label for="password"><strong>Password</strong></label><br />
+        <input type="password" id="password" name="password" required />
+      </div>
+      <div class="row">
+        <label for="role"><strong>Role</strong></label><br />
+        <select id="role" name="role">
+          <option value="operator">operator</option>
+          <option value="admin">admin</option>
+        </select>
+      </div>
+      <div class="row">
+        <label>
+          <input type="checkbox" name="active" value="1" checked />
+          Active
+        </label>
+      </div>
+      <button type="submit">Create User</button>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Users</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Role</th>
+          <th>Active</th>
+          <th>Created</th>
+          <th>Updated</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for user in users %}
+          <tr>
+            <td>{{ user.username }}</td>
+            <td>{{ user.role }}</td>
+            <td>{{ "yes" if user.active else "no" }}</td>
+            <td><code>{{ user.created_at }}</code></td>
+            <td><code>{{ user.updated_at }}</code></td>
+            <td>
+              <form class="inline-form" method="post" action="{{ url_for('admin_users_toggle_active', user_id=user.id) }}">
+                <input type="hidden" name="active" value="{{ 0 if user.active else 1 }}" />
+                <button type="submit">{{ "Disable" if user.active else "Enable" }}</button>
+              </form>
+
+              <form class="inline-form" method="post" action="{{ url_for('admin_users_set_role', user_id=user.id) }}">
+                <select name="role">
+                  <option value="operator" {% if user.role == "operator" %}selected{% endif %}>operator</option>
+                  <option value="admin" {% if user.role == "admin" %}selected{% endif %}>admin</option>
+                </select>
+                <button type="submit">Set Role</button>
+              </form>
+
+              <form class="inline-form" method="post" action="{{ url_for('admin_users_reset_password', user_id=user.id) }}">
+                <input type="password" name="new_password" placeholder="New password" required />
+                <button type="submit">Reset Password</button>
+              </form>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -81,6 +81,9 @@
           <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue_preview') }}">Issue</a>
           <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
           <a class="chip {% if request.path.startswith('/preview') and not request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('preview') }}">Preview</a>
+          {% if authenticated_role == 'admin' %}
+            <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
+          {% endif %}
           <a class="chip {% if request.path == '/' %}active{% endif %}" href="{{ url_for('intake') }}">Add Assets</a>
           <a class="chip" href="{{ url_for('logout') }}">Logout</a>
         </nav>

--- a/assettrack/users.py
+++ b/assettrack/users.py
@@ -33,6 +33,17 @@ def count_users() -> int:
         conn.close()
 
 
+def _count_active_admins(conn) -> int:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) AS c
+        FROM users
+        WHERE role = 'admin' AND active = 1;
+        """
+    ).fetchone()
+    return int(row["c"])
+
+
 def get_user_by_username(username: str) -> dict | None:
     normalized = (username or "").strip()
     if not normalized:
@@ -64,6 +75,59 @@ def get_user_by_id(user_id: int) -> dict | None:
         conn.close()
 
 
+def list_users() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, username, role, active, created_at, updated_at
+            FROM users
+            ORDER BY username COLLATE NOCASE ASC;
+            """
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def guard_last_admin(
+    *,
+    action: str,
+    target_user_id: int,
+    target_role: str | None = None,
+    target_active: bool | None = None,
+) -> None:
+    user = get_user_by_id(target_user_id)
+    if user is None:
+        raise ValueError("User not found.")
+
+    current_role = str(user.get("role") or "").strip().lower()
+    current_active = int(user.get("active") or 0) == 1
+
+    next_role = current_role
+    if target_role is not None:
+        next_role = str(target_role or "").strip().lower()
+        if next_role not in ALLOWED_ROLES:
+            raise ValueError("Role must be admin or operator.")
+
+    next_active = current_active if target_active is None else bool(target_active)
+
+    if not (current_role == "admin" and current_active):
+        return
+
+    if next_role == "admin" and next_active:
+        return
+
+    conn = get_connection()
+    try:
+        active_admins = _count_active_admins(conn)
+    finally:
+        conn.close()
+
+    if active_admins <= 1:
+        raise ValueError(f"Cannot {action}: at least one active admin is required.")
+
+
 def create_user(username: str, password: str, role: str, active: bool = True) -> dict:
     normalized_username = (username or "").strip()
     normalized_role = (role or "").strip().lower()
@@ -87,6 +151,87 @@ def create_user(username: str, password: str, role: str, active: bool = True) ->
         conn.commit()
         created_id = int(cursor.lastrowid)
         row = conn.execute("SELECT * FROM users WHERE id = ?;", (created_id,)).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def set_user_active(user_id: int, active: bool) -> dict:
+    normalized_user_id = int(user_id)
+    guard_last_admin(action="deactivate the last active admin", target_user_id=normalized_user_id, target_active=active)
+
+    now_iso = _now_iso()
+    active_int = 1 if bool(active) else 0
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            UPDATE users
+            SET active = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (active_int, now_iso, normalized_user_id),
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("User not found.")
+        conn.commit()
+        row = conn.execute("SELECT * FROM users WHERE id = ?;", (normalized_user_id,)).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def set_user_role(user_id: int, role: str) -> dict:
+    normalized_user_id = int(user_id)
+    normalized_role = str(role or "").strip().lower()
+    if normalized_role not in ALLOWED_ROLES:
+        raise ValueError("Role must be admin or operator.")
+
+    guard_last_admin(
+        action="demote the last active admin",
+        target_user_id=normalized_user_id,
+        target_role=normalized_role,
+    )
+
+    now_iso = _now_iso()
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            UPDATE users
+            SET role = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (normalized_role, now_iso, normalized_user_id),
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("User not found.")
+        conn.commit()
+        row = conn.execute("SELECT * FROM users WHERE id = ?;", (normalized_user_id,)).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def reset_user_password(user_id: int, new_password: str) -> dict:
+    normalized_user_id = int(user_id)
+    password_hash = _bcrypt_hash(new_password)
+    now_iso = _now_iso()
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            UPDATE users
+            SET password_hash = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (password_hash, now_iso, normalized_user_id),
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("User not found.")
+        conn.commit()
+        row = conn.execute("SELECT * FROM users WHERE id = ?;", (normalized_user_id,)).fetchone()
         return dict(row)
     finally:
         conn.close()

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -1,0 +1,148 @@
+# file: tests/test_admin_user_management.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.users import get_user_by_id, get_user_by_username, verify_password
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def test_admin_can_view_user_table(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    create_test_user(username="operator-a", password="op-pass", role="operator")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.get("/admin/users")
+
+    assert response.status_code == 200
+    assert b"Admin: Users" in response.data
+    assert b"operator-a" in response.data
+
+
+def test_admin_can_create_operator_user(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(
+        "/admin/users/create",
+        data={"username": "new-operator", "password": "new-pass", "role": "operator", "active": "1"},
+    )
+
+    assert response.status_code == 302
+    created = get_user_by_username("new-operator")
+    assert created is not None
+    assert created["role"] == "operator"
+    assert int(created["active"]) == 1
+
+
+def test_admin_can_toggle_active_for_non_last_admin(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    target_user_id = create_test_user(username="operator-a", password="op-pass", role="operator")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(f"/admin/users/{target_user_id}/toggle-active", data={"active": "0"})
+
+    assert response.status_code == 302
+    updated = get_user_by_id(target_user_id)
+    assert updated is not None
+    assert int(updated["active"]) == 0
+
+
+def test_admin_cannot_deactivate_last_active_admin(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="solo-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(f"/admin/users/{admin_user_id}/toggle-active", data={"active": "0"})
+
+    assert response.status_code == 302
+    updated = get_user_by_id(admin_user_id)
+    assert updated is not None
+    assert int(updated["active"]) == 1
+
+
+
+def test_admin_can_reset_password_and_new_password_allows_login(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    target_username = "operator-a"
+    target_user_id = create_test_user(username=target_username, password="old-pass", role="operator")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(
+        f"/admin/users/{target_user_id}/reset-password",
+        data={"new_password": "new-pass-123"},
+    )
+
+    assert response.status_code == 302
+
+    client_with_temp_db.get("/logout")
+
+    old_login = client_with_temp_db.post("/", data={"username": target_username, "password": "old-pass"})
+    assert old_login.status_code == 403
+
+    new_login = client_with_temp_db.post("/", data={"username": target_username, "password": "new-pass-123"})
+    assert new_login.status_code == 302
+    updated = get_user_by_id(target_user_id)
+    assert updated is not None
+    assert verify_password(updated, "new-pass-123")
+
+
+def test_admin_can_change_role_and_persists(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    target_user_id = create_test_user(username="operator-a", password="op-pass", role="operator")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(
+        f"/admin/users/{target_user_id}/set-role",
+        data={"role": "admin"},
+    )
+
+    assert response.status_code == 302
+    updated = get_user_by_id(target_user_id)
+    assert updated is not None
+    assert updated["role"] == "admin"
+
+
+def test_admin_cannot_demote_last_active_admin(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="solo-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(
+        f"/admin/users/{admin_user_id}/set-role",
+        data={"role": "operator"},
+    )
+
+    assert response.status_code == 302
+    updated = get_user_by_id(admin_user_id)
+    assert updated is not None
+    assert updated["role"] == "admin"
+
+
+def test_operator_is_forbidden_for_admin_user_routes(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-a", password="op-pass", role="operator")
+    target_id = create_test_user(username="target", password="target-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    assert client_with_temp_db.get("/admin/users").status_code == 403
+    assert client_with_temp_db.post(
+        "/admin/users/create",
+        data={"username": "x", "password": "y", "role": "operator"},
+    ).status_code == 403
+    assert client_with_temp_db.post(f"/admin/users/{target_id}/toggle-active", data={"active": "0"}).status_code == 403
+    assert client_with_temp_db.post(
+        f"/admin/users/{target_id}/reset-password",
+        data={"new_password": "new-pass"},
+    ).status_code == 403
+    assert client_with_temp_db.post(f"/admin/users/{target_id}/set-role", data={"role": "admin"}).status_code == 403


### PR DESCRIPTION
## Summary

Add an admin-only user management UI to create users, toggle active status, reset passwords, and change roles in an offline-safe way, with zero-trust enforcement and lockout prevention.

## Related Issue

Closes #125 

## Changes

- Added user management helpers in `assettrack/users.py`:
  - list users, toggle active, set role, reset password
  - enforce guardrail: cannot deactivate or demote the last active admin
- Added admin-only routes:
  - GET `/admin/users`
  - POST `/admin/users/create`
  - POST `/admin/users/<id>/toggle-active`
  - POST `/admin/users/<id>/reset-password`
  - POST `/admin/users/<id>/set-role`
- Added minimal admin UI page `admin_users.html` with create form and per-user actions
- Added admin-only navigation link to `/admin/users`
- Added test coverage for admin flows, operator 403s, password reset, role change, and last-admin protections

## Verification checklist

- [x] `PYTHONPATH=. pytest -q` (56 passed)
- [x] Admin can access `/admin/users`
- [x] Admin can create operator user
- [x] Admin can reset password and login with new password
- [x] Admin can change roles and toggle active status
- [x] System prevents deactivating or demoting the last active admin
- [x] Operator receives 403 on `/admin/users` and all related POST routes

## Notes

No schema changes. All enforcement is centralized and offline-safe.