### PR TITLE
Issue 16-1: event terminology rename

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -1,7 +1,9 @@
 # assettrack/dashboard.py
+# file: assettrack/dashboard.py
 from __future__ import annotations
 
 from assettrack.audit import ACTIVE_EVENTS_WHERE
+from assettrack.event_types import issue_event_type_values
 
 from datetime import datetime, timezone
 import sqlite3
@@ -226,36 +228,38 @@ def _in_custody_days_out(conn: sqlite3.Connection, *, now_utc: datetime) -> list
 
     asset_tags = [str(row["asset_tag"]) for row in asset_rows]
     placeholders = ", ".join("?" for _ in asset_tags)
+    issue_values = issue_event_type_values()
+    issue_placeholders = ", ".join("?" for _ in issue_values)
     event_rows = conn.execute(
         f"""
         SELECT asset_tag, event_date, id
         FROM asset_events
-        WHERE event_type = 'STOCK_OUT'
+        WHERE event_type IN ({issue_placeholders})
         AND {ACTIVE_EVENTS_WHERE}
         AND asset_tag IN ({placeholders})
         ORDER BY asset_tag ASC, id ASC;
         """,
-        tuple(asset_tags),
+        tuple(issue_values) + tuple(asset_tags),
     ).fetchall()
 
-    latest_stock_out_by_tag: dict[str, datetime] = {}
+    latest_issue_by_tag: dict[str, datetime] = {}
     for row in event_rows:
         asset_tag = str(row["asset_tag"] or "")
         parsed = _parse_utc_timestamp(row["event_date"])
         if parsed is None:
             continue
-        previous = latest_stock_out_by_tag.get(asset_tag)
+        previous = latest_issue_by_tag.get(asset_tag)
         if previous is None or parsed > previous:
-            latest_stock_out_by_tag[asset_tag] = parsed
+            latest_issue_by_tag[asset_tag] = parsed
 
     rows_with_days: list[dict] = []
     for row in asset_rows:
         asset_tag = str(row["asset_tag"] or "")
-        stock_out_ts = latest_stock_out_by_tag.get(asset_tag)
-        if stock_out_ts is None:
+        issue_ts = latest_issue_by_tag.get(asset_tag)
+        if issue_ts is None:
             continue
 
