### PR TITLE
Issue 24-38: expand case scan into per-asset queue

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -114,12 +114,12 @@ def sanitize_scan(raw: str) -> str:
 
 
 def _queue_contains_asset_tag(asset_tag: str) -> bool:
-    normalized = (asset_tag or "").strip().upper()
+    normalized = sanitize_scan(asset_tag or "")
     if not normalized:
         return False
 
     for queued in SCAN_QUEUE:
-        if str(queued.asset_tag or "").strip().upper() == normalized:
+        if sanitize_scan(queued.asset_tag or "") == normalized:
             return True
     return False
 
@@ -243,6 +243,76 @@ def _find_asset_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
         raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
 
     return dict(rows[0])
+
+
+def _find_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
+    t = (scan_tag or "").strip()
+    if not t:
+        return None
+
+    slot_rows = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+           OR REPLACE(UPPER(case_name), '-', '') = UPPER(?)
+        ORDER BY slot_position ASC, id ASC;
+        """,
+        (t, t),
+    ).fetchall()
+    if not slot_rows:
+        return None
+
+    case_names = {str(row["case_name"] or "").strip().upper() for row in slot_rows if str(row["case_name"] or "").strip()}
+    if len(case_names) > 1:
+        raise ValueError(f"Ambiguous case match for scan '{t}'")
+
+    case_name = str(slot_rows[0]["case_name"] or "").strip().upper()
+    assets: list[dict] = []
+    seen_asset_tags: set[str] = set()
+
+    for slot_row in slot_rows:
+        slot_id = int(slot_row["id"])
+        slot_position = int(slot_row["slot_position"])
+        asset_tag = ""
+
+        occupancy_row = conn.execute(
+            """
+            SELECT a.asset_tag
+            FROM slot_occupancy so
+            JOIN assets a ON a.id = so.asset_id
+            WHERE so.slot_id = ?
+            ORDER BY so.id ASC
+            LIMIT 1;
+            """,
+            (slot_id,),
+        ).fetchone()
+        if occupancy_row is not None:
+            asset_tag = sanitize_scan(str(occupancy_row["asset_tag"] or ""))
+        else:
+            legacy_asset_tag = str(slot_row["current_asset_tag"] or "").strip()
+            if legacy_asset_tag:
+                asset_row = _find_asset_for_scan_tag(conn, legacy_asset_tag)
+                if asset_row is not None:
+                    asset_tag = sanitize_scan(str(asset_row["asset_tag"] or ""))
+
+        if not asset_tag or asset_tag in seen_asset_tags:
+            continue
+
+        seen_asset_tags.add(asset_tag)
+        assets.append(
+            {
+                "asset_tag": asset_tag,
+                "home_slot_id": slot_id,
+                "case_name": case_name,
+                "slot_position": slot_position,
+            }
+        )
+
+    return {
+        "case_name": case_name,
+        "assets": assets,
+    }
 
 
 def _asset_current_slot(conn, asset_id: int, asset_tag: str) -> Optional[dict]:
@@ -2176,13 +2246,6 @@ def intake():
                     return redirect(redirect_target)
                 return redirect(url_for("add_assets"))
 
-            if _queue_contains_asset_tag(value):
-                flash(f"Asset {value} is already queued.", "error")
-                touch_session()
-                if redirect_target.startswith("/") and not redirect_target.startswith("//"):
-                    return redirect(redirect_target)
-                return redirect(url_for("add_assets"))
-
             case_name = (request.form.get("case_name") or "").strip().upper()
             slot_id_raw = (request.form.get("slot_id") or "").strip()
             home_slot_id: Optional[int] = None
@@ -2191,6 +2254,68 @@ def intake():
             if requires_inventory_validation or case_name or slot_id_raw:
                 conn = get_connection()
                 try:
+                    case_match = None
+                    if return_to == "/issue":
+                        try:
+                            case_match = _find_case_assets_for_scan_tag(conn, value)
+                        except ValueError as e:
+                            flash(str(e), "error")
+                            touch_session()
+                            if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                                return redirect(redirect_target)
+                            return redirect(url_for("add_assets"))
+
+                        if case_match is not None:
+                            matched_case_name = str(case_match["case_name"] or value).strip().upper()
+                            case_assets = list(case_match["assets"])
+                            if not case_assets:
+                                flash(f"Case {matched_case_name} has no assets to add.", "error")
+                                touch_session()
+                                if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                                    return redirect(redirect_target)
+                                return redirect(url_for("add_assets"))
+
+                            added_count = 0
+                            skipped_count = 0
+                            for row in case_assets:
+                                asset_tag = str(row["asset_tag"] or "").strip().upper()
+                                if _queue_contains_asset_tag(asset_tag):
+                                    skipped_count += 1
+                                    continue
+                                SCAN_QUEUE.append(
+                                    Scan.now(
+                                        asset_tag,
+                                        equipment_type=selected_equipment_type,
+                                        home_slot_id=int(row["home_slot_id"]),
+                                        case_name=str(row["case_name"] or ""),
+                                        slot_position=int(row["slot_position"]),
+                                    )
+                                )
+                                added_count += 1
+
+                            if added_count > 0:
+                                message = f"Case {matched_case_name} added {added_count} asset"
+                                if added_count != 1:
+                                    message += "s"
+                                message += " to queue."
+                                if skipped_count > 0:
+                                    message += f" Skipped {skipped_count} already queued."
+                                flash(message, "success")
+                            else:
+                                flash(f"Case {matched_case_name} is already fully queued.", "error")
+
+                            touch_session()
+                            if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                                return redirect(redirect_target)
+                            return redirect(url_for("add_assets"))
+
+                    if _queue_contains_asset_tag(value):
+                        flash(f"Asset {value} is already queued.", "error")
+                        touch_session()
+                        if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                            return redirect(redirect_target)
+                        return redirect(url_for("add_assets"))
+
                     if requires_inventory_validation and _find_asset_for_scan_tag(conn, value) is None:
                         flash("Scan rejected. Asset tag not found in inventory.", "error")
                         touch_session()
@@ -2216,6 +2341,12 @@ def intake():
                             slot_position = int(selected_slot["slot_position"])
                 finally:
                     conn.close()
+            elif _queue_contains_asset_tag(value):
+                flash(f"Asset {value} is already queued.", "error")
+                touch_session()
+                if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                    return redirect(redirect_target)
+                return redirect(url_for("add_assets"))
 
             SCAN_QUEUE.append(
                 Scan.now(

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -41,6 +41,18 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     )
     conn.execute(
         """
