### PR TITLE
Issue 23-10: label intake queue timestamps as UTC

### DIFF
--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -89,7 +89,7 @@
     <ul id="queue-list" role="list">
       {% for s in queue %}
         <li data-asset-tag="{{ s.asset_tag }}">
-          <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }}</time>
+          <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
           <code>{{ s.asset_tag }}</code>
         </li>
       {% endfor %}

--- a/tests/test_issue_23_1_active_queue_timestamps.py
+++ b/tests/test_issue_23_1_active_queue_timestamps.py
@@ -47,7 +47,7 @@ def test_issue_and_return_queue_pages_show_scan_timestamps(client_with_temp_db) 
 
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
-    assert b"Queued at 14:03:22" in issue_page.data
+    assert b"Queued at 14:03:22 UTC" in issue_page.data
     assert b"QUEUE-TAG-1" in issue_page.data
 
     with client_with_temp_db.session_transaction() as sess:
@@ -55,5 +55,5 @@ def test_issue_and_return_queue_pages_show_scan_timestamps(client_with_temp_db) 
 
     return_page = client_with_temp_db.get("/return")
     assert return_page.status_code == 200
-    assert b"Queued at 14:03:22" in return_page.data
+    assert b"Queued at 14:03:22 UTC" in return_page.data
     assert b"QUEUE-TAG-1" in return_page.data


### PR DESCRIPTION
## Summary

Add explicit UTC labeling to intake queue timestamps to prevent operator confusion.

## Related Issue

Closes #202 

## Changes

- append UTC label to timestamps on the shared active queue template used by intake workflows
- preserve existing timestamp format and queue ordering
- update focused queue timestamp test coverage

## Verification checklist

- [ ] queue timestamps display UTC
- [ ] timestamp format unchanged
- [ ] queue ordering unchanged
- [ ] workflows remain functional

## Notes

- Presentation-only change
- No schema, persistence, auth, or event logic changes