### PR TITLE
Issue 24-18: add availability stoplight and best-case guidance

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -53,6 +53,24 @@
     .summary-hint { font-weight: 500; font-size: 0.9rem; color: #5b6878; }
     .collapsible-body { padding: 0.75rem 1rem 1rem 1rem; }
     .collapsible-body .table-wrap { margin-top: 0.25rem; }
+    .status-cell { white-space: nowrap; }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 700;
+    }
+    .status-dot {
+      width: 0.7rem;
+      height: 0.7rem;
+      border-radius: 999px;
+      display: inline-block;
+      border: 1px solid rgba(18, 32, 47, 0.18);
+      flex: 0 0 auto;
+    }
+    .status-dot.full { background: #b42318; }
+    .status-dot.low { background: #f79009; }
+    .status-dot.open { background: #12b76a; }
 
     .section-title { margin-top: 1.25rem; }
     .accent {
@@ -173,9 +191,19 @@
       <span>Available Space by Case</span>
       <span class="summary-hint">
         {% if dashboard.snapshots.case_utilization %}
-          {% set best_case = dashboard.snapshots.case_utilization|sort(attribute='case_name')|first %}
-          {% set best_available = best_case.total_slots - best_case.occupied_slots %}
-          {{ best_case.case_name }}: {{ best_available }} open
+          {% set ns = namespace(best_case=None, best_available=-1) %}
+          {% for row in dashboard.snapshots.case_utilization %}
+            {% set available_slots = row.total_slots - row.occupied_slots %}
+            {% if available_slots > ns.best_available %}
+              {% set ns.best_case = row %}
+              {% set ns.best_available = available_slots %}
+            {% endif %}
+          {% endfor %}
+          {% if ns.best_available > 0 %}
+            Best available case: {{ ns.best_case.case_name }} with {{ ns.best_available }} open
+          {% else %}
+            No open slots available.
+          {% endif %}
         {% else %}
           No case slot data is available.
         {% endif %}
@@ -185,26 +213,43 @@
       <div class="accent"></div>
       <div class="table-wrap">
         <table>
-          <thead>
-            <tr>
-              <th>Case Name</th>
-              <th>Available Slots</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for row in dashboard.snapshots.case_utilization %}
-              {% set available_slots = row.total_slots - row.occupied_slots %}
-              <tr>
-                <td>{{ row.case_name }}</td>
-                <td>{{ available_slots }} open</td>
-              </tr>
+        <thead>
+          <tr>
+            <th>Case Name</th>
+            <th>Available Slots</th>
+            <th>Stoplight Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in dashboard.snapshots.case_utilization %}
+            {% set available_slots = row.total_slots - row.occupied_slots %}
+            {% if available_slots == 0 %}
+              {% set status_label = "FULL" %}
+              {% set status_class = "full" %}
+            {% elif available_slots <= 3 %}
+              {% set status_label = "LOW" %}
+              {% set status_class = "low" %}
             {% else %}
-              <tr>
-                <td colspan="2">No case slot data is available.</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+              {% set status_label = "OPEN" %}
+              {% set status_class = "open" %}
+            {% endif %}
+            <tr>
+              <td>{{ row.case_name }}</td>
+              <td>{{ available_slots }} open</td>
+              <td class="status-cell">
+                <span class="status-badge">
+                  <span class="status-dot {{ status_class }}" aria-hidden="true"></span>
+                  <span>{{ status_label }}</span>
+                </span>
+              </td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="3">No case slot data is available.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
       </div>
     </div>
   </details>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -158,9 +158,10 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Available Space by Case", response.data)
         self.assertIn(b"Problems", response.data)
         self.assertIn(b"1 holders, 1 assets out", response.data)
-        self.assertIn(b"CASE-A: 0 open", response.data)
+        self.assertIn(b"No open slots available.", response.data)
         self.assertIn(b"1 unslotted, 1 over 30 days, 0 conflicts", response.data)
         self.assertIn(b"0 open", response.data)
+        self.assertIn(b"FULL", response.data)
         self.assertNotIn(b"0 / 1", response.data)
         self.assertIn(b"AT-UNSLOT", response.data)
 
@@ -175,6 +176,58 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"No unslotted assets.", response.data)
         self.assertIn(b"No overdue in-custody assets.", response.data)
         self.assertIn(b"No slot conflicts detected.", response.data)
+
+    def test_available_space_summary_and_stoplight_statuses(self) -> None:
+        self._insert_slot(1, "CASE-B", 1)
+        self._insert_slot(2, "CASE-B", 2)
+        self._insert_slot(3, "CASE-B", 3)
+        self._insert_slot(4, "CASE-B", 4)
+        self._insert_slot(10, "CASE-C", 1)
+        self._insert_slot(11, "CASE-C", 2)
+        self._insert_slot(12, "CASE-C", 3)
+        self._insert_slot(13, "CASE-C", 4)
+        self._insert_slot(14, "CASE-C", 5)
+        self._insert_slot(20, "CASE-A", 1)
+        self._insert_slot(21, "CASE-A", 2)
+
+        asset_a1 = self._insert_asset("AT-A1", location_type="STORAGE", home_slot_id=20)
+        asset_a2 = self._insert_asset("AT-A2", location_type="STORAGE", home_slot_id=21)
+        asset_b1 = self._insert_asset("AT-B1", location_type="STORAGE", home_slot_id=1)
+        asset_c1 = self._insert_asset("AT-C1", location_type="STORAGE", home_slot_id=10)
+        asset_c2 = self._insert_asset("AT-C2", location_type="STORAGE", home_slot_id=11)
+        asset_c3 = self._insert_asset("AT-C3", location_type="STORAGE", home_slot_id=12)
+        asset_c4 = self._insert_asset("AT-C4", location_type="STORAGE", home_slot_id=13)
+
+        self.conn.executemany(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, '2026-01-01T00:00:00Z');
+            """,
+            [
+                (20, asset_a1),
+                (21, asset_a2),
+                (1, asset_b1),
+                (10, asset_c1),
+                (11, asset_c2),
+                (12, asset_c3),
+                (13, asset_c4),
+            ],
+        )
+        self.conn.commit()
+
+        response = self.client.get("/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Best available case: CASE-B with 3 open", response.data)
+        self.assertIn(b"CASE-A", response.data)
+        self.assertIn(b"0 open", response.data)
+        self.assertIn(b"FULL", response.data)
+        self.assertIn(b"CASE-B", response.data)
+        self.assertIn(b"3 open", response.data)
+        self.assertIn(b"LOW", response.data)
+        self.assertIn(b"CASE-C", response.data)
+        self.assertIn(b"1 open", response.data)
+        self.assertNotIn(b"0 / 2", response.data)
 
     def test_dashboard_metrics_use_distinct_and_most_recent_issue_event(self) -> None:
         self._replace_slot_occupancy_without_unique_constraints()


### PR DESCRIPTION
## Summary
Add availability stoplight and best-case guidance to the dashboard to help operators quickly determine where to place assets.

## Related Issue
Closes #225 

## Changes
- added stoplight status (FULL / LOW / OPEN) to Available Space by Case
- displayed status using text and visual indicator
- added best available case guidance to the collapsed summary
- added clear “no open slots available” state when all cases are full
- reused existing snapshot data with no new queries or backend changes

## Verification checklist
- [x] Available Space section remains collapsible
- [x] collapsed summary shows best case or no-open-space state
- [x] expanded view shows case name, available slots, and stoplight status
- [x] stoplight thresholds render correctly (FULL / LOW / OPEN)
- [x] stoplight uses both text and visual indicator
- [x] no fraction-style wording appears
- [x] no schema, workflow, persistence, or auth changes

## Notes
This change shifts the dashboard from passive reporting to active operator guidance by enabling quick “go / no-go” decisions and directing the operator to the best available case.