### PR TITLE
Issue 24-39: invert case status color mapping

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -81,6 +81,7 @@ def inject_auth_user():
     return {
         "authenticated_user": user,
         "authenticated_role": None if user is None else user.get("role"),
+        "case_status_summary": _case_status_summary,
         "holder_display_name": _holder_display_name,
         "holder_display_type": _holder_display_type,
     }
@@ -420,6 +421,33 @@ def _asset_state_label(location_type: object) -> str:
     if not normalized:
         return "Unknown"
     return normalized.replace("_", " ").title()
+
+
+def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[str, object]:
+    total = int(total_slots or 0)
+    occupied = int(occupied_slots or 0)
+    available = max(0, total - occupied)
+
+    if available == 0:
+        return {
+            "label": "FULL",
+            "text": "FULL - No space",
+            "class_name": "full",
+            "available_slots": available,
+        }
+    if available <= 3:
+        return {
+            "label": "LOW",
+            "text": "LOW - Getting tight",
+            "class_name": "low",
+            "available_slots": available,
+        }
+    return {
+        "label": "OPEN",
+        "text": "OPEN - Use now",
+        "class_name": "open",
+        "available_slots": available,
+    }
 
 
 def _queue_redirect_target(return_to: str) -> str:

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -68,9 +68,9 @@
       border: 1px solid rgba(18, 32, 47, 0.18);
       flex: 0 0 auto;
     }
