### PR TITLE
Issue 24-36: preserve scan queue position after submit

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -420,6 +420,17 @@ def _asset_state_label(location_type: object) -> str:
     return normalized.replace("_", " ").title()
 
 
+def _queue_redirect_target(return_to: str) -> str:
+    target = str(return_to or "").strip()
+    if not target.startswith("/") or target.startswith("//"):
+        return target
+
+    path, sep, fragment = target.partition("#")
+    if path in {"/issue", "/return"} and not fragment:
+        return f"{path}#queue-section"
+    return target
+
+
 def _lookup_asset_for_verification(
     conn: sqlite3.Connection,
     *,
@@ -2083,6 +2094,7 @@ def intake():
         action = (request.form.get("action") or "").strip().lower()
         scan_text = (request.form.get("scan_text") or "").strip()
         return_to = (request.form.get("return_to") or "").strip()
+        redirect_target = _queue_redirect_target(return_to)
         queue_index_raw = (request.form.get("queue_index") or "").strip()
         submitted_equipment_type = request.form.get("equipment_type")
         current_equipment_type = (session.get("equipment_type") or "laptop").strip() or "laptop"
@@ -2108,15 +2120,15 @@ def intake():
             if not value:
                 flash("Scan rejected. Enter a valid asset tag.", "error")
                 touch_session()
-                if return_to.startswith("/") and not return_to.startswith("//"):
-                    return redirect(return_to)
+                if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                    return redirect(redirect_target)
                 return redirect(url_for("add_assets"))
 
             if _queue_contains_asset_tag(value):
                 flash(f"Asset {value} is already queued.", "error")
                 touch_session()
-                if return_to.startswith("/") and not return_to.startswith("//"):
-                    return redirect(return_to)
+                if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                    return redirect(redirect_target)
                 return redirect(url_for("add_assets"))
 
             case_name = (request.form.get("case_name") or "").strip().upper()
@@ -2130,8 +2142,8 @@ def intake():
                     if requires_inventory_validation and _find_asset_for_scan_tag(conn, value) is None:
                         flash("Scan rejected. Asset tag not found in inventory.", "error")
                         touch_session()
-                        if return_to.startswith("/") and not return_to.startswith("//"):
-                            return redirect(return_to)
+                        if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                            return redirect(redirect_target)
                         return redirect(url_for("add_assets"))
 
                     if case_name or slot_id_raw:
@@ -2143,8 +2155,8 @@ def intake():
                         if slot_errors:
                             flash("; ".join(slot_errors), "error")
                             touch_session()
-                            if return_to.startswith("/") and not return_to.startswith("//"):
-                                return redirect(return_to)
+                            if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                                return redirect(redirect_target)
                             return redirect(url_for("add_assets"))
                         if selected_slot is not None:
                             home_slot_id = int(selected_slot["id"])
@@ -2165,8 +2177,8 @@ def intake():
 
         touch_session()
 
-        if return_to.startswith("/") and not return_to.startswith("//"):
-            return redirect(return_to)
+        if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+            return redirect(redirect_target)
         return redirect(url_for("add_assets"))
 
     username = (request.form.get("username") or "").strip()

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -63,6 +63,7 @@
 {% endblock %}
 
 {% block content %}
+  {% set queue_return_to = (return_to or url_for('return_queue')) ~ '#queue-section' %}
   <p><a href="{{ url_for('dashboard') }}">← Back to dashboard</a></p>
 
   {% include "_timeout_status.html" %}
@@ -93,7 +94,7 @@
     <p>Click the box once, then scan. The scanner "types" and hits Enter.</p>
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
-      <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
+      <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
       <input
         id="scan-input"
         type="text"
@@ -106,7 +107,7 @@
     </form>
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
-      <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
+      <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
       <input type="hidden" name="action" value="clear" />
       <button type="submit" onclick="return confirm('Clear the queue?');" data-timeout-lock-target>Clear queue</button>
     </form>
@@ -139,7 +140,7 @@
     <p class="workflow-action"><a class="chip" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Open Return Assets Preview / Confirm" }}</a></p>
   </div>
 
-  <div class="card workflow-card">
+  <div class="card workflow-card" id="queue-section">
     <h2>Queue ({{ queue_len }})</h2>
     <ul id="queue-list" class="queue-list" role="list">
       {% for s in queue %}
@@ -147,7 +148,7 @@
           <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
           <code>{{ s.asset_tag }}</code>
           <form method="post" action="{{ url_for('intake') }}">
-            <input type="hidden" name="return_to" value="{{ return_to or url_for('return_queue') }}" />
+            <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
             <input type="hidden" name="action" value="remove" />
             <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
             <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -251,6 +251,9 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertNotIn(b"REMOVE-ME", preview.data)
 
     def test_return_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_duplicate(self) -> None:
+        self._insert_slot(26, "CASE-RT", 2, None)
+        self._insert_asset("RT200", location_type="IN_CUSTODY", holder_id=9, home_slot_id=26)
+
         first = self.client.post(
             "/",
             data={"scan_text": "rt-200", "return_to": "/return"},
@@ -276,6 +279,27 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(preview.status_code, 200)
         self.assertIn(b"RT200", preview.data)
         self.assertNotIn(b"rt-200", preview.data)
+
+    def test_return_scan_redirects_back_to_queue_anchor(self) -> None:
+        self._insert_slot(25, "CASE-Z", 1, None)
+        self._insert_asset("RT-ANCHOR-1", location_type="IN_CUSTODY", holder_id=5, home_slot_id=25)
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "rt-anchor-1", "return_to": "/return"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers.get("Location") or "").endswith("/return#queue-section"))
+
+    def test_return_scan_validation_error_redirects_back_to_queue_anchor(self) -> None:
+        response = self.client.post(
+            "/",
+            data={"scan_text": "missing-tag", "return_to": "/return"},
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers.get("Location") or "").endswith("/return#queue-section"))
 
 
 if __name__ == "__main__":

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -64,6 +64,15 @@ def test_preview_load_refreshes_last_seen(client_with_temp_db, monkeypatch: pyte
 
 def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
     _login(client_with_temp_db, monkeypatch, last_seen=120)
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO assets (asset_tag, location_type, current_holder_id, home_slot_id)
+        VALUES ('SCAN-TAG-1', 'STORAGE', NULL, NULL);
+        """
+    )
+    conn.commit()
+    conn.close()
     monkeypatch.setattr(intake_app, "now_seconds", lambda: 220)
 
     response = client_with_temp_db.post(
@@ -72,7 +81,7 @@ def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: p
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
     assert len(intake_app.SCAN_QUEUE) == 1
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 220
@@ -89,7 +98,7 @@ def test_queue_action_refreshes_last_seen(client_with_temp_db, monkeypatch: pyte
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
     assert len(intake_app.SCAN_QUEUE) == 0
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 230


### PR DESCRIPTION
## Summary
Preserve operator position in the scan loop by redirecting back to the queue section after each scan.

## Related Issue
Closes #260 

## Changes
- redirect issue and return scan submissions to #queue-section
- added stable queue anchor in shared queue template
- applied anchored return path across scan and queue actions
- updated tests to assert anchored redirects

## Verification checklist
- [x] Targeted tests pass
- [x] Issue scan returns to queue section
- [x] Return scan returns to queue section
- [x] Validation errors still return to queue section
- [x] No workflow regressions (preview, holder, timeout)
- [x] No schema change introduced

## Notes
Uses standard fragment navigation for a minimal, reliable solution.