-        days_out = int((now_utc - stock_out_ts).total_seconds() // 86400)
+        days_out = int((now_utc - issue_ts).total_seconds() // 86400)
         rows_with_days.append(
             {
                 "asset_tag": asset_tag,

--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -6,6 +6,7 @@ import sqlite3
 
 from assettrack.assets import get_asset_table_columns
 from assettrack.audit import ACTIVE_EVENTS_WHERE
+from assettrack.event_types import issue_event_type_values
 
 
 def _parse_utc_timestamp(value: object) -> datetime | None:
@@ -112,19 +113,21 @@ def get_holder_custody_detail(
     placeholders = ", ".join("?" for _ in asset_tags)
 
     # Important: ignore superseded events (Issue 12-2)
+    issue_values = issue_event_type_values()
+    issue_placeholders = ", ".join("?" for _ in issue_values)
     event_rows = conn.execute(
         f"""
         SELECT id, asset_tag, event_date
         FROM asset_events
-        WHERE event_type = 'STOCK_OUT'
+        WHERE event_type IN ({issue_placeholders})
           AND {ACTIVE_EVENTS_WHERE}
           AND asset_tag IN ({placeholders})
         ORDER BY asset_tag ASC, id ASC;
         """,
-        tuple(asset_tags),
+        tuple(issue_values) + tuple(asset_tags),
     ).fetchall()
 
-    latest_stock_out: dict[str, dict] = {}
+    latest_issue: dict[str, dict] = {}
     for row in event_rows:
         asset_tag = str(row["asset_tag"] or "")
         parsed = _parse_utc_timestamp(row["event_date"])
@@ -132,21 +135,21 @@ def get_holder_custody_detail(
             continue
 
         event_id = int(row["id"])
-        previous = latest_stock_out.get(asset_tag)
+        previous = latest_issue.get(asset_tag)
         if previous is None or parsed > previous["ts"] or (parsed == previous["ts"] and event_id > previous["id"]):
-            latest_stock_out[asset_tag] = {
+            latest_issue[asset_tag] = {
                 "ts": parsed,
                 "id": event_id,
                 "event_date": str(row["event_date"]),
             }
 
     for asset in assets:
-        stock_out = latest_stock_out.get(asset["asset_tag"])
-        if stock_out is None:
+        issue_event = latest_issue.get(asset["asset_tag"])
+        if issue_event is None:
             continue
-        days_out = int((current_utc - stock_out["ts"]).total_seconds() // 86400)
+        days_out = int((current_utc - issue_event["ts"]).total_seconds() // 86400)
         asset["days_out"] = max(0, days_out)
-        asset["last_issued_date"] = stock_out["event_date"]
+        asset["last_issued_date"] = issue_event["event_date"]
 
     return {
         "holder_id": int(holder_row["id"]),

--- a/assettrack/event_types.py
+++ b/assettrack/event_types.py
@@ -1,0 +1,27 @@
+# file: assettrack/event_types.py
+from __future__ import annotations
+
+ISSUE_EVENT_TYPE = "ISSUE"
+RETURN_EVENT_TYPE = "RETURN"
+
+_LEGACY_TO_CANONICAL = {
+    "STOCK_OUT": ISSUE_EVENT_TYPE,
+    "STOCK_IN": RETURN_EVENT_TYPE,
+}
+
+
+def normalize_event_type(db_value: object) -> str:
+    raw = str(db_value or "").strip().upper()
+    if not raw:
+        return ""
+    if raw in {ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE}:
+        return raw
+    return _LEGACY_TO_CANONICAL.get(raw, raw)
+
+
+def issue_event_type_values() -> tuple[str, ...]:
+    return ISSUE_EVENT_TYPE, "STOCK_OUT"
+
+
+def return_event_type_values() -> tuple[str, ...]:
+    return RETURN_EVENT_TYPE, "STOCK_IN"

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -37,6 +37,7 @@ from assettrack.auth import current_user, require_login, require_role
 from assettrack.holders import create_holder, get_holder, search_holders
 from assettrack.slots import vacate_slot_by_asset_tag_in_tx
 from assettrack.audit import record_event
+from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
 from assettrack.users import (
     change_own_password,
     count_users,
@@ -1248,7 +1249,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
     return {"assets": assets, "ready_count": ready_count, "blocking_issues": blocking_issues}
 
 
-def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
+def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to issue.")
 
@@ -1382,7 +1383,7 @@ def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
                     )
                     VALUES (?, ?, ?, ?, ?, ?, ?);
                     """,
-                    (canon_tag, "STOCK_OUT", now_iso, "system", None, None, holder_id),
+                    (canon_tag, ISSUE_EVENT_TYPE, now_iso, "system", None, None, holder_id),
                 )
 
             return len(canon_tags)
@@ -1390,7 +1391,7 @@ def _stock_out_batch(asset_tags: list[str], holder_id: int) -> int:
         conn.close()
 
 
-def _stock_in_batch(asset_tags: list[str]) -> int:
+def _return_batch(asset_tags: list[str]) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to return")
 
@@ -1524,7 +1525,7 @@ def _stock_in_batch(asset_tags: list[str]) -> int:
                     )
                     VALUES (?, ?, ?, ?, ?, ?, ?);
                     """,
-                    (canon_tag, "STOCK_IN", now_iso, "system", None, None, None),
+                    (canon_tag, RETURN_EVENT_TYPE, now_iso, "system", None, None, None),
                 )
 
             return len(validated_rows)
@@ -1732,7 +1733,7 @@ def preview():
         validation=validation,
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
         selected_holder=_selected_holder_from_session(),
-        stock_out_mode=bool(session.get("stock_out_mode")),
+        issue_mode=bool(session.get("issue_mode")),
     )
 
 
@@ -1757,10 +1758,10 @@ def preview_mode():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
-    enabled = (request.form.get("stock_out_mode") or "").strip().lower() in {"on", "true", "1", "yes"}
-    session["stock_out_mode"] = bool(enabled)
+    enabled = (request.form.get("issue_mode") or "").strip().lower() in {"on", "true", "1", "yes"}
+    session["issue_mode"] = bool(enabled)
 
-    # If turning off stock-out mode, clear holder selection to avoid confusion.
+    # If turning off issue mode, clear holder selection to avoid confusion.
     if not enabled:
         session.pop("holder_id", None)
 
@@ -1817,11 +1818,11 @@ def preview_commit():
         flash("Please confirm you reviewed the batch before adding it.", "error")
         return redirect(url_for("preview"))
 
-    stock_out_mode = bool(session.get("stock_out_mode"))
+    issue_mode = bool(session.get("issue_mode"))
 
     # Normal intake commit mode
 
-    if not stock_out_mode:
+    if not issue_mode:
         parsed_rows = build_parsed_rows_from_queue()
 
         validation = validate_rows(parsed_rows)
@@ -1857,7 +1858,7 @@ def preview_commit():
             return redirect(url_for("preview"))
 
         SCAN_QUEUE.clear()
-        session.pop("holder_id", None)  # keep tidy; holder is only meaningful for stock-out
+        session.pop("holder_id", None)  # keep tidy; holder is only meaningful for issue mode
         touch_session()
 
         if wants_json():
@@ -1866,7 +1867,7 @@ def preview_commit():
         flash(f"Added {result.committed_count} items to the database.", "success")
         return redirect(url_for("intake"))
 
-    # Stock-out commit mode
+    # Issue commit mode
 
     holder = _selected_holder_from_session()
     if holder is None:
@@ -1882,7 +1883,7 @@ def preview_commit():
     asset_tags = _queue_asset_tags()
 
     try:
-        committed_count = _stock_out_batch(asset_tags, holder["id"])
+        committed_count = _issue_batch(asset_tags, holder["id"])
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400
@@ -1903,8 +1904,8 @@ def preview_commit():
 @app.get("/issue/preview")
 @require_login
 def issue_preview():
-    stock_out_mode = bool(session.get("stock_out_mode"))
-    if not stock_out_mode:
+    issue_mode = bool(session.get("issue_mode"))
+    if not issue_mode:
         flash("Enable issue mode before using Issue Assets.", "error")
         return render_template(
             "issue_preview.html",
@@ -1918,7 +1919,7 @@ def issue_preview():
 
     return render_template(
         "issue_preview.html",
-        stock_out_mode=stock_out_mode,
+        issue_mode=issue_mode,
         selected_holder=selected_holder,
         queued_count=len(asset_tags),
         assets=issue_preview_state["assets"],
@@ -1937,8 +1938,8 @@ def issue_commit():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
-    stock_out_mode = bool(session.get("stock_out_mode"))
-    if not stock_out_mode:
+    issue_mode = bool(session.get("issue_mode"))
+    if not issue_mode:
         if wants_json():
             return {"ok": False, "committed": 0, "error": "Issue mode is not enabled."}, 400
         flash("Enable issue mode before issuing assets.", "error")
@@ -1970,7 +1971,7 @@ def issue_commit():
         return redirect(url_for("issue_preview"))
 
     try:
-        committed_count = _stock_out_batch(asset_tags, holder["id"])
+        committed_count = _issue_batch(asset_tags, holder["id"])
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400
@@ -2072,7 +2073,7 @@ def return_commit():
         return redirect(url_for("return_preview"))
 
     try:
-        committed_count = _stock_in_batch(asset_tags)
+        committed_count = _return_batch(asset_tags)
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -64,14 +64,14 @@
 
     <form method="post" action="{{ url_for('preview_mode') }}" style="margin-top: 10px;">
       <label>
-        <input type="checkbox" name="stock_out_mode" value="on" {% if stock_out_mode %}checked{% endif %} />
+        <input type="checkbox" name="issue_mode" value="on" {% if issue_mode %}checked{% endif %} />
         Enable Issue mode (issue assets to a selected holder)
       </label>
       <br /><br />
       <button type="submit">Save mode</button>
     </form>
 
-    {% if stock_out_mode %}
+    {% if issue_mode %}
       <p style="margin-top: 12px;"><strong>Issue mode:</strong> ON</p>
       {% if selected_holder %}
         <p>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -135,9 +135,9 @@ On failure:
 
 ---
 
-## 7. Issuing Assets (Stock Out)
+## 7. Issuing Assets (Issue)
 
-Stock Out moves assets from STORAGE to IN_CUSTODY.
+Issue moves assets from STORAGE to IN_CUSTODY.
 
 ### Preconditions
 
@@ -164,14 +164,14 @@ Stock Out moves assets from STORAGE to IN_CUSTODY.
 - `location_type` → IN_CUSTODY
 - `current_holder_id` set
 - Slot vacated
-- STOCK_OUT event logged
+- ISSUE event logged
 - Queue cleared
 - Holder cleared
 - Redirect to `/`
 
 ---
 
-## 8. Returning Assets (Stock In)
+## 8. Returning Assets (Return)
 
 Return moves assets from IN_CUSTODY to STORAGE.
 
@@ -198,7 +198,7 @@ Return moves assets from IN_CUSTODY to STORAGE.
 - `location_type` → STORAGE
 - `current_holder_id` cleared
 - Slot reoccupied
-- STOCK_IN event logged
+- RETURN event logged
 - Queue cleared
 - Redirect to `/return`
 

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -1,3 +1,4 @@
+# file: tests/test_admin_retire_asset.py
 from __future__ import annotations
 
 import json
@@ -194,15 +195,15 @@ class AdminRetireAssetTests(unittest.TestCase):
         payload = json.loads(event["payload"])
         self.assertEqual(payload["failure_type"], "LOST")
 
-    def test_retired_assets_are_blocked_from_stock_out_and_stock_in(self) -> None:
+    def test_retired_assets_are_blocked_from_issue_and_return(self) -> None:
         self._insert_asset("RET-300", location_type="DISPOSED", holder_id=None, home_slot_id=20)
         self._insert_slot(20, "CASE-B", 2, current_asset_tag=None)
 
         with self.assertRaisesRegex(ValueError, "Retired/disposed"):
-            intake_app._stock_out_batch(["RET-300"], holder_id=4)
+            intake_app._issue_batch(["RET-300"], holder_id=4)
 
         with self.assertRaisesRegex(ValueError, "Retired/disposed"):
-            intake_app._stock_in_batch(["RET-300"])
+            intake_app._return_batch(["RET-300"])
 
     def test_admin_assign_slot_refuses_retired_asset(self) -> None:
         self._insert_asset("RET-400", location_type="DISPOSED", holder_id=None, home_slot_id=None)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,3 +1,4 @@
+# file: tests/test_dashboard.py
 from __future__ import annotations
 
 import tempfile
@@ -7,6 +8,7 @@ from pathlib import Path
 
 import assettrack.db as db
 from assettrack.dashboard import build_dashboard_data
+from assettrack.event_types import issue_event_type_values
 from assettrack.intake import app as intake_app
 from tests.auth_test_utils import create_test_user, login_session
 
@@ -103,13 +105,15 @@ class DashboardTests(unittest.TestCase):
             (slot_id, case_name, slot_position),
         )
 
-    def _insert_stock_out(self, asset_tag: str, event_date: str) -> None:
+    def _insert_issue_event(self, asset_tag: str, event_date: str, *, legacy: bool = False) -> None:
+        issue_values = issue_event_type_values()
+        event_type = issue_values[1] if legacy else issue_values[0]
         self.conn.execute(
             """
             INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
-            VALUES (?, 'STOCK_OUT', ?, 'tester', NULL, NULL, NULL);
+            VALUES (?, ?, ?, 'tester', NULL, NULL, NULL);
             """,
-            (asset_tag, event_date),
+            (asset_tag, event_type, event_date),
         )
 
     def _replace_slot_occupancy_without_unique_constraints(self) -> None:
@@ -140,7 +144,7 @@ class DashboardTests(unittest.TestCase):
             """,
             (storage_asset_id,),
         )
-        self._insert_stock_out("AT-CUST", "2025-12-01T00:00:00Z")
+        self._insert_issue_event("AT-CUST", "2025-12-01T00:00:00Z")
         self.conn.commit()
 
         response = self.client.get("/dashboard")
@@ -154,7 +158,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Case Utilization", response.data)
         self.assertIn(b"Exceptions Preview", response.data)
 
-    def test_dashboard_metrics_use_distinct_and_most_recent_stock_out(self) -> None:
+    def test_dashboard_metrics_use_distinct_and_most_recent_issue_event(self) -> None:
         self._replace_slot_occupancy_without_unique_constraints()
         self._insert_holder(1, "Alpha")
         self._insert_holder(2, "Bravo")
@@ -178,9 +182,9 @@ class DashboardTests(unittest.TestCase):
             (asset_old, asset_recent, asset_storage),
         )
 
-        self._insert_stock_out("AT-OLD", "2026-01-01T00:00:00Z")
-        self._insert_stock_out("AT-RECENT", "2026-01-01T00:00:00Z")
-        self._insert_stock_out("AT-RECENT", "2026-02-10T00:00:00Z")
+        self._insert_issue_event("AT-OLD", "2026-01-01T00:00:00Z")
+        self._insert_issue_event("AT-RECENT", "2026-01-01T00:00:00Z", legacy=True)
+        self._insert_issue_event("AT-RECENT", "2026-02-10T00:00:00Z")
         self.conn.commit()
 
         data = build_dashboard_data(

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -1,3 +1,4 @@
+# file: tests/test_dashboard_drilldowns.py
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -11,6 +12,7 @@ from assettrack.drilldowns import (
     list_case_summaries,
     list_holders_in_custody,
 )
+from assettrack.event_types import issue_event_type_values
 from assettrack.intake import app as intake_app
 from tests.auth_test_utils import create_test_user, login_session
 
@@ -82,13 +84,15 @@ def _insert_asset(
     return int(cursor.lastrowid)
 
 
-def _insert_stock_out(conn, asset_tag: str, event_date: str) -> None:
+def _insert_issue_event(conn, asset_tag: str, event_date: str, *, legacy: bool = False) -> None:
+    issue_values = issue_event_type_values()
+    event_type = issue_values[1] if legacy else issue_values[0]
     conn.execute(
         """
         INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
-        VALUES (?, 'STOCK_OUT', ?, 'tester', NULL, NULL, NULL);
+        VALUES (?, ?, ?, 'tester', NULL, NULL, NULL);
         """,
-        (asset_tag, event_date),
+        (asset_tag, event_type, event_date),
     )
 
 
@@ -204,7 +208,7 @@ def test_holders_and_cases_deterministic_ordering(app_client) -> None:
     assert [row["case_name"] for row in cases] == ["CASE-B", "CASE-A"]
 
 
-def test_holder_detail_uses_most_recent_stock_out_and_unknown_when_missing(app_client) -> None:
+def test_holder_detail_uses_most_recent_issue_event_and_unknown_when_missing(app_client) -> None:
     conn, _ = app_client
     _insert_holder(conn, 1, "Holder")
     _insert_asset(
@@ -223,8 +227,8 @@ def test_holder_detail_uses_most_recent_stock_out_and_unknown_when_missing(app_c
         holder_id=1,
         equipment_type="tablet",
     )
-    _insert_stock_out(conn, "AT-RECENT", "2026-01-01T00:00:00Z")
-    _insert_stock_out(conn, "AT-RECENT", "2026-02-01T00:00:00Z")
+    _insert_issue_event(conn, "AT-RECENT", "2026-01-01T00:00:00Z", legacy=True)
+    _insert_issue_event(conn, "AT-RECENT", "2026-02-01T00:00:00Z")
     conn.commit()
 
     detail = get_holder_custody_detail(

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -143,7 +143,7 @@ class ReturnBatchTests(unittest.TestCase):
             ("TAG-OK",),
         ).fetchone()
         self.assertIsNotNone(event_row)
-        self.assertEqual(event_row["event_type"], "STOCK_IN")
+        self.assertEqual(event_row["event_type"], "RETURN")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Rename operator-facing event terminology from Stock In / Stock Out to Return / Issue while preserving backward compatibility for historical rows. All new events now persist canonical values (`ISSUE`, `RETURN`). No historical event rows were modified.

## Related Issue

Closes #128 

## Changes

- Added compatibility layer in `assettrack/event_types.py`:
  - Canonical event types: `ISSUE`, `RETURN`
  - Legacy values (`STOCK_OUT`, `STOCK_IN`) isolated and accepted via helper functions only
- Updated intake write paths:
  - Issue flow writes `ISSUE`
  - Return flow writes `RETURN`
  - Renamed internal helpers to `_issue_batch` and `_return_batch`
  - Session/form field renamed to `issue_mode`
- Updated dashboard and drilldowns queries to accept canonical + legacy values using compatibility helpers
- Updated preview UI terminology to Issue / Return
- Updated user guide terminology to Issue / Return
- Updated tests to expect canonical values and added mixed-data compatibility coverage

## Verification checklist

- [x] `pytest` passes (61 passed)
- [x] `rg -n "STOCK_(IN|OUT)" -S .` returns matches only in compatibility layer
- [x] `rg -n "stock[ _-]?(in|out)" -S .` returns matches only in compatibility layer
- [x] Manual sanity: Issue flow writes `ISSUE`; Return flow writes `RETURN`
- [x] No schema changes performed
- [x] No historical rows rewritten

## Notes

Compatibility is read-path only. Legacy event types remain intact in historical data to preserve append-only audit integrity.