### PR TITLE
Issue 24-16: add outstanding holder accountability view

### DIFF
--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -32,13 +32,14 @@ def list_holders_in_custody(conn: sqlite3.Connection) -> list[dict]:
         SELECT
             h.id AS holder_id,
             h.name AS holder_name,
+            h.organization AS organization,
             COUNT(*) AS asset_count
         FROM assets a
         JOIN holders h
           ON h.id = a.current_holder_id
         WHERE a.location_type = 'IN_CUSTODY'
           AND a.current_holder_id IS NOT NULL
-        GROUP BY h.id, h.name
+        GROUP BY h.id, h.name, h.organization
         ORDER BY asset_count DESC, h.name ASC, h.id ASC;
         """
     ).fetchall()
@@ -47,6 +48,7 @@ def list_holders_in_custody(conn: sqlite3.Connection) -> list[dict]:
         {
             "holder_id": int(row["holder_id"]),
             "holder_name": str(row["holder_name"]),
+            "organization": str(row["organization"] or ""),
             "asset_count": int(row["asset_count"] or 0),
         }
         for row in rows
@@ -61,7 +63,7 @@ def get_holder_custody_detail(
 ) -> dict | None:
     holder_row = conn.execute(
         """
-        SELECT id, name
+        SELECT id, name, organization
         FROM holders
         WHERE id = ?;
         """,
@@ -106,6 +108,7 @@ def get_holder_custody_detail(
         return {
             "holder_id": int(holder_row["id"]),
             "holder_name": str(holder_row["name"]),
+            "organization": str(holder_row["organization"] or ""),
             "assets": [],
         }
 
@@ -155,6 +158,7 @@ def get_holder_custody_detail(
     return {
         "holder_id": int(holder_row["id"]),
         "holder_name": str(holder_row["name"]),
+        "organization": str(holder_row["organization"] or ""),
         "assets": assets,
     }
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -78,7 +78,7 @@
     <div class="actions">
       <a class="chip" href="{{ url_for('issue_preview') }}">Issue</a>
       <a class="chip" href="{{ url_for('return_queue') }}">Return</a>
-      <a class="chip" href="{{ url_for('dashboard_holders') }}">Holder Drilldown</a>
+      <a class="chip" href="{{ url_for('dashboard_holders') }}">Outstanding Holders</a>
       <a class="chip" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
     </div>
   </section>

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -2,7 +2,7 @@
 {% extends "base.html" %}
 
 {% block title %}Holder Detail{% endblock %}
-{% block page_heading %}Holder Detail: {{ holder.holder_name }}{% endblock %}
+{% block page_heading %}Outstanding Assets: {{ holder.holder_name }}{% endblock %}
 
 {% block extra_head %}
   <style>
@@ -18,7 +18,15 @@
   </nav>
 
   <section class="card">
-    <h2>Current Custody Assets</h2>
+    <p>
+      <strong>Holder:</strong> {{ holder.holder_name }}<br />
+      <strong>Organization:</strong> {{ holder.organization or "" }}<br />
+      <strong>Outstanding Assets:</strong> {{ holder.assets|length }}
+    </p>
+  </section>
+
+  <section class="card">
+    <h2>Assets Currently Out</h2>
     <table>
       <thead>
         <tr>
@@ -42,7 +50,7 @@
           </tr>
         {% else %}
           <tr>
-            <td colspan="6">None</td>
+            <td colspan="6">No assets are currently out for this holder.</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -16,23 +16,25 @@
   </nav>
 
   <section class="card">
-    <h2>Holders in Custody</h2>
+    <h2>Holders With Assets Out</h2>
     <table>
       <thead>
         <tr>
           <th>Holder Name</th>
-          <th>Asset Count</th>
+          <th>Organization</th>
+          <th>Outstanding Assets</th>
         </tr>
       </thead>
       <tbody>
         {% for row in holders %}
           <tr>
             <td><a href="{{ url_for('dashboard_holder_detail', holder_id=row.holder_id) }}">{{ row.holder_name }}</a></td>
+            <td>{{ row.organization or "" }}</td>
             <td>{{ row.asset_count }}</td>
           </tr>
         {% else %}
           <tr>
-            <td colspan="2">None</td>
+            <td colspan="3">No holders currently have assets out.</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -44,14 +44,14 @@ def app_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     conn.close()
 
 
-def _insert_holder(conn, holder_id: int, name: str) -> None:
+def _insert_holder(conn, holder_id: int, name: str, *, organization: str | None = None) -> None:
     now = "2026-01-01T00:00:00Z"
     conn.execute(
         """
