### PR TITLE
Issue 24-25: fix dashboard case coverage to use full dataset

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from assettrack.audit import ACTIVE_EVENTS_WHERE
 from assettrack.event_types import issue_event_type_values
+from assettrack.drilldowns import list_case_summaries
 
 from datetime import datetime, timezone
 import sqlite3
@@ -294,39 +295,6 @@ def _exceptions_summary(
     }
 
 
-def _case_utilization_preview(conn: sqlite3.Connection, limit: int) -> list[dict]:
-    rows = conn.execute(
-        """
-        SELECT
-            s.case_name,
-            COUNT(*) AS total_slots,
-            COUNT(DISTINCT so.slot_id) AS occupied_slots
-        FROM slots s
-        LEFT JOIN slot_occupancy so
-          ON so.slot_id = s.id
-        GROUP BY s.case_name
-        ORDER BY occupied_slots DESC, s.case_name ASC
-        LIMIT ?;
-        """,
-        (limit,),
-    ).fetchall()
-
-    results: list[dict] = []
-    for row in rows:
-        total_slots = int(row["total_slots"] or 0)
-        occupied_slots = int(row["occupied_slots"] or 0)
-        utilization_percent = int((occupied_slots * 100.0 / total_slots) + 0.5) if total_slots > 0 else 0
-        results.append(
-            {
-                "case_name": str(row["case_name"] or ""),
-                "total_slots": total_slots,
-                "occupied_slots": occupied_slots,
-                "utilization_percent": utilization_percent,
-            }
-        )
-    return results
-
-
 def build_dashboard_data(
     conn: sqlite3.Connection,
     *,
@@ -359,7 +327,7 @@ def build_dashboard_data(
         },
         "snapshots": {
             "top_custody_holders": _top_custody_holders(conn, limit=5),
-            "case_utilization": _case_utilization_preview(conn, limit=5),
+            "case_utilization": list_case_summaries(conn),
             "exceptions": {
                 "unslotted_assets": _unslotted_assets(conn, limit=10),
                 "in_custody_over_threshold": [

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import assettrack.db as db
 from assettrack.dashboard import build_dashboard_data
+from assettrack.drilldowns import list_case_summaries
 from assettrack.event_types import issue_event_type_values
 from assettrack.intake import app as intake_app
 from tests.auth_test_utils import create_test_user, login_session
@@ -228,6 +229,44 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"CASE-C", response.data)
         self.assertIn(b"1 open", response.data)
         self.assertNotIn(b"0 / 2", response.data)
+
+    def test_available_space_uses_full_case_coverage_not_limited_top_five(self) -> None:
+        slot_id = 1
+        for case_name, occupied_slots in [
+            ("CASE-1", 5),
+            ("CASE-2", 4),
+            ("CASE-3", 3),
+            ("CASE-4", 2),
+            ("CASE-5", 1),
+            ("CASE-6", 0),
+        ]:
+            for _ in range(10):
+                self._insert_slot(slot_id, case_name, slot_id)
+                if occupied_slots > 0:
+                    asset_id = self._insert_asset(f"AT-{case_name}-{slot_id}", location_type="STORAGE", home_slot_id=slot_id)
+                    self.conn.execute(
+                        """
+                        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                        VALUES (?, ?, '2026-01-01T00:00:00Z');
+                        """,
+                        (slot_id, asset_id),
+                    )
+                    occupied_slots -= 1
+                slot_id += 1
+        self.conn.commit()
+
+        data = build_dashboard_data(self.conn, custody_days_threshold=30)
+        rendered = self.client.get("/dashboard")
+
+        self.assertEqual([row["case_name"] for row in data["snapshots"]["case_utilization"]], [row["case_name"] for row in list_case_summaries(self.conn)])
+        self.assertIn("CASE-6", [row["case_name"] for row in data["snapshots"]["case_utilization"]])
+        self.assertEqual(
+            next(row for row in data["snapshots"]["case_utilization"] if row["case_name"] == "CASE-6")["empty_slots"],
+            10,
+        )
+        self.assertEqual(rendered.status_code, 200)
+        self.assertIn(b"Best available case: CASE-6 with 10 open", rendered.data)
+        self.assertIn(b"CASE-6", rendered.data)
 
     def test_dashboard_metrics_use_distinct_and_most_recent_issue_event(self) -> None:
         self._replace_slot_occupancy_without_unique_constraints()


### PR DESCRIPTION
## Summary
Fix dashboard case coverage so Available Space by Case reflects all cases, not a limited subset.

## Related Issue
Closes #234 

## Changes
- switched dashboard case coverage source to full case summary
- removed limited top-N case snapshot
- ensured best available case reflects true availability
- kept capacity and occupancy aligned with existing authoritative sources
- added tests for full coverage and correct best-case selection

## Verification checklist
- [x] tests pass
- [x] dashboard uses full case dataset
- [x] best available case matches actual availability
- [x] no schema, auth, or persistence changes
- [ ] manual Docker smoke test completed

## Notes
Fix addresses decision accuracy by removing partial dataset bias without changing underlying slot or occupancy logic.