### PR TITLE
Issue 17-8: redirect authenticated intake POST to add-assets

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1559,7 +1559,7 @@ def intake():
 
         if return_to.startswith("/") and not return_to.startswith("//"):
             return redirect(return_to)
-        return redirect(url_for("intake"))
+        return redirect(url_for("add_assets"))
 
     username = (request.form.get("username") or "").strip()
     password = request.form.get("password") or ""


### PR DESCRIPTION
Summary
Keep operators on the Add Assets intake screen after submitting a scan by redirecting authenticated POST / back to /add-assets when no return_to is provided.

Related Issue
Closes #17-8

Changes
- Updated authenticated scan-ingestion POST / redirect target from url_for('intake') to url_for('add_assets')
- Preserved existing return_to internal redirect behavior for Return flow

Verification checklist
- pytest -q (61 tests) all green
- Manual: /add-assets scan submission stays on /add-assets and queue increments
- Manual: /return submissions still redirect back to /return via return_to

Notes
GET / behavior remains unchanged (auth gateway: splash unauth; /dashboard when authed).