-        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
-        VALUES (?, 'PERSON', ?, NULL, NULL, ?, ?);
+        INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+        VALUES (?, 'PERSON', ?, ?, NULL, NULL, ?, ?);
         """,
-        (holder_id, name, now, now),
+        (holder_id, name, organization, now, now),
     )
 
 
@@ -120,7 +120,7 @@ def test_dashboard_holders_route_returns_200_and_is_read_only(app_client) -> Non
 
     response = client.get("/dashboard/holders")
     assert response.status_code == 200
-    assert b"Holders in Custody" in response.data
+    assert b"Holders With Assets Out" in response.data
 
     counts_after = (
         conn.execute("SELECT COUNT(*) AS c FROM assets;").fetchone()["c"],
@@ -143,7 +143,7 @@ def test_dashboard_holder_detail_200_none_when_no_assets(app_client) -> None:
 
     response = client.get("/dashboard/holders/1")
     assert response.status_code == 200
-    assert b"None" in response.data
+    assert b"No assets are currently out for this holder." in response.data
 
 
 def test_dashboard_cases_route_200_and_missing_case_404(app_client) -> None:
@@ -224,7 +224,7 @@ def test_case_summaries_sort_case_numbers_naturally(app_client) -> None:
 
 def test_holder_detail_uses_most_recent_issue_event_and_unknown_when_missing(app_client) -> None:
     conn, _ = app_client
-    _insert_holder(conn, 1, "Holder")
+    _insert_holder(conn, 1, "Holder", organization="Operations")
     _insert_asset(
         conn,
         "AT-RECENT",
@@ -251,9 +251,44 @@ def test_holder_detail_uses_most_recent_issue_event_and_unknown_when_missing(app
         now_utc=datetime(2026, 2, 20, 0, 0, 0, tzinfo=timezone.utc),
     )
     assert detail is not None
+    assert detail["organization"] == "Operations"
 
     rows = {row["asset_tag"]: row for row in detail["assets"]}
     assert rows["AT-RECENT"]["last_issued_date"] == "2026-02-01T00:00:00Z"
     assert rows["AT-RECENT"]["days_out"] == 19
     assert rows["AT-UNKNOWN"]["last_issued_date"] is None
     assert rows["AT-UNKNOWN"]["days_out"] is None
+
+
+def test_dashboard_holders_only_lists_holders_with_outstanding_assets_and_shows_organization(app_client) -> None:
+    conn, client = app_client
+    _insert_holder(conn, 1, "Alpha", organization="Ops")
+    _insert_holder(conn, 2, "Bravo", organization="Admin")
+    _insert_asset(conn, "AT-1", location_type="IN_CUSTODY", holder_id=1)
+    _insert_asset(conn, "AT-2", location_type="STORAGE", holder_id=2)
+    conn.commit()
+
+    response = client.get("/dashboard/holders")
+
+    assert response.status_code == 200
+    assert b"Alpha" in response.data
+    assert b"Ops" in response.data
+    assert b"Bravo" not in response.data
+    assert b"Admin" not in response.data
+
+
+def test_dashboard_holder_detail_shows_organization_and_outstanding_count(app_client) -> None:
+    conn, client = app_client
+    _insert_holder(conn, 1, "Field Team", organization="Ops")
+    _insert_asset(conn, "AT-100", location_type="IN_CUSTODY", holder_id=1)
+    _insert_asset(conn, "AT-101", location_type="IN_CUSTODY", holder_id=1)
+    conn.commit()
+
+    response = client.get("/dashboard/holders/1")
+
+    assert response.status_code == 200
+    assert b"Outstanding Assets: Field Team" in response.data
+    assert b"Organization:</strong> Ops" in response.data
+    assert b"Outstanding Assets:</strong> 2" in response.data
+    assert b"AT-100" in response.data
+    assert b"AT-101" in response.data


### PR DESCRIPTION
## Summary
Add an Outstanding Holders accountability view so operators can see who currently has assets in custody and drill into what is still out.

## Related Issue
Closes #222 

## Changes
- added Outstanding Holders view using existing custody drilldown path
- display only holders with assets in custody
- show outstanding count per holder
- allow drill-in to holder detail with current asset list
- surface organization where available
- added tests for holder filtering, counts, and detail view

## Verification checklist
- [x] Outstanding Holders link visible on Dashboard
- [x] Only holders with assets out are shown
- [x] Outstanding count per holder is correct
- [x] Holder detail shows correct asset list
- [x] Days Out and Last Issued Date align with event history
- [x] Returning an asset updates counts correctly
- [x] Holders with no outstanding assets are excluded
- [x] Auth/role boundaries unchanged
- [x] No schema or persistence changes

## Notes
Holder detail navigation relies on clicking the holder name. This is functional but not obvious; consider a clearer affordance in a follow-on issue.