### PR TITLE
Issue 23-16: strengthen preview confirmation signal

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -10,6 +10,14 @@
     .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
     .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
     ul { margin: 0.5rem 0 0 1.25rem; }
+    .review-signal {
+      border-left: 4px solid #2f6f3e;
+      background: #f4fbf5;
+    }
+    .review-signal.blocked {
+      border-left-color: #9f3a38;
+      background: #fff5f5;
+    }
   </style>
 {% endblock %}
 
@@ -29,6 +37,17 @@
   {% if workflow_banner_title %}
     {% include "_workflow_context_banner.html" %}
   {% endif %}
+
+  <div class="card review-signal {% if blocking_issues %}blocked{% endif %}">
+    <h2>{% if blocking_issues %}Review Before Issuing{% else %}Ready to Issue{% endif %}</h2>
+    <p>
+      {% if blocking_issues %}
+        Check the issues below before you commit this issue batch.
+      {% else %}
+        Review the listed assets below. Commit Issue is the next step.
+      {% endif %}
+    </p>
+  </div>
 
   <div class="card">
     <h2>Selected Holder</h2>

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -10,6 +10,14 @@
     .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
     .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
     .state-section + .state-section { margin-top: 0.75rem; }
+    .review-signal {
+      border-left: 4px solid #2f6f3e;
+      background: #f4fbf5;
+    }
+    .review-signal.blocked {
+      border-left-color: #9f3a38;
+      background: #fff5f5;
+    }
   </style>
 {% endblock %}
 
@@ -21,6 +29,17 @@
   {% if workflow_banner_title %}
     {% include "_workflow_context_banner.html" %}
   {% endif %}
+
+  <div class="card review-signal {% if blocking_issues %}blocked{% endif %}">
+    <h2>{% if blocking_issues %}Review Before Returning{% else %}Ready to Return{% endif %}</h2>
+    <p>
+      {% if blocking_issues %}
+        Check the issues below before you commit this return batch.
+      {% else %}
+        Review the listed assets below. Commit Return is the next step.
+      {% endif %}
+    </p>
+  </div>
 
   <div class="card">
     <h2>Validation Summary</h2>

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -71,6 +71,8 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     issue_preview = client_with_temp_db.get("/issue/preview")
     assert issue_preview.status_code == 200
     assert b"Confirm Issue" in issue_preview.data
+    assert b"Ready to Issue" in issue_preview.data
+    assert b"Commit Issue is the next step." in issue_preview.data
     assert b"Holder:</strong> Issue Holder" in issue_preview.data
     assert b"Queued:</strong> 1 asset" in issue_preview.data
 

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -77,6 +77,8 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(preview_render.status_code, 200)
         self.assertIn("Return Assets — Preview / Confirm".encode("utf-8"), preview_render.data)
         self.assertIn(b"Confirm Return", preview_render.data)
+        self.assertIn(b"Ready to Return", preview_render.data)
+        self.assertIn(b"Commit Return is the next step.", preview_render.data)
         self.assertIn(b"Destination:</strong> Home slots", preview_render.data)
         self.assertIn(b"Queued:</strong> 1 asset", preview_render.data)
         self.assertIn(b"Current State", preview_render.data)


### PR DESCRIPTION
## Summary
Strengthen the preview-page confirmation signal so operators can immediately tell they are at the final review step before commit.

## Related Issue
Closes #216 

## Changes
- add stronger preview headings for issue and return flows
- add direct one-line review guidance before commit
- keep blocked-state wording consistent with the workflow step
- update focused tests for the new preview wording

## Verification checklist
- [x] `pytest tests/test_issue_23_2_preview_commit_seam.py tests/test_return_batch.py`
- [ ] Manual smoke test