### PR TITLE
Issue 24-32: fix slot utilization rounding

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -86,7 +86,15 @@ def _slot_summary(conn: sqlite3.Connection) -> dict:
     total_slots = int(total_row["total_slots"] or 0)
     occupied_slots = int(occupied_row["occupied_slots"] or 0)
     empty_slots = max(0, total_slots - occupied_slots)
-    utilization_percent = int((occupied_slots * 100.0 / total_slots) + 0.5) if total_slots > 0 else 0
+    utilization_percent: str
+    if total_slots <= 0:
+        utilization_percent = "0"
+    elif occupied_slots >= total_slots:
+        utilization_percent = "100"
+    else:
+        percent = occupied_slots * 100.0 / total_slots
+        rounded = round(percent, 1)
+        utilization_percent = str(int(rounded)) if float(rounded).is_integer() else f"{rounded:.1f}"
 
     return {
         "total_slots": total_slots,

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -273,6 +273,49 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(overdue_rows[0]["asset_tag"], "AT-OLD")
         self.assertEqual(overdue_rows[0]["days_out"], 50)
 
+    def test_slot_utilization_does_not_round_up_to_100_unless_full(self) -> None:
+        for slot_id in range(1, 245):
+            self._insert_slot(slot_id, "CASE-Z", slot_id)
+
+        for slot_id in range(1, 244):
+            asset_id = self._insert_asset(f"AT-{slot_id}", location_type="STORAGE", home_slot_id=slot_id)
+            self.conn.execute(
+                """
+                INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                VALUES (?, ?, '2026-01-01T00:00:00Z');
+                """,
+                (slot_id, asset_id),
+            )
+        self.conn.commit()
+
+        data = build_dashboard_data(self.conn, custody_days_threshold=30)
+
+        self.assertEqual(data["summary"]["slots"]["total_slots"], 244)
+        self.assertEqual(data["summary"]["slots"]["occupied_slots"], 243)
+        self.assertEqual(data["summary"]["slots"]["empty_slots"], 1)
+        self.assertEqual(data["summary"]["slots"]["utilization_percent"], "99.6")
+
+    def test_slot_utilization_displays_100_only_when_full(self) -> None:
+        self._insert_slot(1, "CASE-FULL", 1)
+        self._insert_slot(2, "CASE-FULL", 2)
+        asset_a = self._insert_asset("AT-FULL-1", location_type="STORAGE", home_slot_id=1)
+        asset_b = self._insert_asset("AT-FULL-2", location_type="STORAGE", home_slot_id=2)
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES
+                (1, ?, '2026-01-01T00:00:00Z'),
+                (2, ?, '2026-01-01T00:00:00Z');
+            """,
+            (asset_a, asset_b),
+        )
+        self.conn.commit()
+
+        response = self.client.get("/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Utilization %: <strong>100%</strong>", response.data)
+
     def test_root_redirects_to_dashboard_when_logged_in(self):
         resp = self.client.get("/", follow_redirects=False)
         self.assertEqual(resp.status_code, 302)


### PR DESCRIPTION
## Summary
Fix slot utilization display so it does not show 100% unless slots are actually full.

## Related Issue
Closes #244 

## Changes
- updated utilization percentage formatting in the dashboard helper
- prevented near-full values from rounding up to 100%
- added dashboard tests for near-full and full utilization cases

## Verification checklist
- [ ] tests pass
- [ ] near-full utilization shows a non-100 value
- [ ] full utilization still shows 100%
- [ ] total, occupied, and empty counts remain unchanged
- [ ] no dashboard regressions observed

## Notes
Behavior change is limited to utilization display formatting. No schema, event, or persistence impact.