### PR TITLE
Issue 24-35: add asset search for verification

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -407,6 +407,80 @@ def _humanize_admin_asset_create_error(error_message: str) -> str:
     return error_map.get(error_message, error_message)
 
 
+def _asset_state_label(location_type: object) -> str:
+    normalized = _normalize_location_type(location_type)
+    if normalized == "STORAGE":
+        return "In storage"
+    if normalized == "IN_CUSTODY":
+        return "In custody"
+    if normalized in TERMINAL_LOCATION_TYPES:
+        return "Retired / disposed"
+    if not normalized:
+        return "Unknown"
+    return normalized.replace("_", " ").title()
+
+
+def _lookup_asset_for_verification(
+    conn: sqlite3.Connection,
+    *,
+    asset_tag: str,
+    serial_number: str,
+) -> tuple[Optional[dict], Optional[str], str]:
+    asset_tag_clean = str(asset_tag or "").strip().upper()
+    serial_clean = str(serial_number or "").strip()
+
+    if not asset_tag_clean and not serial_clean:
+        return None, "Enter an asset tag or serial number.", "none"
+
+    lookup_mode = "asset_tag" if asset_tag_clean else "serial_number"
+
+    if lookup_mode == "asset_tag":
+        rows = conn.execute(
+            """
+            SELECT *
+            FROM assets
+            WHERE UPPER(asset_tag) = UPPER(?)
+            LIMIT 1;
+            """,
+            (asset_tag_clean,),
+        ).fetchall()
+        if not rows:
+            return None, "Asset not found.", lookup_mode
+        asset = dict(rows[0])
+    else:
+        rows = conn.execute(
+            """
+            SELECT *
+            FROM assets
+            WHERE TRIM(COALESCE(serial_number, '')) <> ''
+              AND UPPER(serial_number) = UPPER(?)
+            LIMIT 2;
+            """,
+            (serial_clean,),
+        ).fetchall()
+        if not rows:
+            return None, "Asset not found.", lookup_mode
+        if len(rows) > 1:
+            return None, "More than one asset uses that serial number. Search by asset tag.", lookup_mode
+        asset = dict(rows[0])
+
+    home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))
+
+    return (
+        {
+            "id": int(asset["id"]),
+            "asset_tag": str(asset.get("asset_tag") or ""),
+            "serial_number": str(asset.get("serial_number") or ""),
+            "location_type": _normalize_location_type(asset.get("location_type")),
+            "state_label": _asset_state_label(asset.get("location_type")),
+            "home_case_name": "" if home_slot is None else str(home_slot.get("case_name") or ""),
+            "home_slot_position": None if home_slot is None else int(home_slot["slot_position"]),
+        },
+        None,
+        lookup_mode,
+    )
+
+
 def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     errors: list[str] = []
     asset = _find_asset_for_scan_tag(conn, scan_tag)
