### PR TITLE
Issue 24-35: add safe junk asset cleanup path

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -419,6 +419,7 @@ def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], l
 
     current_slot = _asset_current_slot(conn, int(asset["id"]), str(asset["asset_tag"]))
     home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))
+    cleanup_state = _build_admin_asset_cleanup_state(conn, asset, current_slot=current_slot)
 
     return (
         {
@@ -437,9 +438,50 @@ def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], l
             "home_slot_id": asset.get("home_slot_id"),
             "current_slot": current_slot,
             "home_slot": home_slot,
+            "cleanup": cleanup_state,
         },
         [],
     )
+
+
+def _build_admin_asset_cleanup_state(
+    conn: sqlite3.Connection,
+    asset: dict,
+    *,
+    current_slot: Optional[dict] = None,
+) -> dict:
+    reasons: list[str] = []
+    asset_tag = str(asset.get("asset_tag") or "").strip()
+    if not asset_tag:
+        return {"allowed": False, "reasons": ["asset_tag not found"]}
+
+    if conn.execute("SELECT 1 FROM asset_events WHERE asset_tag = ? LIMIT 1;", (asset_tag,)).fetchone():
+        reasons.append("Asset has event history and cannot be removed.")
+
+    if current_slot is None:
+        current_slot = _asset_current_slot(conn, int(asset["id"]), asset_tag)
+    if current_slot is not None:
+        reasons.append("Asset has a current slot placement and cannot be removed.")
+
+    if asset.get("home_slot_id") is not None:
+        reasons.append("Asset has a home slot assignment and cannot be removed.")
+
+    asset_columns = get_asset_table_columns(conn)
+    case_number = str(asset.get("case_number") or "").strip()
+    slot_number = str(asset.get("slot_number") or "").strip()
+    if "case_number" in asset_columns and case_number:
+        reasons.append("Asset still has a case assignment and cannot be removed.")
+    if "slot_number" in asset_columns and slot_number:
+        reasons.append("Asset still has a slot assignment field and cannot be removed.")
+
+    if asset.get("current_holder_id") is not None:
+        reasons.append("Asset is assigned to a holder and cannot be removed.")
+
+    location_type = _normalize_location_type(asset.get("location_type"))
+    if location_type in {"STORAGE", "IN_CUSTODY"}:
+        reasons.append(f"Asset is in active inventory state {location_type} and cannot be removed.")
+
+    return {"allowed": not reasons, "reasons": reasons}
 
 
 def _build_admin_slot_move_source_view(conn, slot_id: int) -> Optional[dict]:
@@ -1941,48 +1983,63 @@ def intake():
 
         if scan_text:
             value = sanitize_scan(scan_text)
-            if value:
-                if _queue_contains_asset_tag(value):
-                    flash(f"Asset {value} is already queued.", "error")
-                    touch_session()
-                    if return_to.startswith("/") and not return_to.startswith("//"):
-                        return redirect(return_to)
-                    return redirect(url_for("add_assets"))
+            if not value:
+                flash("Scan rejected. Enter a valid asset tag.", "error")
+                touch_session()
+                if return_to.startswith("/") and not return_to.startswith("//"):
+                    return redirect(return_to)
+                return redirect(url_for("add_assets"))
 
