### PR TITLE
Issue 24-19: allow per-item removal from intake queue

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1906,6 +1906,7 @@ def intake():
         action = (request.form.get("action") or "").strip().lower()
         scan_text = (request.form.get("scan_text") or "").strip()
         return_to = (request.form.get("return_to") or "").strip()
+        queue_index_raw = (request.form.get("queue_index") or "").strip()
         submitted_equipment_type = request.form.get("equipment_type")
         current_equipment_type = (session.get("equipment_type") or "laptop").strip() or "laptop"
         if submitted_equipment_type is None:
@@ -1916,6 +1917,14 @@ def intake():
 
         if action == "clear":
             SCAN_QUEUE.clear()
+        elif action == "remove":
+            try:
+                queue_index = int(queue_index_raw)
+            except ValueError:
+                queue_index = -1
+
+            if 0 <= queue_index < len(SCAN_QUEUE):
+                SCAN_QUEUE.pop(queue_index)
 
         if scan_text:
             value = sanitize_scan(scan_text)

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -9,6 +9,17 @@
     input[type="text"], input[type="password"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
     .queue-ts { color: #5b6878; font-size: 0.9rem; margin-right: 0.4rem; }
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    .queue-row { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; }
+    .queue-row form { margin: 0 0 0 auto; }
+    .queue-remove {
+      padding: 0.25rem 0.5rem;
+      border: 1px solid #d7deea;
+      border-radius: 999px;
+      background: #fff;
+      color: #243447;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
   </style>
 {% endblock %}
 
@@ -113,12 +124,18 @@
     <h2>Queue ({{ queue_len }})</h2>
     <ul id="queue-list" role="list">
       {% for s in queue %}
-        <li data-asset-tag="{{ s.asset_tag }}">
+        <li class="queue-row" data-asset-tag="{{ s.asset_tag }}">
           <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }}</time>
           <code>{{ s.asset_tag }}</code>
           {% if s.case_name and s.slot_position is not none %}
             <span class="muted">→ {{ s.case_name }} / Slot {{ s.slot_position }}</span>
           {% endif %}
+          <form method="post" action="{{ url_for('intake') }}">
+            <input type="hidden" name="return_to" value="{{ url_for('add_assets') }}" />
+            <input type="hidden" name="action" value="remove" />
+            <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
+            <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>
+          </form>
         </li>
       {% endfor %}
     </ul>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -47,6 +47,18 @@
       font-size: 0.95rem;
       font-weight: 600;
     }
