### PR TITLE
Issue 18-2: add admin system health page with DB path

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -20,9 +20,10 @@ from datetime import datetime, timezone
 
 from flask import Flask, abort, flash, jsonify, redirect, render_template, request, session, url_for
 
+import assettrack.db as db_module
 from assettrack.assets import get_asset_table_columns
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
-from assettrack.db import DB_PATH, assert_schema_present, get_connection
+from assettrack.db import assert_schema_present, get_connection
 from assettrack.drilldowns import (
     get_case_slot_detail,
     get_holder_custody_detail,
@@ -55,7 +56,7 @@ from assettrack.users import (
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
 
-assert_schema_present(DB_PATH)
+assert_schema_present(db_module.DB_PATH)
 
 # In-memory only: wiped on restart
 SCAN_QUEUE: list[Scan] = []
@@ -2300,6 +2301,34 @@ def holders_clear():
 def admin_users():
     users = list_users()
     return render_template("admin_users.html", users=users)
+
+
+@app.get("/admin/system")
+@require_login
+@require_role("admin")
+def admin_system():
+    resolved_db_path = db_module.DB_PATH.expanduser().resolve()
+    holder_count: int | None = None
+    asset_count: int | None = None
+    schema_warning: str | None = None
+
+    try:
+        conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
+        try:
+            holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+            asset_count = int(conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0])
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        schema_warning = f"Could not read system health data: {exc}"
+
+    return render_template(
+        "admin_system.html",
+        db_path=str(resolved_db_path),
+        holder_count=holder_count,
+        asset_count=asset_count,
+        schema_warning=schema_warning,
+    )
 
 
 @app.post("/admin/users/create")

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+
+{% block title %}Admin System Health{% endblock %}
+{% block page_heading %}Admin: System Health{% endblock %}
+
+{% block content %}
+  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+
+  {% if schema_warning %}
+    <div class="flash error">{{ schema_warning }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Database</h2>
+    <table>
+      <tbody>
+        <tr>
+          <th>DB path</th>
+          <td><code id="db-path">{{ db_path }}</code></td>
+        </tr>
+        <tr>
+          <th>Holder count</th>
+          <td id="holder-count">{{ holder_count if holder_count is not none else "N/A" }}</td>
+        </tr>
+        <tr>
+          <th>Asset count</th>
+          <td id="asset-count">{{ asset_count if asset_count is not none else "N/A" }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _create_assets_table(conn) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS assets (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            asset_tag TEXT NOT NULL UNIQUE,
+            serial_number TEXT NULL,
+            manufacturer TEXT NULL,
+            equipment_type TEXT NOT NULL,
+            building TEXT NULL,
+            room TEXT NULL,
+            model TEXT NULL,
+            model_code TEXT NULL,
+            notes TEXT NULL,
+            building_room TEXT NULL,
+            custody_state TEXT NOT NULL,
+            accountability_status TEXT NOT NULL,
+            condition TEXT NOT NULL,
+            created_date TEXT NOT NULL,
+            updated_date TEXT NULL,
+            location_type TEXT NULL,
+            current_holder_id INTEGER NULL,
+            home_slot_id INTEGER NULL
+        );
+        """
+    )
+
+
+def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    conn = db.get_connection()
+    _create_assets_table(conn)
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Jane Operator', NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (
+            'AT-100',
+            'SN-100',
+            'Dell',
+            'laptop',
+            'HQ',
+            '100',
+            'ModelX',
+            'MX',
+            NULL,
+            'HQ/100',
+            'in_stock',
+            'accountable',
+            'serviceable',
+            '2026-01-01',
+            '2026-01-01T00:00:00Z',
+            NULL,
+            NULL,
+            NULL
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.get("/admin/system")
+
+    assert response.status_code == 200
+    assert b"Admin: System Health" in response.data
+    assert b'id="holder-count">1<' in response.data
+    assert b'id="asset-count">1<' in response.data
+    assert b"assettrack.db" in response.data
+
+
+def test_operator_is_forbidden_for_system_health(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-a", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.get("/admin/system")
+
+    assert response.status_code == 403
+
+
+def test_system_health_renders_warning_when_assets_query_fails(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/system")
+
+    assert response.status_code == 200
+    assert b"Could not read system health data:" in response.data
+    assert b'id="asset-count">N/A<' in response.data


### PR DESCRIPTION
## Summary
Add an admin-only System Health page to provide basic operational visibility into the active SQLite database and inventory counts.

## Related Issue
Closes #135 

## Changes
- Added GET `/admin/system` route protected by `require_login` and `require_role("admin")`
- Displays configured DB path, holder count, and asset count
- Uses SQLite read-only mode (`mode=ro`) for safety
- Gracefully handles DB query errors and displays a warning instead of crashing
- Added template `admin_system.html`
- Added tests for admin access, operator denial, and warning rendering

## Verification checklist
- [ ] `pytest` passes locally
- [ ] Admin can access `/admin/system`
- [ ] Operator receives `403`
- [ ] DB path, holder count, and asset count render correctly
- [ ] Page still renders with warning if DB query fails

## Notes
This page provides lightweight operational diagnostics without modifying database state.