### PR TITLE
Issue 22-2: Lock intake UI on timeout:

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1764,6 +1764,8 @@ def preview():
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
         selected_holder=_selected_holder_from_session(),
         issue_mode=bool(session.get("issue_mode")),
+        last_seen_age_seconds=seconds_since_last_seen(),
+        timeout_seconds=INTAKE_TIMEOUT_SECONDS,
     )
 
 
@@ -2004,6 +2006,8 @@ def issue_preview():
         assets=issue_preview_state["assets"],
         ready_count=issue_preview_state["ready_count"],
         blocking_issues=issue_preview_state["blocking_issues"],
+        last_seen_age_seconds=seconds_since_last_seen(),
+        timeout_seconds=INTAKE_TIMEOUT_SECONDS,
     )
 
 
@@ -2096,6 +2100,8 @@ def return_queue():
         queued_count=len(asset_tags),
         ready_count=state["ready_count"],
         blocking_issues=state["blocking_issues"],
+        last_seen_age_seconds=seconds_since_last_seen(),
+        timeout_seconds=INTAKE_TIMEOUT_SECONDS,
     )
 
 
@@ -2118,6 +2124,8 @@ def return_preview():
         preview_rows=state["assets"],
         ready_count=state["ready_count"],
         blocking_issues=state["blocking_issues"],
+        last_seen_age_seconds=seconds_since_last_seen(),
+        timeout_seconds=INTAKE_TIMEOUT_SECONDS,
     )
 
 

--- a/assettrack/intake/templates/_timeout_lock_script.html
+++ b/assettrack/intake/templates/_timeout_lock_script.html
@@ -1,0 +1,99 @@
+<script>
+  const LOCK_HINT_TEXT = "Session expired. Redirecting to login...";
+  let timeoutLocked = false;
+
+  const lockHintEl = document.getElementById("lock-hint");
+  const lastActivityEl = document.getElementById("last-activity-seconds");
+  const timeoutSourceEl = document.getElementById("timeout-seconds");
+  const countdownEl = document.getElementById("timeout-countdown-seconds");
+  const timeoutLockPanelEl = document.getElementById("timeout-lock-panel");
+  const timeoutLockStateEl = document.getElementById("timeout-lock-state");
+  const timeoutLockTargets = Array.from(document.querySelectorAll("[data-timeout-lock-target]"));
+
+  const lockUi = () => {
+    if (timeoutLocked) {
+      return;
+    }
+    timeoutLocked = true;
+    window.assetTrackTimeoutLocked = true;
+
+    timeoutLockTargets.forEach((targetEl) => {
+      targetEl.classList.add("locked-control");
+      if ("disabled" in targetEl) {
+        targetEl.disabled = true;
+      } else {
+        targetEl.setAttribute("aria-disabled", "true");
+        targetEl.setAttribute("tabindex", "-1");
+      }
+    });
+
+    if (countdownEl) countdownEl.classList.remove("countdown-pulse");
+    if (timeoutLockPanelEl) timeoutLockPanelEl.classList.add("locked");
+    if (timeoutLockStateEl) timeoutLockStateEl.textContent = "Locked";
+    if (lockHintEl) {
+      lockHintEl.textContent = LOCK_HINT_TEXT;
+      lockHintEl.hidden = false;
+    }
+  };
+
+  const redirectToLogout = () => {
+    if (window.location.pathname !== "/logout") {
+      window.location = "/logout";
+    }
+  };
+
+  document.addEventListener("click", (event) => {
+    if (!window.assetTrackTimeoutLocked) {
+      return;
+    }
+    const lockedLink = event.target.closest("a[aria-disabled='true']");
+    if (lockedLink) {
+      event.preventDefault();
+    }
+  });
+
+  if (lastActivityEl && timeoutSourceEl && countdownEl) {
+    let lastActivitySeconds = parseInt(lastActivityEl.textContent, 10);
+    const timeoutSeconds = parseInt(timeoutSourceEl.textContent, 10);
+
+    const update = () => {
+      lastActivitySeconds += 1;
+      lastActivityEl.textContent = lastActivitySeconds;
+
+      const remaining = Math.max(0, timeoutSeconds - lastActivitySeconds);
+      countdownEl.textContent = remaining;
+
+      if (remaining > 0 && remaining < 10) {
+        countdownEl.classList.add("countdown-pulse");
+      } else {
+        countdownEl.classList.remove("countdown-pulse");
+      }
+
+      if (remaining <= 0 && !timeoutLocked) {
+        lockUi();
+        redirectToLogout();
+        return true;
+      }
+      return false;
+    };
+
+    const initialRemaining = Math.max(0, timeoutSeconds - lastActivitySeconds);
+    countdownEl.textContent = initialRemaining;
+
+    if (initialRemaining > 0 && initialRemaining < 10) {
+      countdownEl.classList.add("countdown-pulse");
+    }
+
+    if (initialRemaining <= 0 && !timeoutLocked) {
+      lockUi();
+      redirectToLogout();
+    } else {
+      const timerId = setInterval(() => {
+        const isLocked = update();
+        if (isLocked) {
+          clearInterval(timerId);
+        }
+      }, 1000);
+    }
+  }
+</script>

