### PR TITLE
Issue 19-x: remove bullet list styling from Issue/Return validation s…

### DIFF
--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -9,8 +9,9 @@
     .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
     .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
     .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
-    ul { margin: 0.5rem 0 0 1.25rem; }
     input[type="text"] { padding: 0.6rem; font-size: 1rem; width: 420px; }
+    .validation-messages { margin-top: 0.5rem; }
+    .validation-message { margin: 0.35rem 0; }
   </style>
 {% endblock %}
 
@@ -62,9 +63,9 @@
       {% endif %}
     </p>
     {% if blocking_issues %}
-      <div role="list" style="margin: 0.5rem 0 0 1.25rem;">
+      <div class="validation-messages">
         {% for issue in blocking_issues %}
-          <div role="listitem">• <span>{{ issue }}</span></div>
+          <p class="validation-message">{{ issue }}</p>
         {% endfor %}
       </div>
     {% endif %}


### PR DESCRIPTION
## Summary
Removes the “floating bullet” rendering in the Issue/Return Validation Summary by replacing single-item bullet output with clean paragraph messages.

## Related Issue
Issue 19-x — Remove random bullet in Validation Summary

## Changes
- Updated `assettrack/intake/templates/return_queue.html`:
  - Replaced bullet-style validation rendering with stacked paragraph messages.
  - Introduced a wrapper `<div class="validation-messages">` with `<p class="validation-message">`.
  - Added minimal local template CSS for spacing.
- No route, queue, validation, redirect, authentication, schema, or dependency changes.

## Verification checklist
- [x] `pytest` (65 passed)
- [x] `/issue` empty queue message renders without bullet
- [x] Blocked/validation states display clean paragraph messages
- [x] Issue workflow unchanged (scan → preview → commit)
- [x] Return workflow unchanged
- [x] No schema changes
- [x] No dependency changes

## Notes
`return_queue.html` is shared by the Issue and Return queue views, so this presentation cleanup applies consistently across both workflows while keeping behavior unchanged.