### PR TITLE
Issue 25-5: remove preview nav chip

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -124,7 +124,6 @@
           <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
           <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
           <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
-          <a class="chip {% if request.path.startswith('/preview') and not request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('preview') }}">Preview</a>
           {% if authenticated_role == 'admin' %}
             <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
             <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">System Health</a>

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -94,6 +94,20 @@ def test_asset_search_requires_login(client_with_temp_db) -> None:
     assert response.status_code == 403
 
 
+def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(client_with_temp_db) -> None:
+    create_user("operator", "op-pass", "operator", True)
+    _login(client_with_temp_db, "operator", "op-pass")
+
+    dashboard_response = client_with_temp_db.get("/dashboard")
+    assert dashboard_response.status_code == 200
+    assert b">Preview</a>" not in dashboard_response.data
+    assert b">Issue</a>" in dashboard_response.data
+    assert b">Return</a>" in dashboard_response.data
+
+    preview_response = client_with_temp_db.get("/preview")
+    assert preview_response.status_code == 200
+
+
 def test_bootstrap_only_when_empty(client_with_temp_db) -> None:
     bootstrap_get = client_with_temp_db.get("/bootstrap/admin")
     assert bootstrap_get.status_code == 200


### PR DESCRIPTION
Summary
Remove the top-level Preview chip from main navigation.

Related Issue
Closes #276 

Changes
- Removed Preview from shared primary nav
- Kept Issue and Return workflow preview buttons unchanged
- Preserved direct /preview route behavior
- Added regression coverage for nav and direct preview access

Verification checklist
- [x] Preview no longer appears in main nav
- [x] Issue flow still reaches preview
- [x] Return flow still reaches preview
- [x] Direct /preview still loads
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
UI-only change. No schema, event, auth, redirect, or workflow logic changes.