### PR TITLE
Issue 18-1: DB integrity guardrail

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -3,6 +3,9 @@ import os
 import sqlite3
 from pathlib import Path
 
+REQUIRED_TABLES = {"assets", "holders"}
+EVENT_TABLE_ALIASES = ("events", "asset_events")
+
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
     cursor = conn.execute(
@@ -129,6 +132,38 @@ def _rebuild_asset_events_for_corrections(conn: sqlite3.Connection) -> None:
 # - Defaults to local development path (data/assettrack.db)
 # - Can be overridden via ASSETTRACK_DB_PATH for Docker/WSL persistence
 DB_PATH = Path(os.environ.get("ASSETTRACK_DB_PATH", "data/assettrack.db"))
+
+
+def assert_schema_present(db_path: Path) -> None:
+    """
+    Validate that a DB file contains the required AssetTrack tables.
+    Raises RuntimeError when schema is missing/incomplete.
+    """
+    conn = sqlite3.connect(db_path)
+    try:
+        cursor = conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table';
+            """
+        )
+        existing_tables = {str(row[0]) for row in cursor.fetchall()}
+    finally:
+        conn.close()
+
+    missing_tables = sorted(REQUIRED_TABLES - existing_tables)
+    if not any(name in existing_tables for name in EVENT_TABLE_ALIASES):
+        missing_tables.append("events")
+
+    if missing_tables:
+        missing_display = ", ".join(missing_tables)
+        raise RuntimeError(
+            "AssetTrack DB schema missing.\n"
+            f"DB: {db_path}\n"
+            f"Missing tables: {missing_display}\n"
+            "Restore a valid database or initialize the approved schema."
+        )
 
 
 def get_connection():

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -22,7 +22,7 @@ from flask import Flask, abort, flash, jsonify, redirect, render_template, reque
 
 from assettrack.assets import get_asset_table_columns
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
-from assettrack.db import get_connection
+from assettrack.db import DB_PATH, assert_schema_present, get_connection
 from assettrack.drilldowns import (
     get_case_slot_detail,
     get_holder_custody_detail,
@@ -54,6 +54,8 @@ from assettrack.users import (
 
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
+
+assert_schema_present(DB_PATH)
 
 # In-memory only: wiped on restart
 SCAN_QUEUE: list[Scan] = []


### PR DESCRIPTION
## Summary
Add a startup database integrity guardrail to prevent AssetTrack from running with a missing or incomplete SQLite schema.

## Related Issue
Closes #134 

## Changes
- Added `assert_schema_present(db_path)` in `assettrack/db.py`
- Validates required tables (`assets`, `holders`, `events`) using `sqlite_master`
- Raises clear `RuntimeError` if schema is missing or incomplete
- Wired guardrail into Flask startup in `assettrack/intake/app.py`
- Application now fails early instead of allowing runtime DB failures

## Verification checklist
- [x] `pytest` passes locally
- [ ] App refuses to start with blank DB
- [ ] Error message clearly identifies missing tables and DB path
- [ ] App starts normally with valid DB
- [ ] No schema modifications or migrations performed

## Notes
Implements a defensive startup check to prevent silent failures when the SQLite database is blank or corrupted.