### PR TITLE
Issue 25-4: support partial asset search

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -570,14 +570,16 @@ def _lookup_asset_for_verification(
     *,
     asset_tag: str,
     serial_number: str,
-) -> tuple[Optional[dict], Optional[str], str]:
+) -> tuple[list[dict], Optional[str], str]:
     asset_tag_clean = str(asset_tag or "").strip().upper()
     serial_clean = str(serial_number or "").strip()
 
     if not asset_tag_clean and not serial_clean:
-        return None, "Enter an asset tag or serial number.", "none"
+        return [], "Enter an asset tag or serial number.", "none"
 
     lookup_mode = "asset_tag" if asset_tag_clean else "serial_number"
+    query_value = asset_tag_clean if lookup_mode == "asset_tag" else serial_clean
+    like_pattern = f"%{query_value}%"
 
     if lookup_mode == "asset_tag":
         rows = conn.execute(
@@ -591,14 +593,17 @@ def _lookup_asset_for_verification(
             FROM assets a
             LEFT JOIN holders h
               ON h.id = a.current_holder_id
-            WHERE UPPER(asset_tag) = UPPER(?)
-            LIMIT 1;
+            WHERE UPPER(a.asset_tag) LIKE UPPER(?)
+            ORDER BY
+                CASE WHEN UPPER(a.asset_tag) = UPPER(?) THEN 0 ELSE 1 END,
+                UPPER(a.asset_tag) ASC,
+                a.id ASC
+            LIMIT 25;
             """,
-            (asset_tag_clean,),
+            (like_pattern, asset_tag_clean),
         ).fetchall()
         if not rows:
-            return None, "Asset not found.", lookup_mode
-        asset = dict(rows[0])
+            return [], "Asset not found.", lookup_mode
     else:
         rows = conn.execute(
             """
@@ -612,49 +617,54 @@ def _lookup_asset_for_verification(
             LEFT JOIN holders h
               ON h.id = a.current_holder_id
             WHERE TRIM(COALESCE(serial_number, '')) <> ''
-              AND UPPER(serial_number) = UPPER(?)
-            LIMIT 2;
+              AND UPPER(a.serial_number) LIKE UPPER(?)
+            ORDER BY
+                CASE WHEN UPPER(a.serial_number) = UPPER(?) THEN 0 ELSE 1 END,
+                UPPER(a.serial_number) ASC,
+                UPPER(a.asset_tag) ASC,
+                a.id ASC
+            LIMIT 25;
             """,
-            (serial_clean,),
+            (like_pattern, serial_clean),
         ).fetchall()
         if not rows:
-            return None, "Asset not found.", lookup_mode
-        if len(rows) > 1:
-            return None, "More than one asset uses that serial number. Search by asset tag.", lookup_mode
-        asset = dict(rows[0])
+            return [], "Asset not found.", lookup_mode
 
-    home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))
-    holder_row = None
-    if asset.get("holder_record_id") is not None:
-        holder_row = {
-            "id": int(asset["holder_record_id"]),
-            "holder_type": str(asset.get("holder_record_type") or ""),
-            "name": str(asset.get("holder_record_name") or ""),
-            "organization": str(asset.get("holder_record_organization") or ""),
-        }
-    holder_label = ""
-    if holder_row is not None:
-        holder_name = str(holder_row.get("name") or "").strip()
-        holder_org = str(holder_row.get("organization") or "").strip()
-        if holder_name and holder_org and holder_org != holder_name:
-            holder_label = f"{holder_name} ({holder_org})"
-        else:
-            holder_label = _holder_display_name(holder_row)
+    results: list[dict] = []
+    for raw_row in rows:
+        asset = dict(raw_row)
+        home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))
+        holder_row = None
+        if asset.get("holder_record_id") is not None:
+            holder_row = {
+                "id": int(asset["holder_record_id"]),
+                "holder_type": str(asset.get("holder_record_type") or ""),
+                "name": str(asset.get("holder_record_name") or ""),
+                "organization": str(asset.get("holder_record_organization") or ""),
+            }
+        holder_label = ""
+        if holder_row is not None:
+            holder_name = str(holder_row.get("name") or "").strip()
+            holder_org = str(holder_row.get("organization") or "").strip()
+            if holder_name and holder_org and holder_org != holder_name:
+                holder_label = f"{holder_name} ({holder_org})"
+            else:
+                holder_label = _holder_display_name(holder_row)
 
-    return (
-        {
-            "id": int(asset["id"]),
-            "asset_tag": str(asset.get("asset_tag") or ""),
-            "serial_number": str(asset.get("serial_number") or ""),
-            "location_type": _normalize_location_type(asset.get("location_type")),
-            "state_label": _asset_state_label(asset.get("location_type")),
-            "holder_label": holder_label,
-            "home_case_name": "" if home_slot is None else str(home_slot.get("case_name") or ""),
-            "home_slot_position": None if home_slot is None else int(home_slot["slot_position"]),
-        },
-        None,
-        lookup_mode,
-    )
+        results.append(
+            {
+                "id": int(asset["id"]),
+                "asset_tag": str(asset.get("asset_tag") or ""),
+                "serial_number": str(asset.get("serial_number") or ""),
+                "location_type": _normalize_location_type(asset.get("location_type")),
+                "state_label": _asset_state_label(asset.get("location_type")),
+                "holder_label": holder_label,
+                "home_case_name": "" if home_slot is None else str(home_slot.get("case_name") or ""),
+                "home_slot_position": None if home_slot is None else int(home_slot["slot_position"]),
+            }
+        )
+
+    return (results, None, lookup_mode)
 
 
 def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
@@ -2626,14 +2636,14 @@ def asset_search():
         "asset_tag": (request.args.get("asset_tag") or "").strip().upper(),
         "serial_number": (request.args.get("serial_number") or "").strip(),
     }
-    asset = None
+    assets: list[dict] = []
     error_message: Optional[str] = None
     lookup_mode = "none"
 
     if form_state["asset_tag"] or form_state["serial_number"]:
         conn = get_connection()
         try:
-            asset, error_message, lookup_mode = _lookup_asset_for_verification(
+            assets, error_message, lookup_mode = _lookup_asset_for_verification(
                 conn,
                 asset_tag=form_state["asset_tag"],
                 serial_number=form_state["serial_number"],
@@ -2644,7 +2654,7 @@ def asset_search():
     return render_template(
         "asset_search.html",
         form=form_state,
-        asset=asset,
+        assets=assets,
         error_message=error_message,
         lookup_mode=lookup_mode,
     )

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -8,6 +8,7 @@
     .search-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    .results-table code { white-space: nowrap; }
   </style>
 {% endblock %}
 
@@ -34,46 +35,49 @@
     </form>
   </div>
 
-  {% if asset %}
+  {% if assets %}
     <div class="card">
-      <h2>Asset Found</h2>
+      <h2>{% if assets|length == 1 %}Asset Found{% else %}Assets Found{% endif %}</h2>
       <p class="muted">
         {% if lookup_mode == "asset_tag" %}
           Matched by asset tag.
         {% elif lookup_mode == "serial_number" %}
           Matched by serial number.
         {% endif %}
+        {% if assets|length != 1 %}
+          {{ assets|length }} matches shown.
+        {% endif %}
       </p>
-      <div class="result-grid">
-        <div class="row">
-          <strong>Asset tag</strong><br />
-          {{ asset.asset_tag or "" }}
-        </div>
-        <div class="row">
-          <strong>Serial number</strong><br />
-          {{ asset.serial_number or "Not recorded" }}
-        </div>
-        <div class="row">
-          <strong>Current state</strong><br />
-          {{ asset.state_label }}
-        </div>
-        <div class="row">
-          <strong>Current holder</strong><br />
-          {{ asset.holder_label or "Not assigned" }}
-        </div>
-        <div class="row">
-          <strong>Home case</strong><br />
-          {{ asset.home_case_name or "Not assigned" }}
-        </div>
-        <div class="row">
-          <strong>Home slot</strong><br />
-          {% if asset.home_slot_position is not none %}
-            Slot {{ asset.home_slot_position }}
-          {% else %}
-            Not assigned
-          {% endif %}
-        </div>
-      </div>
+      <table class="results-table">
+        <thead>
+          <tr>
+            <th>Asset tag</th>
+            <th>Serial number</th>
+            <th>Current state</th>
+            <th>Current holder</th>
+            <th>Home case</th>
+            <th>Home slot</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for asset in assets %}
+            <tr>
+              <td><code>{{ asset.asset_tag or "" }}</code></td>
+              <td>{{ asset.serial_number or "Not recorded" }}</td>
+              <td>{{ asset.state_label }}</td>
+              <td>{{ asset.holder_label or "Not assigned" }}</td>
+              <td>{{ asset.home_case_name or "Not assigned" }}</td>
+              <td>
+                {% if asset.home_slot_position is not none %}
+                  Slot {{ asset.home_slot_position }}
+                {% else %}
+                  Not assigned
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -113,6 +113,36 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Not assigned", response.data)
         self.assertIn(b"Not assigned", response.data)
 
+    def test_partial_asset_tag_search_returns_matching_assets(self) -> None:
+        self._insert_holder(1, "Alex Holder", "Field Ops")
+        self._insert_asset("AT-100", serial_number="SER-100", location_type="IN_CUSTODY", home_slot_id=None, current_holder_id=1)
+        self._insert_asset("AT-101", serial_number="SER-101", location_type="STORAGE", home_slot_id=None)
+        self._insert_asset("BX-200", serial_number="SER-200", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=AT-10")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Assets Found", response.data)
+        self.assertIn(b"2 matches shown.", response.data)
+        self.assertIn(b"AT-100", response.data)
+        self.assertIn(b"AT-101", response.data)
+        self.assertNotIn(b"BX-200", response.data)
+        self.assertIn(b"Alex Holder (Field Ops)", response.data)
+
+    def test_partial_serial_search_returns_matching_assets(self) -> None:
+        self._insert_asset("AT-200", serial_number="SER-200", location_type="IN_CUSTODY", home_slot_id=None)
+        self._insert_asset("AT-201", serial_number="SER-201", location_type="STORAGE", home_slot_id=None)
+        self._insert_asset("AT-999", serial_number="XYZ-999", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?serial_number=SER-20")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Assets Found", response.data)
+        self.assertIn(b"2 matches shown.", response.data)
+        self.assertIn(b"AT-200", response.data)
+        self.assertIn(b"AT-201", response.data)
+        self.assertNotIn(b"AT-999", response.data)
+
     def test_search_shows_plain_not_found_feedback(self) -> None:
         response = self.client.get("/assets/search?asset_tag=AT-MISSING")
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Summary
Support partial asset tag and serial number search.

Related Issue
Closes #275 

Changes
- Extended asset search from exact-only to bounded partial matching for asset tag and serial number
- Kept current holder join and current state fields in results
- Ordered exact matches first
- Updated search UI to render single or multiple results
- Added targeted tests for partial, exact, holder, and no-results behavior

Verification checklist
- [x] Partial asset tag search returns expected matches
- [x] Partial serial search returns expected matches
- [x] Exact search still works
- [x] Holder display still works
- [x] No-results case still works
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
Read-only search projection change only. No schema, event, auth, or workflow changes.