### PR TITLE
Issue 17-7: add add-assets route and fix nav link

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1578,6 +1578,27 @@ def intake():
     return redirect("/dashboard")
 
 
+@app.get("/add-assets")
+def add_assets():
+    if current_user() is None:
+        return redirect(url_for("intake"))
+
+    if session.get("last_seen") is None:
+        touch_session()
+
+    return render_template(
+        "index.html",
+        auth_enabled=auth_enabled(),
+        authed=is_authed(),
+        last_seen_age_seconds=seconds_since_last_seen(),
+        timeout_seconds=INTAKE_TIMEOUT_SECONDS,
+        queue=SCAN_QUEUE,
+        queue_len=len(SCAN_QUEUE),
+        latest=(SCAN_QUEUE[-1].asset_tag if SCAN_QUEUE else ""),
+        equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+    )
+
+
 @app.route("/bootstrap/admin", methods=["GET", "POST"])
 def bootstrap_admin():
     if count_users() != 0:

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -96,7 +96,7 @@
             <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
           {% endif %}
           <a class="chip {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
-          <a class="chip {% if request.path == '/' %}active{% endif %}" href="{{ url_for('intake') }}">Add Assets</a>
+          <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Add Assets</a>
           {% if authenticated_role == 'admin' %}
             <span class="chip mode-badge" aria-label="Admin mode">ADMIN</span>
           {% endif %}


### PR DESCRIPTION
Summary
Add a dedicated /add-assets route that renders the intake scanning UI for authenticated users, and update the top nav “Add Assets” link to point to it.

Related Issue
Closes #17-7

Changes
- Added GET /add-assets route to render index.html with expected queue/timer context for authenticated users
- Updated base.html nav “Add Assets” to use url_for('add_assets') and correct active-state highlighting

Verification checklist
- pytest -q (61 tests) all green
- Manual: authenticated user clicks Add Assets and reaches intake scanning page

Notes
GET / behavior remains unchanged (splash for unauth; redirect to /dashboard for authed).