@@ -2297,6 +2371,42 @@ def dashboard_case_detail(case_name: str):
     return render_template(
         "dashboard_case_detail.html",
         case_detail=detail,
+    )
+
+
+@app.get("/assets/search")
+@require_login
+def asset_search():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    form_state = {
+        "asset_tag": (request.args.get("asset_tag") or "").strip().upper(),
+        "serial_number": (request.args.get("serial_number") or "").strip(),
+    }
+    asset = None
+    error_message: Optional[str] = None
+    lookup_mode = "none"
+
+    if form_state["asset_tag"] or form_state["serial_number"]:
+        conn = get_connection()
+        try:
+            asset, error_message, lookup_mode = _lookup_asset_for_verification(
+                conn,
+                asset_tag=form_state["asset_tag"],
+                serial_number=form_state["serial_number"],
+            )
+        finally:
+            conn.close()
+
+    return render_template(
+        "asset_search.html",
+        form=form_state,
+        asset=asset,
+        error_message=error_message,
+        lookup_mode=lookup_mode,
     )
 
 

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% block title %}Asset Search{% endblock %}
+{% block page_heading %}Asset Search{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .search-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Find Asset</h2>
+    <p class="muted">Search by asset tag or serial number. If both are entered, asset tag is used first.</p>
+    <form method="get" action="{{ url_for('asset_search') }}">
+      <div class="search-grid">
+        <div class="row">
+          <label for="asset_tag"><strong>Asset tag</strong></label><br />
+          <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" autofocus />
+        </div>
+        <div class="row">
+          <label for="serial_number"><strong>Serial number</strong></label><br />
+          <input type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" />
+        </div>
+      </div>
+      <button type="submit">Search</button>
+    </form>
+  </div>
+
+  {% if asset %}
+    <div class="card">
+      <h2>Asset Found</h2>
+      <p class="muted">
+        {% if lookup_mode == "asset_tag" %}
+          Matched by asset tag.
+        {% elif lookup_mode == "serial_number" %}
+          Matched by serial number.
+        {% endif %}
+      </p>
+      <div class="result-grid">
+        <div class="row">
+          <strong>Asset tag</strong><br />
+          {{ asset.asset_tag or "" }}
+        </div>
+        <div class="row">
+          <strong>Serial number</strong><br />
+          {{ asset.serial_number or "Not recorded" }}
+        </div>
+        <div class="row">
+          <strong>Current state</strong><br />
+          {{ asset.state_label }}
+        </div>
+        <div class="row">
+          <strong>Home case</strong><br />
+          {{ asset.home_case_name or "Not assigned" }}
+        </div>
+        <div class="row">
+          <strong>Home slot</strong><br />
+          {% if asset.home_slot_position is not none %}
+            Slot {{ asset.home_slot_position }}
+          {% else %}
+            Not assigned
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -123,6 +123,7 @@
           <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
           <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
           <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
+          <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
           <a class="chip {% if request.path.startswith('/preview') and not request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('preview') }}">Preview</a>
           {% if authenticated_role == 'admin' %}
             <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+class AssetSearchUiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+        operator_user_id = create_test_user(username="operator", password="operator-pass", role="operator")
+        login_session(self.client, operator_user_id)
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, NULL);
+            """,
+            (slot_id, case_name, slot_position),
+        )
+        self.conn.commit()
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        serial_number: str,
+        location_type: str,
+        home_slot_id: int | None,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                manufacturer,
+                equipment_type,
+                building,
+                room,
+                building_room,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                updated_date,
+                location_type,
+                current_holder_id,
+                home_slot_id
+            )
+            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '100', 'HQ/100', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, NULL, ?);
+            """,
+            (asset_tag, serial_number, location_type, home_slot_id),
+        )
+        self.conn.commit()
+
+    def test_search_page_allows_authenticated_operator(self) -> None:
+        response = self.client.get("/assets/search")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset Search", response.data)
+        self.assertIn(b"Search by asset tag or serial number", response.data)
+
+    def test_search_finds_asset_by_asset_tag(self) -> None:
+        self._insert_slot(10, "CASE-A", 4)
+        self._insert_asset("AT-100", serial_number="SER-100", location_type="STORAGE", home_slot_id=10)
+
+        response = self.client.get("/assets/search?asset_tag=AT-100")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset Found", response.data)
+        self.assertIn(b"Matched by asset tag.", response.data)
+        self.assertIn(b"AT-100", response.data)
+        self.assertIn(b"SER-100", response.data)
+        self.assertIn(b"In storage", response.data)
+        self.assertIn(b"CASE-A", response.data)
+        self.assertIn(b"Slot 4", response.data)
+
+    def test_search_finds_asset_by_serial_number(self) -> None:
+        self._insert_asset("AT-200", serial_number="SER-200", location_type="IN_CUSTODY", home_slot_id=None)
+
+        response = self.client.get("/assets/search?serial_number=SER-200")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset Found", response.data)
+        self.assertIn(b"Matched by serial number.", response.data)
+        self.assertIn(b"AT-200", response.data)
+        self.assertIn(b"SER-200", response.data)
+        self.assertIn(b"In custody", response.data)
+        self.assertIn(b"Not assigned", response.data)
+
+    def test_search_shows_plain_not_found_feedback(self) -> None:
+        response = self.client.get("/assets/search?asset_tag=AT-MISSING")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset not found.", response.data)
+        self.assertNotIn(b"Asset Found", response.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -86,6 +86,11 @@ def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     assert edit_response.status_code == 200
 
 
+def test_asset_search_requires_login(client_with_temp_db) -> None:
+    response = client_with_temp_db.get("/assets/search")
+    assert response.status_code == 403
+
+
 def test_bootstrap_only_when_empty(client_with_temp_db) -> None:
     bootstrap_get = client_with_temp_db.get("/bootstrap/admin")
     assert bootstrap_get.status_code == 200


### PR DESCRIPTION
## Summary
Add a simple asset search page so operators can verify asset existence and state.

## Related Issue
Closes #259 

## Changes
- added authenticated asset search page (asset_tag and serial_number)
- displays current state and home case/slot in plain language
- added navigation entry for Asset Search
- added focused UI tests and auth coverage

## Verification checklist
- [x] Targeted tests pass
- [x] Search by asset_tag returns correct result
- [x] Search by serial_number returns correct result
- [x] No-result case shows clear feedback
- [x] Auth required for access
- [x] No schema change introduced

## Notes
Serial-number ambiguity returns a clear message directing operator to use asset tag.