### PR TITLE
Issue 23-11: show final return location in success message

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2590,7 +2590,17 @@ def return_commit():
     if wants_json():
         return {"ok": True, "committed": committed_count, "error": None}
 
-    flash(f"Returned {committed_count} assets.", "success")
+    if committed_count == 1 and len(state["assets"]) == 1:
+        returned_asset = state["assets"][0]
+        flash(
+            "Returned "
+            f"{returned_asset['canonical_tag'] or returned_asset['scanned_tag']}. "
+            f"Location: {returned_asset['after_location_type']}. "
+            f"Slot: {returned_asset['destination_slot']}.",
+            "success",
+        )
+    else:
+        flash(f"Returned {committed_count} assets.", "success")
     return redirect(url_for("return_queue"))
 
 @app.get("/lock")

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -157,6 +157,32 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIsNotNone(event_row)
         self.assertEqual(event_row["event_type"], "RETURN")
 
+    def test_single_asset_return_success_message_shows_final_location(self) -> None:
+        self._insert_slot(30, "CASE-13", 6, None)
+        self._insert_asset("MVPLAPTOP02", location_type="IN_CUSTODY", holder_id=7, home_slot_id=30)
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="MVPLAPTOP02", equipment_type="laptop"))
+
+        response = self.client.post(
+            "/return/commit",
+            data={"confirm_reviewed": "on"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Returned MVPLAPTOP02.", response.data)
+        self.assertIn(b"Location: STORAGE.", response.data)
+        self.assertIn(b"Slot: CASE-13 / 6.", response.data)
+
+        asset_after = self.conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
+            ("MVPLAPTOP02",),
+        ).fetchone()
+        self.assertIsNotNone(asset_after)
+        self.assertEqual(asset_after["location_type"], "STORAGE")
+        self.assertIsNone(asset_after["current_holder_id"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Update the single-asset return confirmation so operators can immediately see which asset was returned, its final logical state, and its final slot destination.

## Related Issue
Closes #203 

## Changes
- update the single-asset return success flash to include asset tag, final STORAGE state, and resolved slot destination
- preserve existing multi-asset batch confirmation wording
- add focused regression coverage for the return confirmation content

## Verification checklist
- [ ] Focused tests pass
- [ ] Single-asset return confirmation shows asset identifier
- [ ] Single-asset return confirmation shows final logical state
- [ ] Single-asset return confirmation shows final slot destination
- [ ] Return workflow still completes normally
- [ ] Issue workflow confirmation text remains unchanged

## Notes
- No schema, persistence, auth, event, or custody logic was changed.
- The success message uses existing resolved return preview state already available in return_commit().