### PR TITLE
Issue 23-4: Wire add-assets case and slot assignment

### DIFF
--- a/assettrack/ingest/committer.py
+++ b/assettrack/ingest/committer.py
@@ -102,6 +102,139 @@ def _asset_exists(conn: sqlite3.Connection, asset_tag: str) -> bool:
     return cursor.fetchone() is not None
 
 
+def _assign_new_asset_to_home_slot(
+    conn: sqlite3.Connection,
+    *,
+    asset_tag: str,
+    event_date: str,
+    actor: str | None,
+    notes: str | None,
+    data: dict[str, Any],
+) -> None:
+    home_slot_raw = data.get("home_slot_id")
+    case_number = str(data.get("case_number", "")).strip().upper()
+    slot_number_raw = str(data.get("slot_number", "")).strip()
+
+    slot_row: sqlite3.Row | None = None
+    if home_slot_raw not in {None, ""}:
+        try:
+            home_slot_id = int(str(home_slot_raw).strip())
+        except ValueError as e:
+            raise BatchCommitError("home_slot_id must be an integer") from e
+        slot_row = conn.execute(
+            """
+            SELECT id, case_name, slot_position, current_asset_tag
+            FROM slots
+            WHERE id = ?
+            LIMIT 1;
+            """,
+            (home_slot_id,),
+        ).fetchone()
+        if slot_row is None:
+            raise BatchCommitError(f"home_slot_id does not reference an existing slot for {asset_tag}")
+    elif case_number or slot_number_raw:
+        if not case_number or not slot_number_raw:
+            raise BatchCommitError(f"case_number and slot_number must both be present for {asset_tag}")
+        try:
+            slot_position = int(slot_number_raw)
+        except ValueError as e:
+            raise BatchCommitError(f"slot_number must be an integer for {asset_tag}") from e
+        slot_row = conn.execute(
+            """
+            SELECT id, case_name, slot_position, current_asset_tag
+            FROM slots
+            WHERE UPPER(case_name) = UPPER(?)
+              AND slot_position = ?
+            LIMIT 1;
+            """,
+            (case_number, slot_position),
+        ).fetchone()
+        if slot_row is None:
+            raise BatchCommitError(f"Selected slot does not exist for {asset_tag}")
+
+    asset_row = conn.execute(
+        """
+        SELECT id
+        FROM assets
+        WHERE UPPER(asset_tag) = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_tag,),
+    ).fetchone()
+    if asset_row is None:
+        raise BatchCommitError(f"Asset {asset_tag} was not created")
+
+    # Normalize new intake-created assets into storage semantics used by issue/return flows.
+    asset_columns = {row[1] for row in conn.execute("PRAGMA table_info(assets);").fetchall()}
+    update_clauses: list[str] = []
+    update_values: list[Any] = []
+    if "location_type" in asset_columns:
+        update_clauses.append("location_type = ?")
+        update_values.append("STORAGE")
+    if "current_holder_id" in asset_columns:
+        update_clauses.append("current_holder_id = NULL")
+    if "home_slot_id" in asset_columns:
+        update_clauses.append("home_slot_id = ?")
+        update_values.append(None if slot_row is None else int(slot_row["id"]))
+    if "updated_date" in asset_columns:
+        update_clauses.append("updated_date = ?")
+        update_values.append(event_date)
+    if update_clauses:
+        update_values.append(int(asset_row["id"]))
+        conn.execute(
+            f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+            tuple(update_values),
+        )
+
+    if slot_row is None:
+        return
+
+    occupied = conn.execute(
+        """
+        SELECT 1
+        FROM slot_occupancy
+        WHERE slot_id = ?
+        LIMIT 1;
+        """,
+        (int(slot_row["id"]),),
+    ).fetchone()
+    if occupied:
+        raise BatchCommitError(f"Selected slot is already occupied for {asset_tag}")
+    if str(slot_row["current_asset_tag"] or "").strip():
+        raise BatchCommitError(f"Selected slot is already occupied for {asset_tag}")
+
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (?, ?, ?);
+        """,
+        (int(slot_row["id"]), int(asset_row["id"]), event_date),
+    )
+    conn.execute(
+        """
+        UPDATE slots
+        SET current_asset_tag = ?
+        WHERE id = ?;
+        """,
+        (asset_tag, int(slot_row["id"])),
+    )
+
+    record_event(
+        conn,
+        asset_tag=asset_tag,
+        event_type="SLOT_ASSIGN",
+        event_date=event_date,
+        actor=actor,
+        notes=notes,
+        payload={
+            "slot_id": int(slot_row["id"]),
+            "case_number": str(slot_row["case_name"] or ""),
+            "slot_number": int(slot_row["slot_position"]),
+            "equipment_type": str(data.get("equipment_type", "") or "").strip(),
+        },
+    )
+
+
 def _apply_one_event(conn: sqlite3.Connection, data: dict[str, Any]) -> None:
     """
     Apply a single ingest event to the DB.
@@ -141,6 +274,14 @@ def _apply_one_event(conn: sqlite3.Connection, data: dict[str, Any]) -> None:
     # SCAN creates the asset if it's new; otherwise treat as an update of location-ish fields.
     if event_type == "SCAN" and not exists:
         create_asset(conn, asset_data=data)
+        _assign_new_asset_to_home_slot(
+            conn,
+            asset_tag=asset_tag,
+            event_date=event_date,
+            actor=actor,
+            notes=notes,
+            data=data,
+        )
     else:
         update_asset(
             conn,

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -239,6 +239,97 @@ def _asset_current_slot(conn, asset_id: int, asset_tag: str) -> Optional[dict]:
     return dict(legacy_row) if legacy_row else None
 
 
+def _asset_home_slot(conn, home_slot_id: object) -> Optional[dict]:
+    if home_slot_id is None:
+        return None
+    row = conn.execute(
+        """
+        SELECT id AS slot_id, case_name, slot_position
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (int(home_slot_id),),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def _list_slot_options(conn) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            s.id,
+            s.case_name,
+            s.slot_position,
+            so.asset_id AS occupied_asset_id,
+            a.asset_tag AS occupied_asset_tag,
+            s.current_asset_tag AS legacy_asset_tag
+        FROM slots s
+        LEFT JOIN slot_occupancy so ON so.slot_id = s.id
+        LEFT JOIN assets a ON a.id = so.asset_id
+        ORDER BY UPPER(s.case_name) ASC, s.slot_position ASC, s.id ASC;
+        """
+    ).fetchall()
+    return [
+        {
+            "id": int(row["id"]),
+            "case_name": str(row["case_name"] or ""),
+            "slot_position": int(row["slot_position"]),
+            "occupied_asset_id": None if row["occupied_asset_id"] is None else int(row["occupied_asset_id"]),
+            "occupied_asset_tag": str(row["occupied_asset_tag"] or row["legacy_asset_tag"] or ""),
+        }
+        for row in rows
+    ]
+
+
+def _slot_case_options(slot_options: list[dict]) -> list[str]:
+    return sorted({str(row["case_name"]) for row in slot_options if str(row["case_name"]).strip()})
+
+
+def _resolve_slot_selection(
+    conn: sqlite3.Connection,
+    *,
+    case_name: str,
+    slot_id_raw: str,
+) -> tuple[Optional[dict], list[str]]:
+    case_name_clean = str(case_name or "").strip().upper()
+    slot_id_text = str(slot_id_raw or "").strip()
+    errors: list[str] = []
+
+    if bool(case_name_clean) != bool(slot_id_text):
+        errors.append("case and slot must both be selected.")
+        return None, errors
+
+    if not case_name_clean and not slot_id_text:
+        return None, errors
+
+    try:
+        slot_id = int(slot_id_text)
+    except ValueError:
+        errors.append("slot selection is invalid.")
+        return None, errors
+
+    slot_row = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (slot_id,),
+    ).fetchone()
+    if slot_row is None:
+        errors.append("selected slot does not exist.")
+        return None, errors
+
+    resolved_case = str(slot_row["case_name"] or "").strip().upper()
+    if resolved_case != case_name_clean:
+        errors.append("selected slot does not belong to the selected case.")
+        return None, errors
+
+    return dict(slot_row), errors
+
+
 def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     errors: list[str] = []
     asset = _find_asset_for_scan_tag(conn, scan_tag)
@@ -286,6 +377,40 @@ def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict],
         "home_slot_id": asset.get("home_slot_id"),
     }
     return view, errors
+
+
+def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
+    asset = _find_asset_for_scan_tag(conn, scan_tag)
+    if not asset:
+        return None, ["asset_tag not found"]
+
+    location_type = _normalize_location_type(asset.get("location_type"))
+    if _is_terminal_location_type(location_type):
+        return None, ["Asset is retired/disposed and cannot be edited."]
+
+    current_slot = _asset_current_slot(conn, int(asset["id"]), str(asset["asset_tag"]))
+    home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))
+
+    return (
+        {
+            "id": int(asset["id"]),
+            "asset_tag": str(asset.get("asset_tag") or ""),
+            "serial_number": str(asset.get("serial_number") or ""),
+            "manufacturer": str(asset.get("manufacturer") or ""),
+            "equipment_type": str(asset.get("equipment_type") or ""),
+            "building": str(asset.get("building") or ""),
+            "room": str(asset.get("room") or ""),
+            "model": str(asset.get("model") or ""),
+            "model_code": str(asset.get("model_code") or ""),
+            "notes": str(asset.get("notes") or ""),
+            "location_type": location_type,
+            "current_holder_id": asset.get("current_holder_id"),
+            "home_slot_id": asset.get("home_slot_id"),
+            "current_slot": current_slot,
+            "home_slot": home_slot,
+        },
+        [],
+    )
 
 
 def _build_admin_slot_move_source_view(conn, slot_id: int) -> Optional[dict]:
@@ -833,6 +958,235 @@ def _create_admin_asset_in_tx(
         "home_slot_id": home_slot_id,
         "location_type": "STORAGE",
         "current_holder_id": None,
+    }
+
+
+def _update_admin_asset_in_tx(
+    conn: sqlite3.Connection,
+    *,
+    asset_id: int,
+    actor: str,
+    serial_number: str,
+    manufacturer: str,
+    equipment_type: str,
+    building: str,
+    room: str,
+    model: Optional[str],
+    model_code: Optional[str],
+    notes: Optional[str],
+    selected_slot: Optional[dict],
+) -> dict:
+    locked = conn.execute(
+        """
+        SELECT *
+        FROM assets
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (asset_id,),
+    ).fetchone()
+    if not locked:
+        raise ValueError("asset not found.")
+
+    asset = dict(locked)
+    asset_tag = str(asset.get("asset_tag") or "")
+    location_type = _normalize_location_type(asset.get("location_type"))
+    if _is_terminal_location_type(location_type):
+        raise ValueError("Asset is retired/disposed and cannot be edited.")
+
+    if serial_number:
+        duplicate_serial = conn.execute(
+            """
+            SELECT id
+            FROM assets
+            WHERE id <> ?
+              AND TRIM(COALESCE(serial_number, '')) <> ''
+              AND UPPER(serial_number) = UPPER(?)
+            LIMIT 1;
+            """,
+            (asset_id, serial_number),
+        ).fetchone()
+        if duplicate_serial:
+            raise ValueError("serial_number already exists.")
+
+    current_slot = _asset_current_slot(conn, asset_id, asset_tag)
+    current_slot_id = None if current_slot is None else int(current_slot["slot_id"])
+    target_slot_id = None if selected_slot is None else int(selected_slot["id"])
+
+    if target_slot_id is None and asset.get("home_slot_id") is not None:
+        raise ValueError("Clearing an existing home slot is not supported here.")
+
+    if current_slot is not None and location_type != "STORAGE":
+        raise ValueError("Asset slot occupancy is inconsistent with its location_type.")
+
+    if selected_slot is not None:
+        occupied_row = conn.execute(
+            """
+            SELECT asset_id
+            FROM slot_occupancy
+            WHERE slot_id = ?
+            LIMIT 1;
+            """,
+            (target_slot_id,),
+        ).fetchone()
+        if occupied_row and int(occupied_row["asset_id"]) != asset_id:
+            raise ValueError("Selected slot is already occupied.")
+
+        legacy_occupied = str(selected_slot.get("current_asset_tag") or "").strip()
+        if legacy_occupied and legacy_occupied.upper() != asset_tag.upper():
+            raise ValueError("Selected slot is already occupied.")
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    building_room = f"{building}/{room}"
+    asset_columns = get_asset_table_columns(conn)
+
+    changed_fields: dict[str, object] = {}
+    field_values = {
+        "serial_number": serial_number,
+        "manufacturer": manufacturer,
+        "equipment_type": equipment_type,
+        "building": building,
+        "room": room,
+        "building_room": building_room,
+        "model": model,
+        "model_code": model_code,
+        "notes": notes,
+    }
+    for key, value in field_values.items():
+        if key in asset_columns and asset.get(key) != value:
+            changed_fields[key] = value
+
+    if "home_slot_id" in asset_columns and asset.get("home_slot_id") != target_slot_id:
+        changed_fields["home_slot_id"] = target_slot_id
+    if "case_number" in asset_columns:
+        next_case_number = None if selected_slot is None else str(selected_slot["case_name"])
+        if asset.get("case_number") != next_case_number:
+            changed_fields["case_number"] = next_case_number
+    if "slot_number" in asset_columns:
+        next_slot_number = None if selected_slot is None else str(selected_slot["slot_position"])
+        if asset.get("slot_number") != next_slot_number:
+            changed_fields["slot_number"] = next_slot_number
+
+    if location_type == "STORAGE" and current_slot_id != target_slot_id:
+        if current_slot_id is not None:
+            conn.execute("DELETE FROM slot_occupancy WHERE asset_id = ?;", (asset_id,))
+            conn.execute("UPDATE slots SET current_asset_tag = NULL WHERE id = ?;", (current_slot_id,))
+        if target_slot_id is not None:
+            conn.execute(
+                """
+                INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                VALUES (?, ?, ?);
+                """,
+                (target_slot_id, asset_id, now_iso),
+            )
+            conn.execute(
+                """
+                UPDATE slots
+                SET current_asset_tag = ?
+                WHERE id = ?;
+                """,
+                (asset_tag, target_slot_id),
+            )
+    elif location_type not in {"STORAGE", "IN_CUSTODY", ""}:
+        raise ValueError("Asset location_type is not supported for admin edit.")
+
+    update_clauses: list[str] = []
+    update_values: list[object] = []
+    for key, value in changed_fields.items():
+        update_clauses.append(f"{key} = ?")
+        update_values.append(value)
+    if "updated_date" in asset_columns:
+        update_clauses.append("updated_date = ?")
+        update_values.append(now_iso)
+    if update_clauses:
+        update_values.append(asset_id)
+        conn.execute(
+            f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+            tuple(update_values),
+        )
+
+    if current_slot_id != target_slot_id:
+        if location_type == "STORAGE" and current_slot_id is None and selected_slot is not None:
+            payload = {
+                "slot_id": target_slot_id,
+                "case_number": str(selected_slot["case_name"]),
+                "slot_number": int(selected_slot["slot_position"]),
+                "building": building,
+                "room": room,
+                "equipment_type": equipment_type,
+            }
+            conn.execute(
+                """
+                INSERT INTO asset_events (
+                    asset_tag,
+                    event_type,
+                    event_date,
+                    actor,
+                    notes,
+                    payload,
+                    holder_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?);
+                """,
+                (asset_tag, "SLOT_ASSIGN", now_iso, actor, notes, json.dumps(payload), None),
+            )
+        else:
+            payload = {
+                "from_slot_id": current_slot_id,
+                "to_slot_id": target_slot_id,
+                "case_number": None if selected_slot is None else str(selected_slot["case_name"]),
+                "slot_number": None if selected_slot is None else int(selected_slot["slot_position"]),
+                "location_type": location_type,
+            }
+            conn.execute(
+                """
+                INSERT INTO asset_events (
+                    asset_tag,
+                    event_type,
+                    event_date,
+                    actor,
+                    notes,
+                    payload,
+                    holder_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?);
+                """,
+                (asset_tag, "ASSET_UPDATED", now_iso, actor, notes, json.dumps(payload), asset.get("current_holder_id")),
+            )
+
+    metadata_payload = dict(changed_fields)
+    if metadata_payload:
+        metadata_payload["asset_id"] = asset_id
+        conn.execute(
+            """
+            INSERT INTO asset_events (
+                asset_tag,
+                event_type,
+                event_date,
+                actor,
+                notes,
+                payload,
+                holder_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                asset_tag,
+                "ASSET_UPDATED",
+                now_iso,
+                actor,
+                notes,
+                json.dumps(metadata_payload),
+                asset.get("current_holder_id"),
+            ),
+        )
+
+    return {
+        "asset_id": asset_id,
+        "asset_tag": asset_tag,
+        "location_type": location_type,
+        "home_slot_id": target_slot_id,
+        "current_holder_id": asset.get("current_holder_id"),
     }
 
 
@@ -1548,7 +1902,40 @@ def intake():
         if scan_text:
             value = sanitize_scan(scan_text)
             if value:
-                SCAN_QUEUE.append(Scan.now(value, equipment_type=selected_equipment_type))
+                case_name = (request.form.get("case_name") or "").strip().upper()
+                slot_id_raw = (request.form.get("slot_id") or "").strip()
+                home_slot_id: Optional[int] = None
+                slot_position: Optional[int] = None
+                if case_name or slot_id_raw:
+                    conn = get_connection()
+                    try:
+                        selected_slot, slot_errors = _resolve_slot_selection(
+                            conn,
+                            case_name=case_name,
+                            slot_id_raw=slot_id_raw,
+                        )
+                    finally:
+                        conn.close()
+                    if slot_errors:
+                        flash("; ".join(slot_errors), "error")
+                        touch_session()
+                        if return_to.startswith("/") and not return_to.startswith("//"):
+                            return redirect(return_to)
+                        return redirect(url_for("add_assets"))
+                    if selected_slot is not None:
+                        home_slot_id = int(selected_slot["id"])
+                        case_name = str(selected_slot["case_name"])
+                        slot_position = int(selected_slot["slot_position"])
+
+                SCAN_QUEUE.append(
+                    Scan.now(
+                        value,
+                        equipment_type=selected_equipment_type,
+                        home_slot_id=home_slot_id,
+                        case_name=case_name,
+                        slot_position=slot_position,
+                    )
+                )
 
         touch_session()
 
@@ -1581,6 +1968,15 @@ def add_assets():
     if session.get("last_seen") is None:
         touch_session()
 
+    slot_options: list[dict] = []
+    case_options: list[str] = []
+    conn = get_connection()
+    try:
+        slot_options = _list_slot_options(conn)
+        case_options = _slot_case_options(slot_options)
+    finally:
+        conn.close()
+
     return render_template(
         "index.html",
         auth_enabled=auth_enabled(),
@@ -1591,6 +1987,8 @@ def add_assets():
         queue_len=len(SCAN_QUEUE),
         latest=(SCAN_QUEUE[-1].asset_tag if SCAN_QUEUE else ""),
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+        slot_options=slot_options,
+        case_options=case_options,
     )
 
 
@@ -2438,62 +2836,61 @@ def admin_new_asset():
         "model": "",
         "model_code": "",
         "notes": "",
-        "assign_now": "no",
-        "case_number": "",
-        "slot_number": "",
+        "case_name": "",
+        "slot_id": "",
     }
     error_message: Optional[str] = None
+    conn = get_connection()
+    try:
+        slot_options = _list_slot_options(conn)
+        case_options = _slot_case_options(slot_options)
 
-    if request.method == "POST":
-        form_state = {
-            "asset_tag": (request.form.get("asset_tag") or "").strip().upper(),
-            "serial_number": (request.form.get("serial_number") or "").strip(),
-            "manufacturer": (request.form.get("manufacturer") or "").strip(),
-            "equipment_type": (request.form.get("equipment_type") or "").strip() or "laptop",
-            "building": (request.form.get("building") or "").strip(),
-            "room": (request.form.get("room") or "").strip(),
-            "model": (request.form.get("model") or "").strip(),
-            "model_code": (request.form.get("model_code") or "").strip(),
-            "notes": (request.form.get("notes") or "").strip(),
-            "assign_now": "yes" if _is_truthy(request.form.get("assign_now")) else "no",
-            "case_number": (request.form.get("case_number") or "").strip().upper(),
-            "slot_number": (request.form.get("slot_number") or "").strip(),
-        }
+        if request.method == "POST":
+            form_state = {
+                "asset_tag": (request.form.get("asset_tag") or "").strip().upper(),
+                "serial_number": (request.form.get("serial_number") or "").strip(),
+                "manufacturer": (request.form.get("manufacturer") or "").strip(),
+                "equipment_type": (request.form.get("equipment_type") or "").strip() or "laptop",
+                "building": (request.form.get("building") or "").strip(),
+                "room": (request.form.get("room") or "").strip(),
+                "model": (request.form.get("model") or "").strip(),
+                "model_code": (request.form.get("model_code") or "").strip(),
+                "notes": (request.form.get("notes") or "").strip(),
+                "case_name": (request.form.get("case_name") or "").strip().upper(),
+                "slot_id": (request.form.get("slot_id") or "").strip(),
+            }
 
-        errors: list[str] = []
-        if not form_state["asset_tag"]:
-            errors.append("asset_tag is required.")
-        if not form_state["serial_number"]:
-            errors.append("serial_number is required.")
-        if not form_state["manufacturer"]:
-            errors.append("manufacturer is required.")
-        if not form_state["equipment_type"]:
-            errors.append("equipment_type is required.")
-        if not form_state["building"]:
-            errors.append("building is required.")
-        if not form_state["room"]:
-            errors.append("room is required.")
+            errors: list[str] = []
+            if not form_state["asset_tag"]:
+                errors.append("asset_tag is required.")
+            if not form_state["serial_number"]:
+                errors.append("serial_number is required.")
+            if not form_state["manufacturer"]:
+                errors.append("manufacturer is required.")
+            if not form_state["equipment_type"]:
+                errors.append("equipment_type is required.")
+            if not form_state["building"]:
+                errors.append("building is required.")
+            if not form_state["room"]:
+                errors.append("room is required.")
 
-        assign_slot_number: Optional[int] = None
-        assign_case_number: Optional[str] = None
-        if form_state["assign_now"] == "yes":
-            if not form_state["case_number"]:
-                errors.append("case_number is required when assign_now is enabled.")
-            if not form_state["slot_number"]:
-                errors.append("slot_number is required when assign_now is enabled.")
-            if form_state["slot_number"]:
-                try:
-                    assign_slot_number = int(form_state["slot_number"])
-                except ValueError:
-                    errors.append("slot_number must be an integer.")
-            assign_case_number = form_state["case_number"] or None
+            selected_slot, slot_errors = _resolve_slot_selection(
+                conn,
+                case_name=form_state["case_name"],
+                slot_id_raw=form_state["slot_id"],
+            )
+            errors.extend(slot_errors)
 
-        if errors:
-            error_message = "; ".join(errors)
-            return render_template("admin_new_asset.html", form=form_state, error_message=error_message)
+            if errors:
+                error_message = "; ".join(errors)
+                return render_template(
+                    "admin_new_asset.html",
+                    form=form_state,
+                    error_message=error_message,
+                    slot_options=slot_options,
+                    case_options=case_options,
+                )
 
-        conn = get_connection()
-        try:
             try:
                 conn.execute("BEGIN;")
                 _create_admin_asset_in_tx(
@@ -2508,28 +2905,244 @@ def admin_new_asset():
                     model=form_state["model"] or None,
                     model_code=form_state["model_code"] or None,
                     notes=form_state["notes"] or None,
-                    assign_case_number=assign_case_number,
-                    assign_slot_number=assign_slot_number,
+                    assign_case_number=None if selected_slot is None else str(selected_slot["case_name"]),
+                    assign_slot_number=None if selected_slot is None else int(selected_slot["slot_position"]),
                 )
                 conn.commit()
             except ValueError as e:
                 conn.rollback()
                 error_message = str(e)
-                return render_template("admin_new_asset.html", form=form_state, error_message=error_message)
+                return render_template(
+                    "admin_new_asset.html",
+                    form=form_state,
+                    error_message=error_message,
+                    slot_options=slot_options,
+                    case_options=case_options,
+                )
             except sqlite3.IntegrityError as e:
                 conn.rollback()
                 error_message = f"create failed: {e}"
-                return render_template("admin_new_asset.html", form=form_state, error_message=error_message)
+                return render_template(
+                    "admin_new_asset.html",
+                    form=form_state,
+                    error_message=error_message,
+                    slot_options=slot_options,
+                    case_options=case_options,
+                )
             except Exception:
                 conn.rollback()
                 raise
-        finally:
-            conn.close()
 
-        flash(f"Created asset {form_state['asset_tag']}.", "success")
-        return redirect(url_for("admin_new_asset"))
+            flash(f"Created asset {form_state['asset_tag']}.", "success")
+            return redirect(url_for("admin_new_asset"))
+    finally:
+        conn.close()
 
-    return render_template("admin_new_asset.html", form=form_state, error_message=error_message)
+    return render_template(
+        "admin_new_asset.html",
+        form=form_state,
+        error_message=error_message,
+        slot_options=slot_options,
+        case_options=case_options,
+    )
+
+
+@app.route("/admin/assets/edit", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_edit_asset():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    form_state = {
+        "lookup_asset_tag": (request.args.get("asset_tag") or "").strip().upper(),
+        "asset_tag": "",
+        "serial_number": "",
+        "manufacturer": "",
+        "equipment_type": "",
+        "building": "",
+        "room": "",
+        "model": "",
+        "model_code": "",
+        "notes": "",
+        "case_name": "",
+        "slot_id": "",
+    }
+    asset_view: Optional[dict] = None
+    error_message: Optional[str] = None
+
+    conn = get_connection()
+    try:
+        slot_options = _list_slot_options(conn)
+        case_options = _slot_case_options(slot_options)
+
+        if form_state["lookup_asset_tag"]:
+            asset_view, blocking_errors = _build_admin_edit_asset_view(conn, form_state["lookup_asset_tag"])
+            if asset_view:
+                selected_home_slot = asset_view["home_slot"] or asset_view["current_slot"]
+                form_state.update(
+                    {
+                        "asset_tag": asset_view["asset_tag"],
+                        "serial_number": asset_view["serial_number"],
+                        "manufacturer": asset_view["manufacturer"],
+                        "equipment_type": asset_view["equipment_type"],
+                        "building": asset_view["building"],
+                        "room": asset_view["room"],
+                        "model": asset_view["model"],
+                        "model_code": asset_view["model_code"],
+                        "notes": asset_view["notes"],
+                        "case_name": "" if selected_home_slot is None else str(selected_home_slot["case_name"]),
+                        "slot_id": "" if selected_home_slot is None else str(selected_home_slot["slot_id"]),
+                    }
+                )
+            elif blocking_errors:
+                error_message = "; ".join(blocking_errors)
+
+        if request.method == "POST":
+            action = (request.form.get("action") or "lookup").strip().lower()
+            lookup_asset_tag = (request.form.get("lookup_asset_tag") or "").strip().upper()
+            form_state["lookup_asset_tag"] = lookup_asset_tag
+
+            if action == "lookup":
+                asset_view, blocking_errors = _build_admin_edit_asset_view(conn, lookup_asset_tag)
+                if asset_view:
+                    selected_home_slot = asset_view["home_slot"] or asset_view["current_slot"]
+                    form_state.update(
+                        {
+                            "asset_tag": asset_view["asset_tag"],
+                            "serial_number": asset_view["serial_number"],
+                            "manufacturer": asset_view["manufacturer"],
+                            "equipment_type": asset_view["equipment_type"],
+                            "building": asset_view["building"],
+                            "room": asset_view["room"],
+                            "model": asset_view["model"],
+                            "model_code": asset_view["model_code"],
+                            "notes": asset_view["notes"],
+                            "case_name": "" if selected_home_slot is None else str(selected_home_slot["case_name"]),
+                            "slot_id": "" if selected_home_slot is None else str(selected_home_slot["slot_id"]),
+                        }
+                    )
+                elif not lookup_asset_tag:
+                    error_message = "asset_tag is required."
+                elif blocking_errors:
+                    error_message = "; ".join(blocking_errors)
+            elif action == "update":
+                form_state.update(
+                    {
+                        "asset_tag": (request.form.get("asset_tag") or "").strip().upper(),
+                        "serial_number": (request.form.get("serial_number") or "").strip(),
+                        "manufacturer": (request.form.get("manufacturer") or "").strip(),
+                        "equipment_type": (request.form.get("equipment_type") or "").strip(),
+                        "building": (request.form.get("building") or "").strip(),
+                        "room": (request.form.get("room") or "").strip(),
+                        "model": (request.form.get("model") or "").strip(),
+                        "model_code": (request.form.get("model_code") or "").strip(),
+                        "notes": (request.form.get("notes") or "").strip(),
+                        "case_name": (request.form.get("case_name") or "").strip().upper(),
+                        "slot_id": (request.form.get("slot_id") or "").strip(),
+                    }
+                )
+                asset_view, blocking_errors = _build_admin_edit_asset_view(conn, lookup_asset_tag or form_state["asset_tag"])
+                if asset_view is None:
+                    error_message = "; ".join(blocking_errors or ["asset_tag not found"])
+                    return render_template(
+                        "admin_edit_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                    )
+
+                errors: list[str] = []
+                if not form_state["serial_number"]:
+                    errors.append("serial_number is required.")
+                if not form_state["manufacturer"]:
+                    errors.append("manufacturer is required.")
+                if not form_state["equipment_type"]:
+                    errors.append("equipment_type is required.")
+                if not form_state["building"]:
+                    errors.append("building is required.")
+                if not form_state["room"]:
+                    errors.append("room is required.")
+
+                selected_slot, slot_errors = _resolve_slot_selection(
+                    conn,
+                    case_name=form_state["case_name"],
+                    slot_id_raw=form_state["slot_id"],
+                )
+                errors.extend(slot_errors)
+
+                if errors:
+                    error_message = "; ".join(errors)
+                    return render_template(
+                        "admin_edit_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                    )
+
+                try:
+                    conn.execute("BEGIN;")
+                    _update_admin_asset_in_tx(
+                        conn,
+                        asset_id=int(asset_view["id"]),
+                        actor="admin",
+                        serial_number=form_state["serial_number"],
+                        manufacturer=form_state["manufacturer"],
+                        equipment_type=form_state["equipment_type"],
+                        building=form_state["building"],
+                        room=form_state["room"],
+                        model=form_state["model"] or None,
+                        model_code=form_state["model_code"] or None,
+                        notes=form_state["notes"] or None,
+                        selected_slot=selected_slot,
+                    )
+                    conn.commit()
+                except ValueError as e:
+                    conn.rollback()
+                    error_message = str(e)
+                    return render_template(
+                        "admin_edit_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                    )
+                except sqlite3.IntegrityError as e:
+                    conn.rollback()
+                    error_message = f"update failed: {e}"
+                    return render_template(
+                        "admin_edit_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                    )
+                except Exception:
+                    conn.rollback()
+                    raise
+
+                flash(f"Updated asset {form_state['asset_tag']}.", "success")
+                return redirect(url_for("admin_edit_asset", asset_tag=form_state["asset_tag"]))
+            else:
+                error_message = "Unknown action."
+    finally:
+        conn.close()
+
+    return render_template(
+        "admin_edit_asset.html",
+        form=form_state,
+        asset=asset_view,
+        error_message=error_message,
+        slot_options=slot_options,
+        case_options=case_options,
+    )
 
 
 @app.route("/admin/assets/retire", methods=["GET", "POST"])

--- a/assettrack/intake/scan.py
+++ b/assettrack/intake/scan.py
@@ -21,12 +21,18 @@ class Scan:
     scanned_at: datetime
     equipment_type: str = "laptop"
     operator_id: str | None = None
+    home_slot_id: int | None = None
+    case_name: str = ""
+    slot_position: int | None = None
 
     @staticmethod
     def now(
         asset_tag: str,
         operator_id: str | None = None,
         equipment_type: str = "laptop",
+        home_slot_id: int | None = None,
+        case_name: str = "",
+        slot_position: int | None = None,
     ) -> "Scan":
         """Convenience constructor for 'scan happened right now'."""
         equipment_type = (equipment_type or "").strip() or "laptop"
@@ -35,4 +41,7 @@ class Scan:
             scanned_at=datetime.now(timezone.utc),
             operator_id=operator_id,
             equipment_type=equipment_type,
+            home_slot_id=home_slot_id,
+            case_name=(case_name or "").strip().upper(),
+            slot_position=slot_position,
         )

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -1,0 +1,163 @@
+<!-- assettrack/intake/templates/admin_edit_asset.html -->
+{% extends "base.html" %}
+
+{% block title %}Admin Edit Asset{% endblock %}
+{% block page_heading %}Admin: Edit Asset{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="actions">
+    <a class="chip" href="{{ url_for('dashboard') }}">Back to dashboard</a>
+    <a class="chip" href="{{ url_for('admin_new_asset') }}">Create asset</a>
+  </div>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Lookup Asset</h2>
+    <form method="post" action="{{ url_for('admin_edit_asset') }}">
+      <input type="hidden" name="action" value="lookup" />
+      <div class="row">
+        <label for="lookup_asset_tag"><strong>asset_tag</strong></label><br />
+        <input
+          type="text"
+          id="lookup_asset_tag"
+          name="lookup_asset_tag"
+          value="{{ form.lookup_asset_tag or '' }}"
+          required
+          autofocus
+        />
+      </div>
+      <button type="submit">Load Asset</button>
+    </form>
+  </div>
+
+  {% if asset %}
+    <div class="card">
+      <h2>Edit Asset</h2>
+      <p class="muted">Home location stays relationship-based through `slots` and `home_slot_id`.</p>
+      <form method="post" action="{{ url_for('admin_edit_asset') }}">
+        <input type="hidden" name="action" value="update" />
+        <input type="hidden" name="lookup_asset_tag" value="{{ form.lookup_asset_tag or asset.asset_tag }}" />
+        <div class="grid">
+          <div class="row">
+            <label for="asset_tag"><strong>asset_tag</strong></label><br />
+            <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" readonly />
+          </div>
+          <div class="row">
+            <label><strong>location_type</strong></label><br />
+            <input type="text" value="{{ asset.location_type }}" readonly />
+          </div>
+          <div class="row">
+            <label for="serial_number"><strong>serial_number</strong> (required)</label><br />
+            <input type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" required />
+          </div>
+          <div class="row">
+            <label for="manufacturer"><strong>manufacturer</strong> (required)</label><br />
+            <input type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" required />
+          </div>
+          <div class="row">
+            <label for="equipment_type"><strong>equipment_type</strong> (required)</label><br />
+            <input type="text" id="equipment_type" name="equipment_type" value="{{ form.equipment_type or '' }}" required />
+          </div>
+          <div class="row">
+            <label for="building"><strong>building</strong> (required)</label><br />
+            <input type="text" id="building" name="building" value="{{ form.building or '' }}" required />
+          </div>
+          <div class="row">
+            <label for="room"><strong>room</strong> (required)</label><br />
+            <input type="text" id="room" name="room" value="{{ form.room or '' }}" required />
+          </div>
+          <div class="row">
+            <label for="model"><strong>model</strong> (optional)</label><br />
+            <input type="text" id="model" name="model" value="{{ form.model or '' }}" />
+          </div>
+          <div class="row">
+            <label for="model_code"><strong>model_code</strong> (optional)</label><br />
+            <input type="text" id="model_code" name="model_code" value="{{ form.model_code or '' }}" />
+          </div>
+          <div class="row">
+            <label for="notes"><strong>notes</strong> (optional)</label><br />
+            <input type="text" id="notes" name="notes" value="{{ form.notes or '' }}" />
+          </div>
+          <div class="row">
+            <label for="case_name"><strong>case</strong></label><br />
+            <select id="case_name" name="case_name">
+              <option value="">Unassigned</option>
+              {% for case_name in case_options %}
+                <option value="{{ case_name }}" {% if form.case_name == case_name %}selected{% endif %}>{{ case_name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="row">
+            <label for="slot_id"><strong>slot</strong></label><br />
+            <select id="slot_id" name="slot_id">
+              <option value="">Unassigned</option>
+              {% for slot in slot_options %}
+                <option
+                  value="{{ slot.id }}"
+                  data-case="{{ slot.case_name }}"
+                  {% if form.slot_id == (slot.id|string) %}selected{% endif %}
+                >
+                  {{ slot.case_name }} / Slot {{ slot.slot_position }}{% if slot.occupied_asset_tag %} - occupied by {{ slot.occupied_asset_tag }}{% endif %}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        <button type="submit">Save Asset</button>
+      </form>
+    </div>
+  {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+  <script>
+    const caseSelect = document.getElementById("case_name");
+    const slotSelect = document.getElementById("slot_id");
+
+    if (caseSelect && slotSelect) {
+      const slotOptions = Array.from(slotSelect.options);
+
+      function syncSlotOptions() {
+        const selectedCase = caseSelect.value;
+        const selectedSlot = slotSelect.value;
+
+        slotOptions.forEach((option) => {
+          if (!option.value) {
+            option.hidden = false;
+            return;
+          }
+          const matchesCase = !selectedCase || option.dataset.case === selectedCase;
+          const isSelected = option.value === selectedSlot;
+          option.hidden = !matchesCase && !isSelected;
+        });
+
+        const selectedOption = slotSelect.selectedOptions[0];
+        if (selectedOption && selectedOption.value && selectedOption.dataset.case !== selectedCase) {
+          slotSelect.value = "";
+        }
+      }
+
+      caseSelect.addEventListener("change", syncSlotOptions);
+      syncSlotOptions();
+    }
+  </script>
+{% endblock %}

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -7,13 +7,14 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
     .hidden { display: none; }
   </style>
 {% endblock %}
 
 {% block content %}
   <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <p><a href="{{ url_for('admin_edit_asset') }}">Edit an existing asset</a></p>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -70,19 +71,31 @@
         </div>
       </div>
 
-      <div class="row">
-        <label for="assign_now"><strong>Assign to slot now?</strong></label><br />
-        <input type="checkbox" id="assign_now" name="assign_now" value="yes" {% if form.assign_now == "yes" %}checked{% endif %} />
-      </div>
-
-      <div id="assign-fields" class="{% if form.assign_now != 'yes' %}hidden{% endif %}">
+      <div class="grid">
         <div class="row">
-          <label for="case_number"><strong>case_number</strong> (required when assigning)</label><br />
-          <input type="text" id="case_number" name="case_number" value="{{ form.case_number or '' }}" />
+          <label for="case_name"><strong>case</strong> (optional)</label><br />
+          <select id="case_name" name="case_name">
+            <option value="">Unassigned</option>
+            {% for case_name in case_options %}
+              <option value="{{ case_name }}" {% if form.case_name == case_name %}selected{% endif %}>{{ case_name }}</option>
+            {% endfor %}
+          </select>
         </div>
         <div class="row">
-          <label for="slot_number"><strong>slot_number</strong> (required when assigning)</label><br />
-          <input type="text" id="slot_number" name="slot_number" value="{{ form.slot_number or '' }}" />
+          <label for="slot_id"><strong>slot</strong> (optional)</label><br />
+          <select id="slot_id" name="slot_id">
+            <option value="">Unassigned</option>
+            {% for slot in slot_options %}
+              <option
+                value="{{ slot.id }}"
+                data-case="{{ slot.case_name }}"
+                {% if form.slot_id == (slot.id|string) %}selected{% endif %}
+              >
+                {{ slot.case_name }} / Slot {{ slot.slot_position }}{% if slot.occupied_asset_tag %} - occupied by {{ slot.occupied_asset_tag }}{% endif %}
+              </option>
+            {% endfor %}
+          </select>
+          <p class="muted">Choose both case and slot to assign a home location, or leave both blank.</p>
         </div>
       </div>
 
@@ -93,19 +106,31 @@
 
 {% block extra_scripts %}
   <script>
-    const assignNow = document.getElementById("assign_now");
-    const assignFields = document.getElementById("assign-fields");
-    const caseNumber = document.getElementById("case_number");
-    const slotNumber = document.getElementById("slot_number");
+    const caseSelect = document.getElementById("case_name");
+    const slotSelect = document.getElementById("slot_id");
+    const slotOptions = Array.from(slotSelect.options);
 
-    function syncAssignFields() {
-      const enabled = assignNow.checked;
-      assignFields.classList.toggle("hidden", !enabled);
-      caseNumber.required = enabled;
-      slotNumber.required = enabled;
+    function syncSlotOptions() {
+      const selectedCase = caseSelect.value;
+      const selectedSlot = slotSelect.value;
+
+      slotOptions.forEach((option) => {
+        if (!option.value) {
+          option.hidden = false;
+          return;
+        }
+        const matchesCase = !selectedCase || option.dataset.case === selectedCase;
+        const isSelected = option.value === selectedSlot;
+        option.hidden = !matchesCase && !isSelected;
+      });
+
+      const selectedOption = slotSelect.selectedOptions[0];
+      if (selectedOption && selectedOption.value && selectedOption.dataset.case !== selectedCase) {
+        slotSelect.value = "";
+      }
     }
 
-    assignNow.addEventListener("change", syncAssignFields);
-    syncAssignFields();
+    caseSelect.addEventListener("change", syncSlotOptions);
+    syncSlotOptions();
   </script>
 {% endblock %}

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -6,8 +6,9 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"], input[type="password"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], input[type="password"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
     .queue-ts { color: #5b6878; font-size: 0.9rem; margin-right: 0.4rem; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
   </style>
 {% endblock %}
 
@@ -58,6 +59,31 @@
           />
         </div>
 
+        {% if authenticated_role == 'admin' %}
+          <div class="grid">
+            <div class="row">
+              <label for="case_name"><strong>Case</strong> (optional per scanned asset)</label><br />
+              <select id="case_name" name="case_name" data-timeout-lock-target>
+                <option value="">Unassigned</option>
+                {% for case_name in case_options %}
+                  <option value="{{ case_name }}">{{ case_name }}</option>
+                {% endfor %}
+              </select>
+            </div>
+            <div class="row">
+              <label for="slot_id"><strong>Slot</strong> (optional per scanned asset)</label><br />
+              <select id="slot_id" name="slot_id" data-timeout-lock-target>
+                <option value="">Unassigned</option>
+                {% for slot in slot_options %}
+                  <option value="{{ slot.id }}" data-case="{{ slot.case_name }}">
+                    {{ slot.case_name }} / Slot {{ slot.slot_position }}{% if slot.occupied_asset_tag %} - occupied by {{ slot.occupied_asset_tag }}{% endif %}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+        {% endif %}
+
         <div class="row">
           <input
             type="text"
@@ -90,6 +116,9 @@
         <li data-asset-tag="{{ s.asset_tag }}">
           <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }}</time>
           <code>{{ s.asset_tag }}</code>
+          {% if s.case_name and s.slot_position is not none %}
+            <span class="muted">→ {{ s.case_name }} / Slot {{ s.slot_position }}</span>
+          {% endif %}
         </li>
       {% endfor %}
     </ul>
@@ -97,5 +126,38 @@
 {% endblock %}
 
 {% block extra_scripts %}
+  {% if authenticated_role == 'admin' %}
+    <script>
+      const addAssetsCaseSelect = document.getElementById("case_name");
+      const addAssetsSlotSelect = document.getElementById("slot_id");
+
+      if (addAssetsCaseSelect && addAssetsSlotSelect) {
+        const addAssetsSlotOptions = Array.from(addAssetsSlotSelect.options);
+
+        function syncAddAssetsSlotOptions() {
+          const selectedCase = addAssetsCaseSelect.value;
+          const selectedSlot = addAssetsSlotSelect.value;
+
+          addAssetsSlotOptions.forEach((option) => {
+            if (!option.value) {
+              option.hidden = false;
+              return;
+            }
+            const matchesCase = !selectedCase || option.dataset.case === selectedCase;
+            const isSelected = option.value === selectedSlot;
+            option.hidden = !matchesCase && !isSelected;
+          });
+
+          const selectedOption = addAssetsSlotSelect.selectedOptions[0];
+          if (selectedOption && selectedOption.value && selectedOption.dataset.case !== selectedCase) {
+            addAssetsSlotSelect.value = "";
+          }
+        }
+
+        addAssetsCaseSelect.addEventListener("change", syncAddAssetsSlotOptions);
+        syncAddAssetsSlotOptions();
+      }
+    </script>
+  {% endif %}
   {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/assettrack/intake/to_ingest.py
+++ b/assettrack/intake/to_ingest.py
@@ -26,6 +26,9 @@ def scan_to_ingest_row(scan: Scan) -> dict:
 
     operator_id = (scan.operator_id or DEFAULT_OPERATOR_ID or "").strip()
     equipment_type = (getattr(scan, "equipment_type", "") or "").strip() or "laptop"
+    case_name = (getattr(scan, "case_name", "") or "").strip().upper()
+    slot_position = getattr(scan, "slot_position", None)
+    home_slot_id = getattr(scan, "home_slot_id", None)
 
     return {
         "asset_tag": (scan.asset_tag or "").strip().upper(),
@@ -33,8 +36,9 @@ def scan_to_ingest_row(scan: Scan) -> dict:
         "event_type": "SCAN",
         "issued_to_name": "",   # not required for SCAN
         "operator_id": operator_id,
-        "case_number": "",      # optional for SCAN (validator controls)
-        "slot_number": "",      # optional for SCAN (validator controls)
+        "case_number": case_name,
+        "slot_number": "" if slot_position is None else str(slot_position),
+        "home_slot_id": home_slot_id,
         "building_room": "",    # optional
         "notes": "",            # optional
         "row_number": None,     # preview convenience

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -92,6 +92,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
         response = self.client.get("/admin/assets/new")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Add Asset", response.data)
+        self.assertIn(b'name="case_name"', response.data)
+        self.assertIn(b'name="slot_id"', response.data)
 
     def test_add_assets_queue_renders_scan_timestamps_from_queue_items(self) -> None:
         intake_app.SCAN_QUEUE.clear()
@@ -108,6 +110,15 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b'14:03:22', response.data)
         self.assertIn(b'datetime="2026-01-01T14:03:22+00:00"', response.data)
         self.assertNotIn(b"localStorage.getItem", response.data)
+
+    def test_add_assets_route_shows_case_and_slot_selectors_for_admin(self) -> None:
+        self._insert_slot(110, "CASE-LIVE", 4)
+
+        response = self.client.get("/add-assets")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'name="case_name"', response.data)
+        self.assertIn(b'name="slot_id"', response.data)
+        self.assertIn(b"CASE-LIVE", response.data)
 
     def test_scans_keep_equipment_type_captured_at_scan_time(self) -> None:
         intake_app.SCAN_QUEUE.clear()
@@ -221,9 +232,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
                 "equipment_type": "tablet",
                 "building": "HQ",
                 "room": "220",
-                "assign_now": "yes",
-                "case_number": "CASE-A",
-                "slot_number": "7",
+                "case_name": "CASE-A",
+                "slot_id": "101",
             },
         )
         self.assertEqual(response.status_code, 302)
@@ -269,9 +279,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
                 "equipment_type": "laptop",
                 "building": "HQ",
                 "room": "330",
-                "assign_now": "yes",
-                "case_number": "CASE-B",
-                "slot_number": "1",
+                "case_name": "CASE-B",
+                "slot_id": "102",
             },
         )
         self.assertEqual(response.status_code, 200)
@@ -303,9 +312,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
                 "equipment_type": "laptop",
                 "building": "HQ",
                 "room": "331",
-                "assign_now": "yes",
-                "case_number": "CASE-C",
-                "slot_number": "9",
+                "case_name": "CASE-C",
+                "slot_id": "103",
             },
         )
         self.assertEqual(response.status_code, 200)
@@ -315,6 +323,104 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIsNone(created)
         event = self.conn.execute("SELECT 1 FROM asset_events WHERE asset_tag = ?;", ("AT-801",)).fetchone()
         self.assertIsNone(event)
+
+    def test_add_assets_live_seam_commits_new_asset_with_selected_slot(self) -> None:
+        self._insert_slot(120, "CASE-Q", 5)
+        stored_tag = "ATLIVE1"
+
+        queued = self.client.post(
+            "/",
+            data={
+                "scan_text": "AT-LIVE-1",
+                "equipment_type": "tablet",
+                "case_name": "CASE-Q",
+                "slot_id": "120",
+                "return_to": "/add-assets",
+            },
+        )
+        self.assertEqual(queued.status_code, 302)
+        self.assertEqual(len(intake_app.SCAN_QUEUE), 1)
+        self.assertEqual(intake_app.SCAN_QUEUE[0].asset_tag, stored_tag)
+        self.assertEqual(intake_app.SCAN_QUEUE[0].home_slot_id, 120)
+        self.assertEqual(intake_app.SCAN_QUEUE[0].case_name, "CASE-Q")
+        self.assertEqual(intake_app.SCAN_QUEUE[0].slot_position, 5)
+
+        committed = self.client.post(
+            "/preview/commit",
+            data={"confirm_reviewed": "on"},
+            follow_redirects=True,
+        )
+        self.assertEqual(committed.status_code, 200)
+        self.assertIn(b"Added 1 item to the database.", committed.data)
+
+        verify_conn = db.get_connection()
+        try:
+            asset_row = verify_conn.execute(
+                """
+                SELECT asset_tag, equipment_type, location_type, current_holder_id, home_slot_id
+                FROM assets
+                WHERE asset_tag = ?;
+                """,
+                (stored_tag,),
+            ).fetchone()
+            self.assertIsNotNone(asset_row)
+            self.assertEqual(asset_row["asset_tag"], stored_tag)
+            self.assertEqual(asset_row["equipment_type"], "tablet")
+            self.assertEqual(asset_row["location_type"], "STORAGE")
+            self.assertIsNone(asset_row["current_holder_id"])
+            self.assertEqual(asset_row["home_slot_id"], 120)
+
+            occ = verify_conn.execute(
+                "SELECT slot_id FROM slot_occupancy WHERE asset_id = (SELECT id FROM assets WHERE asset_tag = ?);",
+                (stored_tag,),
+            ).fetchone()
+            self.assertIsNotNone(occ)
+            self.assertEqual(occ["slot_id"], 120)
+
+            slot = verify_conn.execute("SELECT current_asset_tag FROM slots WHERE id = 120;").fetchone()
+            self.assertEqual(slot["current_asset_tag"], stored_tag)
+        finally:
+            verify_conn.close()
+
+    def test_add_assets_live_seam_rejects_occupied_slot_on_commit(self) -> None:
+        existing_id = self._insert_asset("AT-OCC-LIVE", "SER-OCC-LIVE")
+        self._insert_slot(130, "CASE-O", 8, current_asset_tag="AT-OCC-LIVE")
+        stored_tag = "ATLIVE2"
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (130, ?, '2026-01-02T00:00:00Z');
+            """,
+            (existing_id,),
+        )
+        self.conn.commit()
+
+        queued = self.client.post(
+            "/",
+            data={
+                "scan_text": "AT-LIVE-2",
+                "equipment_type": "laptop",
+                "case_name": "CASE-O",
+                "slot_id": "130",
+                "return_to": "/add-assets",
+            },
+        )
+        self.assertEqual(queued.status_code, 302)
+
+        blocked = self.client.post(
+            "/preview/commit",
+            data={"confirm_reviewed": "on"},
+            follow_redirects=True,
+        )
+        self.assertEqual(blocked.status_code, 200)
+        self.assertIn(b"Selected slot is already occupied", blocked.data)
+
+        verify_conn = db.get_connection()
+        try:
+            created = verify_conn.execute("SELECT 1 FROM assets WHERE asset_tag = ?;", (stored_tag,)).fetchone()
+            self.assertIsNone(created)
+        finally:
+            verify_conn.close()
 
 
 if __name__ == "__main__":

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+class AdminEditAssetUiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+        admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+        login_session(self.client, admin_user_id)
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int, *, current_asset_tag: str | None = None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            (slot_id, case_name, slot_position, current_asset_tag),
+        )
+        self.conn.commit()
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        serial_number: str,
+        location_type: str,
+        current_holder_id: int | None,
+        home_slot_id: int | None,
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                manufacturer,
+                equipment_type,
+                building,
+                room,
+                model,
+                model_code,
+                notes,
+                building_room,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                updated_date,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                case_number,
+                slot_number
+            )
+            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '110', 'Latitude', '5400', 'seed', 'HQ/110', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, NULL, NULL);
+            """,
+            (asset_tag, serial_number, location_type, current_holder_id, home_slot_id),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def _occupy_slot(self, slot_id: int, asset_id: int, asset_tag: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, '2026-01-02T00:00:00Z');
+            """,
+            (slot_id, asset_id),
+        )
+        self.conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", (asset_tag, slot_id))
+        self.conn.commit()
+
+    def test_get_admin_edit_asset_route_allows_admin(self) -> None:
+        response = self.client.get("/admin/assets/edit")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Admin: Edit Asset", response.data)
+
+    def test_edit_storage_asset_moves_slot_and_persists_fields(self) -> None:
+        self._insert_slot(201, "CASE-A", 1)
+        self._insert_slot(202, "CASE-B", 2)
+        asset_id = self._insert_asset(
+            "AT-EDIT-1",
+            serial_number="SER-EDIT-1",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=201,
+        )
+        self._occupy_slot(201, asset_id, "AT-EDIT-1")
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-1",
+                "asset_tag": "AT-EDIT-1",
+                "serial_number": "SER-EDIT-1A",
+                "manufacturer": "Lenovo",
+                "equipment_type": "tablet",
+                "building": "HQ",
+                "room": "210",
+                "model": "X1",
+                "model_code": "GEN9",
+                "notes": "relocated",
+                "case_name": "CASE-B",
+                "slot_id": "202",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            """
+            SELECT serial_number, manufacturer, equipment_type, building_room, home_slot_id, case_number, slot_number
+            FROM assets
+            WHERE id = ?;
+            """,
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset_row["serial_number"], "SER-EDIT-1A")
+        self.assertEqual(asset_row["manufacturer"], "Lenovo")
+        self.assertEqual(asset_row["equipment_type"], "tablet")
+        self.assertEqual(asset_row["building_room"], "HQ/210")
+        self.assertEqual(asset_row["home_slot_id"], 202)
+        self.assertEqual(asset_row["case_number"], "CASE-B")
+        self.assertEqual(asset_row["slot_number"], "2")
+
+        occ = self.conn.execute("SELECT slot_id FROM slot_occupancy WHERE asset_id = ?;", (asset_id,)).fetchone()
+        self.assertEqual(occ["slot_id"], 202)
+        old_slot = self.conn.execute("SELECT current_asset_tag FROM slots WHERE id = 201;").fetchone()
+        new_slot = self.conn.execute("SELECT current_asset_tag FROM slots WHERE id = 202;").fetchone()
+        self.assertIsNone(old_slot["current_asset_tag"])
+        self.assertEqual(new_slot["current_asset_tag"], "AT-EDIT-1")
+
+        events = self.conn.execute(
+            """
+            SELECT event_type, payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id ASC;
+            """,
+            ("AT-EDIT-1",),
+        ).fetchall()
+        self.assertTrue(any(row["event_type"] == "ASSET_UPDATED" for row in events))
+        payloads = [json.loads(row["payload"]) for row in events if row["payload"]]
+        self.assertTrue(any(payload.get("home_slot_id") == 202 for payload in payloads))
+
+    def test_edit_in_custody_asset_updates_home_slot_without_occupancy(self) -> None:
+        self._insert_slot(301, "CASE-C", 3)
+        self._insert_slot(302, "CASE-D", 4)
+        asset_id = self._insert_asset(
+            "AT-EDIT-2",
+            serial_number="SER-EDIT-2",
+            location_type="IN_CUSTODY",
+            current_holder_id=77,
+            home_slot_id=301,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-2",
+                "asset_tag": "AT-EDIT-2",
+                "serial_number": "SER-EDIT-2",
+                "manufacturer": "Dell",
+                "equipment_type": "laptop",
+                "building": "HQ",
+                "room": "111",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "new return slot",
+                "case_name": "CASE-D",
+                "slot_id": "302",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id, case_number, slot_number FROM assets WHERE id = ?;",
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset_row["location_type"], "IN_CUSTODY")
+        self.assertEqual(asset_row["current_holder_id"], 77)
+        self.assertEqual(asset_row["home_slot_id"], 302)
+        self.assertEqual(asset_row["case_number"], "CASE-D")
+        self.assertEqual(asset_row["slot_number"], "4")
+
+        occ = self.conn.execute("SELECT 1 FROM slot_occupancy WHERE asset_id = ?;", (asset_id,)).fetchone()
+        self.assertIsNone(occ)
+
+    def test_edit_rejects_occupied_target_slot(self) -> None:
+        self._insert_slot(401, "CASE-E", 1)
+        self._insert_slot(402, "CASE-E", 2, current_asset_tag="AT-OCCUPIER")
+        asset_id = self._insert_asset(
+            "AT-EDIT-3",
+            serial_number="SER-EDIT-3",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=401,
+        )
+        self._occupy_slot(401, asset_id, "AT-EDIT-3")
+        occupier_id = self._insert_asset(
+            "AT-OCCUPIER",
+            serial_number="SER-OCC",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=402,
+        )
+        self._occupy_slot(402, occupier_id, "AT-OCCUPIER")
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-3",
+                "asset_tag": "AT-EDIT-3",
+                "serial_number": "SER-EDIT-3",
+                "manufacturer": "Dell",
+                "equipment_type": "laptop",
+                "building": "HQ",
+                "room": "110",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "attempted move",
+                "case_name": "CASE-E",
+                "slot_id": "402",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"already occupied", response.data)
+
+        asset_row = self.conn.execute("SELECT home_slot_id FROM assets WHERE id = ?;", (asset_id,)).fetchone()
+        self.assertEqual(asset_row["home_slot_id"], 401)
+        occ = self.conn.execute("SELECT slot_id FROM slot_occupancy WHERE asset_id = ?;", (asset_id,)).fetchone()
+        self.assertEqual(occ["slot_id"], 401)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -64,6 +64,8 @@ def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     _login(client_with_temp_db, "admin", "admin-pass")
     response = client_with_temp_db.get("/admin/assets/new")
     assert response.status_code == 200
