### PR TITLE
Issue 23-15: replace preview jargon with operator language

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -72,7 +72,7 @@
   </div>
 
   <div class="card">
-    <h2>Per-Asset Diff</h2>
+    <h2>Items to Be Issued</h2>
 
     {% if assets %}
       <table>

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -47,7 +47,7 @@
   </div>
 
   <div class="card">
-    <h2>Per-Asset Preview</h2>
+    <h2>Items to Be Returned</h2>
 
     {% if preview_rows %}
       <table>


### PR DESCRIPTION
## Summary
Replace technical preview wording with plain operator language on issue and return preview pages.

## Related Issue
Closes #215 

## Changes
- replace "Per-Asset Diff" with "Items to Be Issued" on issue preview
- replace "Per-Asset Preview" with "Items to Be Returned" on return preview

## Verification checklist
- [x] `pytest tests/test_issue_23_2_preview_commit_seam.py tests/test_return_batch.py`
- [ ] Manual smoke test