### PR TITLE
Issue 25-2: add recent activity to dashboard

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from assettrack.audit import ACTIVE_EVENTS_WHERE
-from assettrack.event_types import issue_event_type_values
+from assettrack.event_types import issue_event_type_values, normalize_event_type
 from assettrack.drilldowns import list_case_summaries
 
 from datetime import datetime, timezone
@@ -36,6 +36,93 @@ def _parse_utc_timestamp(value: object) -> datetime | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def _holder_label(name: object, organization: object) -> str:
+    holder_name = str(name or "").strip()
+    holder_org = str(organization or "").strip()
+    if holder_name and holder_org and holder_org != holder_name:
+        return f"{holder_name} ({holder_org})"
+    if holder_name:
+        return holder_name
+    if holder_org:
+        return holder_org
+    return ""
+
+
+def _event_type_label(raw_event_type: object) -> str:
+    normalized = normalize_event_type(raw_event_type)
+    label_map = {
+        "ISSUE": "Issued",
+        "RETURN": "Returned",
+        "ASSET_CREATED": "Asset created",
+        "ASSET_UPDATED": "Asset updated",
+        "SLOT_ASSIGN": "Slot assigned",
+        "ASSET_RETIRED": "Asset retired",
+        "ASSET_RETIRED_IN_FIELD": "Retired in field",
+    }
+    if normalized in label_map:
+        return label_map[normalized]
+    if not normalized:
+        return "Unknown"
+    return normalized.replace("_", " ").title()
+
+
+def get_recent_activity(conn: sqlite3.Connection, limit: int = 10) -> list[dict]:
+    active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
+    rows = conn.execute(
+        f"""
+        SELECT
+            e.id,
+            e.asset_tag,
+            e.event_type,
+            e.event_date,
+            e.holder_id,
+            h.name AS holder_name,
+            h.organization AS holder_organization
+        FROM asset_events e
+        LEFT JOIN holders h
+          ON h.id = e.holder_id
+        WHERE {active_events_where}
+        ORDER BY e.id DESC
+        LIMIT ?;
+        """,
+        (limit,),
+    ).fetchall()
+
+    activity: list[dict] = []
+    for row in rows:
+        parsed = _parse_utc_timestamp(row["event_date"])
+        if parsed is None:
+            timestamp_display = str(row["event_date"] or "")
+        else:
+            timestamp_display = parsed.strftime("%Y-%m-%d %H:%M UTC")
+
+        activity.append(
+            {
+                "id": int(row["id"]),
+                "event_type": normalize_event_type(row["event_type"]),
+                "event_label": _event_type_label(row["event_type"]),
+                "asset_tag": str(row["asset_tag"] or ""),
+                "holder_label": _holder_label(row["holder_name"], row["holder_organization"]),
+                "event_date": str(row["event_date"] or ""),
+                "event_timestamp_display": timestamp_display,
+                "_sort_ts": parsed,
+            }
+        )
+
+    activity.sort(
+        key=lambda row: (
+            row["_sort_ts"] is not None,
+            row["_sort_ts"] or datetime.min.replace(tzinfo=timezone.utc),
+            row["id"],
+        ),
+        reverse=True,
+    )
+
+    for row in activity:
+        row.pop("_sort_ts", None)
+    return activity
 
 
 def _inventory_summary(conn: sqlite3.Connection) -> dict:
