### PR TITLE
Issue 24-28: add drilldown link to return confirmation

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1546,6 +1546,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
                 "before_holder": "null",
                 "after_holder": "null",
                 "destination_slot": "unknown",
+                "destination_case_name": None,
                 "before_slot_occupancy": "empty",
                 "after_slot_occupancy": "occupied",
                 "ready": False,
@@ -1599,6 +1600,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
                 assets.append(row)
                 continue
 
+            row["destination_case_name"] = str(slot["case_name"])
             row["destination_slot"] = f"{slot['case_name']} / {slot['slot_position']}"
             if slot["current_asset_tag"] is not None:
                 row["asset_issues"].append(f"Home slot occupied by {slot['current_asset_tag']}")
@@ -2551,6 +2553,8 @@ def return_queue():
 
     asset_tags = _queue_asset_tags()
     state = _build_return_preview_state(asset_tags)
+    recent_return_cases_raw = session.pop("recent_return_cases", [])
+    recent_return_cases = [str(case_name) for case_name in recent_return_cases_raw if str(case_name or "").strip()]
 
     if wants_json():
         return {
@@ -2570,6 +2574,7 @@ def return_queue():
         queued_count=len(asset_tags),
         ready_count=state["ready_count"],
         blocking_issues=state["blocking_issues"],
+        recent_return_cases=recent_return_cases,
         queue=SCAN_QUEUE,
         queue_len=len(SCAN_QUEUE),
         last_seen_age_seconds=seconds_since_last_seen(),
@@ -2644,6 +2649,12 @@ def return_commit():
 
     SCAN_QUEUE.clear()
     touch_session()
+    returned_cases: list[str] = []
+    for row in state["assets"]:
+        case_name = str(row.get("destination_case_name") or "").strip()
+        if case_name and case_name not in returned_cases:
+            returned_cases.append(case_name)
+    session["recent_return_cases"] = returned_cases
 
     if wants_json():
         return {"ok": True, "committed": committed_count, "error": None}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -75,6 +75,15 @@
     {% endif %}
   {% endwith %}
 
+  {% if recent_return_cases %}
+    <div class="flash success">
+      Verify home slots:
+      {% for case_name in recent_return_cases %}
+        <a href="{{ url_for('dashboard_case_detail', case_name=case_name) }}">{{ case_name }}</a>{% if not loop.last %}, {% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+
   {% if workflow_banner_title %}
     {% include "_workflow_context_banner.html" %}
   {% endif %}

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -176,6 +176,8 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"Returned MVPLAPTOP02.", response.data)
         self.assertIn(b"Location: STORAGE.", response.data)
         self.assertIn(b"Slot: CASE-13 / 6.", response.data)
+        self.assertIn(b"Verify home slots:", response.data)
+        self.assertIn(b'href="/dashboard/cases/CASE-13"', response.data)
 
         asset_after = self.conn.execute(
             "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
@@ -184,6 +186,49 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIsNotNone(asset_after)
         self.assertEqual(asset_after["location_type"], "STORAGE")
         self.assertIsNone(asset_after["current_holder_id"])
+
+    def test_multi_asset_return_same_case_shows_one_case_drilldown_link(self) -> None:
+        self._insert_slot(40, "CASE-SAME", 1, None)
+        self._insert_slot(41, "CASE-SAME", 2, None)
+        self._insert_asset("SAME-1", location_type="IN_CUSTODY", holder_id=7, home_slot_id=40)
+        self._insert_asset("SAME-2", location_type="IN_CUSTODY", holder_id=8, home_slot_id=41)
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="SAME-1", equipment_type="laptop"))
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="SAME-2", equipment_type="laptop"))
+
+        response = self.client.post(
+            "/return/commit",
+            data={"confirm_reviewed": "on"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Returned 2 assets.", response.data)
+        self.assertIn(b"Verify home slots:", response.data)
+        self.assertEqual(response.data.count(b'href="/dashboard/cases/CASE-SAME"'), 1)
+
+    def test_multi_asset_return_different_cases_shows_one_link_per_case(self) -> None:
+        self._insert_slot(50, "CASE-X", 1, None)
+        self._insert_slot(60, "CASE-Y", 1, None)
+        self._insert_asset("DIFF-1", location_type="IN_CUSTODY", holder_id=7, home_slot_id=50)
+        self._insert_asset("DIFF-2", location_type="IN_CUSTODY", holder_id=8, home_slot_id=60)
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="DIFF-1", equipment_type="laptop"))
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="DIFF-2", equipment_type="laptop"))
+
+        response = self.client.post(
+            "/return/commit",
+            data={"confirm_reviewed": "on"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Returned 2 assets.", response.data)
+        self.assertIn(b"Verify home slots:", response.data)
+        self.assertEqual(response.data.count(b'href="/dashboard/cases/CASE-X"'), 1)
+        self.assertEqual(response.data.count(b'href="/dashboard/cases/CASE-Y"'), 1)
 
     def test_return_queue_can_remove_one_item_and_preview_only_remaining_items(self) -> None:
         intake_app.SCAN_QUEUE.clear()


### PR DESCRIPTION
## Summary
Add case drilldown link(s) to return confirmation so operators can verify asset placement in one click.

## Related Issue
Closes #237 

## Changes
- added case drilldown link(s) to post-return confirmation area
- derived case(s) from authoritative home slot data
- handled multi-case returns with one unique link per case
- avoided duplicate links and preserved order
- reused existing drilldown routes
- no changes to return logic or confirmation semantics

## Verification checklist
- [x] targeted tests pass
- [x] single return shows one case link
- [x] multi-return (same case) shows one link
- [x] multi-return (different cases) shows one link per case
- [x] links navigate to correct case drilldown
- [x] no schema, persistence, auth, or event changes
- [ ] manual Docker smoke test completed

## Notes
This is a presentation-only improvement that reduces post-action friction without changing workflow behavior or system logic.