### PR TITLE
Issue 25-1: fix case scan recognition

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -536,6 +536,14 @@ def _queue_redirect_target(return_to: str) -> str:
     return target
 
 
+def _return_to_path(return_to: str) -> str:
+    target = str(return_to or "").strip()
+    if not target.startswith("/") or target.startswith("//"):
+        return target
+    path, _, _ = target.partition("#")
+    return path
+
+
 def _holder_display_name(holder: Optional[dict]) -> str:
     if not holder:
         return ""
@@ -2221,6 +2229,7 @@ def intake():
         action = (request.form.get("action") or "").strip().lower()
         scan_text = (request.form.get("scan_text") or "").strip()
         return_to = (request.form.get("return_to") or "").strip()
+        return_to_path = _return_to_path(return_to)
         redirect_target = _queue_redirect_target(return_to)
         queue_index_raw = (request.form.get("queue_index") or "").strip()
         submitted_equipment_type = request.form.get("equipment_type")
@@ -2255,12 +2264,12 @@ def intake():
             slot_id_raw = (request.form.get("slot_id") or "").strip()
             home_slot_id: Optional[int] = None
             slot_position: Optional[int] = None
-            requires_inventory_validation = return_to in {"/issue", "/return"}
+            requires_inventory_validation = return_to_path in {"/issue", "/return"}
             if requires_inventory_validation or case_name or slot_id_raw:
                 conn = get_connection()
                 try:
                     case_match = None
-                    if return_to == "/issue":
+                    if return_to_path == "/issue":
                         try:
                             case_match = _find_case_assets_for_scan_tag(conn, value)
                         except ValueError as e:

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -70,9 +70,9 @@ def test_issue_case_scan_expands_expected_assets(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db, "operator-case-expand")
 
     conn = db.get_connection()
-    _insert_slot(conn, 10, "CASE-12", 1)
-    _insert_slot(conn, 11, "CASE-12", 2)
-    _insert_slot(conn, 12, "CASE-12", 3)
+    _insert_slot(conn, 10, "CASE-2", 1)
+    _insert_slot(conn, 11, "CASE-2", 2)
+    _insert_slot(conn, 12, "CASE-2", 3)
     _insert_asset(conn, 100, "CI-100", home_slot_id=10)
     _insert_asset(conn, 101, "CI-101", home_slot_id=11)
     _occupy_slot(conn, 10, 100)
@@ -82,14 +82,15 @@ def test_issue_case_scan_expands_expected_assets(client_with_temp_db) -> None:
 
     response = client_with_temp_db.post(
         "/",
-        data={"scan_text": "case-12", "return_to": "/issue"},
+        data={"scan_text": "case-2", "return_to": "/issue#queue-section"},
         follow_redirects=True,
     )
 
     assert response.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["CI100", "CI101"]
-    assert b"Case CASE-12 added 2 assets to queue." in response.data
+    assert b"Case CASE-2 added 2 assets to queue." in response.data
     assert b"Queue (2)" in response.data
+    assert b"CASE2" not in response.data
 
 
 def test_issue_case_scan_skips_already_queued_assets(client_with_temp_db) -> None:
@@ -109,7 +110,7 @@ def test_issue_case_scan_skips_already_queued_assets(client_with_temp_db) -> Non
 
     response = client_with_temp_db.post(
         "/",
-        data={"scan_text": "CASE20", "return_to": "/issue"},
+        data={"scan_text": "CASE20", "return_to": "/issue#queue-section"},
         follow_redirects=True,
     )
 
@@ -129,7 +130,7 @@ def test_issue_case_scan_reports_empty_case(client_with_temp_db) -> None:
 
     response = client_with_temp_db.post(
         "/",
-        data={"scan_text": "CASE-30", "return_to": "/issue"},
+        data={"scan_text": "CASE-30", "return_to": "/issue#queue-section"},
         follow_redirects=True,
     )
 
@@ -148,7 +149,7 @@ def test_issue_single_asset_scan_still_behaves_normally(client_with_temp_db) -> 
 
     response = client_with_temp_db.post(
         "/",
-        data={"scan_text": "single-300", "return_to": "/issue"},
+        data={"scan_text": "single-300", "return_to": "/issue#queue-section"},
         follow_redirects=True,
     )
 
@@ -172,7 +173,7 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
 
     scan_response = client_with_temp_db.post(
         "/",
-        data={"scan_text": "CASE-40", "return_to": "/issue"},
+        data={"scan_text": "CASE-40", "return_to": "/issue#queue-section"},
         follow_redirects=True,
     )
     assert scan_response.status_code == 200
@@ -214,3 +215,42 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
         ("CI-400", "IN_CUSTODY", 1),
         ("CI-401", "IN_CUSTODY", 1),
     ]
+
+
+def test_issue_case_scan_without_dash_also_expands_matching_case(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-case-no-dash")
+
+    conn = db.get_connection()
+    _insert_slot(conn, 50, "CASE-2", 1)
+    _insert_slot(conn, 51, "CASE-2", 2)
+    _insert_asset(conn, 500, "CI-500", home_slot_id=50)
+    _insert_asset(conn, 501, "CI-501", home_slot_id=51)
+    _occupy_slot(conn, 50, 500)
+    _occupy_slot(conn, 51, 501)
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "CASE2", "return_to": "/issue#queue-section"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["CI500", "CI501"]
+    assert b"Case CASE-2 added 2 assets to queue." in response.data
+
+
+def test_invalid_case_scan_does_not_enqueue_pseudo_asset(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-invalid-case")
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "CASE-404", "return_to": "/issue#queue-section"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"CASE404" not in response.data
+    assert b"Scan rejected. Asset tag not found in inventory." in response.data


### PR DESCRIPTION
Summary
Fix case scan recognition in intake when return_to includes fragment (e.g. /issue#queue-section).

Related Issue
Closes #272 

Changes
- Updated intake classification to evaluate return_to by path instead of exact string match
- Ensures case detection runs for Issue flow regardless of fragment
- Preserved normalization, queue behavior, preview, and commit logic
- Added regression tests for CASE-2 and CASE2 with fragment-based return_to

Verification checklist
- [ ] CASE-2 scan enqueues multiple assets
- [ ] CASE2 does not appear as pseudo asset
- [ ] Asset scan still works
- [ ] Preview and commit succeed
- [ ] Tests pass locally

Notes
Fix is localized to intake classification and does not affect schema, events, or persistence.