### PR TITLE
Issue 24-21: normalize asset tags to uppercase at intake

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -106,7 +106,18 @@ def _should_refresh_session_activity() -> bool:
 
 def sanitize_scan(raw: str) -> str:
     """Keep only letters and numbers; drop tabs/newlines/suffix junk."""
-    return "".join(ch for ch in raw if ch.isalnum())
+    return "".join(ch for ch in raw if ch.isalnum()).upper()
+
+
+def _queue_contains_asset_tag(asset_tag: str) -> bool:
+    normalized = (asset_tag or "").strip().upper()
+    if not normalized:
+        return False
+
+    for queued in SCAN_QUEUE:
+        if str(queued.asset_tag or "").strip().upper() == normalized:
+            return True
+    return False
 
 
 def auth_enabled() -> bool:
@@ -1929,6 +1940,13 @@ def intake():
         if scan_text:
             value = sanitize_scan(scan_text)
             if value:
+                if _queue_contains_asset_tag(value):
+                    flash(f"Asset {value} is already queued.", "error")
+                    touch_session()
+                    if return_to.startswith("/") and not return_to.startswith("//"):
+                        return redirect(return_to)
+                    return redirect(url_for("add_assets"))
+
                 case_name = (request.form.get("case_name") or "").strip().upper()
                 slot_id_raw = (request.form.get("slot_id") or "").strip()
                 home_slot_id: Optional[int] = None

--- a/assettrack/intake/scan.py
+++ b/assettrack/intake/scan.py
@@ -36,6 +36,7 @@ class Scan:
     ) -> "Scan":
         """Convenience constructor for 'scan happened right now'."""
         equipment_type = (equipment_type or "").strip() or "laptop"
+        asset_tag = (asset_tag or "").strip().upper()
         return Scan(
             asset_tag=asset_tag,
             scanned_at=datetime.now(timezone.utc),

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -107,3 +107,40 @@ def test_operator_can_clear_queue_from_issue_preview_and_return_to_issue(client_
     assert b"Issuing Assets" in response.data
     assert b"Queue (0)" in response.data
     assert b"Queued assets:</strong> 0" in response.data
+
+
+def test_issue_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_duplicate(
+    client_with_temp_db,
+) -> None:
+    operator_id = create_test_user(username="operator-uppercase-issue", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    first = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ab-123", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert first.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["AB123"]
+    assert b"AB123" in first.data
+    assert b"ab-123" not in first.data
+
+    second = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "AB123", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert second.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["AB123"]
+    assert b"Asset AB123 is already queued." in second.data
+
+    preview = client_with_temp_db.get("/issue/preview")
+    assert preview.status_code == 200
+    assert b"AB123" in preview.data
+    assert b"ab-123" not in preview.data

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -205,6 +205,33 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"KEEP-ME", preview.data)
         self.assertNotIn(b"REMOVE-ME", preview.data)
 
+    def test_return_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_duplicate(self) -> None:
+        first = self.client.post(
+            "/",
+            data={"scan_text": "rt-200", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT200"])
+        self.assertIn(b"RT200", first.data)
+        self.assertNotIn(b"rt-200", first.data)
+
+        second = self.client.post(
+            "/",
+            data={"scan_text": "RT200", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT200"])
+        self.assertIn(b"Asset RT200 is already queued.", second.data)
+
+        preview = self.client.get("/return/preview")
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"RT200", preview.data)
+        self.assertNotIn(b"rt-200", preview.data)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Normalize asset tags to uppercase at intake to ensure consistent display and prevent case-variant duplicates.

## Related Issue
Closes #230 

## Changes
- normalize asset tags to uppercase at input boundary before queue insertion
- block duplicate queue entries caused by case-variant rescans
- ensure queue objects store uppercase tags
- preserve preview and commit behavior using normalized values
- added tests for normalization and duplicate prevention

## Verification checklist
- [x] targeted tests pass
- [x] lowercase input converts to uppercase immediately
- [x] case-variant rescans do not create duplicates
- [x] preview shows uppercase tags
- [x] commit behavior unchanged
- [x] no schema, persistence, auth, or event changes
- [ ] manual Docker smoke test completed

## Notes
This enforces a canonical asset tag format at the intake boundary, improving data consistency without changing event or commit semantics.