### PR TITLE
Issue 23-12: refresh session activity on authenticated requests

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -67,6 +67,13 @@ TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
 
 
+@app.after_request
+def refresh_session_activity(response):
+    if _should_refresh_session_activity():
+        touch_session()
+    return response
+
+
 @app.context_processor
 def inject_auth_user():
     user = current_user()
@@ -84,6 +91,17 @@ def now_seconds() -> int:
 
 def touch_session() -> None:
     session["last_seen"] = now_seconds()
+
+
+def _should_refresh_session_activity() -> bool:
+    if current_user() is None:
+        return False
+
+    endpoint = str(request.endpoint or "").strip()
+    if endpoint in {"logout", "static"}:
+        return False
+
+    return True
 
 
 def sanitize_scan(raw: str) -> str:

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.intake.scan import Scan
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login(client, monkeypatch: pytest.MonkeyPatch, *, last_seen: int = 100) -> int:
+    user_id = create_test_user(username=f"user-{last_seen}", password="op-pass", role="operator")
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+        sess["last_seen"] = last_seen
+    return user_id
+
+
+def test_authenticated_navigation_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=100)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 200)
+
+    response = client_with_temp_db.get("/dashboard")
+
+    assert response.status_code == 200
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 200
+
+
+def test_preview_load_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=110)
+    intake_app.SCAN_QUEUE.append(Scan.now("PREVIEW-TAG"))
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 210)
+
+    response = client_with_temp_db.get("/issue/preview")
+
+    assert response.status_code == 200
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 210
+
+
+def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=120)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 220)
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "SCAN-TAG-1", "return_to": "/issue"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert len(intake_app.SCAN_QUEUE) == 1
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 220
+
+
+def test_queue_action_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=130)
+    intake_app.SCAN_QUEUE.append(Scan.now("CLEAR-ME"))
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 230)
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"action": "clear", "return_to": "/issue"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert len(intake_app.SCAN_QUEUE) == 0
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 230
+
+
+def test_public_unauthenticated_request_does_not_refresh_last_seen(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 999)
+
+    response = client_with_temp_db.get("/")
+
+    assert response.status_code == 200
+    with client_with_temp_db.session_transaction() as sess:
+        assert "last_seen" not in sess


### PR DESCRIPTION
## Summary

Refresh session activity on authenticated requests so active operators are not logged out during normal workflow navigation.

## Related Issue

Closes #204 

## Changes

- add a centralized authenticated-request hook to refresh session activity on real user requests
- cover navigation, preview loads, scan submission, and queue clear behavior
- exclude unauthenticated, logout, and static requests from session refresh
- add focused regression coverage for session activity refresh behavior

## Verification checklist

- [ ] navigation updates session activity
- [ ] preview loads update session activity
- [ ] scan submissions update session activity
- [ ] queue actions update session activity
- [ ] active operators remain logged in during normal workflow use
- [ ] idle timeout still functions correctly
- [ ] auth behavior remains unchanged

## Notes

- No schema, persistence, auth model, timeout duration, or security boundary changes
- Full manual smoke should still be run before milestone close