### PR TITLE
Issue 22-1: Add holders list view

### DIFF
--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -33,6 +33,30 @@ def search_holders(query: str, limit: int = 20) -> list[dict]:
         conn.close()
 
 
+def list_holders() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                h.id,
+                h.holder_type,
+                h.name,
+                h.identifier,
+                h.contact_info,
+                COUNT(a.id) AS asset_count
+            FROM holders h
+            LEFT JOIN assets a
+              ON a.current_holder_id = h.id
+            GROUP BY h.id, h.holder_type, h.name, h.identifier, h.contact_info
+            ORDER BY h.name COLLATE NOCASE ASC, h.id ASC;
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
 def get_holder(holder_id: int) -> dict | None:
     if holder_id is None:
         return None

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -35,7 +35,7 @@ from assettrack.ingest.committer import BatchCommitError, commit_batch
 from assettrack.intake.scan import Scan
 from assettrack.intake.to_ingest import scan_to_ingest_row
 from assettrack.auth import current_user, require_login, require_role
-from assettrack.holders import create_holder, get_holder, search_holders
+from assettrack.holders import create_holder, get_holder, list_holders, search_holders
 from assettrack.audit import record_event
 from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
 from assettrack.users import (
@@ -2194,6 +2194,18 @@ def holders_search():
         results=results,
         selected_holder=_selected_holder_from_session(),
     )
+
+
+@app.get("/holders/list")
+@require_login
+def holders_list():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    holders = list_holders()
+    return render_template("holders_list.html", holders=holders)
 
 
 @app.get("/holders/new")

--- a/assettrack/intake/templates/holders_list.html
+++ b/assettrack/intake/templates/holders_list.html
@@ -1,0 +1,47 @@
+<!-- file: assettrack/intake/templates/holders_list.html -->
+{% extends "base.html" %}
+
+{% block title %}All Holders{% endblock %}
+{% block page_heading %}All Holders{% endblock %}
+
+{% block extra_head %}
+  <style>
+    th, td { border-bottom: 1px solid #eee; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p><a href="{{ url_for('holders_search') }}">← Back to holder search</a></p>
+
+  <div class="card">
+    <h2>Holders</h2>
+    {% if holders %}
+      <table>
+        <thead>
+          <tr>
+            <th style="width: 90px;">ID</th>
+            <th style="width: 120px;">Type</th>
+            <th style="width: 250px;">Name</th>
+            <th style="width: 200px;">Identifier</th>
+            <th>Contact</th>
+            <th style="width: 120px;">Assets</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for h in holders %}
+            <tr>
+              <td><code>{{ h["id"] }}</code></td>
+              <td>{{ h["holder_type"] }}</td>
+              <td>{{ h["name"] }}</td>
+              <td><code>{{ h["identifier"] or "" }}</code></td>
+              <td>{{ h["contact_info"] or "" }}</td>
+              <td>{{ h["asset_count"] }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p>No holders found.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -24,7 +24,7 @@
   {% endwith %}
 
   <div class="card">
-    <p><a href="{{ url_for('holders_new') }}">Add Holder</a></p>
+    <p><a href="{{ url_for('holders_new') }}">Add Holder</a> | <a href="{{ url_for('holders_list') }}">View all holders</a></p>
     <form method="get" action="{{ url_for('holders_search') }}">
       {% if return_to %}
         <input type="hidden" name="return_to" value="{{ return_to }}" />

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -28,6 +28,11 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Create Holder", response.data)
 
+    def test_get_holders_list_route_exists(self) -> None:
+        response = self.client.get("/holders/list")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"All Holders", response.data)
+
     def test_post_holders_new_persists_holder(self) -> None:
         holder_name = "Viability Gate Holder"
         response = self.client.post(
@@ -85,6 +90,27 @@ class HolderCreationViabilityTests(unittest.TestCase):
         )
         self.assertEqual(select_response.status_code, 200)
         self.assertIn(f"Selected holder: {holder_name}".encode("utf-8"), select_response.data)
+
+    def test_holders_list_shows_holders_and_asset_count(self) -> None:
+        holder_name = "Holder List Person"
+        self.client.post("/holders/new", data={"name": holder_name})
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            (holder_name,),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        self.conn.execute(
+            "INSERT INTO assets (asset_tag, current_holder_id) VALUES (?, ?);",
+            ("HOLDER-LIST-ASSET-1", holder_id),
+        )
+        self.conn.commit()
+
+        response = self.client.get("/holders/list")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(holder_name.encode("utf-8"), response.data)
+        self.assertIn(b">1<", response.data)
 
 
 if __name__ == "__main__":

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import assettrack.db as db
-from assettrack.holders import get_holder, search_holders
+from assettrack.holders import get_holder, list_holders, search_holders
 
 
 class HoldersTests(unittest.TestCase):
@@ -62,3 +62,22 @@ class HoldersTests(unittest.TestCase):
         by_identifier = search_holders("BR-77")
         self.assertEqual(len(by_identifier), 1)
         self.assertEqual(by_identifier[0]["name"], "Bravo Org")
+
+    def test_list_holders_includes_asset_count(self) -> None:
+        alpha_id = self._insert_holder("Person", "Alpha User", "A-001", None)
+        self._insert_holder("Organization", "Bravo Org", "BR-77", "contact@bravo.org")
+
+        self.conn.execute(
+            "INSERT INTO assets (asset_tag, current_holder_id) VALUES (?, ?);",
+            ("A-TAG-1", alpha_id),
+        )
+        self.conn.execute(
+            "INSERT INTO assets (asset_tag, current_holder_id) VALUES (?, ?);",
+            ("A-TAG-2", alpha_id),
+        )
+        self.conn.commit()
+
+        rows = list_holders()
+        self.assertEqual([row["name"] for row in rows], ["Alpha User", "Bravo Org"])
+        self.assertEqual(int(rows[0]["asset_count"]), 2)
+        self.assertEqual(int(rows[1]["asset_count"]), 0)


### PR DESCRIPTION
## Summary
Adds a read-only holders list page so authorized users can browse all holders and validate records more easily.

## Related Issue
Closes #178 

## Changes
- Added `list_holders()` query helper
- Added authenticated `/holders/list` route
- Added `holders_list.html` template
- Added “View all holders” link from holders search
- Added test coverage for route and rendered holder counts

## Verification checklist
- [x] Holders list page added
- [x] Authorized access verified
- [x] Existing workflows unchanged
- [x] Tests pass

## Notes
- Kept scope read-only with no edit, delete, merge, or schema changes.