### PR TITLE
Issue 24-20: add clear queue action to preview page

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -190,6 +190,11 @@
       <input type="hidden" name="return_to" value="{{ url_for('issue') }}" />
       <button type="submit" data-timeout-lock-target>Discard batch</button>
     </form>
+    <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
+      <input type="hidden" name="action" value="clear" />
+      <input type="hidden" name="return_to" value="{{ url_for('issue') }}" />
+      <button type="submit" data-timeout-lock-target>Clear Queue</button>
+    </form>
     <p style="margin-top: 10px;">{{ url_for('issue_commit') }}?json=1</p>
   </div>
 {% endblock %}

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -80,3 +80,30 @@ def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicate
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
     assert b"Queue (2)" in issue_page.data
+
+
+def test_operator_can_clear_queue_from_issue_preview_and_return_to_issue(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-clear-preview", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.extend([Scan.now("TAG-1"), Scan.now("TAG-2")])
+
+    preview_page = client_with_temp_db.get("/issue/preview")
+    assert preview_page.status_code == 200
+    assert b"Clear Queue" in preview_page.data
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"action": "clear", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"Issuing Assets" in response.data
+    assert b"Queue (0)" in response.data
+    assert b"Queued assets:</strong> 0" in response.data


### PR DESCRIPTION
## Summary
Add Clear Queue action to issue preview page so operators can reset the queue without leaving the workflow.

## Related Issue
Closes #229 

## Changes
- added Clear Queue control to /issue/preview
- reused existing queue clear handler (no duplicate logic)
- redirect to /issue after clearing to preserve workflow seam
- ensured no empty preview state
- updated tests to cover preview-based clearing and redirect

## Verification checklist
- [x] targeted tests pass
- [x] clear queue works from /issue/preview
- [x] redirect lands on /issue
- [x] queue is empty after clearing
- [x] commit and preview behavior unchanged
- [x] no schema, persistence, auth, or event changes
- [ ] manual Docker smoke test completed

## Notes
This is a workflow continuity improvement. It removes a navigation break without changing queue, preview, or commit semantics.