-                case_name = (request.form.get("case_name") or "").strip().upper()
-                slot_id_raw = (request.form.get("slot_id") or "").strip()
-                home_slot_id: Optional[int] = None
-                slot_position: Optional[int] = None
-                if case_name or slot_id_raw:
-                    conn = get_connection()
-                    try:
+            if _queue_contains_asset_tag(value):
+                flash(f"Asset {value} is already queued.", "error")
+                touch_session()
+                if return_to.startswith("/") and not return_to.startswith("//"):
+                    return redirect(return_to)
+                return redirect(url_for("add_assets"))
+
+            case_name = (request.form.get("case_name") or "").strip().upper()
+            slot_id_raw = (request.form.get("slot_id") or "").strip()
+            home_slot_id: Optional[int] = None
+            slot_position: Optional[int] = None
+            requires_inventory_validation = return_to in {"/issue", "/return"}
+            if requires_inventory_validation or case_name or slot_id_raw:
+                conn = get_connection()
+                try:
+                    if requires_inventory_validation and _find_asset_for_scan_tag(conn, value) is None:
+                        flash("Scan rejected. Asset tag not found in inventory.", "error")
+                        touch_session()
+                        if return_to.startswith("/") and not return_to.startswith("//"):
+                            return redirect(return_to)
+                        return redirect(url_for("add_assets"))
+
+                    if case_name or slot_id_raw:
                         selected_slot, slot_errors = _resolve_slot_selection(
                             conn,
                             case_name=case_name,
                             slot_id_raw=slot_id_raw,
                         )
-                    finally:
-                        conn.close()
-                    if slot_errors:
-                        flash("; ".join(slot_errors), "error")
-                        touch_session()
-                        if return_to.startswith("/") and not return_to.startswith("//"):
-                            return redirect(return_to)
-                        return redirect(url_for("add_assets"))
-                    if selected_slot is not None:
-                        home_slot_id = int(selected_slot["id"])
-                        case_name = str(selected_slot["case_name"])
-                        slot_position = int(selected_slot["slot_position"])
+                        if slot_errors:
+                            flash("; ".join(slot_errors), "error")
+                            touch_session()
+                            if return_to.startswith("/") and not return_to.startswith("//"):
+                                return redirect(return_to)
+                            return redirect(url_for("add_assets"))
+                        if selected_slot is not None:
+                            home_slot_id = int(selected_slot["id"])
+                            case_name = str(selected_slot["case_name"])
+                            slot_position = int(selected_slot["slot_position"])
+                finally:
+                    conn.close()
 
