### PR TITLE
Issue 17-2: standardize global layout across primary views

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -78,9 +78,12 @@
   </head>
   <body>
     <div class="page">
-      <header class="page-header">
-        <h1>{% block page_heading %}{% endblock %}</h1>
-      </header>
+      {% set heading = self.page_heading() | trim %}
+      {% if heading %}
+        <header class="page-header">
+          <h1>{{ heading }}</h1>
+        </header>
+      {% endif %}
 
       {% if authenticated_user %}
         <nav class="top-nav" aria-label="Primary">

--- a/assettrack/intake/templates/splash.html
+++ b/assettrack/intake/templates/splash.html
@@ -335,9 +335,6 @@
       }
     }
 
-    /* Hide the normal top nav on the splash */
-    .top-nav { display: none; }
-    .page-header { display: none; }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
Standardize layout behavior across login, dashboard, and admin views by removing CSS-based layout overrides and centralizing header rendering logic in `base.html`.

## Related Issue
Closes #132 

## Changes
- `base.html`
  - Added layout-only conditional header rendering.
  - `page_heading` is captured and trimmed.
  - `<header class="page-header">` renders only when heading content is present.
  - Navigation structure unchanged.

- `splash.html`
  - Removed CSS rules hiding global layout elements:
    - `.top-nav { display: none; }`
    - `.page-header { display: none; }`
  - Removed associated comment.
  - Splash visual design otherwise unchanged.

## Verification
- Confirm `.top-nav` and `.page-header` hiding rules are removed.
- Splash page renders without a blank header band.
- Dashboard and admin views render with normal header and navigation.
- Templates parse successfully under Jinja.

## Notes
Layout contract is now owned by `base.html`, ensuring consistent structure across all templates that extend it.