### PR TITLE
Issue 24-24: clarify post-issue banner state

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2380,6 +2380,20 @@ def issue():
 
     asset_tags = _queue_asset_tags()
     issue_state = _build_issue_preview_state(asset_tags, selected_holder)
+    issued_count_raw = (request.args.get("issued") or "").strip()
+    issued_count = 0
+    if issued_count_raw:
+        try:
+            issued_count = max(0, int(issued_count_raw))
+        except ValueError:
+            issued_count = 0
+    workflow_banner_outcome = None
+    if issued_count > 0 and not asset_tags:
+        workflow_banner_outcome = (
+            f"Issued {issued_count} asset successfully."
+            if issued_count == 1
+            else f"Issued {issued_count} assets successfully."
+        )
 
     return render_template(
         "return_queue.html",
@@ -2388,6 +2402,7 @@ def issue():
         scan_heading="Scan issues",
         workflow_banner_title="Issuing Assets",
         workflow_banner_queued_count=len(asset_tags),
+        workflow_banner_outcome=workflow_banner_outcome,
         return_to=url_for("issue"),
         preview_url=url_for("issue_preview"),
         preview_label="Open Issue Assets Preview / Confirm",
@@ -2494,7 +2509,7 @@ def issue_commit():
         return {"ok": True, "committed": committed_count, "error": None}
 
     flash(f"Issued {committed_count} assets.", "success")
-    return redirect(url_for("issue"))
+    return redirect(url_for("issue", issued=committed_count))
 
 
 @app.get("/return")

--- a/assettrack/intake/templates/_workflow_context_banner.html
+++ b/assettrack/intake/templates/_workflow_context_banner.html
@@ -11,6 +11,10 @@
     {% if workflow_banner_destination %}
       <strong>Destination:</strong> {{ workflow_banner_destination }}<br />
     {% endif %}
-    <strong>Queued:</strong> {{ workflow_banner_queued_count }} asset{% if workflow_banner_queued_count != 1 %}s{% endif %}
+    {% if workflow_banner_outcome %}
+      <strong>Status:</strong> {{ workflow_banner_outcome }}
+    {% else %}
+      <strong>Queued:</strong> {{ workflow_banner_queued_count }} asset{% if workflow_banner_queued_count != 1 %}s{% endif %}
+    {% endif %}
   </p>
 </div>

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -89,6 +89,8 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Issued 1 assets." in commit.data
     assert b"Issuing Assets" in commit.data
     assert b"Holder:</strong> Issue Holder" in commit.data
+    assert b"Status:</strong> Issued 1 asset successfully." in commit.data
+    assert b"Queued:</strong> 0 assets" not in commit.data
     assert len(intake_app.SCAN_QUEUE) == 0
 
     with client_with_temp_db.session_transaction() as sess:

--- a/tests/test_issue_slot_occupancy_consistency.py
+++ b/tests/test_issue_slot_occupancy_consistency.py
@@ -69,7 +69,7 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
 
     commit = client_with_temp_db.post("/issue/commit", data={"confirm_reviewed": "on"})
     assert commit.status_code == 302
-    assert (commit.headers.get("Location") or "").endswith("/issue")
+    assert (commit.headers.get("Location") or "").endswith("/issue?issued=1")
 
     conn = db.get_connection()
     try:
@@ -107,5 +107,6 @@ def test_issue_commit_redirect_shows_success_without_holder_warning(client_with_
     assert commit_response.status_code == 200
     assert b"Issued 1 assets." in commit_response.data
     assert b"Select a holder before issuing assets." not in commit_response.data
-    assert b"Queued assets:</strong> 0" in commit_response.data
+    assert b"Status:</strong> Issued 1 asset successfully." in commit_response.data
+    assert b"Queued:</strong> 0 assets" not in commit_response.data
     assert len(intake_app.SCAN_QUEUE) == 0


### PR DESCRIPTION
## Summary
Clarify post-issue banner to reflect completed action instead of empty queue state.

## Related Issue
Closes #233 

## Changes
- added outcome-based banner state after issue commit
- replaced misleading queued 0 assets message with status messaging
- preserved normal queue display during active scanning

## Verification checklist
- [ ] tests pass
- [ ] post-commit banner shows status message
- [ ] no "Queued: 0 assets" after commit
- [ ] queue banner returns during new scan
- [ ] no workflow regressions observed

## Notes
UI-only change. No schema, event, or persistence impact.