### PR TITLE
Issue 25-3: show holder in asset search

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -582,8 +582,15 @@ def _lookup_asset_for_verification(
     if lookup_mode == "asset_tag":
         rows = conn.execute(
             """
-            SELECT *
-            FROM assets
+            SELECT
+                a.*,
+                h.id AS holder_record_id,
+                h.holder_type AS holder_record_type,
+                h.name AS holder_record_name,
+                h.organization AS holder_record_organization
+            FROM assets a
+            LEFT JOIN holders h
+              ON h.id = a.current_holder_id
             WHERE UPPER(asset_tag) = UPPER(?)
             LIMIT 1;
             """,
@@ -595,8 +602,15 @@ def _lookup_asset_for_verification(
     else:
         rows = conn.execute(
             """
-            SELECT *
-            FROM assets
+            SELECT
+                a.*,
+                h.id AS holder_record_id,
+                h.holder_type AS holder_record_type,
+                h.name AS holder_record_name,
+                h.organization AS holder_record_organization
+            FROM assets a
+            LEFT JOIN holders h
+              ON h.id = a.current_holder_id
             WHERE TRIM(COALESCE(serial_number, '')) <> ''
               AND UPPER(serial_number) = UPPER(?)
             LIMIT 2;
@@ -610,6 +624,22 @@ def _lookup_asset_for_verification(
         asset = dict(rows[0])
 
     home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))
+    holder_row = None
+    if asset.get("holder_record_id") is not None:
+        holder_row = {
+            "id": int(asset["holder_record_id"]),
+            "holder_type": str(asset.get("holder_record_type") or ""),
+            "name": str(asset.get("holder_record_name") or ""),
+            "organization": str(asset.get("holder_record_organization") or ""),
+        }
+    holder_label = ""
+    if holder_row is not None:
+        holder_name = str(holder_row.get("name") or "").strip()
+        holder_org = str(holder_row.get("organization") or "").strip()
+        if holder_name and holder_org and holder_org != holder_name:
+            holder_label = f"{holder_name} ({holder_org})"
+        else:
+            holder_label = _holder_display_name(holder_row)
 
     return (
         {
@@ -618,6 +648,7 @@ def _lookup_asset_for_verification(
             "serial_number": str(asset.get("serial_number") or ""),
             "location_type": _normalize_location_type(asset.get("location_type")),
             "state_label": _asset_state_label(asset.get("location_type")),
+            "holder_label": holder_label,
             "home_case_name": "" if home_slot is None else str(home_slot.get("case_name") or ""),
             "home_slot_position": None if home_slot is None else int(home_slot["slot_position"]),
         },

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -58,6 +58,10 @@
           {{ asset.state_label }}
         </div>
         <div class="row">
+          <strong>Current holder</strong><br />
+          {{ asset.holder_label or "Not assigned" }}
+        </div>
+        <div class="row">
           <strong>Home case</strong><br />
           {{ asset.home_case_name or "Not assigned" }}
         </div>

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -23,6 +23,16 @@ class AssetSearchUiTests(unittest.TestCase):
         self.conn.close()
         self.temp_dir.cleanup()
 
+    def _insert_holder(self, holder_id: int, name: str, organization: str | None = None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+            VALUES (?, 'PERSON', ?, ?, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (holder_id, name, organization),
+        )
+        self.conn.commit()
+
     def _insert_slot(self, slot_id: int, case_name: str, slot_position: int) -> None:
         self.conn.execute(
             """
@@ -40,6 +50,7 @@ class AssetSearchUiTests(unittest.TestCase):
         serial_number: str,
         location_type: str,
         home_slot_id: int | None,
+        current_holder_id: int | None = None,
     ) -> None:
         self.conn.execute(
             """
@@ -60,9 +71,9 @@ class AssetSearchUiTests(unittest.TestCase):
                 current_holder_id,
                 home_slot_id
             )
-            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '100', 'HQ/100', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, NULL, ?);
+            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '100', 'HQ/100', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?);
             """,
-            (asset_tag, serial_number, location_type, home_slot_id),
+            (asset_tag, serial_number, location_type, current_holder_id, home_slot_id),
         )
         self.conn.commit()
 
@@ -73,8 +84,9 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Search by asset tag or serial number", response.data)
 
     def test_search_finds_asset_by_asset_tag(self) -> None:
+        self._insert_holder(1, "Alex Holder", "Field Ops")
         self._insert_slot(10, "CASE-A", 4)
-        self._insert_asset("AT-100", serial_number="SER-100", location_type="STORAGE", home_slot_id=10)
+        self._insert_asset("AT-100", serial_number="SER-100", location_type="STORAGE", home_slot_id=10, current_holder_id=1)
 
         response = self.client.get("/assets/search?asset_tag=AT-100")
         self.assertEqual(response.status_code, 200)
@@ -83,6 +95,7 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"AT-100", response.data)
         self.assertIn(b"SER-100", response.data)
         self.assertIn(b"In storage", response.data)
+        self.assertIn(b"Alex Holder (Field Ops)", response.data)
         self.assertIn(b"CASE-A", response.data)
         self.assertIn(b"Slot 4", response.data)
 
@@ -96,6 +109,8 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"AT-200", response.data)
         self.assertIn(b"SER-200", response.data)
         self.assertIn(b"In custody", response.data)
+        self.assertIn(b"Current holder", response.data)
+        self.assertIn(b"Not assigned", response.data)
         self.assertIn(b"Not assigned", response.data)
 
     def test_search_shows_plain_not_found_feedback(self) -> None:


### PR DESCRIPTION
Summary
Show the current holder in asset search results.

Related Issue
Closes #274 

Changes
- Joined holders from `assets.current_holder_id` in the asset search lookup
- Added Current holder display to the asset search UI
- Added fallback for unassigned assets
- Added targeted tests for assigned, unassigned, and existing search behavior

Verification checklist
- [x] Assigned asset shows holder
- [x] Unassigned asset shows fallback
- [x] Asset-tag search still works
- [x] Serial-number search still works
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
Read-only projection change only. No schema, event, auth, or search-semantics change.