### PR TITLE
Issue 23-8: Enforce holder selection before issue workflow

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2356,12 +2356,12 @@ def issue():
     if session.get("last_seen") is None:
         touch_session()
 
-    asset_tags = _queue_asset_tags()
     selected_holder = _selected_holder_from_session()
-    if selected_holder is None and asset_tags:
+    if selected_holder is None:
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("holders_search", return_to=url_for("issue")))
 
+    asset_tags = _queue_asset_tags()
     issue_state = _build_issue_preview_state(asset_tags, selected_holder)
 
     return render_template(

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def test_issue_requires_holder_selection_before_queue_access(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-prereq", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+
+    response = client_with_temp_db.get("/issue")
+
+    assert response.status_code == 302
+    location = response.headers.get("Location") or ""
+    assert location.endswith("/holders?return_to=/issue")
+
+
+def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-return", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+
+    issue_redirect = client_with_temp_db.get("/issue")
+    assert issue_redirect.status_code == 302
+    assert (issue_redirect.headers.get("Location") or "").endswith("/holders?return_to=/issue")
+
+    select_response = client_with_temp_db.post(
+        "/holders/select",
+        data={"holder_id": "1", "return_to": "/issue"},
+    )
+    assert select_response.status_code == 302
+    assert (select_response.headers.get("Location") or "").endswith("/issue")
+
+    issue_page = client_with_temp_db.get("/issue")
+    assert issue_page.status_code == 200
+    assert b"Issue Assets" in issue_page.data
+    assert b"Open Issue Assets Preview / Confirm" in issue_page.data
+
+
+def test_issue_with_selected_holder_still_loads_normally(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-selected", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+
+    response = client_with_temp_db.get("/issue")
+
+    assert response.status_code == 200
+    assert b"Select a holder before issuing assets." not in response.data
+    assert b"Issue Assets" in response.data


### PR DESCRIPTION
## Summary

Enforces holder selection as a prerequisite for entering the Issue workflow.

If /issue is accessed without a selected holder, the system redirects to holder selection with return_to=/issue. Once a holder is selected, the user returns to /issue and the issue workflow continues normally.

## Related Issue

Closes #200 

## Changes

- Added holder prerequisite guard to the /issue route
- Reused existing holder session mechanism
- Reused existing safe redirect pattern with return_to=/issue
- Added focused tests for redirect behavior and normal issue-page loading

## Verification checklist

- [x] /issue redirects to holder selection when no holder selected
- [x] return_to=/issue preserved
- [x] selecting holder returns user to /issue
- [x] issue queue loads normally after holder selected
- [x] preview and commit workflows unchanged
- [x] no schema or persistence changes