### PR TITLE
Issue 25-8: refine recent activity labels

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -53,12 +53,12 @@ def _holder_label(name: object, organization: object) -> str:
 def _event_type_label(raw_event_type: object) -> str:
     normalized = normalize_event_type(raw_event_type)
     label_map = {
-        "ISSUE": "Issued",
-        "RETURN": "Returned",
-        "ASSET_CREATED": "Asset created",
-        "ASSET_UPDATED": "Asset updated",
-        "SLOT_ASSIGN": "Slot assigned",
-        "ASSET_RETIRED": "Asset retired",
+        "ISSUE": "Issued to",
+        "RETURN": "Returned to storage",
+        "ASSET_CREATED": "Added",
+        "ASSET_UPDATED": "Updated",
+        "SLOT_ASSIGN": "Assigned to slot",
+        "ASSET_RETIRED": "Retired",
         "ASSET_RETIRED_IN_FIELD": "Retired in field",
     }
     if normalized in label_map:

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -274,10 +274,10 @@
         <table>
           <thead>
             <tr>
-              <th>What happened</th>
+              <th>Action</th>
               <th>Asset</th>
               <th>Holder</th>
-              <th>When</th>
+              <th>When (UTC)</th>
             </tr>
           </thead>
           <tbody>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -195,7 +195,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"FULL", response.data)
         self.assertNotIn(b"0 / 1", response.data)
         self.assertIn(b"AT-UNSLOT", response.data)
-        self.assertIn(b"Issued", response.data)
+        self.assertIn(b"Issued to", response.data)
         self.assertIn(b"AT-CUST", response.data)
         self.assertIn(b'href="/holders/1"', response.data)
 
@@ -436,16 +436,17 @@ class DashboardTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Recent Activity", response.data)
-        self.assertIn(b"Asset created", response.data)
-        self.assertIn(b"Returned", response.data)
-        self.assertIn(b"Issued", response.data)
+        self.assertIn(b"Added", response.data)
+        self.assertIn(b"Returned to storage", response.data)
+        self.assertIn(b"Issued to", response.data)
         self.assertIn(b"Alpha Holder", response.data)
         self.assertIn(b"\xe2\x80\x94", response.data)
         self.assertIn(b"2026-01-01 12:00 UTC", response.data)
+        self.assertIn(b"When (UTC)", response.data)
 
-        created_index = response.data.index(b"Asset created")
-        returned_index = response.data.index(b"Returned")
-        issued_index = response.data.index(b"Issued")
+        created_index = response.data.index(b"Added")
+        returned_index = response.data.index(b"Returned to storage")
+        issued_index = response.data.index(b"Issued to")
         self.assertLess(created_index, returned_index)
         self.assertLess(returned_index, issued_index)
 


### PR DESCRIPTION
Summary
Improve readability of Recent Activity labels and headers.

Related Issue
Closes #25-8

Changes
- Updated action labels to plain-language (Issued to, Returned to storage, Added, etc.)
- Updated column headers to Action and When (UTC)
- Adjusted tests to lock updated wording

Verification checklist
- [x] Labels are clearer and consistent
- [x] UTC explicitly shown in header
- [x] Dashboard rendering unchanged
- [x] Tests pass locally
- [x] Manual smoke test passed

Notes
UI-only wording change. No query, schema, event, auth, or workflow changes.