### PR TITLE
Issue 17-9: remove new-tab links in intake page

### DIFF
--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -60,8 +60,8 @@
 
   <div class="card">
     <p><strong>How to use:</strong> click the box once, then scan. The scanner “types” and hits Enter.</p>
-    <p><a href="{{ url_for('preview') }}" target="_blank">Preview batch</a></p>
-    <p><a href="{{ url_for('return_queue') }}" target="_blank">Return Assets</a></p>
+    <p><a href="{{ url_for('preview') }}">Preview batch</a></p>
+    <p><a href="{{ url_for('return_queue') }}">Return Assets</a></p>
 
     {% if auth_enabled and not authed %}
       <form method="post">


### PR DESCRIPTION
Summary
Remove target="_blank" from intake page links so Preview batch and Return Assets open in the same tab.

Related Issue
Closes #17-9

Changes
- Updated index.html to remove target="_blank" from:
  - Preview batch link
  - Return Assets link

Verification checklist
- pytest -q (61 tests) all green
- Manual: links open in same tab
- Manual: Logout returns to login screen

Notes
Template-only UX change.