### PR TITLE
Issue 24-37: support group-based holders

### DIFF
--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -91,9 +91,11 @@ def create_holder(
     contact_info: str | None = None,
 ) -> dict:
     normalized_name = (name or "").strip()
-    if not normalized_name:
-        raise ValueError("name is required")
     normalized_organization = (organization or "").strip() or None
+    if not normalized_name and not normalized_organization:
+        raise ValueError("name or organization is required")
+    normalized_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else holder_type
+    persisted_name = normalized_name or str(normalized_organization or "").strip()
 
     now_iso = datetime.now(timezone.utc).isoformat()
     conn = get_connection()
@@ -103,7 +105,7 @@ def create_holder(
             INSERT INTO holders (holder_type, name, organization, identifier, contact_info, created_at, updated_at)
             VALUES (?, ?, ?, ?, ?, ?, ?);
             """,
-            (holder_type, normalized_name, normalized_organization, identifier, contact_info, now_iso, now_iso),
+            (normalized_holder_type, persisted_name, normalized_organization, identifier, contact_info, now_iso, now_iso),
         )
         conn.commit()
         created_id = int(cursor.lastrowid)
@@ -131,9 +133,11 @@ def update_holder(
         raise ValueError("holder_id is required") from e
 
     normalized_name = (name or "").strip()
-    if not normalized_name:
-        raise ValueError("name is required")
     normalized_organization = (organization or "").strip() or None
+    if not normalized_name and not normalized_organization:
+        raise ValueError("name or organization is required")
+    persisted_name = normalized_name or str(normalized_organization or "").strip()
+    persisted_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else "PERSON"
     now_iso = datetime.now(timezone.utc).isoformat()
 
     conn = get_connection()
@@ -141,10 +145,10 @@ def update_holder(
         cursor = conn.execute(
             """
             UPDATE holders
-            SET name = ?, organization = ?, updated_at = ?
+            SET holder_type = ?, name = ?, organization = ?, updated_at = ?
             WHERE id = ?;
             """,
-            (normalized_name, normalized_organization, now_iso, normalized_id),
+            (persisted_holder_type, persisted_name, normalized_organization, now_iso, normalized_id),
         )
         if cursor.rowcount != 1:
             raise ValueError("holder not found")

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -81,6 +81,8 @@ def inject_auth_user():
     return {
         "authenticated_user": user,
         "authenticated_role": None if user is None else user.get("role"),
+        "holder_display_name": _holder_display_name,
+        "holder_display_type": _holder_display_type,
     }
 
 
@@ -429,6 +431,27 @@ def _queue_redirect_target(return_to: str) -> str:
     if path in {"/issue", "/return"} and not fragment:
         return f"{path}#queue-section"
     return target
+
+
+def _holder_display_name(holder: Optional[dict]) -> str:
+    if not holder:
+        return ""
+
+    name = str(holder.get("name") or "").strip()
+    organization = str(holder.get("organization") or "").strip()
+    return name or organization
+
+
+def _holder_display_type(holder: Optional[dict]) -> str:
+    if not holder:
+        return ""
+
+    holder_type = str(holder.get("holder_type") or "").strip().upper()
+    if holder_type == "ORGANIZATION":
+        return "Group / organization"
+    if holder_type == "PERSON":
+        return "Person"
+    return holder_type.replace("_", " ").title()
 
 
 def _lookup_asset_for_verification(
@@ -1533,7 +1556,8 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
     holder_label = None
     if selected_holder:
         identifier = (selected_holder.get("identifier") or "").strip()
-        holder_label = selected_holder["name"] if not identifier else f"{selected_holder['name']} ({identifier})"
+        display_name = _holder_display_name(selected_holder)
+        holder_label = display_name if not identifier else f"{display_name} ({identifier})"
 
     assets: list[dict] = []
     unknown_tags: list[str] = []
@@ -2995,10 +3019,10 @@ def holders_create():
         return render_template(
             "holder_new.html",
             form=form,
-            error_message="Name is required.",
+            error_message="Enter a person or group name, or enter a group / organization.",
         )
 
-    flash(f"Created holder: {created['name']}", "success")
+    flash(f"Created holder: {_holder_display_name(created)}", "success")
     return redirect(url_for("holders_search"))
 
 
@@ -3053,11 +3077,15 @@ def holders_edit_submit(holder_id: int):
             "holder_edit.html",
             holder=holder,
             form=form,
-            error_message="Name is required." if str(e) == "name is required" else str(e),
+            error_message=(
+                "Enter a person or group name, or enter a group / organization."
+                if str(e) == "name or organization is required"
+                else str(e)
+            ),
         )
 
-    flash(f"Updated holder: {updated['name']}", "success")
-    return redirect(url_for("holders_search", q=updated["name"]))
+    flash(f"Updated holder: {_holder_display_name(updated)}", "success")
+    return redirect(url_for("holders_search", q=_holder_display_name(updated)))
 
 
 @app.post("/holders/select")
@@ -3085,7 +3113,7 @@ def holders_select():
 
     session["holder_id"] = holder["id"]
     touch_session()
-    flash(f"Selected holder: {holder['name']}", "success")
+    flash(f"Selected holder: {_holder_display_name(holder)}", "success")
     if return_to.startswith("/") and not return_to.startswith("//"):
         return redirect(return_to)
     return redirect(url_for("holders_search"))

--- a/assettrack/intake/templates/_workflow_context_banner.html
+++ b/assettrack/intake/templates/_workflow_context_banner.html
@@ -4,7 +4,7 @@
   <p>
     {% if selected_holder %}
       <strong>Issued to:</strong>
-      {{ selected_holder["name"] }}{% if selected_holder["organization"] %} ({{ selected_holder["organization"] }}){% endif %}<br />
+      {{ holder_display_name(selected_holder) }}{% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %} ({{ selected_holder["organization"] }}){% endif %}<br />
     {% endif %}
     {% if workflow_banner_destination %}
       <strong>Home location:</strong> {{ workflow_banner_destination }}<br />

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -2,7 +2,7 @@
 {% extends "base.html" %}
 
 {% block title %}Holder Detail{% endblock %}
-{% block page_heading %}Holder: {{ holder.name }}{% endblock %}
+{% block page_heading %}Holder: {{ holder_display_name(holder) }}{% endblock %}
 
 {% block extra_head %}
   <style>
@@ -27,7 +27,8 @@
 
   <section class="card">
     <p>
-      <strong>Holder:</strong> {{ holder.name }}<br />
+      <strong>Type:</strong> {{ holder_display_type(holder) }}<br />
+      <strong>Person or group:</strong> {{ holder_display_name(holder) }}<br />
       <strong>Organization:</strong> {{ holder.organization or "" }}<br />
       <strong>Identifier:</strong> {{ holder.identifier or "" }}<br />
       <strong>Contact information:</strong> {{ holder.contact_info or "" }}

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -27,13 +27,14 @@
 
   <div class="card">
     <h2>Edit Holder</h2>
+    <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
     <form method="post" action="{{ url_for('holders_edit_submit', holder_id=holder.id) }}">
       <div class="row">
-        <label for="name"><strong>Name</strong> (required)</label><br />
-        <input type="text" id="name" name="name" value="{{ form.name or '' }}" required autofocus />
+        <label for="name"><strong>Person or group name</strong> (optional if group / organization is entered)</label><br />
+        <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
-        <label for="organization"><strong>Organization</strong> (optional)</label><br />
+        <label for="organization"><strong>Group / organization</strong> (optional)</label><br />
         <input type="text" id="organization" name="organization" value="{{ form.organization or '' }}" />
       </div>
       <button type="submit">Save Holder</button>

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -27,13 +27,14 @@
 
   <div class="card">
     <h2>New Holder</h2>
+    <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
     <form method="post" action="{{ url_for('holders_create') }}">
       <div class="row">
-        <label for="name"><strong>Name</strong> (required)</label><br />
-        <input type="text" id="name" name="name" value="{{ form.name or '' }}" required autofocus />
+        <label for="name"><strong>Person or group name</strong> (optional if group / organization is entered)</label><br />
+        <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
-        <label for="organization"><strong>Organization</strong> (optional)</label><br />
+        <label for="organization"><strong>Group / organization</strong> (optional)</label><br />
         <input type="text" id="organization" name="organization" value="{{ form.organization or '' }}" />
       </div>
       <button type="submit">Create Holder</button>

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -36,12 +36,12 @@
       {% if return_to %}
         <input type="hidden" name="return_to" value="{{ return_to }}" />
       {% endif %}
-      <label for="q"><strong>Search by name or identifier</strong></label><br />
+      <label for="q"><strong>Search by person name, group, organization, or identifier</strong></label><br />
       <input
         type="text"
         id="q"
         name="q"
-        placeholder="e.g. Jane Doe or ID123"
+        placeholder="e.g. Jane Doe, Field Team, or ID123"
         value="{{ query or '' }}"
         autocomplete="off"
       />
@@ -53,8 +53,8 @@
     <h2>Selected Holder</h2>
     {% if selected_holder %}
       <p>
-        <strong>Type:</strong> {{ selected_holder["holder_type"] }}<br />
-        <strong>Name:</strong> {{ selected_holder["name"] }}<br />
+        <strong>Type:</strong> {{ holder_display_type(selected_holder) }}<br />
+        <strong>Person or group:</strong> {{ holder_display_name(selected_holder) }}<br />
         <strong>Organization:</strong> {{ selected_holder["organization"] or "" }}<br />
         <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}
       </p>
@@ -85,12 +85,12 @@
         <tbody>
           {% for h in results %}
             <tr>
-              <td>{{ h["holder_type"] }}</td>
+              <td>{{ holder_display_type(h) }}</td>
               <td>
                 {% if return_to %}
-                  <a href="{{ url_for('holder_detail', holder_id=h['id'], return_to=return_to) }}">{{ h["name"] }}</a>
+                  <a href="{{ url_for('holder_detail', holder_id=h['id'], return_to=return_to) }}">{{ holder_display_name(h) }}</a>
                 {% else %}
-                  <a href="{{ url_for('holder_detail', holder_id=h['id']) }}">{{ h["name"] }}</a>
+                  <a href="{{ url_for('holder_detail', holder_id=h['id']) }}">{{ holder_display_name(h) }}</a>
                 {% endif %}
               </td>
               <td>{{ h["organization"] or "" }}</td>

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -75,8 +75,9 @@
     <h2>Selected Holder</h2>
     {% if selected_holder %}
       <p class="holder-summary">
-        <strong>Type:</strong> {{ selected_holder["holder_type"] }}<br />
-        <strong>Name:</strong> {{ selected_holder["name"] }}<br />
+        <strong>Type:</strong> {{ holder_display_type(selected_holder) }}<br />
+        <strong>Person or group:</strong> {{ holder_display_name(selected_holder) }}<br />
+        <strong>Organization:</strong> {{ selected_holder["organization"] or "" }}<br />
         <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}
       </p>
       <div class="actions" style="margin-top: 0.75rem;">

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -79,7 +79,7 @@
       {% if selected_holder %}
         <p>
           <strong>Selected holder:</strong>
-          {{ selected_holder["name"] }}
+          {{ holder_display_name(selected_holder) }}
           {% if selected_holder["identifier"] %}
             ({{ selected_holder["identifier"] }})
           {% endif %}

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -52,13 +52,31 @@ class HolderCreationViabilityTests(unittest.TestCase):
     def test_post_holders_new_rejects_blank_name(self) -> None:
         response = self.client.post(
             "/holders/new",
-            data={"name": "   "},
+            data={"name": "   ", "organization": "   "},
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Name is required.", response.data)
+        self.assertIn(b"Enter a person or group name, or enter a group / organization.", response.data)
 
         count = self.conn.execute("SELECT COUNT(*) AS c FROM holders;").fetchone()["c"]
         self.assertEqual(count, 0)
+
+    def test_post_holders_new_allows_group_only_holder(self) -> None:
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "", "organization": "Maintenance Shop"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Created holder: Maintenance Shop", response.data)
+        self.assertIn(b"Maintenance Shop", response.data)
+
+        row = self.conn.execute(
+            "SELECT holder_type, name, organization FROM holders WHERE name = ?;",
+            ("Maintenance Shop",),
+        ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(row["holder_type"], "ORGANIZATION")
+        self.assertEqual(row["organization"], "Maintenance Shop")
 
     def test_create_search_and_select_holder_workflow(self) -> None:
         holder_name = "ZZ Test Holder 21-4"
@@ -151,7 +169,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Holder Directory", response.data)
         self.assertIn(b"Alpha Holder", response.data)
         self.assertIn(b"Bravo Holder", response.data)
-        self.assertIn(b"Search by name or identifier", response.data)
+        self.assertIn(b"Search by person name, group, organization, or identifier", response.data)
 
     def test_holder_detail_shows_metadata_and_assigned_assets(self) -> None:
         self.client.post("/holders/new", data={"name": "Detail Holder", "organization": "Org Detail"})
@@ -193,6 +211,20 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Assigned Assets (0)", response.data)
         self.assertIn(b"No assigned assets.", response.data)
+
+    def test_holder_detail_displays_group_holder_cleanly(self) -> None:
+        self.client.post("/holders/new", data={"name": "", "organization": "Ops Section"})
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Ops Section",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        response = self.client.get(f"/holders/{int(holder_row['id'])}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Type:</strong> Group / organization", response.data)
+        self.assertIn(b"Person or group:</strong> Ops Section", response.data)
 
 
 if __name__ == "__main__":

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -99,3 +99,9 @@ class HoldersTests(unittest.TestCase):
         fetched = get_holder(int(created["id"]))
         self.assertIsNotNone(fetched)
         self.assertEqual(fetched["organization"], "Bravo Org")
+
+    def test_create_holder_allows_org_only_holder(self) -> None:
+        created = create_holder("", organization="Field Team")
+        self.assertEqual(created["holder_type"], "ORGANIZATION")
+        self.assertEqual(created["name"], "Field Team")
+        self.assertEqual(created["organization"], "Field Team")

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -92,3 +92,29 @@ def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> Non
     assert b"Issued to:</strong>" in response.data
     assert b"Issue Holder (Issue Org)" in response.data
     assert b"Queued:</strong> 0 assets" in response.data
+
+
+def test_issue_page_displays_selected_group_holder_context(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-group-holder", password="op-pass", role="operator")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+        VALUES (2, 'ORGANIZATION', 'Maintenance Team', 'Maintenance Team', NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 2
+
+    response = client_with_temp_db.get("/issue")
+
+    assert response.status_code == 200
+    assert b"Issuing Assets" in response.data
+    assert b"Issued to:</strong>" in response.data
+    assert b"Maintenance Team" in response.data
+    assert b"Maintenance Team (Maintenance Team)" not in response.data


### PR DESCRIPTION
## Summary
Support group-based holders so assets can be issued to an organization, not just a person.

## Related Issue
Closes #261 

## Changes
- allow org-only holder create/update using existing schema
- derive stable display text for group holders
- clarify holder UI text to support person or group
- render group holders cleanly in directory, detail, preview, and issue workflow banner
- add focused tests for create, selection, and issue workflow display

## Verification checklist
- [x] Targeted tests pass
- [x] Group holder can be created without person name
- [x] Blank holder submission is still rejected
- [x] Group holder displays clearly in holder directory and detail
- [x] Group holder can be selected into issue workflow
- [x] Issue banner shows clean group-holder context
- [x] No schema change introduced

## Notes
Group holders currently derive display name from the existing organization field to stay within current persistence rules.