### PR TITLE
Issue 25-7: enable holder drilldown from dashboard

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -197,6 +197,7 @@ def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
         """
         SELECT
             a.current_holder_id AS holder_id,
+            h.id AS holder_detail_id,
             COALESCE(NULLIF(TRIM(h.name), ''), 'ID ' || a.current_holder_id) AS holder_name,
             COUNT(*) AS asset_count
         FROM assets a
@@ -204,7 +205,7 @@ def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
           ON h.id = a.current_holder_id
         WHERE a.location_type = 'IN_CUSTODY'
           AND a.current_holder_id IS NOT NULL
-        GROUP BY a.current_holder_id, COALESCE(NULLIF(TRIM(h.name), ''), 'ID ' || a.current_holder_id)
+        GROUP BY a.current_holder_id, h.id, COALESCE(NULLIF(TRIM(h.name), ''), 'ID ' || a.current_holder_id)
         ORDER BY asset_count DESC, holder_name ASC, a.current_holder_id ASC
         LIMIT ?;
         """,
@@ -214,6 +215,7 @@ def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
     return [
         {
             "holder_id": int(row["holder_id"]),
+            "holder_detail_id": None if row["holder_detail_id"] is None else int(row["holder_detail_id"]),
             "holder_name": str(row["holder_name"]),
             "asset_count": int(row["asset_count"] or 0),
         }

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -129,7 +129,14 @@
       <p class="metric">
         Top Holder:
         {% if dashboard.summary.custody.top_holder %}
-          <strong>{{ dashboard.summary.custody.top_holder.holder_name }} ({{ dashboard.summary.custody.top_holder.asset_count }})</strong>
+          <strong>
+            {% if dashboard.summary.custody.top_holder.holder_detail_id %}
+              <a href="{{ url_for('holder_detail', holder_id=dashboard.summary.custody.top_holder.holder_detail_id) }}">{{ dashboard.summary.custody.top_holder.holder_name }}</a>
+            {% else %}
+              {{ dashboard.summary.custody.top_holder.holder_name }}
+            {% endif %}
+            ({{ dashboard.summary.custody.top_holder.asset_count }})
+          </strong>
         {% else %}
           <strong>None</strong>
         {% endif %}
@@ -172,7 +179,13 @@
           <tbody>
             {% for row in dashboard.snapshots.top_custody_holders %}
               <tr>
-                <td>{{ row.holder_name }}</td>
+                <td>
+                  {% if row.holder_detail_id %}
+                    <a href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                  {% else %}
+                    {{ row.holder_name }}
+                  {% endif %}
+                </td>
                 <td>{{ row.asset_count }}</td>
               </tr>
             {% else %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -197,6 +197,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"AT-UNSLOT", response.data)
         self.assertIn(b"Issued", response.data)
         self.assertIn(b"AT-CUST", response.data)
+        self.assertIn(b'href="/holders/1"', response.data)
 
     def test_dashboard_empty_states_are_operator_facing(self) -> None:
         response = self.client.get("/dashboard")
@@ -397,6 +398,32 @@ class DashboardTests(unittest.TestCase):
         resp = self.client.get("/", follow_redirects=False)
         self.assertEqual(resp.status_code, 302)
         self.assertTrue((resp.headers.get("Location") or "").endswith("/dashboard"))
+
+    def test_dashboard_holder_name_links_to_existing_holder_detail_page(self) -> None:
+        self._insert_holder(1, "Alex Holder")
+        self._insert_asset("AT-CUST-1", location_type="IN_CUSTODY", current_holder_id=1)
+        self.conn.commit()
+
+        dashboard_response = self.client.get("/dashboard")
+
+        self.assertEqual(dashboard_response.status_code, 200)
+        self.assertIn(b'href="/holders/1"', dashboard_response.data)
+        self.assertIn(b"Alex Holder", dashboard_response.data)
+
+        holder_detail = self.client.get("/holders/1")
+        self.assertEqual(holder_detail.status_code, 200)
+        self.assertIn(b"Alex Holder", holder_detail.data)
+        self.assertIn(b"AT-CUST-1", holder_detail.data)
+
+    def test_dashboard_holder_name_falls_back_to_plain_text_when_holder_detail_missing(self) -> None:
+        self._insert_asset("AT-CUST-PLAIN", location_type="IN_CUSTODY", current_holder_id=77)
+        self.conn.commit()
+
+        dashboard_response = self.client.get("/dashboard")
+
+        self.assertEqual(dashboard_response.status_code, 200)
+        self.assertIn(b"ID 77", dashboard_response.data)
+        self.assertNotIn(b'href="/holders/77"', dashboard_response.data)
 
     def test_recent_activity_renders_newest_events_first_with_holder_and_return_fallback(self) -> None:
         self._insert_holder(1, "Alpha Holder")


### PR DESCRIPTION
Summary
Make dashboard holder names clickable to drill into holder detail.

Related Issue
Closes #278 

Changes
- Linked holder names on dashboard to `/holders/<id>`
- Added nullable holder id in dashboard projection for safe linking
- Kept plain text fallback when holder record not present
- Added tests for link rendering, fallback, and drilldown behavior

Verification checklist
- [x] Holder names render as links when valid
- [x] Links navigate to holder detail page
- [x] Assigned assets visible on holder page
- [x] Missing holder rows render as plain text
- [x] Dashboard still renders correctly
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
UI-only enhancement using existing routes and data. No schema, event, auth, or workflow changes.