### PR TITLE
Issue 24-40: add admin database export

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -15,10 +15,11 @@ import json
 import os
 import sqlite3
 import time
+from pathlib import Path
 from typing import Optional
 from datetime import datetime, timezone
 
-from flask import Flask, abort, flash, jsonify, redirect, render_template, request, session, url_for
+from flask import Flask, abort, flash, jsonify, redirect, render_template, request, send_file, session, url_for
 
 import assettrack.db as db_module
 from assettrack.assets import get_asset_table_columns
@@ -491,6 +492,10 @@ def _asset_state_label(location_type: object) -> str:
     if not normalized:
         return "Unknown"
     return normalized.replace("_", " ").title()
+
+
+def _resolved_runtime_db_path() -> Path:
+    return db_module.DB_PATH.expanduser().resolve()
 
 
 def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[str, object]:
@@ -3304,7 +3309,7 @@ def admin_users():
 @require_login
 @require_role("admin")
 def admin_system():
-    resolved_db_path = db_module.DB_PATH.expanduser().resolve()
+    resolved_db_path = _resolved_runtime_db_path()
     holder_count: int | None = None
     asset_count: int | None = None
     schema_warning: str | None = None
@@ -3325,6 +3330,25 @@ def admin_system():
         holder_count=holder_count,
         asset_count=asset_count,
         schema_warning=schema_warning,
+    )
+
+
+@app.get("/admin/db/export")
+@require_login
+@require_role("admin")
+def admin_db_export():
+    resolved_db_path = _resolved_runtime_db_path()
+    if not resolved_db_path.exists() or not resolved_db_path.is_file():
+        return "Database file not found.", 404
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    download_name = f"assettrack-backup-{timestamp}.db"
+    return send_file(
+        resolved_db_path,
+        as_attachment=True,
+        download_name=download_name,
+        mimetype="application/octet-stream",
+        conditional=False,
     )
 
 

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -12,6 +12,7 @@
 
   <div class="card">
     <h2>Database</h2>
+    <p><a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a></p>
     <table>
       <tbody>
         <tr>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -113,6 +113,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b'id="holder-count">1<' in response.data
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
+    assert b"Download Database Backup" in response.data
 
 
 def test_operator_is_forbidden_for_system_health(client_with_temp_db) -> None:
@@ -122,6 +123,36 @@ def test_operator_is_forbidden_for_system_health(client_with_temp_db) -> None:
     response = client_with_temp_db.get("/admin/system")
 
     assert response.status_code == 403
+
+
+def test_admin_can_download_database_export(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-export", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/db/export")
+
+    assert response.status_code == 200
+    disposition = response.headers.get("Content-Disposition") or ""
+    assert "attachment;" in disposition
+    assert "assettrack-backup-" in disposition
+    assert ".db" in disposition
+    assert len(response.data) > 0
+
+
+def test_database_export_returns_clear_error_when_file_missing(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    admin_id = create_test_user(username="admin-missing-export", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    missing_path = tmp_path / "missing-export.db"
+    monkeypatch.setattr(intake_app, "_resolved_runtime_db_path", lambda: missing_path)
+
+    response = client_with_temp_db.get("/admin/db/export")
+
+    assert response.status_code == 404
+    assert b"Database file not found." in response.data
 
 
 def test_system_health_renders_warning_when_assets_query_fails(

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -77,6 +77,9 @@ def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:
     )
     assert cleanup_response.status_code == 403
 
+    export_response = client_with_temp_db.get("/admin/db/export")
+    assert export_response.status_code == 403
+
 def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     create_user("admin", "admin-pass", "admin", True)
     _login(client_with_temp_db, "admin", "admin-pass")


### PR DESCRIPTION
## Summary
Add an admin-only database export so operators can download a backup of the live SQLite file.

## Related Issue
Closes #264 

## Changes
- added admin-only `/admin/db/export` route
- serves the current configured SQLite file as a download
- uses a timestamped backup filename
- added export control to the admin system page
- added focused tests for success, headers, missing file, and operator denial

## Verification checklist
- [x] Targeted tests pass
- [x] Admin can download database backup
- [x] Non-admin access is denied
- [x] Download uses attachment headers with timestamped filename
- [x] Downloaded file is non-zero and passes integrity check
- [x] No schema change introduced
- [x] Persistence behavior unchanged

## Notes
This is a direct read-only export of the live SQLite file. Hot-backup hardening, if needed later, should be handled as a separate feature.