### PR TITLE
Issue 17-6: implement authenticated scan ingestion

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1541,6 +1541,26 @@ def intake():
             return redirect("/dashboard")
         return render_template("splash.html", error=None)
 
+    if current_user() is not None:
+        action = (request.form.get("action") or "").strip().lower()
+        scan_text = (request.form.get("scan_text") or "").strip()
+        return_to = (request.form.get("return_to") or "").strip()
+
+        if action == "clear":
+            SCAN_QUEUE.clear()
+
+        if scan_text:
+            value = sanitize_scan(scan_text)
+            if value:
+                equipment_type = (session.get("equipment_type") or "laptop").strip() or "laptop"
+                SCAN_QUEUE.append(Scan.now(value, equipment_type=equipment_type))
+
+        touch_session()
+
+        if return_to.startswith("/") and not return_to.startswith("//"):
+            return redirect(return_to)
+        return redirect(url_for("intake"))
+
     username = (request.form.get("username") or "").strip()
     password = request.form.get("password") or ""
     user = get_user_by_username(username)


### PR DESCRIPTION
Summary
Restore intake scan ingestion by handling authenticated POST / submissions (scan_text + action=clear) and enqueuing scans into SCAN_QUEUE while preserving unauthenticated login behavior.

Related Issue
Closes #17-6

Changes
- Added authenticated POST branch in intake() to:
  - Clear queue via action=clear
  - Sanitize and enqueue scan_text into SCAN_QUEUE with equipment_type from session (default laptop)
  - Redirect safely using optional return_to (internal paths only)
- Preserved existing unauthenticated POST / login flow unchanged

Verification checklist
- python -m py_compile assettrack/intake/app.py
- pytest -q (61 tests) all green
- Verified Scan.now() signature supports equipment_type (assettrack/intake/scan.py)

Notes
Completes the missing scan ingress path that templates already target (POST /), without schema changes and without modifying the event model.