-    .status-dot.full { background: #b42318; }
+    .status-dot.full { background: #12b76a; }
     .status-dot.low { background: #f79009; }
-    .status-dot.open { background: #12b76a; }
+    .status-dot.open { background: #b42318; }
 
     .section-title { margin-top: 1.25rem; }
     .accent {
@@ -222,27 +222,14 @@
         </thead>
         <tbody>
           {% for row in dashboard.snapshots.case_utilization %}
-            {% set available_slots = row.total_slots - row.occupied_slots %}
-            {% if available_slots == 0 %}
-              {% set status_label = "FULL" %}
-              {% set status_text = "FULL - No space" %}
-              {% set status_class = "full" %}
-            {% elif available_slots <= 3 %}
-              {% set status_label = "LOW" %}
-              {% set status_text = "LOW - Getting tight" %}
-              {% set status_class = "low" %}
-            {% else %}
-              {% set status_label = "OPEN" %}
-              {% set status_text = "OPEN - Use now" %}
-              {% set status_class = "open" %}
-            {% endif %}
+            {% set status = case_status_summary(row.total_slots, row.occupied_slots) %}
             <tr>
               <td>{{ row.case_name }}</td>
-              <td>{{ available_slots }} open</td>
+              <td>{{ status.available_slots }} open</td>
               <td class="status-cell">
                 <span class="status-badge">
-                  <span class="status-dot {{ status_class }}" aria-hidden="true"></span>
-                  <span>{{ status_text }}</span>
+                  <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>
+                  <span>{{ status.text }}</span>
                 </span>
               </td>
             </tr>

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -8,14 +8,50 @@
   <style>
     .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .status-card { margin-bottom: 1rem; }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 700;
+    }
+    .status-dot {
+      width: 0.7rem;
+      height: 0.7rem;
+      border-radius: 999px;
+      display: inline-block;
+      border: 1px solid rgba(18, 32, 47, 0.18);
+      flex: 0 0 auto;
+    }
+    .status-dot.full { background: #12b76a; }
+    .status-dot.low { background: #f79009; }
+    .status-dot.open { background: #b42318; }
   </style>
 {% endblock %}
 
 {% block content %}
+  {% set occupied_slots = case_detail.slots | selectattr("asset_tag") | list | length %}
+  {% set total_slots = case_detail.slots | length %}
+  {% set empty_slots = total_slots - occupied_slots %}
+  {% set status = case_status_summary(total_slots, occupied_slots) %}
   <nav class="actions" aria-label="Contextual navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="chip" href="{{ url_for('dashboard_cases') }}">Back to Cases</a>
   </nav>
+
+  <section class="card status-card">
+    <h2>Case Status</h2>
+    <p>
+      <span class="status-badge">
+        <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>
+        <span>{{ status.text }}</span>
+      </span>
+      <br />
+      <strong>Total slots:</strong> {{ total_slots }}<br />
+      <strong>Occupied slots:</strong> {{ occupied_slots }}<br />
+      <strong>Empty slots:</strong> {{ empty_slots }}
+    </p>
+  </section>
 
   <section class="card">
     <h2>Slot Layout</h2>

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -7,6 +7,24 @@
 {% block extra_head %}
   <style>
     .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+    .status-cell { white-space: nowrap; }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-weight: 700;
+    }
+    .status-dot {
+      width: 0.7rem;
+      height: 0.7rem;
+      border-radius: 999px;
+      display: inline-block;
+      border: 1px solid rgba(18, 32, 47, 0.18);
+      flex: 0 0 auto;
+    }
+    .status-dot.full { background: #12b76a; }
+    .status-dot.low { background: #f79009; }
+    .status-dot.open { background: #b42318; }
   </style>
 {% endblock %}
 
@@ -21,6 +39,7 @@
       <thead>
         <tr>
           <th>Case Name</th>
+          <th>Status</th>
           <th>Total Slots</th>
           <th>Occupied Slots</th>
           <th>Empty Slots</th>
@@ -29,8 +48,15 @@
       </thead>
       <tbody>
         {% for row in cases %}
+          {% set status = case_status_summary(row.total_slots, row.occupied_slots) %}
           <tr>
             <td><a href="{{ url_for('dashboard_case_detail', case_name=row.case_name) }}">{{ row.case_name }}</a></td>
+            <td class="status-cell">
+              <span class="status-badge">
+                <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>
+                <span>{{ status.text }}</span>
+              </span>
+            </td>
             <td>{{ row.total_slots }}</td>
             <td>{{ row.occupied_slots }}</td>
             <td>{{ row.empty_slots }}</td>
@@ -38,7 +64,7 @@
           </tr>
         {% else %}
           <tr>
-            <td colspan="5">None</td>
+            <td colspan="6">None</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -229,6 +229,11 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"CASE-C", response.data)
         self.assertIn(b"1 open", response.data)
         self.assertNotIn(b"0 / 2", response.data)
+        self.assertIn(b".status-dot.full { background: #12b76a; }", response.data)
+        self.assertIn(b".status-dot.low { background: #f79009; }", response.data)
+        self.assertIn(b".status-dot.open { background: #b42318; }", response.data)
+        self.assertIn(b'status-dot full', response.data)
+        self.assertIn(b'status-dot low', response.data)
 
     def test_available_space_uses_full_case_coverage_not_limited_top_five(self) -> None:
         slot_id = 1

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -149,11 +149,15 @@ def test_dashboard_holder_detail_200_none_when_no_assets(app_client) -> None:
 def test_dashboard_cases_route_200_and_missing_case_404(app_client) -> None:
     conn, client = app_client
     _insert_slot(conn, 10, "CASE-A", 1)
+    _insert_slot(conn, 11, "CASE-A", 2)
     conn.commit()
 
     cases_response = client.get("/dashboard/cases")
     assert cases_response.status_code == 200
     assert b"Case Summary" in cases_response.data
+    assert b"Status" in cases_response.data
+    assert b"LOW - Getting tight" in cases_response.data
+    assert b"status-dot low" in cases_response.data
 
     missing_response = client.get("/dashboard/cases/CASE-MISSING")
     assert missing_response.status_code == 404
@@ -175,6 +179,12 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
 
     response = client.get("/dashboard/cases/CASE-A")
     assert response.status_code == 200
+    assert b"Case Status" in response.data
+    assert b"LOW - Getting tight" in response.data
+    assert b"status-dot low" in response.data
+    assert b"Total slots:</strong> 2" in response.data
+    assert b"Occupied slots:</strong> 1" in response.data
+    assert b"Empty slots:</strong> 1" in response.data
     assert b"Slot Position" in response.data
     assert b">1<" in response.data
     assert b">2<" in response.data


### PR DESCRIPTION
## Summary
Align case status colors with operator expectations without changing slot logic.

## Related Issue
Closes #263 

## Changes
- added a small display helper for case status badges
- remapped status colors so FULL is green, LOW is yellow, and OPEN is red
- applied the same status badge mapping across dashboard and case drilldowns
- updated focused dashboard and drilldown tests

## Verification checklist
- [x] Targeted tests pass
- [x] FULL cases render green
- [x] LOW cases render yellow
- [x] OPEN cases render red
- [x] Labels and colors stay aligned across views
- [x] No slot logic or threshold changes
- [x] No schema change introduced

## Notes
This is display-only. Existing FULL / LOW / OPEN wording and thresholds remain unchanged.