@@ -328,6 +415,7 @@ def build_dashboard_data(
         "snapshots": {
             "top_custody_holders": _top_custody_holders(conn, limit=5),
             "case_utilization": list_case_summaries(conn),
+            "recent_activity": get_recent_activity(conn, limit=10),
             "exceptions": {
                 "unslotted_assets": _unslotted_assets(conn, limit=10),
                 "in_custody_over_threshold": [

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -246,6 +246,48 @@
 
   <details class="collapsible">
     <summary>
+      <span>Recent Activity</span>
+      <span class="summary-hint">
+        {% if dashboard.snapshots.recent_activity %}
+          {{ dashboard.snapshots.recent_activity|length }} latest event{% if dashboard.snapshots.recent_activity|length != 1 %}s{% endif %}
+        {% else %}
+          No recent activity
+        {% endif %}
+      </span>
+    </summary>
+    <div class="collapsible-body">
+      <div class="accent"></div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>What happened</th>
+              <th>Asset</th>
+              <th>Holder</th>
+              <th>When</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in dashboard.snapshots.recent_activity %}
+              <tr>
+                <td>{{ row.event_label }}</td>
+                <td><code>{{ row.asset_tag }}</code></td>
+                <td>{{ row.holder_label or "—" }}</td>
+                <td>{{ row.event_timestamp_display }}</td>
+              </tr>
+            {% else %}
+              <tr>
+                <td colspan="4">No recent activity.</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details class="collapsible">
+    <summary>
       <span>Problems</span>
       <span class="summary-hint">
         {{ dashboard.summary.exceptions.unslotted_assets }} unslotted, {{ dashboard.summary.exceptions.in_custody_over_threshold }} over {{ custody_days_threshold }} days, {{ dashboard.summary.exceptions.slot_conflicts }} conflicts

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -117,6 +117,35 @@ class DashboardTests(unittest.TestCase):
             (asset_tag, event_type, event_date),
         )
 
+    def _insert_event(
+        self,
+        asset_tag: str,
+        event_type: str,
+        event_date: str,
+        *,
+        holder_id: int | None = None,
+        supersedes_event_id: int | None = None,
+        correction_reason: str | None = None,
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO asset_events (
+                asset_tag,
+                event_type,
+                event_date,
+                actor,
+                notes,
+                payload,
+                holder_id,
+                supersedes_event_id,
+                correction_reason
+            )
+            VALUES (?, ?, ?, 'tester', NULL, NULL, ?, ?, ?);
+            """,
+            (asset_tag, event_type, event_date, holder_id, supersedes_event_id, correction_reason),
+        )
+        return int(cursor.lastrowid)
+
     def _replace_slot_occupancy_without_unique_constraints(self) -> None:
         self.conn.execute("DROP TABLE slot_occupancy;")
         self.conn.execute(
@@ -157,6 +186,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Exceptions Summary", response.data)
         self.assertIn(b"Outstanding Holders Summary", response.data)
         self.assertIn(b"Available Space by Case", response.data)
+        self.assertIn(b"Recent Activity", response.data)
         self.assertIn(b"Problems", response.data)
         self.assertIn(b"1 holders, 1 assets out", response.data)
         self.assertIn(b"Based on open slots. No open slots available.", response.data)
@@ -165,6 +195,8 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"FULL", response.data)
         self.assertNotIn(b"0 / 1", response.data)
         self.assertIn(b"AT-UNSLOT", response.data)
+        self.assertIn(b"Issued", response.data)
+        self.assertIn(b"AT-CUST", response.data)
 
     def test_dashboard_empty_states_are_operator_facing(self) -> None:
         response = self.client.get("/dashboard")
@@ -173,6 +205,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"0 holders, 0 assets out", response.data)
         self.assertIn(b"No holders currently have assets out.", response.data)
         self.assertIn(b"Based on open slots. No case slot data is available.", response.data)
+        self.assertIn(b"No recent activity.", response.data)
         self.assertIn(b"0 unslotted, 0 over 30 days, 0 conflicts", response.data)
         self.assertIn(b"No unslotted assets.", response.data)
         self.assertIn(b"No overdue in-custody assets.", response.data)
@@ -364,3 +397,44 @@ class DashboardTests(unittest.TestCase):
         resp = self.client.get("/", follow_redirects=False)
         self.assertEqual(resp.status_code, 302)
         self.assertTrue((resp.headers.get("Location") or "").endswith("/dashboard"))
+
+    def test_recent_activity_renders_newest_events_first_with_holder_and_return_fallback(self) -> None:
+        self._insert_holder(1, "Alpha Holder")
+        self._insert_event("AT-1", "ISSUE", "2026-01-01T10:00:00Z", holder_id=1)
+        self._insert_event("AT-2", "RETURN", "2026-01-01T11:00:00Z")
+        self._insert_event("AT-3", "ASSET_CREATED", "2026-01-01T12:00:00Z")
+        self.conn.commit()
+
+        response = self.client.get("/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Recent Activity", response.data)
+        self.assertIn(b"Asset created", response.data)
+        self.assertIn(b"Returned", response.data)
+        self.assertIn(b"Issued", response.data)
+        self.assertIn(b"Alpha Holder", response.data)
+        self.assertIn(b"\xe2\x80\x94", response.data)
+        self.assertIn(b"2026-01-01 12:00 UTC", response.data)
+
+        created_index = response.data.index(b"Asset created")
+        returned_index = response.data.index(b"Returned")
+        issued_index = response.data.index(b"Issued")
+        self.assertLess(created_index, returned_index)
+        self.assertLess(returned_index, issued_index)
+
+    def test_recent_activity_excludes_superseded_events(self) -> None:
+        original_id = self._insert_event("AT-1", "ISSUE", "2026-01-01T10:00:00Z")
+        self._insert_event(
+            "AT-1",
+            "RETURN",
+            "2026-01-01T11:00:00Z",
+            supersedes_event_id=original_id,
+            correction_reason="Correction",
+        )
+        self.conn.commit()
+
+        data = build_dashboard_data(self.conn, custody_days_threshold=30)
+
+        self.assertEqual(len(data["snapshots"]["recent_activity"]), 1)
+        self.assertEqual(data["snapshots"]["recent_activity"][0]["event_type"], "RETURN")
+        self.assertEqual(data["snapshots"]["recent_activity"][0]["asset_tag"], "AT-1")


### PR DESCRIPTION
Summary
Add a Recent Activity section to the dashboard showing the latest asset events.

Related Issue
Closes #273 

Changes
- Added bounded recent-activity query using asset_events with ACTIVE_EVENTS_WHERE
- Joined holder data for readable display
- Normalized event labels (Issued, Returned, etc.)
- Rendered Recent Activity snapshot in dashboard template
- Added tests for ordering, empty state, holder display, and superseded filtering

Verification checklist
- [x] Recent Activity section renders
- [x] Shows newest events first
- [x] Superseded events excluded
- [x] Holder shown for issue events
- [x] Return events show correct fallback
- [x] Empty state renders correctly
- [x] Tests pass locally
- [x] Manual smoke test passed

Notes
Read-only dashboard projection. No schema, event, auth, or workflow changes.