+        INSERT INTO assets (
+            id, asset_tag, serial_number, equipment_type, manufacturer, model,
+            location_type, current_holder_id, home_slot_id
+        )
+        VALUES (
+            504, 'FOLLOW-UP-TAG', 'SN-4', 'laptop', 'Dell', 'Latitude',
+            'STORAGE', NULL, NULL
+        );
+        """
+    )
+    conn.execute(
+        """
         INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
         VALUES (101, 501, '2026-01-01T00:00:00Z');
         """

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_issue_operator(client, username: str) -> None:
+    operator_id = create_test_user(username=username, password="op-pass", role="operator")
+    with client.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+
+def _insert_slot(conn, slot_id: int, case_name: str, slot_position: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (?, ?, ?, NULL);
+        """,
+        (slot_id, case_name, slot_position),
+    )
+
+
+def _insert_asset(conn, asset_id: int, asset_tag: str, *, home_slot_id: int | None = None) -> None:
+    conn.execute(
+        """
+        INSERT INTO assets (id, asset_tag, location_type, home_slot_id, current_holder_id)
+        VALUES (?, ?, 'STORAGE', ?, NULL);
+        """,
+        (asset_id, asset_tag, home_slot_id),
+    )
+
+
+def _occupy_slot(conn, slot_id: int, asset_id: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (?, ?, '2026-01-01T00:00:00Z');
+        """,
+        (slot_id, asset_id),
+    )
+
+
+def test_issue_case_scan_expands_expected_assets(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-case-expand")
+
+    conn = db.get_connection()
+    _insert_slot(conn, 10, "CASE-12", 1)
+    _insert_slot(conn, 11, "CASE-12", 2)
+    _insert_slot(conn, 12, "CASE-12", 3)
+    _insert_asset(conn, 100, "CI-100", home_slot_id=10)
+    _insert_asset(conn, 101, "CI-101", home_slot_id=11)
+    _occupy_slot(conn, 10, 100)
+    _occupy_slot(conn, 11, 101)
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "case-12", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["CI100", "CI101"]
+    assert b"Case CASE-12 added 2 assets to queue." in response.data
+    assert b"Queue (2)" in response.data
+
+
+def test_issue_case_scan_skips_already_queued_assets(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-case-duplicate")
+
+    conn = db.get_connection()
+    _insert_slot(conn, 20, "CASE-20", 1)
+    _insert_slot(conn, 21, "CASE-20", 2)
+    _insert_asset(conn, 200, "CI-200", home_slot_id=20)
+    _insert_asset(conn, 201, "CI-201", home_slot_id=21)
+    _occupy_slot(conn, 20, 200)
+    _occupy_slot(conn, 21, 201)
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now("CI200"))
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "CASE20", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["CI200", "CI201"]
+    assert b"Case CASE-20 added 1 asset to queue. Skipped 1 already queued." in response.data
+
+
+def test_issue_case_scan_reports_empty_case(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-case-empty")
+
+    conn = db.get_connection()
+    _insert_slot(conn, 30, "CASE-30", 1)
+    _insert_slot(conn, 31, "CASE-30", 2)
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "CASE-30", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"Case CASE-30 has no assets to add." in response.data
+
+
+def test_issue_single_asset_scan_still_behaves_normally(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-single-regression")
+
+    conn = db.get_connection()
+    _insert_asset(conn, 300, "SINGLE-300")
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "single-300", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["SINGLE300"]
+    assert b"SINGLE300" in response.data
+
+
+def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-case-commit")
+
+    conn = db.get_connection()
+    _insert_slot(conn, 40, "CASE-40", 1)
+    _insert_slot(conn, 41, "CASE-40", 2)
+    _insert_asset(conn, 400, "CI-400", home_slot_id=40)
+    _insert_asset(conn, 401, "CI-401", home_slot_id=41)
+    _occupy_slot(conn, 40, 400)
+    _occupy_slot(conn, 41, 401)
+    conn.commit()
+    conn.close()
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "CASE-40", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+    assert scan_response.status_code == 200
+
+    commit_response = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=False,
+    )
+
+    assert commit_response.status_code == 302
+    assert (commit_response.headers.get("Location") or "").endswith("/issue?issued=2")
+    assert len(intake_app.SCAN_QUEUE) == 0
+
+    conn = db.get_connection()
+    rows = conn.execute(
+        """
+        SELECT asset_tag, event_type, holder_id
+        FROM asset_events
+        WHERE event_type = 'ISSUE'
+        ORDER BY asset_tag ASC;
+        """
+    ).fetchall()
+    asset_rows = conn.execute(
+        """
+        SELECT asset_tag, location_type, current_holder_id
+        FROM assets
+        WHERE id IN (400, 401)
+        ORDER BY asset_tag ASC;
+        """
+    ).fetchall()
+    conn.close()
+
+    assert [(str(row["asset_tag"]), str(row["event_type"]), int(row["holder_id"])) for row in rows] == [
+        ("CI-400", "ISSUE", 1),
+        ("CI-401", "ISSUE", 1),
+    ]
+    assert [(str(row["asset_tag"]), str(row["location_type"]), int(row["current_holder_id"])) for row in asset_rows] == [
+        ("CI-400", "IN_CUSTODY", 1),
+        ("CI-401", "IN_CUSTODY", 1),
+    ]

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -44,7 +44,7 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
     assert len(intake_app.SCAN_QUEUE) == 0
 
     issue_page = client_with_temp_db.get("/issue")
@@ -74,7 +74,7 @@ def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicate
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DUP-TAG", "KEEP-TAG"]
 
     issue_page = client_with_temp_db.get("/issue")
@@ -114,6 +114,16 @@ def test_issue_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_du
 ) -> None:
     operator_id = create_test_user(username="operator-uppercase-issue", password="op-pass", role="operator")
 
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO assets (id, asset_tag, location_type)
+        VALUES (1, 'AB-123', 'STORAGE');
+        """
+    )
+    conn.commit()
+    conn.close()
+
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
@@ -142,5 +152,5 @@ def test_issue_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_du
 
     preview = client_with_temp_db.get("/issue/preview")
     assert preview.status_code == 200
-    assert b"AB123" in preview.data
+    assert b"AB-123" in preview.data
     assert b"ab-123" not in preview.data


### PR DESCRIPTION
## Summary
Allow scanning a case barcode to enqueue all contained assets for issue.

## Related Issue
Closes #262 

## Changes
- detect case scan in issue workflow and expand into contained assets
- enqueue each asset through existing scan path (no bulk events)
- prevent duplicates in queue, including hyphen variants
- add clear operator feedback for success, duplicate-only rescans, and empty cases
- added focused tests for expansion, duplicates, empty case, and per-asset ISSUE events

## Verification checklist
- [x] Targeted tests pass
- [x] Case scan expands into expected assets
- [x] Duplicate assets are not re-added to queue
- [x] Empty case shows clear feedback
- [x] Each asset generates its own ISSUE event on commit
- [x] Single-asset scan behavior unchanged
- [x] No schema change introduced

## Notes
Case detection currently prefers case-name matches; any future asset/case identifier collision should be handled as a separate UX rule.