### PR TITLE
Issue 25-11: add dashboard performance guards

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 from assettrack.audit import ACTIVE_EVENTS_WHERE
 from assettrack.event_types import issue_event_type_values, normalize_event_type
-from assettrack.drilldowns import list_case_summaries
 
 from datetime import datetime, timezone
 import sqlite3
+
+MAX_DASHBOARD_TOP_HOLDERS = 5
+MAX_DASHBOARD_CASE_SUMMARIES = 10
+MAX_DASHBOARD_RECENT_ACTIVITY = 10
+MAX_DASHBOARD_EXCEPTION_PREVIEW = 10
 
 
 def get_custody_days_threshold(raw_value: object, default: int = 30) -> int:
@@ -223,6 +227,34 @@ def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
     ]
 
 
+def _dashboard_case_utilization(conn: sqlite3.Connection, limit: int) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            s.case_name,
+            COUNT(*) AS total_slots,
+            COUNT(DISTINCT so.slot_id) AS occupied_slots
+        FROM slots s
+        LEFT JOIN slot_occupancy so
+          ON so.slot_id = s.id
+        GROUP BY s.case_name
+        ORDER BY (COUNT(*) - COUNT(DISTINCT so.slot_id)) DESC, s.case_name ASC
+        LIMIT ?;
+        """,
+        (limit,),
+    ).fetchall()
+
+    return [
+        {
+            "case_name": str(row["case_name"]),
+            "total_slots": int(row["total_slots"] or 0),
+            "occupied_slots": int(row["occupied_slots"] or 0),
+            "empty_slots": max(0, int(row["total_slots"] or 0) - int(row["occupied_slots"] or 0)),
+        }
+        for row in rows
+    ]
+
+
 def _custody_summary(conn: sqlite3.Connection) -> dict:
     unique_holders_row = conn.execute(
         """
@@ -415,15 +447,15 @@ def build_dashboard_data(
             "exceptions": exceptions_summary,
         },
         "snapshots": {
-            "top_custody_holders": _top_custody_holders(conn, limit=5),
-            "case_utilization": list_case_summaries(conn),
-            "recent_activity": get_recent_activity(conn, limit=10),
+            "top_custody_holders": _top_custody_holders(conn, limit=MAX_DASHBOARD_TOP_HOLDERS),
+            "case_utilization": _dashboard_case_utilization(conn, limit=MAX_DASHBOARD_CASE_SUMMARIES),
+            "recent_activity": get_recent_activity(conn, limit=MAX_DASHBOARD_RECENT_ACTIVITY),
             "exceptions": {
-                "unslotted_assets": _unslotted_assets(conn, limit=10),
+                "unslotted_assets": _unslotted_assets(conn, limit=MAX_DASHBOARD_EXCEPTION_PREVIEW),
                 "in_custody_over_threshold": [
                     row for row in in_custody_days_out if row["days_out"] > custody_days_threshold
-                ][:10],
-                "slot_conflicts": _slot_conflicts_preview(conn, limit=10),
+                ][:MAX_DASHBOARD_EXCEPTION_PREVIEW],
+                "slot_conflicts": _slot_conflicts_preview(conn, limit=MAX_DASHBOARD_EXCEPTION_PREVIEW),
             },
         },
     }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -7,8 +7,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import assettrack.db as db
-from assettrack.dashboard import build_dashboard_data
-from assettrack.drilldowns import list_case_summaries
+from assettrack.dashboard import (
+    MAX_DASHBOARD_CASE_SUMMARIES,
+    MAX_DASHBOARD_RECENT_ACTIVITY,
+    build_dashboard_data,
+)
 from assettrack.event_types import issue_event_type_values
 from assettrack.intake import app as intake_app
 from tests.auth_test_utils import create_test_user, login_session
@@ -269,16 +272,14 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b'status-dot full', response.data)
         self.assertIn(b'status-dot low', response.data)
 
-    def test_available_space_uses_full_case_coverage_not_limited_top_five(self) -> None:
+    def test_dashboard_case_snapshot_is_bounded_and_keeps_best_available_case(self) -> None:
         slot_id = 1
-        for case_name, occupied_slots in [
-            ("CASE-1", 5),
-            ("CASE-2", 4),
-            ("CASE-3", 3),
-            ("CASE-4", 2),
-            ("CASE-5", 1),
-            ("CASE-6", 0),
-        ]:
+        cases: list[tuple[str, int]] = []
+        for index in range(1, 16):
+            occupied_slots = 0 if index == 6 else 1 + (index % 5)
+            cases.append((f"CASE-{index}", occupied_slots))
+
+        for case_name, occupied_slots in cases:
             for _ in range(10):
                 self._insert_slot(slot_id, case_name, slot_id)
                 if occupied_slots > 0:
@@ -297,7 +298,7 @@ class DashboardTests(unittest.TestCase):
         data = build_dashboard_data(self.conn, custody_days_threshold=30)
         rendered = self.client.get("/dashboard")
 
-        self.assertEqual([row["case_name"] for row in data["snapshots"]["case_utilization"]], [row["case_name"] for row in list_case_summaries(self.conn)])
+        self.assertLessEqual(len(data["snapshots"]["case_utilization"]), MAX_DASHBOARD_CASE_SUMMARIES)
         self.assertIn("CASE-6", [row["case_name"] for row in data["snapshots"]["case_utilization"]])
         self.assertEqual(
             next(row for row in data["snapshots"]["case_utilization"] if row["case_name"] == "CASE-6")["empty_slots"],
@@ -466,3 +467,16 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(len(data["snapshots"]["recent_activity"]), 1)
         self.assertEqual(data["snapshots"]["recent_activity"][0]["event_type"], "RETURN")
         self.assertEqual(data["snapshots"]["recent_activity"][0]["asset_tag"], "AT-1")
+
+    def test_recent_activity_snapshot_is_bounded(self) -> None:
+        for index in range(MAX_DASHBOARD_RECENT_ACTIVITY + 5):
+            self._insert_event(
+                f"AT-{index}",
+                "RETURN",
+                f"2026-01-{(index % 28) + 1:02d}T12:00:00Z",
+            )
+        self.conn.commit()
+
+        data = build_dashboard_data(self.conn, custody_days_threshold=30)
+
+        self.assertEqual(len(data["snapshots"]["recent_activity"]), MAX_DASHBOARD_RECENT_ACTIVITY)


### PR DESCRIPTION
Summary
Add explicit bounds to dashboard queries to protect performance.

Related Issue
Closes #25-11

Changes
- Added explicit LIMITs to all dashboard snapshot queries
- Introduced bounded case utilization helper for dashboard-only use
- Updated tests to enforce bounded behavior and recent activity limits

Verification checklist
- [x] All dashboard sections are bounded
- [x] Case snapshot limited without affecting drilldown
- [x] Recent activity capped correctly
- [x] Tests pass locally
- [x] Manual smoke test passed

Notes
Read-only projection change. No schema, event, auth, or workflow impact.