--- a/assettrack/intake/templates/_timeout_status.html
+++ b/assettrack/intake/templates/_timeout_status.html
@@ -1,0 +1,16 @@
+{% if timeout_seconds is defined and timeout_seconds is not none and last_seen_age_seconds is not none %}
+  <div id="timeout-lock-panel" class="timeout-panel" data-timeout-lock-panel>
+    <p>
+      <strong>Session status:</strong>
+      <span id="timeout-lock-state">Active</span>
+      <br />
+      <strong>Timeout in:</strong>
+      <span id="timeout-countdown-seconds"></span>s
+      <span id="lock-hint" class="muted" hidden>Session expired. Controls locked.</span>
+      <br />
+      <strong>Last activity:</strong>
+      <span id="last-activity-seconds">{{ last_seen_age_seconds }}</span>s ago
+    </p>
+    <span id="timeout-seconds" hidden>{{ timeout_seconds }}</span>
+  </div>
+{% endif %}

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -73,6 +73,27 @@
       button { padding: 0.6rem 1rem; font-size: 1rem; }
       .row { margin: 0.75rem 0; }
       .muted { color: #555; }
+      .timeout-panel {
+        margin: 0 0 1rem 0;
+        padding: 0.75rem 1rem;
+        border: 1px solid #d7deea;
+        border-radius: 10px;
+        background: #eef3fb;
+      }
+      .timeout-panel.locked {
+        background: #fff1f1;
+        border-color: #e0b4b4;
+        color: #7a1f1f;
+      }
+      .locked-control {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      a.locked-control {
+        color: #6b7280;
+        pointer-events: none;
+        text-decoration: none;
+      }
     </style>
     {% block extra_head %}{% endblock %}
   </head>

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -23,25 +23,7 @@
     <p><strong>Status:</strong> {{ "Unlocked" if authed else "Locked" }}</p>
 
     {% if authed %}
-      <p>
-        Timeout in:
-        {% if last_seen_age_seconds is not none %}
-          <span id="timeout-countdown-seconds"></span>s
-          <span id="lock-hint" class="muted" hidden>Locked. Refresh to continue.</span>
-        {% else %}
-          n/a
-        {% endif %}
-        <br />
-        <br />
-        Last activity:
-        {% if last_seen_age_seconds is not none %}
-          <span id="last-activity-seconds">{{ last_seen_age_seconds }}</span>s ago
-        {% else %}
-          n/a
-        {% endif %}
-      </p>
-
-      <span id="timeout-seconds" hidden>{{ timeout_seconds }}</span>
+      {% include "_timeout_status.html" %}
     {% else %}
       <p>Locked. Enter access code to unlock.</p>
     {% endif %}
@@ -60,7 +42,7 @@
 
   <div class="card">
     <p><strong>How to use:</strong> click the box once, then scan. The scanner “types” and hits Enter.</p>
-    <p><a href="{{ url_for('preview') }}">Preview batch</a></p>
+    <p><a href="{{ url_for('preview') }}" data-timeout-lock-target>Preview batch</a></p>
     <p><a href="{{ url_for('return_queue') }}">Return Assets</a></p>
 
     {% if auth_enabled and not authed %}
@@ -79,6 +61,7 @@
             placeholder="e.g. laptop"
             value="{{ equipment_type or '' }}"
             autocomplete="off"
+            data-timeout-lock-target
           />
         </div>
 
@@ -90,14 +73,15 @@
             placeholder="Scan here..."
             autofocus
             autocomplete="off"
+            data-timeout-lock-target
           />
-          <button id="submit-scan" type="submit">Submit</button>
-          <button id="clear-queue" type="submit" name="action" value="clear">Clear queue</button>
+          <button id="submit-scan" type="submit" data-timeout-lock-target>Submit</button>
+          <button id="clear-queue" type="submit" name="action" value="clear" data-timeout-lock-target>Clear queue</button>
         </div>
       </form>
     {% endif %}
     <form method="post" action="{{ url_for('preview_commit') }}" style="margin-top: 10px;">
-      <button id="add-to-db" type="submit">Add to database</button>
+      <button id="add-to-db" type="submit" data-timeout-lock-target>Add to database</button>
     </form>
   </div>
 
@@ -121,76 +105,7 @@
 
 {% block extra_scripts %}
   <script>
-    const LOCK_HINT_TEXT = "Locked. Refresh to continue.";
     const TS_STORAGE_KEY = "assettrack:intake:queue_ts";
-
-    const lockHintEl = document.getElementById("lock-hint");
-    const intakeFormEl = document.getElementById("intake-form");
-    const scanInputEl = document.getElementById("scan-input");
-    const submitScanEl = document.getElementById("submit-scan");
-    const clearQueueEl = document.getElementById("clear-queue");
-    const addToDbEl = document.getElementById("add-to-db");
-    const lastActivityEl = document.getElementById("last-activity-seconds");
-    const timeoutSourceEl = document.getElementById("timeout-seconds");
-    const countdownEl = document.getElementById("timeout-countdown-seconds");
-
-    const lockUi = () => {
-      if (scanInputEl) scanInputEl.disabled = true;
-      if (submitScanEl) submitScanEl.disabled = true;
-      if (clearQueueEl) clearQueueEl.disabled = true;
-      if (addToDbEl) addToDbEl.disabled = true;
-      if (intakeFormEl) intakeFormEl.setAttribute("aria-disabled", "true");
-      if (countdownEl) countdownEl.classList.remove("countdown-pulse");
-      if (lockHintEl) {
-        lockHintEl.textContent = LOCK_HINT_TEXT;
-        lockHintEl.hidden = false;
-      }
-    };
-
-    if (lastActivityEl && timeoutSourceEl && countdownEl) {
-      let lastActivitySeconds = parseInt(lastActivityEl.textContent, 10);
-      const timeoutSeconds = parseInt(timeoutSourceEl.textContent, 10);
-      let uiLocked = false;
-
-      const update = () => {
-        lastActivitySeconds += 1;
-        lastActivityEl.textContent = lastActivitySeconds;
-
-        const remaining = Math.max(0, timeoutSeconds - lastActivitySeconds);
-        countdownEl.textContent = remaining;
-
-        if (remaining > 0 && remaining < 10) {
-          countdownEl.classList.add("countdown-pulse");
-        } else {
-          countdownEl.classList.remove("countdown-pulse");
-        }
-
-        if (remaining === 0 && !uiLocked) {
-          uiLocked = true;
-          lockUi();
-          return true;
-        }
-        return false;
-      };
-
-      const initialRemaining = Math.max(0, timeoutSeconds - lastActivitySeconds);
-      countdownEl.textContent = initialRemaining;
-
-      if (initialRemaining > 0 && initialRemaining < 10) {
-        countdownEl.classList.add("countdown-pulse");
-      }
-      if (initialRemaining === 0) {
-        uiLocked = true;
-        lockUi();
-      }
-
-      const timerId = setInterval(() => {
-        const isLocked = update();
-        if (isLocked) {
-          clearInterval(timerId);
-        }
-      }, 1000);
-    }
 
     const queueListEl = document.getElementById("queue-list");
     if (queueListEl) {
@@ -223,4 +138,5 @@
       }
     }
   </script>
+  {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -16,6 +16,8 @@
 {% block content %}
   <p><a href="{{ url_for('preview') }}">← Back to batch preview</a></p>
 
+  {% include "_timeout_status.html" %}
+
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
@@ -125,12 +127,12 @@
         <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
         I reviewed this batch and want to add it to the database.
       </label>
-      <button id="issue_btn" type="submit" disabled>Commit Issue</button>
+      <button id="issue_btn" type="submit" disabled data-timeout-lock-target>Commit Issue</button>
     </form>
     <form method="post" action="{{ url_for('preview_discard') }}" style="margin-top: 10px;"
           onsubmit="return confirm('Discard this batch? This clears the queue.');">
       <input type="hidden" name="return_to" value="{{ url_for('issue') }}" />
-      <button type="submit">Discard batch</button>
+      <button type="submit" data-timeout-lock-target>Discard batch</button>
     </form>
     <p style="margin-top: 10px;">{{ url_for('issue_commit') }}?json=1</p>
   </div>
@@ -146,4 +148,5 @@
       sync();
     }
   </script>
+  {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -18,6 +18,8 @@
     <a href="{{ url_for('dashboard') }}">← Back to dashboard</a>
   </div>
 
+  {% include "_timeout_status.html" %}
+
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
@@ -46,13 +48,13 @@
         I reviewed this batch and want to add it to the database.
       </label>
 
-      <button id="add_btn" type="submit" disabled>Add to database</button>
+      <button id="add_btn" type="submit" disabled data-timeout-lock-target>Add to database</button>
     </form>
 
     <form method="post" action="{{ url_for('preview_discard') }}" style="margin-top: 10px;"
           onsubmit="return confirm('Discard this batch? This clears the queue.');">
       <input type="hidden" name="return_to" value="{{ url_for('add_assets') }}" />
-      <button type="submit">Discard batch</button>
+      <button type="submit" data-timeout-lock-target>Discard batch</button>
     </form>
 
     <p style="margin-top: 10px;">
@@ -148,4 +150,5 @@
       sync();
     }
   </script>
+  {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -15,6 +15,8 @@
 {% block content %}
   <p><a href="{{ url_for('return_queue') }}">← Back to Return Queue</a></p>
 
+  {% include "_timeout_status.html" %}
+
   <div class="card">
     <h2>Validation Summary</h2>
     <p>
@@ -101,7 +103,7 @@
           I have reviewed the changes and confirm this return batch.
         </label>
         <br /><br />
-        <button type="submit">Commit Return</button>
+        <button type="submit" data-timeout-lock-target>Commit Return</button>
       </form>
     {% else %}
       <p class="flash error">
@@ -109,4 +111,8 @@
       </p>
     {% endif %}
   </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -18,6 +18,8 @@
 {% block content %}
   <p><a href="{{ url_for('dashboard') }}">← Back to dashboard</a></p>
 
+  {% include "_timeout_status.html" %}
+
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}
@@ -33,18 +35,20 @@
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
       <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
       <input
+        id="scan-input"
         type="text"
         name="scan_text"
         placeholder="Scan here..."
         autofocus
+        data-timeout-lock-target
       />
-      <button type="submit">Submit</button>
+      <button type="submit" data-timeout-lock-target>Submit</button>
     </form>
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
       <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
       <input type="hidden" name="action" value="clear" />
-      <button type="submit" onclick="return confirm('Clear the queue?');">Clear queue</button>
+      <button type="submit" onclick="return confirm('Clear the queue?');" data-timeout-lock-target>Clear queue</button>
     </form>
   </div>
 
@@ -72,6 +76,10 @@
   </div>
 
   <div class="card">
-    <p><a href="{{ preview_url or url_for('return_preview') }}"><strong>{{ preview_label or "Open Return Assets Preview / Confirm" }}</strong></a></p>
+    <p><a href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target><strong>{{ preview_label or "Open Return Assets Preview / Confirm" }}</strong></a></p>
   </div>
+{% endblock %}
+
+{% block extra_scripts %}
+  {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.intake.scan import Scan
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (101, 'CASE-1', 1, NULL);
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            id, asset_tag, serial_number, equipment_type, manufacturer, model,
+            location_type, current_holder_id, home_slot_id
+        )
+        VALUES (
+            501, 'LOCK-TAG-1', 'SN-1', 'laptop', 'Dell', 'Latitude',
+            'IN_CUSTODY', 1, 101
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_with_timeout(client, *, role: str = "admin") -> int:
+    user_id = create_test_user(username=f"{role}-timeout-user", password="op-pass", role=role)
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["last_seen"] = intake_app.now_seconds()
+    return user_id
+
+
+def test_add_assets_and_preview_render_timeout_lock_targets(client_with_temp_db) -> None:
+    _login_with_timeout(client_with_temp_db)
+    intake_app.SCAN_QUEUE.append(Scan.now("LOCK-TAG-NEW"))
+
+    add_assets = client_with_temp_db.get("/add-assets")
+    assert add_assets.status_code == 200
+    assert add_assets.data.count(b"data-timeout-lock-target") >= 5
+    assert b"remaining <= 0 && !timeoutLocked" in add_assets.data
+
+    preview = client_with_temp_db.get("/preview")
+    assert preview.status_code == 200
+    assert b'id="timeout-lock-panel"' in preview.data
+    assert b'id="timeout-lock-state">Active<' in preview.data
+    assert b"Session expired. Redirecting to login..." in preview.data
+    assert b'let timeoutLocked = false;' in preview.data
+    assert b'window.location = "/logout";' in preview.data
+    assert b'data-timeout-lock-target>Add to database<' in preview.data
+    assert b'data-timeout-lock-target>Discard batch<' in preview.data
+
+
+def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db) -> None:
+    _login_with_timeout(client_with_temp_db, role="operator")
+    intake_app.SCAN_QUEUE.append(Scan.now("LOCKTAG1"))
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    issue_queue = client_with_temp_db.get("/issue")
+    assert issue_queue.status_code == 200
+    assert b'id="timeout-lock-panel"' in issue_queue.data
+    assert b"Open Issue Assets Preview / Confirm" in issue_queue.data
+    assert issue_queue.data.count(b"data-timeout-lock-target") >= 4
+
+    issue_preview = client_with_temp_db.get("/issue/preview")
+    assert issue_preview.status_code == 200
+    assert b'id="timeout-lock-panel"' in issue_preview.data
+    assert b'data-timeout-lock-target>Commit Issue<' in issue_preview.data
+    assert b'data-timeout-lock-target>Discard batch<' in issue_preview.data
+
+    return_queue = client_with_temp_db.get("/return")
+    assert return_queue.status_code == 200
+    assert b'id="timeout-lock-panel"' in return_queue.data
+    assert b"Open Return Assets Preview / Confirm" in return_queue.data
+
+    return_preview = client_with_temp_db.get("/return/preview")
+    assert return_preview.status_code == 200
+    assert b'id="timeout-lock-panel"' in return_preview.data
+    assert b'data-timeout-lock-target>Commit Return<' in return_preview.data


### PR DESCRIPTION
## Summary
Makes the intake workflow visibly lock at timeout and immediately logs the operator out when the countdown reaches 0 seconds.

## Related Issue
Closes #179 

## Changes
- Added shared timeout status and lock script partials
- Updated intake queue and preview screens to show timeout state consistently
- Disabled scan, preview, discard, and commit controls when the timer reaches 0
- Redirected the operator to `/logout` immediately at timeout
- Added focused test coverage for timeout UI lock behavior

## Verification checklist
- [x] UI locks at 0 seconds
- [x] No refresh required
- [x] Redirect occurs at timeout
- [x] Navigation cannot bypass timeout
- [x] Backend timeout enforcement unchanged
- [x] Tests pass

## Notes
Strict enforcement was implemented so that once the inactivity timer expires the operator is immediately logged out, ensuring UI behavior stays aligned with backend session enforcement.