+    edit_response = client_with_temp_db.get("/admin/assets/edit")
+    assert edit_response.status_code == 200
 
 
 def test_bootstrap_only_when_empty(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Adds case and slot selection to the real `/add-assets` workflow so admins can assign a home location when creating assets. The selection now persists through queue → preview → commit and correctly updates `home_slot_id`, `slot_occupancy`, and `slots.current_asset_tag`.

## Related Issue
Closes #194 

## Changes
- add admin-only case and slot selectors to the live `/add-assets` page
- carry selected slot metadata through the scan queue and preview
- persist `home_slot_id`, `slot_occupancy`, and `slots.current_asset_tag` during asset creation
- keep slot assignment relationship-based and preserve occupied-slot rejection
- add admin asset edit flow for updating case/slot
- add focused tests for create/edit asset location behavior and auth guard

## Verification checklist
- [x] Tests pass
- [x] Manual admin asset create verified
- [x] Manual admin asset edit verified
- [x] Issue workflow verified
- [x] Return workflow verified
- [x] Docker restart persistence verified

## Notes
- Live create seam: `/add-assets` → `add_assets()` → `assettrack/intake/templates/index.html`
- Create commit path: `/preview/commit` → `preview_commit()` → queued `Scan` → `scan_to_ingest_row()` → `commit_batch()`
- No schema change required
- Asset edit reachable at `/admin/assets/edit?asset_tag=<tag>`; full asset navigation remains a separate future issue