### PR TITLE
Issue 24-15: sort case summary by numeric case order

### DIFF
--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import re
 import sqlite3
 
 from assettrack.assets import get_asset_table_columns
@@ -188,7 +189,16 @@ def list_case_summaries(conn: sqlite3.Connection) -> list[dict]:
                 "utilization_percent": utilization_percent,
             }
         )
-    return results
+
+    def _sort_key(item: tuple[int, dict]) -> tuple[int, int, int]:
+        original_index, case = item
+        case_name = str(case["case_name"] or "").strip().upper()
+        match = re.fullmatch(r"CASE-(\d+)", case_name)
+        if match:
+            return (0, int(match.group(1)), original_index)
+        return (1, original_index, 0)
+
+    return [case for _, case in sorted(enumerate(results), key=_sort_key)]
 
 
 def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | None:

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -208,6 +208,20 @@ def test_holders_and_cases_deterministic_ordering(app_client) -> None:
     assert [row["case_name"] for row in cases] == ["CASE-B", "CASE-A"]
 
 
+def test_case_summaries_sort_case_numbers_naturally(app_client) -> None:
+    conn, _ = app_client
+    _insert_slot(conn, 10, "CASE-13", 1)
+    _insert_slot(conn, 11, "CASE-2", 1)
+    _insert_slot(conn, 12, "CASE-111", 1)
+    _insert_slot(conn, 13, "CASE-1", 1)
+    _insert_slot(conn, 14, "CASE-16", 1)
+    conn.commit()
+
+    cases = list_case_summaries(conn)
+
+    assert [row["case_name"] for row in cases] == ["CASE-1", "CASE-2", "CASE-13", "CASE-16", "CASE-111"]
+
+
 def test_holder_detail_uses_most_recent_issue_event_and_unknown_when_missing(app_client) -> None:
     conn, _ = app_client
     _insert_holder(conn, 1, "Holder")


### PR DESCRIPTION
## Summary
Sort the case summary on /dashboard/cases by numeric case order instead of string order.

## Related Issue
Closes #24-15

## Changes
- sort case summary rows in Python by numeric suffix from case name
- preserve stable ordering for non-matching case names
- add focused regression coverage for natural case ordering

## Verification checklist
- [x] `pytest tests/test_dashboard_drilldowns.py tests/test_dashboard.py`
- [ ] Manual smoke test