### PR TITLE
Issue 22-4: Render queue timestamps from Scan metadata

### DIFF
--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -7,14 +7,7 @@
 {% block extra_head %}
   <style>
     input[type="text"], input[type="password"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
-    @keyframes countdownPulse {
-      0%, 100% { opacity: 1; transform: scale(1); }
-      50% { opacity: 0.7; transform: scale(1.03); }
-    }
-    .countdown-pulse {
-      display: inline-block;
-      animation: countdownPulse 0.9s ease-in-out infinite;
-    }
+    .queue-ts { color: #5b6878; font-size: 0.9rem; margin-right: 0.4rem; }
   </style>
 {% endblock %}
 
@@ -95,7 +88,7 @@
     <ul id="queue-list" role="list">
       {% for s in queue %}
         <li data-asset-tag="{{ s.asset_tag }}">
-          <span class="queue-ts"></span>
+          <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }}</time>
           <code>{{ s.asset_tag }}</code>
         </li>
       {% endfor %}
@@ -104,39 +97,5 @@
 {% endblock %}
 
 {% block extra_scripts %}
-  <script>
-    const TS_STORAGE_KEY = "assettrack:intake:queue_ts";
-
-    const queueListEl = document.getElementById("queue-list");
-    if (queueListEl) {
-      const nowTime = () => new Date().toLocaleTimeString("en-US", { hour12: false });
-      const queueItems = Array.from(queueListEl.querySelectorAll("li"));
-
-      let storedTimes = [];
-      try {
-        const raw = localStorage.getItem(TS_STORAGE_KEY);
-        const parsed = raw ? JSON.parse(raw) : [];
-        storedTimes = Array.isArray(parsed) ? parsed : [];
-      } catch (error) {
-        storedTimes = [];
-      }
-
-      const currentTimes = [];
-      queueItems.forEach((itemEl, idx) => {
-        const tsEl = itemEl.querySelector(".queue-ts");
-        const displayTime = storedTimes[idx] || nowTime();
-        currentTimes[idx] = displayTime;
-        if (tsEl) {
-          tsEl.textContent = `[${displayTime}] `;
-        }
-      });
-
-      try {
-        localStorage.setItem(TS_STORAGE_KEY, JSON.stringify(currentTimes));
-      } catch (error) {
-        // Ignore storage failures to avoid impacting scan responsiveness.
-      }
-    }
-  </script>
   {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
+from assettrack.intake.scan import Scan
 from tests.auth_test_utils import create_test_user, login_session
 
 
@@ -90,6 +92,22 @@ class AdminAddAssetUiTests(unittest.TestCase):
         response = self.client.get("/admin/assets/new")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Add Asset", response.data)
+
+    def test_add_assets_queue_renders_scan_timestamps_from_queue_items(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(
+            Scan(
+                asset_tag="AT-QUEUE-1",
+                scanned_at=datetime(2026, 1, 1, 14, 3, 22, tzinfo=timezone.utc),
+                equipment_type="laptop",
+            )
+        )
+
+        response = self.client.get("/add-assets")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'14:03:22', response.data)
+        self.assertIn(b'datetime="2026-01-01T14:03:22+00:00"', response.data)
+        self.assertNotIn(b"localStorage.getItem", response.data)
 
     def test_post_creates_unslotted_asset_and_enforces_serial_uniqueness(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
## Summary
Display a per-scan timestamp for each item in the active intake queue so operators can understand scan order and timing during the workflow.

The queue was previously generating display timestamps in the browser using localStorage. The queue already stored a real timestamp (`Scan.scanned_at`) when the scan object was created, so the fix was to render that value directly and remove the client-side timestamp generation.

## Related Issue
Closes #181 

## Changes
- render queue timestamps directly from `Scan.scanned_at`
- format timestamps as compact `HH:MM:SS`
- remove browser-side queue timestamp generation from `index.html`
- add focused test verifying `/add-assets` renders the server timestamp

## Verification checklist
- [x] Tests pass
- [ ] Manual smoke test completed (deferred until full MVP smoke test)
- [x] Scope adhered to

## Notes
- The queue already contained correct per-item timestamps via the `Scan` object.
- This change removes client-side timestamp fabrication and uses the existing server-side metadata instead.
- No schema, persistence, event payload, or workflow changes were introduced.