### PR TITLE
Issue 25-6: preserve holder on preview discard

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2682,6 +2682,7 @@ def preview_discard():
     # Enforce auth and inactivity timeout for discard requests.
     authed = enforce_inactivity_timeout()
     return_to = (request.form.get("return_to") or "").strip()
+    return_to_path = _return_to_path(return_to)
     if auth_enabled() and not authed:
         if wants_json():
             return {"ok": False, "discarded": 0, "error": "Locked"}, 401
@@ -2690,7 +2691,8 @@ def preview_discard():
 
     discarded = len(SCAN_QUEUE)
     SCAN_QUEUE.clear()
-    session.pop("holder_id", None)
+    if return_to_path != "/issue":
+        session.pop("holder_id", None)
 
     # Reset UI defaults back to laptop (same invariant as intake()).
     session["equipment_type"] = "laptop"

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -109,6 +109,179 @@ def test_operator_can_clear_queue_from_issue_preview_and_return_to_issue(client_
     assert b"Queued assets:</strong> 0" in response.data
 
 
+def test_issue_preview_discard_preserves_selected_holder_and_allows_rescan(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="admin-discard-issue", password="op-pass", role="admin")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO assets (id, asset_tag, location_type)
+        VALUES (1, 'TAG-RESCAN', 'STORAGE');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.extend([Scan.now("TAG-1"), Scan.now("TAG-2")])
+
+    response = client_with_temp_db.post(
+        "/preview/discard",
+        data={"return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"Issuing Assets" in response.data
+    assert b"Issued to:</strong>" in response.data
+    assert b"Issue Holder" in response.data
+    assert b"Queue (0)" in response.data
+    assert b"Queued assets:</strong> 0" in response.data
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess.get("holder_id") == 1
+
+    rescan = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "TAG-RESCAN", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert rescan.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["TAGRESCAN"]
+    assert b"Queue (1)" in rescan.data
+    assert b"Issued to:</strong>" in rescan.data
+    assert b"Issue Holder" in rescan.data
+
+
+def test_issue_preview_discard_preserves_holder_through_rescan_preview_and_commit(
+    client_with_temp_db,
+) -> None:
+    operator_id = create_test_user(username="admin-discard-commit", password="op-pass", role="admin")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (101, 'CASE-1', 1, 'VALID-ISSUE-TAG');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            id, asset_tag, serial_number, equipment_type, manufacturer, model,
+            location_type, current_holder_id, home_slot_id
+        )
+        VALUES (
+            101, 'VALID-ISSUE-TAG', 'SN-101', 'laptop', 'Dell', 'Latitude',
+            'STORAGE', NULL, 101
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (101, 101, '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+    intake_app.SCAN_QUEUE.extend([Scan.now("TAG-1"), Scan.now("TAG-2")])
+
+    discard = client_with_temp_db.post(
+        "/preview/discard",
+        data={"return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert discard.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"Issue Holder" in discard.data
+
+    rescan = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "VALID-ISSUE-TAG", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert rescan.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["VALIDISSUETAG"]
+    assert b"Issue Holder" in rescan.data
+
+    preview = client_with_temp_db.get("/issue/preview")
+    assert preview.status_code == 200
+    assert b"Ready to Issue" in preview.data
+    assert b"Issue Holder" in preview.data
+    assert b"VALID-ISSUE-TAG" in preview.data
+
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=True,
+    )
+
+    assert commit.status_code == 200
+    assert b"Issued 1 assets." in commit.data
+    assert b"Issue Holder" in commit.data
+    assert len(intake_app.SCAN_QUEUE) == 0
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess.get("holder_id") == 1
+
+    conn = db.get_connection()
+    try:
+        asset_row = conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE id = 101 LIMIT 1;"
+        ).fetchone()
+        occupancy = conn.execute(
+            "SELECT 1 FROM slot_occupancy WHERE asset_id = 101 LIMIT 1;"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert asset_row is not None
+    assert str(asset_row["location_type"]) == "IN_CUSTODY"
+    assert int(asset_row["current_holder_id"]) == 1
+    assert occupancy is None
+
+
+def test_non_issue_preview_discard_still_clears_holder_selection(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="admin-discard-general", password="op-pass", role="admin")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+        sess["equipment_type"] = "tablet"
+
+    intake_app.SCAN_QUEUE.append(Scan.now("TAG-1"))
+
+    response = client_with_temp_db.post(
+        "/preview/discard",
+        data={"return_to": "/add-assets"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/add-assets")
+    assert len(intake_app.SCAN_QUEUE) == 0
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert "holder_id" not in sess
+        assert sess.get("equipment_type") == "laptop"
+
+
 def test_issue_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_duplicate(
     client_with_temp_db,
 ) -> None:


### PR DESCRIPTION
Summary
Preserve the selected holder when discarding an Issue batch from preview.

Related Issue
Closes #277 

Changes
- Updated `preview_discard()` to preserve `holder_id` when returning to `/issue`
- Kept queue clearing behavior intact on discard
- Preserved broader reset behavior for non-Issue discard targets
- Added regressions for Issue discard/rescan flow and non-Issue discard behavior

Verification checklist
- [x] Issue preview discard clears queue
- [x] Issue preview discard preserves selected holder
- [x] Rescan works immediately after discard
- [x] Preview and commit still work after rescan
- [x] Non-Issue preview discard still clears holder and resets equipment type
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
Fix is narrowly scoped to preview discard behavior for Issue flow and does not change schema, events, auth, or main queue clear behavior.