### PR TITLE
Issue 16-2: UI label standardization

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -73,7 +73,7 @@
   </div>
 
   <nav class="actions" aria-label="Quick actions">
-    <a class="chip" href="{{ url_for('issue_preview') }}">Issue (Checkout)</a>
+    <a class="chip" href="{{ url_for('issue_preview') }}">Issue (Check-out)</a>
     <a class="chip" href="{{ url_for('return_queue') }}">Return (Check-in)</a>
     <a class="chip" href="{{ url_for('dashboard_holders') }}">Holder Drilldown</a>
     <a class="chip" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -13,7 +13,7 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('preview') }}">← Back to preview</a> | <a href="{{ url_for('issue_preview') }}">Issue Assets preview</a></p>
+  <p><a href="{{ url_for('preview') }}">← Back to preview</a> | <a href="{{ url_for('issue_preview') }}">Issue Assets Preview</a></p>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -2,7 +2,7 @@
 {% extends "base.html" %}
 
 {% block title %}Issue Assets Preview{% endblock %}
-{% block page_heading %}Issue Assets Preview / Confirm{% endblock %}
+{% block page_heading %}Issue Assets — Preview / Confirm{% endblock %}
 
 {% block extra_head %}
   <style>
@@ -125,7 +125,7 @@
         <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
         I reviewed this batch and want to add it to the database.
       </label>
-      <button id="issue_btn" type="submit" disabled>Issue assets</button>
+      <button id="issue_btn" type="submit" disabled>Commit Issue</button>
     </form>
     <form method="post" action="{{ url_for('preview_discard') }}" style="margin-top: 10px;"
           onsubmit="return confirm('Discard this batch? This clears the queue.');">


### PR DESCRIPTION
## Summary

Standardize UI terminology to consistently use Issue and Return across templates. This is a presentation-only update with no behavioral changes.

## Related Issue

Closes #129 

## Changes

- Standardized "Issue (Checkout)" → "Issue (Check-out)" in dashboard.
- Updated Issue preview heading to "Issue Assets — Preview / Confirm".
- Updated Issue commit button to "Commit Issue".
- Standardized "Issue Assets Preview" link text.
- No Python, logic, schema, or route changes.

## Verification checklist

- [x] pytest passes (61 passed)
- [x] No legacy terminology in templates
- [x] No layout or behavioral changes introduced

## Notes

UI-only update. Event model and compatibility layer unchanged.