### PR TITLE
Issue 23-9: Display selected holder on issue page

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2383,6 +2383,7 @@ def issue():
         queued_count=len(asset_tags),
         ready_count=issue_state["ready_count"],
         blocking_issues=issue_state["blocking_issues"],
+        selected_holder=selected_holder,
     )
 
 

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -29,6 +29,21 @@
     {% endif %}
   {% endwith %}
 
+  {% if selected_holder %}
+    <div class="card">
+      <h2>Issuing Assets To</h2>
+      <p>
+        <strong>Holder:</strong> {{ selected_holder["name"] }}<br />
+        {% if selected_holder["organization"] %}
+          <strong>Organization:</strong> {{ selected_holder["organization"] }}<br />
+        {% endif %}
+        {% if selected_holder["identifier"] %}
+          <strong>Identifier:</strong> {{ selected_holder["identifier"] }}
+        {% endif %}
+      </p>
+    </div>
+  {% endif %}
+
   <div class="card">
     <h2>{{ scan_heading or "Scan returns" }}</h2>
     <p>Click the box once, then scan. The scanner "types" and hits Enter.</p>

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -16,8 +16,8 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     conn = db.get_connection()
     conn.execute(
         """
-        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
-        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'Issue Org', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
         """
     )
     conn.commit()
@@ -76,3 +76,18 @@ def test_issue_with_selected_holder_still_loads_normally(client_with_temp_db) ->
     assert response.status_code == 200
     assert b"Select a holder before issuing assets." not in response.data
     assert b"Issue Assets" in response.data
+
+
+def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-holder-display", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+
+    response = client_with_temp_db.get("/issue")
+
+    assert response.status_code == 200
+    assert b"Issuing Assets To" in response.data
+    assert b"Holder:</strong> Issue Holder" in response.data
+    assert b"Organization:</strong> Issue Org" in response.data


### PR DESCRIPTION
## Summary

Displays the selected holder on the Issue page so operators can immediately confirm who assets are being issued to.

This adds a small holder context card near the top of the existing queue UI while keeping issue queue, preview, and commit behavior unchanged.

## Related Issue

Closes #201 

## Changes

- Passed the existing selected holder into the Issue page template render
- Added an “Issuing Assets To” card to the shared queue template
- Displayed holder name, organization, and identifier when available
- Added focused test coverage to verify holder context appears on `/issue`

## Verification checklist

- [x] Issue page shows selected holder context
- [x] Holder name renders correctly
- [x] Organization renders correctly when available
- [x] Issue queue UI remains unchanged
- [x] Preview and commit still work normally
- [x] No schema, persistence, or event logic changes