### PR TITLE
Issue 22-5: Preserve intake equipment type selection semantics

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -124,7 +124,7 @@ def build_parsed_rows_from_queue() -> list[dict]:
     """
     Build rows in the validator/committer format:
       [{"row_number": 1, "data": {...}}, ...]
-    Also inject session equipment_type for SCAN rows missing it.
+    Each queued Scan already carries its own equipment_type.
     """
     rows: list[dict] = []
 
@@ -1533,8 +1533,13 @@ def intake():
         action = (request.form.get("action") or "").strip().lower()
         scan_text = (request.form.get("scan_text") or "").strip()
         return_to = (request.form.get("return_to") or "").strip()
-        form_equipment_type = (request.form.get("equipment_type") or "").strip()
-        session["equipment_type"] = form_equipment_type or "laptop"
+        submitted_equipment_type = request.form.get("equipment_type")
+        current_equipment_type = (session.get("equipment_type") or "laptop").strip() or "laptop"
+        if submitted_equipment_type is None:
+            selected_equipment_type = current_equipment_type
+        else:
+            selected_equipment_type = (submitted_equipment_type or "").strip() or "laptop"
+        session["equipment_type"] = selected_equipment_type
 
         if action == "clear":
             SCAN_QUEUE.clear()
@@ -1542,7 +1547,7 @@ def intake():
         if scan_text:
             value = sanitize_scan(scan_text)
             if value:
-                SCAN_QUEUE.append(Scan.now(value, equipment_type=session["equipment_type"]))
+                SCAN_QUEUE.append(Scan.now(value, equipment_type=selected_equipment_type))
 
         touch_session()
 

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -109,6 +109,58 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b'datetime="2026-01-01T14:03:22+00:00"', response.data)
         self.assertNotIn(b"localStorage.getItem", response.data)
 
+    def test_scans_keep_equipment_type_captured_at_scan_time(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+
+        first = self.client.post(
+            "/",
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "tablet"},
+        )
+        self.assertEqual(first.status_code, 302)
+
+        second = self.client.post(
+            "/",
+            data={"scan_text": "AT-QUEUE-2", "equipment_type": "laptop"},
+        )
+        self.assertEqual(second.status_code, 302)
+
+        self.assertEqual([scan.equipment_type for scan in intake_app.SCAN_QUEUE], ["tablet", "laptop"])
+
+        preview = self.client.get("/preview?json=1")
+        self.assertEqual(preview.status_code, 200)
+        rows = preview.json["rows"]
+        self.assertEqual(rows[0]["equipment_type"], "tablet")
+        self.assertEqual(rows[1]["equipment_type"], "laptop")
+
+    def test_blank_equipment_type_uses_default_and_missing_field_preserves_selection(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+
+        select_tablet = self.client.post(
+            "/",
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "tablet"},
+        )
+        self.assertEqual(select_tablet.status_code, 302)
+
+        preserve_selection = self.client.post(
+            "/",
+            data={"action": "clear", "return_to": "/add-assets"},
+        )
+        self.assertEqual(preserve_selection.status_code, 302)
+
+        with self.client.session_transaction() as sess:
+            self.assertEqual(sess["equipment_type"], "tablet")
+
+        default_scan = self.client.post(
+            "/",
+            data={"scan_text": "AT-QUEUE-2", "equipment_type": ""},
+        )
+        self.assertEqual(default_scan.status_code, 302)
+        self.assertEqual(len(intake_app.SCAN_QUEUE), 1)
+        self.assertEqual(intake_app.SCAN_QUEUE[0].equipment_type, "laptop")
+
+        with self.client.session_transaction() as sess:
+            self.assertEqual(sess["equipment_type"], "laptop")
+
     def test_post_creates_unslotted_asset_and_enforces_serial_uniqueness(self) -> None:
         response = self.client.post(
             "/admin/assets/new",


### PR DESCRIPTION
## Summary
Fix intake equipment type handling so the active selection behaves predictably and each queued scan retains its own equipment type.

The fix stays in the intake behavior layer: a missing `equipment_type` field now preserves the current selection, an explicitly blank value falls back to `laptop`, and each new queued scan continues to capture its resolved type at queue-add time.

## Related Issue
Closes #182 

## Changes
- update intake POST handling to distinguish between missing and blank `equipment_type`
- preserve current session selection when the field is omitted
- fall back to the default when the field is explicitly blank
- keep per-item equipment type captured on each queued `Scan`
- add regression coverage for selection semantics and per-item queue behavior

## Verification checklist
- [x] Tests pass
- [ ] Manual smoke test completed (deferred until full MVP smoke test)
- [x] Scope adhered to

## Notes
- The reduced patch stays in `assettrack/intake/app.py` plus tests only.
- No schema, persistence, event-model, or dependency changes were introduced.
- Earlier queued items remain stable because each `Scan` already stores its own `equipment_type`.