### PR TITLE
Issue 24-2: Initialize schema on first Docker startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ cd AssetTrack
 docker compose up -d --build
 ```
 
+On a first run with no database file, AssetTrack initializes the approved SQLite schema automatically in the mounted `/app/data/assettrack.db` path before the web app starts.
+
 Open the application:
 
 `http://localhost:8000`

--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -135,6 +135,35 @@ def _rebuild_asset_events_for_corrections(conn: sqlite3.Connection) -> None:
 DB_PATH = Path(os.environ.get("ASSETTRACK_DB_PATH", "data/assettrack.db"))
 
 
+def initialize_schema(db_path: Path) -> None:
+    """
+    Create the approved AssetTrack schema at the given path.
+    Safe to run repeatedly against an existing valid database.
+    """
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        # SQLite only enforces foreign keys when enabled.
+        conn.execute("PRAGMA foreign_keys = ON;")
+        _create_schema(conn)
+    finally:
+        conn.close()
+
+
+def initialize_if_missing_or_empty(db_path: Path) -> bool:
+    """
+    Initialize schema only for first-run DB paths.
+    Returns True when schema bootstrap was performed.
+    """
+    if db_path.exists() and db_path.stat().st_size > 0:
+        return False
+
+    initialize_schema(db_path)
+    return True
+
+
 def assert_schema_present(db_path: Path) -> None:
     """
     Validate that a DB file contains the required AssetTrack tables.
@@ -172,15 +201,12 @@ def get_connection():
     Returns a SQLite connection to the AssetTrack database.
     Ensures the database and schema exist.
     """
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-
+    initialize_schema(DB_PATH)
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
 
     # SQLite only enforces foreign keys when enabled.
     conn.execute("PRAGMA foreign_keys = ON;")
-
-    _create_schema(conn)
     return conn
 
 

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -23,7 +23,7 @@ from flask import Flask, abort, flash, jsonify, redirect, render_template, reque
 import assettrack.db as db_module
 from assettrack.assets import get_asset_table_columns
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
-from assettrack.db import assert_schema_present, get_connection
+from assettrack.db import assert_schema_present, get_connection, initialize_if_missing_or_empty
 from assettrack.drilldowns import (
     get_case_slot_detail,
     get_holder_custody_detail,
@@ -55,6 +55,7 @@ from assettrack.users import (
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
 
+initialize_if_missing_or_empty(db_module.DB_PATH)
 assert_schema_present(db_module.DB_PATH)
 
 # In-memory only: wiped on restart

--- a/docs/release/deployment.md
+++ b/docs/release/deployment.md
@@ -36,6 +36,7 @@ What this does:
 1. Builds the AssetTrack Docker image.
 2. Starts the AssetTrack container in the background.
 3. Exposes the application on port `8000`.
+4. On first run, initializes the approved SQLite schema in `/app/data/assettrack.db` if the database file is missing or empty.
 
 After startup, open:
 

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+
+
+def test_initialize_if_missing_or_empty_bootstraps_missing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+
+    initialized = db.initialize_if_missing_or_empty(db_path)
+
+    assert initialized is True
+    assert db_path.exists()
+    assert db_path.stat().st_size > 0
+    db.assert_schema_present(db_path)
+
+
+def test_initialize_if_missing_or_empty_bootstraps_zero_byte_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.touch()
+
+    assert db_path.stat().st_size == 0
+
+    initialized = db.initialize_if_missing_or_empty(db_path)
+
+    assert initialized is True
+    assert db_path.stat().st_size > 0
+    db.assert_schema_present(db_path)
+
+
+def test_initialize_if_missing_or_empty_preserves_existing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db.initialize_schema(db_path)
+    before_size = db_path.stat().st_size
+
+    initialized = db.initialize_if_missing_or_empty(db_path)
+
+    assert initialized is False
+    assert db_path.stat().st_size == before_size
+    db.assert_schema_present(db_path)
+
+
+def test_initialize_if_missing_or_empty_does_not_mask_invalid_nonempty_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db_path.write_bytes(b"not-a-valid-schema")
+
+    initialized = db.initialize_if_missing_or_empty(db_path)
+
+    assert initialized is False
+    with pytest.raises((RuntimeError, sqlite3.DatabaseError)) as exc_info:
+        db.assert_schema_present(db_path)
+
+    if isinstance(exc_info.value, RuntimeError):
+        assert "AssetTrack DB schema missing." in str(exc_info.value)


### PR DESCRIPTION
## Summary
Adds a safe first-run database initialization path for Docker startup so a fresh install can boot successfully without masking invalid existing databases.

## Related Issue
Closes #24-2

## Changes
- Added schema bootstrap helpers in `assettrack/db.py`.
- Invoked first-run bootstrap before startup schema validation in `assettrack/intake/app.py`.
- Added regression coverage for missing DB, empty DB, valid existing DB, and invalid non-empty DB.
- Updated README and release deployment docs for first-run Docker behavior.

## Verification checklist
- [x] Removed existing `data/assettrack.db`
- [x] Ran `docker compose down`
- [x] Ran `docker compose up -d --build`
- [x] Confirmed container reached healthy running state
- [x] Confirmed DB file was recreated as non-zero
- [x] Confirmed `/bootstrap/admin` was available on first run
- [x] Restarted with `docker compose down` / `docker compose up -d`
- [x] Confirmed DB persisted across restart
- [x] Ran full test suite successfully (`83 passed`)

## Notes
Non-empty invalid databases still fail safely and are not auto-initialized or masked.