### PR TITLE
Issue 24-22: replace null with human language

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -105,20 +105,23 @@
         </thead>
         <tbody>
           {% for row in assets %}
+            {% set before_holder_display = "Not assigned" if row.before_holder == "null" else row.before_holder %}
+            {% set before_slot_display = "Not assigned" if row.before_slot == "null" else row.before_slot %}
+            {% set after_slot_display = "Not assigned" if row.after_slot == "null" else row.after_slot %}
             <tr>
               <td><code>{{ row.asset_tag }}</code></td>
 
               <td>
                 <strong>Location:</strong> <code>{{ row.before_location_type }}</code><br />
-                <strong>Holder:</strong> <code>{{ row.before_holder }}</code><br />
-                <strong>Slot:</strong> <code>{{ row.before_slot }}</code><br />
+                <strong>Holder:</strong> <code>{{ before_holder_display }}</code><br />
+                <strong>Slot:</strong> <code>{{ before_slot_display }}</code><br />
                 <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code>
               </td>
 
               <td>
                 <strong>Location:</strong> <code>{{ row.after_location_type }}</code><br />
                 <strong>Holder:</strong> <code>{{ row.after_holder }}</code><br />
-                <strong>Slot:</strong> <code>{{ row.after_slot }}</code><br />
+                <strong>Slot:</strong> <code>{{ after_slot_display }}</code><br />
                 <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code> → <code>{{ row.after_slot_occupancy }}</code>
               </td>
 

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -87,11 +87,11 @@
                 <div class="state-section">
                   <strong>Current State</strong><br />
                   Location: {{ row.before_location_type }}<br />
-                  Holder: {{ row.before_holder if row.before_holder != "null" else "—" }}
+                  Holder: {{ row.before_holder if row.before_holder != "null" else "Not assigned" }}
                 </div>
                 <div class="state-section">
                   <strong>Home Location</strong><br />
-                  Slot: {{ row.destination_slot if row.destination_slot != "unknown" else "—" }}
+                  Slot: {{ row.destination_slot if row.destination_slot != "unknown" else "Not available" }}
                 </div>
               </td>
 
@@ -99,8 +99,8 @@
                 <div class="state-section">
                   <strong>After Return</strong><br />
                   Location: {{ row.after_location_type }}<br />
-                  Holder: —<br />
-                  Slot: {{ row.destination_slot if row.destination_slot != "unknown" else "—" }}
+                  Holder: Not assigned<br />
+                  Slot: {{ row.destination_slot if row.destination_slot != "unknown" else "Not available" }}
                 </div>
               </td>
 

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -75,6 +75,9 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Commit Issue is the next step." in issue_preview.data
     assert b"Holder:</strong> Issue Holder" in issue_preview.data
     assert b"Queued:</strong> 1 asset" in issue_preview.data
+    assert b"Holder:</strong> <code>Not assigned</code>" in issue_preview.data
+    assert b"Slot:</strong> <code>Not assigned</code>" in issue_preview.data
+    assert b"null" not in issue_preview.data
 
     commit = client_with_temp_db.post(
         "/issue/commit",

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -87,6 +87,7 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"Location: IN_CUSTODY", preview_render.data)
         self.assertIn(b"Holder: holder_id 5", preview_render.data)
         self.assertIn(b"Slot: A / 1", preview_render.data)
+        self.assertNotIn(b"null", preview_render.data)
 
         unreviewed = self.client.post("/return/commit?json=1")
         self.assertEqual(unreviewed.status_code, 400)


### PR DESCRIPTION
## Summary
Replace visible "null" values in preview screens with operator-friendly language.

## Related Issue
Closes #231 

## Changes
- replaced issue preview null holder and slot values with plain language
- replaced return preview null-style placeholders with operator-friendly wording
- updated preview-flow tests to verify null is not rendered

## Verification checklist
- [ ] tests pass
- [ ] `/issue/preview` shows no "null"
- [ ] `/return/preview` shows no "null"
- [ ] preview and commit flows still work
- [ ] no workflow regressions observed

## Notes
UI-only change. No schema, event, or persistence impact.