### PR TITLE
Issue 15-3: self-service password change

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -38,6 +38,7 @@ from assettrack.holders import create_holder, get_holder, search_holders
 from assettrack.slots import vacate_slot_by_asset_tag_in_tx
 from assettrack.audit import record_event
 from assettrack.users import (
+    change_own_password,
     count_users,
     create_user,
     get_user_by_id,
@@ -1589,6 +1590,37 @@ def bootstrap_admin():
 def logout():
     session.pop("user_id", None)
     return redirect("/")
+
+
+@app.get("/account/change-password")
+@require_login
+def account_change_password():
+    return render_template("account_change_password.html")
+
+
+@app.post("/account/change-password")
+@require_login
+def account_change_password_submit():
+    user = current_user()
+    if user is None:
+        return {"ok": False, "error": "Forbidden"}, 403
+
+    current_password = request.form.get("current_password") or ""
+    new_password = request.form.get("new_password") or ""
+    confirm_new_password = request.form.get("confirm_new_password") or ""
+
+    if new_password != confirm_new_password:
+        flash("New password and confirmation must match.", "error")
+        return redirect(url_for("account_change_password"))
+
+    try:
+        change_own_password(int(user["id"]), current_password, new_password)
+    except ValueError as e:
+        flash(str(e), "error")
+        return redirect(url_for("account_change_password"))
+
+    flash("Password updated.", "success")
+    return redirect(url_for("account_change_password"))
 
 
 @app.get("/dashboard")

--- a/assettrack/intake/templates/account_change_password.html
+++ b/assettrack/intake/templates/account_change_password.html
@@ -1,0 +1,37 @@
+<!-- file: assettrack/intake/templates/account_change_password.html -->
+{% extends "base.html" %}
+
+{% block title %}Change Password{% endblock %}
+{% block page_heading %}Account: Change Password{% endblock %}
+
+{% block content %}
+  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card">
+    <h2>Change Password</h2>
+    <form method="post" action="{{ url_for('account_change_password_submit') }}">
+      <div class="row">
+        <label for="current_password"><strong>Current password</strong></label><br />
+        <input type="password" id="current_password" name="current_password" required />
+      </div>
+      <div class="row">
+        <label for="new_password"><strong>New password</strong></label><br />
+        <input type="password" id="new_password" name="new_password" required />
+      </div>
+      <div class="row">
+        <label for="confirm_new_password"><strong>Confirm new password</strong></label><br />
+        <input type="password" id="confirm_new_password" name="confirm_new_password" required />
+      </div>
+      <button type="submit">Update Password</button>
+    </form>
+    <p class="muted">Password must be at least 12 characters and include at least one letter and one number.</p>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -84,6 +84,7 @@
           {% if authenticated_role == 'admin' %}
             <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
           {% endif %}
+          <a class="chip {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
           <a class="chip {% if request.path == '/' %}active{% endif %}" href="{{ url_for('intake') }}">Add Assets</a>
           <a class="chip" href="{{ url_for('logout') }}">Logout</a>
         </nav>

--- a/assettrack/users.py
+++ b/assettrack/users.py
@@ -24,6 +24,19 @@ def _bcrypt_hash(password: str) -> str:
     return password_hash
 
 
+def _validate_new_password(username: str, current_password: str, new_password: str) -> None:
+    if len(new_password) < 12:
+        raise ValueError("New password must be at least 12 characters.")
+    if not any(ch.isalpha() for ch in new_password):
+        raise ValueError("New password must include at least one letter.")
+    if not any(ch.isdigit() for ch in new_password):
+        raise ValueError("New password must include at least one number.")
+    if new_password.casefold() == str(username or "").casefold():
+        raise ValueError("New password must not equal username.")
+    if new_password == current_password:
+        raise ValueError("New password must not equal current password.")
+
+
 def count_users() -> int:
     conn = get_connection()
     try:
@@ -232,6 +245,37 @@ def reset_user_password(user_id: int, new_password: str) -> dict:
             raise ValueError("User not found.")
         conn.commit()
         row = conn.execute("SELECT * FROM users WHERE id = ?;", (normalized_user_id,)).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def change_own_password(user_id: int, current_password: str, new_password: str) -> dict:
+    user = get_user_by_id(user_id)
+    if user is None:
+        raise ValueError("User not found.")
+
+    if not verify_password(user, current_password):
+        raise ValueError("Current password is incorrect.")
+
+    _validate_new_password(str(user.get("username") or ""), current_password, new_password)
+    password_hash = _bcrypt_hash(new_password)
+    now_iso = _now_iso()
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            UPDATE users
+            SET password_hash = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (password_hash, now_iso, int(user["id"])),
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("User not found.")
+        conn.commit()
+        row = conn.execute("SELECT * FROM users WHERE id = ?;", (int(user["id"]),)).fetchone()
         return dict(row)
     finally:
         conn.close()

--- a/tests/test_account_change_password.py
+++ b/tests/test_account_change_password.py
@@ -1,0 +1,132 @@
+# file: tests/test_account_change_password.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.users import get_user_by_id, verify_password
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def test_unauthenticated_user_cannot_access_change_password(client_with_temp_db) -> None:
+    get_response = client_with_temp_db.get("/account/change-password")
+    post_response = client_with_temp_db.post(
+        "/account/change-password",
+        data={
+            "current_password": "whatever",
+            "new_password": "VerySecure123",
+            "confirm_new_password": "VerySecure123",
+        },
+    )
+
+    assert get_response.status_code == 403
+    assert post_response.status_code == 403
+
+
+def test_authenticated_user_can_change_password_and_session_stays_valid(client_with_temp_db) -> None:
+    user_id = create_test_user(username="operator-a", password="OldPassword123", role="operator")
+    login_session(client_with_temp_db, user_id)
+
+    response = client_with_temp_db.post(
+        "/account/change-password",
+        data={
+            "current_password": "OldPassword123",
+            "new_password": "NewPassword456",
+            "confirm_new_password": "NewPassword456",
+        },
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/account/change-password")
+
+    updated = get_user_by_id(user_id)
+    assert updated is not None
+    assert verify_password(updated, "NewPassword456")
+    assert not verify_password(updated, "OldPassword123")
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert int(sess["user_id"]) == user_id
+
+    holders = client_with_temp_db.get("/holders")
+    assert holders.status_code == 200
+
+    client_with_temp_db.get("/logout")
+    old_login = client_with_temp_db.post("/", data={"username": "operator-a", "password": "OldPassword123"})
+    new_login = client_with_temp_db.post("/", data={"username": "operator-a", "password": "NewPassword456"})
+    assert old_login.status_code == 403
+    assert new_login.status_code == 302
+
+
+def test_wrong_current_password_fails_without_hash_change(client_with_temp_db) -> None:
+    user_id = create_test_user(username="operator-a", password="OldPassword123", role="operator")
+    login_session(client_with_temp_db, user_id)
+    before = get_user_by_id(user_id)
+    assert before is not None
+
+    response = client_with_temp_db.post(
+        "/account/change-password",
+        data={
+            "current_password": "wrong-password",
+            "new_password": "NewPassword456",
+            "confirm_new_password": "NewPassword456",
+        },
+    )
+
+    assert response.status_code == 302
+    after = get_user_by_id(user_id)
+    assert after is not None
+    assert after["password_hash"] == before["password_hash"]
+
+
+def test_weak_password_fails_without_hash_change(client_with_temp_db) -> None:
+    user_id = create_test_user(username="operator-a", password="OldPassword123", role="operator")
+    login_session(client_with_temp_db, user_id)
+    before = get_user_by_id(user_id)
+    assert before is not None
+
+    response = client_with_temp_db.post(
+        "/account/change-password",
+        data={
+            "current_password": "OldPassword123",
+            "new_password": "short1",
+            "confirm_new_password": "short1",
+        },
+    )
+
+    assert response.status_code == 302
+    after = get_user_by_id(user_id)
+    assert after is not None
+    assert after["password_hash"] == before["password_hash"]
+
+
+def test_confirm_mismatch_fails_without_hash_change(client_with_temp_db) -> None:
+    user_id = create_test_user(username="operator-a", password="OldPassword123", role="operator")
+    login_session(client_with_temp_db, user_id)
+    before = get_user_by_id(user_id)
+    assert before is not None
+
+    response = client_with_temp_db.post(
+        "/account/change-password",
+        data={
+            "current_password": "OldPassword123",
+            "new_password": "NewPassword456",
+            "confirm_new_password": "Mismatch789",
+        },
+    )
+
+    assert response.status_code == 302
+    after = get_user_by_id(user_id)
+    assert after is not None
+    assert after["password_hash"] == before["password_hash"]


### PR DESCRIPTION
## Summary

Add a self-service password change flow so authenticated users can update their own password without admin intervention, while preserving offline-first bcrypt hashing and session continuity.

## Related Issue

Closes #126 

## Changes

- Added `change_own_password(...)` helper with basic password rules and bcrypt re-hash
- Added `/account/change-password` GET/POST routes (login required)
- Added minimal change-password form template
- Added authenticated nav link to the account password page
- Added tests for success and failure cases, including session continuity and old/new password behavior

## Verification checklist

- [x] `PYTHONPATH=. pytest -q` (61 passed)
- [x] Unauthenticated access denied (403)
- [x] Current password required and verified
- [x] Password rules enforced (min 12, letter+number, not username, not current password)
- [x] Hash updated and persisted
- [x] Session remains valid after change
- [x] Old password fails login, new password succeeds

## Notes

No schema changes. Uses existing pure-Python bcrypt hashing path.