### PR TITLE
Issue 18-smoke-fix-a: fix Clear queue posting to admin-only /preview

### DIFF
--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -40,8 +40,9 @@
       <button type="submit">Submit</button>
     </form>
 
-    <form method="post" action="{{ url_for('preview_discard') }}" style="margin-top: 10px;">
+    <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
       <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
+      <input type="hidden" name="action" value="clear" />
       <button type="submit" onclick="return confirm('Clear the queue?');">Clear queue</button>
     </form>
   </div>

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.intake.scan import Scan
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-clear", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.append(Scan.now("UNKNOWN-TAG"))
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"action": "clear", "return_to": "/issue"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert len(intake_app.SCAN_QUEUE) == 0
+
+    issue_page = client_with_temp_db.get("/issue")
+    assert issue_page.status_code == 200
+    assert b"Queued assets:</strong> 0" in issue_page.data


### PR DESCRIPTION
## Summary
Fix Issue workflow “Clear queue” so operators can clear the scan queue without hitting an admin-only endpoint (403).

## Related Issue
Closes #18-smoke-fix-a

## Changes
- Updated `return_queue.html` so **Clear queue** posts to the authenticated intake endpoint (`/`) with `action=clear`.
- Preserved `return_to=/issue` so the operator is redirected deterministically back to the Issue scan page.
- Ensured the action remains **POST** (no unsafe mutating GET).
- Added regression test `test_issue_clear_queue.py` verifying that an operator can clear the queue and is redirected to `/issue`.

## Verification checklist
- [x] `pytest` passes (65 passed)
- [x] Operator smoke test:
  - scan asset → queue count increased
  - clear queue → redirect to `/issue`
  - queue count reset to 0
- [x] `/admin/system` remains forbidden for operator
- [x] No schema changes
- [x] No dependency changes

## Notes
Root cause was an endpoint mismatch: the shared Issue/Return template posted the clear action to `/preview/discard`, which is admin-only.  
This fix aligns the Issue clear action with the existing operator-safe queue clear path on `/`.