-                SCAN_QUEUE.append(
-                    Scan.now(
-                        value,
-                        equipment_type=selected_equipment_type,
-                        home_slot_id=home_slot_id,
-                        case_name=case_name,
-                        slot_position=slot_position,
-                    )
+            SCAN_QUEUE.append(
+                Scan.now(
+                    value,
+                    equipment_type=selected_equipment_type,
+                    home_slot_id=home_slot_id,
+                    case_name=case_name,
+                    slot_position=slot_position,
                 )
+            )
 
         touch_session()
 
@@ -3302,6 +3359,73 @@ def admin_edit_asset():
 
                 flash(f"Updated asset {form_state['asset_tag']}.", "success")
                 return redirect(url_for("admin_edit_asset", asset_tag=form_state["asset_tag"]))
+            elif action == "cleanup":
+                target_asset_tag = lookup_asset_tag or (request.form.get("asset_tag") or "").strip().upper()
+                asset_view, blocking_errors = _build_admin_edit_asset_view(conn, target_asset_tag)
+                if asset_view is None:
+                    error_message = "; ".join(blocking_errors or ["asset_tag not found"])
+                    return render_template(
+                        "admin_edit_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                    )
+
+                selected_home_slot = asset_view["home_slot"] or asset_view["current_slot"]
+                form_state.update(
+                    {
+                        "asset_tag": asset_view["asset_tag"],
+                        "serial_number": asset_view["serial_number"],
+                        "manufacturer": asset_view["manufacturer"],
+                        "equipment_type": asset_view["equipment_type"],
+                        "building": asset_view["building"],
+                        "room": asset_view["room"],
+                        "model": asset_view["model"],
+                        "model_code": asset_view["model_code"],
+                        "notes": asset_view["notes"],
+                        "case_name": "" if selected_home_slot is None else str(selected_home_slot["case_name"]),
+                        "slot_id": "" if selected_home_slot is None else str(selected_home_slot["slot_id"]),
+                    }
+                )
+
+                try:
+                    conn.execute("BEGIN;")
+                    asset_row = _find_asset_for_scan_tag(conn, asset_view["asset_tag"])
+                    if asset_row is None:
+                        raise ValueError("asset_tag not found")
+
+                    cleanup_state = _build_admin_asset_cleanup_state(conn, asset_row)
+                    if not cleanup_state["allowed"]:
+                        raise ValueError("; ".join(cleanup_state["reasons"]))
+
+                    deleted = conn.execute(
+                        "DELETE FROM assets WHERE id = ?;",
+                        (int(asset_row["id"]),),
+                    )
+                    if deleted.rowcount != 1:
+                        raise ValueError("Asset could not be removed.")
+
+                    conn.commit()
+                except ValueError as e:
+                    conn.rollback()
+                    error_message = str(e)
+                    asset_view, _ = _build_admin_edit_asset_view(conn, target_asset_tag)
+                    return render_template(
+                        "admin_edit_asset.html",
+                        form=form_state,
+                        asset=asset_view,
+                        error_message=error_message,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                    )
+                except Exception:
+                    conn.rollback()
+                    raise
+
+                flash(f"Removed junk asset {asset_view['asset_tag']}.", "success")
+                return redirect(url_for("admin_edit_asset"))
             else:
                 error_message = "Unknown action."
     finally:

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -125,6 +125,26 @@
         <button type="submit">Save Asset</button>
       </form>
     </div>
+
+    <div class="card">
+      <h2>Cleanup Junk Asset</h2>
+      {% if asset.cleanup.allowed %}
+        <p>This asset has no event history, no slot assignment, and no active custody state. It can be removed.</p>
+      {% else %}
+        <p>This asset cannot be removed.</p>
+        <ul>
+          {% for reason in asset.cleanup.reasons %}
+            <li>{{ reason }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+      <form method="post" action="{{ url_for('admin_edit_asset') }}">
+        <input type="hidden" name="action" value="cleanup" />
+        <input type="hidden" name="lookup_asset_tag" value="{{ form.lookup_asset_tag or asset.asset_tag }}" />
+        <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
+        <button type="submit" {% if not asset.cleanup.allowed %}disabled{% endif %}>Remove Junk Asset</button>
+      </form>
+    </div>
   {% endif %}
 {% endblock %}
 

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -42,6 +42,8 @@ class AdminEditAssetUiTests(unittest.TestCase):
         location_type: str,
         current_holder_id: int | None,
         home_slot_id: int | None,
+        case_number: str | None = None,
+        slot_number: str | None = None,
     ) -> int:
         cursor = self.conn.execute(
             """
@@ -67,12 +69,22 @@ class AdminEditAssetUiTests(unittest.TestCase):
                 case_number,
                 slot_number
             )
-            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '110', 'Latitude', '5400', 'seed', 'HQ/110', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, NULL, NULL);
+            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '110', 'Latitude', '5400', 'seed', 'HQ/110', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, ?, ?);
             """,
-            (asset_tag, serial_number, location_type, current_holder_id, home_slot_id),
+            (asset_tag, serial_number, location_type, current_holder_id, home_slot_id, case_number, slot_number),
         )
         self.conn.commit()
         return int(cursor.lastrowid)
+
+    def _insert_event(self, asset_tag: str, event_type: str = "ASSET_UPDATED") -> None:
+        self.conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES (?, ?, '2026-01-02T00:00:00Z', 'admin', NULL, NULL, NULL);
+            """,
+            (asset_tag, event_type),
+        )
+        self.conn.commit()
 
     def _occupy_slot(self, slot_id: int, asset_id: int, asset_tag: str) -> None:
         self.conn.execute(
@@ -247,6 +259,129 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertEqual(asset_row["home_slot_id"], 401)
         occ = self.conn.execute("SELECT slot_id FROM slot_occupancy WHERE asset_id = ?;", (asset_id,)).fetchone()
         self.assertEqual(occ["slot_id"], 401)
+
+    def test_cleanup_removes_safe_junk_asset_with_no_history(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-JUNK-1",
+            serial_number="SER-JUNK-1",
+            location_type="",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "cleanup",
+                "lookup_asset_tag": "AT-JUNK-1",
+                "asset_tag": "AT-JUNK-1",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Removed junk asset AT-JUNK-1.", response.data)
+
+        deleted = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
+        self.assertIsNone(deleted)
+
+    def test_cleanup_blocks_asset_with_event_history(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-JUNK-2",
+            serial_number="SER-JUNK-2",
+            location_type="",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+        self._insert_event("AT-JUNK-2")
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "cleanup",
+                "lookup_asset_tag": "AT-JUNK-2",
+                "asset_tag": "AT-JUNK-2",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset has event history and cannot be removed.", response.data)
+        still_present = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
+        self.assertIsNotNone(still_present)
+
+    def test_cleanup_blocks_asset_with_home_slot_assignment(self) -> None:
+        self._insert_slot(501, "CASE-F", 1)
+        asset_id = self._insert_asset(
+            "AT-JUNK-3",
+            serial_number="SER-JUNK-3",
+            location_type="",
+            current_holder_id=None,
+            home_slot_id=501,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "cleanup",
+                "lookup_asset_tag": "AT-JUNK-3",
+                "asset_tag": "AT-JUNK-3",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset has a home slot assignment and cannot be removed.", response.data)
+        still_present = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
+        self.assertIsNotNone(still_present)
+
+    def test_cleanup_blocks_asset_with_case_and_slot_fields(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-JUNK-4",
+            serial_number="SER-JUNK-4",
+            location_type="",
+            current_holder_id=None,
+            home_slot_id=None,
+            case_number="CASE-G",
+            slot_number="7",
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "cleanup",
+                "lookup_asset_tag": "AT-JUNK-4",
+                "asset_tag": "AT-JUNK-4",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset still has a case assignment and cannot be removed.", response.data)
+        self.assertIn(b"Asset still has a slot assignment field and cannot be removed.", response.data)
+        still_present = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
+        self.assertIsNotNone(still_present)
+
+    def test_cleanup_blocks_asset_in_active_custody_state(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-JUNK-5",
+            serial_number="SER-JUNK-5",
+            location_type="IN_CUSTODY",
+            current_holder_id=77,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "cleanup",
+                "lookup_asset_tag": "AT-JUNK-5",
+                "asset_tag": "AT-JUNK-5",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset is assigned to a holder and cannot be removed.", response.data)
+        self.assertIn(b"Asset is in active inventory state IN_CUSTODY and cannot be removed.", response.data)
+        still_present = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
+        self.assertIsNotNone(still_present)
 
 
 if __name__ == "__main__":

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -57,6 +57,11 @@ def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:
     _login(client_with_temp_db, "operator", "op-pass")
     response = client_with_temp_db.get("/admin/assets/new")
     assert response.status_code == 403
+    cleanup_response = client_with_temp_db.post(
+        "/admin/assets/edit",
+        data={"action": "cleanup", "lookup_asset_tag": "AT-JUNK-1", "asset_tag": "AT-JUNK-1"},
+    )
+    assert cleanup_response.status_code == 403
 
 
 def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Added an admin-only cleanup path for junk assets that are safe to remove.

## Related Issue
Closes #24-35

## Changes
- added safe-removal eligibility checks using persisted state only
- added admin cleanup action on the edit-asset workflow
- blocked cleanup when event history, slot assignment, holder assignment, or active custody/location state exists
- added plain-language UI feedback explaining when cleanup is allowed or blocked
- added targeted tests for allowed cleanup, blocked cleanup, and unauthorized access

## Verification checklist
- [x] targeted tests passed
- [x] no schema change made
- [ ] admin browser smoke test completed for allowed cleanup
- [ ] admin browser smoke test completed for blocked cleanup
- [ ] unauthorized access check confirmed

## Notes
Cleanup is intentionally narrow and only applies to assets with no event history and no active placement or custody state.