### PR TITLE
Issue 18-5: fix issue post-commit redirect seam

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1950,12 +1950,12 @@ def issue():
     if session.get("last_seen") is None:
         touch_session()
 
+    asset_tags = _queue_asset_tags()
     selected_holder = _selected_holder_from_session()
-    if selected_holder is None:
+    if selected_holder is None and asset_tags:
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("holders_search", return_to=url_for("issue")))
 
-    asset_tags = _queue_asset_tags()
     issue_state = _build_issue_preview_state(asset_tags, selected_holder)
 
     return render_template(

--- a/tests/test_issue_slot_occupancy_consistency.py
+++ b/tests/test_issue_slot_occupancy_consistency.py
@@ -86,3 +86,26 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
     assert asset is not None
     assert str(asset["location_type"]) == "IN_CUSTODY"
     assert int(asset["current_holder_id"]) == 1
+
+
+def test_issue_commit_redirect_shows_success_without_holder_warning(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-seam", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.append(Scan.now("DDC4CY002645"))
+
+    commit_response = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=True,
+    )
+
+    assert commit_response.status_code == 200
+    assert b"Issued 1 assets." in commit_response.data
+    assert b"Select a holder before issuing assets." not in commit_response.data
+    assert b"Queued assets:</strong> 0" in commit_response.data
+    assert len(intake_app.SCAN_QUEUE) == 0


### PR DESCRIPTION
## Summary
Fixes the Issue workflow post-commit seam so operators no longer see a contradictory holder warning after a successful issue commit.

## Related Issue
Closes #18-5

## Changes
- Updated the Issue holder-warning gate to trigger only when no holder is selected and the queue is non-empty
- Added a regression test covering post-commit success state, empty queue, and absence of the contradictory warning

## Verification checklist
- [x] Targeted tests passed
- [x] Full test suite passed
- [x] Manual operator smoke test passed
- [x] Queue clears after issue commit
- [x] Success flash appears after issue commit
- [x] Contradictory holder warning no longer appears immediately after commit

## Notes
- Minimal seam-only fix
- No schema changes
- No slot-model changes
- No auth changes