### PR TITLE
Issue 17-1: Remove duplicate dashboard navigation

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -44,6 +44,14 @@
         color: white;
         font-weight: 600;
       }
+      .chip.mode-badge {
+        background: #f8f1e3;
+        border-color: #dfcfac;
+        color: #5a4b2c;
+        letter-spacing: 0.04em;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+      }
       .card {
         margin-top: 1rem;
         padding: 1rem;
@@ -86,6 +94,9 @@
           {% endif %}
           <a class="chip {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
           <a class="chip {% if request.path == '/' %}active{% endif %}" href="{{ url_for('intake') }}">Add Assets</a>
+          {% if authenticated_role == 'admin' %}
+            <span class="chip mode-badge" aria-label="Admin mode">ADMIN</span>
+          {% endif %}
           <a class="chip" href="{{ url_for('logout') }}">Logout</a>
         </nav>
       {% endif %}

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -72,14 +72,16 @@
     <p class="muted subtitle">Operational + Accountability Command View</p>
   </div>
 
-  <nav class="actions" aria-label="Quick actions">
-    <a class="chip" href="{{ url_for('issue_preview') }}">Issue (Check-out)</a>
-    <a class="chip" href="{{ url_for('return_queue') }}">Return (Check-in)</a>
-    <a class="chip" href="{{ url_for('dashboard_holders') }}">Holder Drilldown</a>
-    <a class="chip" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
-    <a class="chip secondary" href="{{ url_for('intake') }}">Add Assets</a>
-    <a class="chip secondary" href="{{ url_for('dashboard') }}">Dashboard</a>
-  </nav>
+  <section class="card" aria-label="Quick actions panel">
+    <h2>Quick Actions</h2>
+    <div class="accent"></div>
+    <div class="actions">
+      <a class="chip" href="{{ url_for('issue_preview') }}">Issue</a>
+      <a class="chip" href="{{ url_for('return_queue') }}">Return</a>
+      <a class="chip" href="{{ url_for('dashboard_holders') }}">Holder Drilldown</a>
+      <a class="chip" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
+    </div>
+  </section>
 
   <div class="grid">
     <section class="card">

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Dashboard navigation">
+  <nav class="actions" aria-label="Contextual navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="chip" href="{{ url_for('dashboard_cases') }}">Back to Cases</a>
   </nav>

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -11,9 +11,8 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Dashboard navigation">
+  <nav class="actions" aria-label="Contextual navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="chip" href="{{ url_for('dashboard_holders') }}">Holder View</a>
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Dashboard navigation">
+  <nav class="actions" aria-label="Contextual navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="chip" href="{{ url_for('dashboard_holders') }}">Back to Holders</a>
   </nav>

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -11,9 +11,8 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Dashboard navigation">
+  <nav class="actions" aria-label="Contextual navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="chip" href="{{ url_for('dashboard_cases') }}">Case View</a>
   </nav>
 
   <section class="card">


### PR DESCRIPTION
## Summary
Removes duplicate dashboard navigation and establishes a consistent command-panel pattern.  
Dashboard now shows a Quick Actions section while global navigation remains the single navigation surface.  
Adds a subtle ADMIN badge to indicate admin mode.

## Related Issue
Closes #131 

## Changes
- Removed duplicate dashboard navigation row.
- Introduced **Quick Actions** command panel on dashboard.
- Removed duplicate actions (Dashboard, Add Assets) from dashboard quick actions.
- Simplified dashboard subpage links to contextual “Back” navigation only.
- Added subtle **ADMIN** badge for admin users.
- Moved ADMIN badge next to Logout to indicate session mode.
- Standardized navigation pattern across dashboard templates.

## Verification checklist
- [ ] Dashboard displays a single global navigation bar.
- [ ] Quick Actions panel visible on dashboard with:
  - Issue
  - Return
  - Holder Drilldown
  - Case Drilldown
- [ ] No duplicate navigation rows appear.
- [ ] Dashboard subpages show only contextual back links.
- [ ] ADMIN badge appears only for admin users.
- [ ] ADMIN badge appears before Logout.
- [ ] Operator login does not display ADMIN badge.
- [ ] Navigation routes behave unchanged.

## Notes
Template-only change. No backend logic, schema, or tests modified.