+    .queue-item form {
+      margin-left: auto;
+    }
+    .queue-remove {
+      padding: 0.3rem 0.55rem;
+      border: 1px solid #d7deea;
+      border-radius: 999px;
+      background: #fff;
+      color: #243447;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
   </style>
 {% endblock %}
 
@@ -125,6 +137,12 @@
         <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
           <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
           <code>{{ s.asset_tag }}</code>
+          <form method="post" action="{{ url_for('intake') }}">
+            <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
+            <input type="hidden" name="action" value="remove" />
+            <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
+            <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>
+          </form>
         </li>
       {% endfor %}
     </ul>

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -124,3 +124,108 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert str(asset["location_type"]) == "IN_CUSTODY"
     assert int(asset["current_holder_id"]) == 1
     assert occupancy is None
+
+
+def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-remove-preview", password="op-pass", role="operator")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES
+            (102, 'CASE-1', 2, 'DDC4CY002646'),
+            (103, 'CASE-1', 3, 'DDC4CY002647');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            id, asset_tag, serial_number, equipment_type, manufacturer, model,
+            location_type, current_holder_id, home_slot_id
+        )
+        VALUES
+            (502, 'DDC4CY002646', 'SN-2', 'laptop', 'Dell', 'Latitude', 'STORAGE', NULL, 102),
+            (503, 'DDC4CY002647', 'SN-3', 'laptop', 'Dell', 'Latitude', 'STORAGE', NULL, 103);
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES
+            (102, 502, '2026-01-01T00:00:00Z'),
+            (103, 503, '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.extend(
+        [
+            Scan.now("DDC4CY002645"),
+            Scan.now("DDC4CY002646"),
+            Scan.now("DDC4CY002647"),
+        ]
+    )
+
+    remove = client_with_temp_db.post(
+        "/",
+        data={"action": "remove", "queue_index": "1", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert remove.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DDC4CY002645", "DDC4CY002647"]
+    assert b"Queue (2)" in remove.data
+    assert b"Queued assets:</strong> 2" in remove.data
+
+    issue_preview = client_with_temp_db.get("/issue/preview")
+    assert issue_preview.status_code == 200
+    assert b"DDC4CY002645" in issue_preview.data
+    assert b"DDC4CY002647" in issue_preview.data
+    assert b"DDC4CY002646" not in issue_preview.data
+
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=True,
+    )
+
+    assert commit.status_code == 200
+    assert b"Issued 2 assets." in commit.data
+    assert len(intake_app.SCAN_QUEUE) == 0
+
+    conn = db.get_connection()
+    try:
+        issued_rows = conn.execute(
+            """
+            SELECT asset_tag, location_type, current_holder_id
+            FROM assets
+            WHERE asset_tag IN ('DDC4CY002645', 'DDC4CY002646', 'DDC4CY002647')
+            ORDER BY asset_tag;
+            """
+        ).fetchall()
+        remaining_occupancy = conn.execute(
+            """
+            SELECT slot_id, asset_id
+            FROM slot_occupancy
+            WHERE asset_id IN (501, 502, 503)
+            ORDER BY asset_id;
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    by_tag = {str(row["asset_tag"]): row for row in issued_rows}
+    assert str(by_tag["DDC4CY002645"]["location_type"]) == "IN_CUSTODY"
+    assert int(by_tag["DDC4CY002645"]["current_holder_id"]) == 1
+    assert str(by_tag["DDC4CY002647"]["location_type"]) == "IN_CUSTODY"
+    assert int(by_tag["DDC4CY002647"]["current_holder_id"]) == 1
+    assert str(by_tag["DDC4CY002646"]["location_type"]) == "STORAGE"
+    assert by_tag["DDC4CY002646"]["current_holder_id"] is None
+    assert [(int(row["slot_id"]), int(row["asset_id"])) for row in remaining_occupancy] == [(102, 502)]

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -50,3 +50,33 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
     assert b"Queued assets:</strong> 0" in issue_page.data
+
+
+def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicates(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-remove-one", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.extend(
+        [
+            Scan.now("DUP-TAG"),
+            Scan.now("DUP-TAG"),
+            Scan.now("KEEP-TAG"),
+        ]
+    )
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"action": "remove", "queue_index": "1", "return_to": "/issue"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DUP-TAG", "KEEP-TAG"]
+
+    issue_page = client_with_temp_db.get("/issue")
+    assert issue_page.status_code == 200
+    assert b"Queue (2)" in issue_page.data

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -185,6 +185,26 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(asset_after["location_type"], "STORAGE")
         self.assertIsNone(asset_after["current_holder_id"])
 
+    def test_return_queue_can_remove_one_item_and_preview_only_remaining_items(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="REMOVE-ME", equipment_type="laptop"))
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="KEEP-ME", equipment_type="laptop"))
+
+        remove = self.client.post(
+            "/",
+            data={"action": "remove", "queue_index": "0", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(remove.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["KEEP-ME"])
+        self.assertIn(b"Queue (1)", remove.data)
+
+        preview = self.client.get("/return/preview")
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"KEEP-ME", preview.data)
+        self.assertNotIn(b"REMOVE-ME", preview.data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Allow operators to remove one item from the intake queue without clearing the whole batch.

## Related Issue
Closes #228 

## Changes
- added per-row Remove control to shared queue views
- removed queued items by queue index so duplicate-looking rows stay safe
- preserved queue order for remaining items
- left preview and commit behavior unchanged so they continue to operate on the live queue
- added tests for single-item removal, preview reflection, and commit behavior

## Verification checklist
- [x] targeted tests pass
- [x] one queued item can be removed without clearing the rest
- [x] preview reflects updated queue
- [x] commit processes only remaining items
- [x] no schema, persistence, auth, or event changes
- [x] manual workflow check completed

## Notes
This is a narrow queue-behavior improvement. It reduces operator rework without changing event or commit semantics.