### PR TITLE
Issue 25-12: remove preview discard action

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -186,11 +186,6 @@
       </label>
       <button id="issue_btn" type="submit" disabled data-timeout-lock-target>Commit Issue</button>
     </form>
-    <form method="post" action="{{ url_for('preview_discard') }}" style="margin-top: 10px;"
-          onsubmit="return confirm('Discard this batch? This clears the queue.');">
-      <input type="hidden" name="return_to" value="{{ url_for('issue') }}" />
-      <button type="submit" data-timeout-lock-target>Discard batch</button>
-    </form>
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
       <input type="hidden" name="action" value="clear" />
       <input type="hidden" name="return_to" value="{{ url_for('issue') }}" />

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -51,12 +51,6 @@
       <button id="add_btn" type="submit" disabled data-timeout-lock-target>{{ "Commit Issue" if issue_mode else "Add to database" }}</button>
     </form>
 
-    <form method="post" action="{{ url_for('preview_discard') }}" style="margin-top: 10px;"
-          onsubmit="return confirm('Discard this batch? This clears the queue.');">
-      <input type="hidden" name="return_to" value="{{ url_for('add_assets') }}" />
-      <button type="submit" data-timeout-lock-target>Discard batch</button>
-    </form>
-
     <p style="margin-top: 10px;">
       Tip: for raw JSON, open <code>/preview?json=1</code> or <code>/preview/validate</code>.
     </p>

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -75,7 +75,8 @@ def test_add_assets_and_preview_render_timeout_lock_targets(client_with_temp_db)
     assert b'let timeoutLocked = false;' in preview.data
     assert b'window.location = "/logout";' in preview.data
     assert b'data-timeout-lock-target>Add to database<' in preview.data
-    assert b'data-timeout-lock-target>Discard batch<' in preview.data
+    assert b"Discard batch" not in preview.data
+    assert b'action="/preview/discard"' not in preview.data
 
 
 def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db) -> None:
@@ -96,7 +97,8 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     assert issue_preview.status_code == 200
     assert b'id="timeout-lock-panel"' in issue_preview.data
     assert b'data-timeout-lock-target>Commit Issue<' in issue_preview.data
-    assert b'data-timeout-lock-target>Discard batch<' in issue_preview.data
+    assert b"Discard batch" not in issue_preview.data
+    assert b'action="/preview/discard"' not in issue_preview.data
 
     return_queue = client_with_temp_db.get("/return")
     assert return_queue.status_code == 200
@@ -107,3 +109,5 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     assert return_preview.status_code == 200
     assert b'id="timeout-lock-panel"' in return_preview.data
     assert b'data-timeout-lock-target>Commit Return<' in return_preview.data
+    assert b"Discard batch" not in return_preview.data
+    assert b'action="/preview/discard"' not in return_preview.data


### PR DESCRIPTION
Summary
Remove preview discard action from UI to eliminate a broken and redundant path.

Related Issue
Closes #25-12

Changes
- Removed Discard action from Issue and generic preview templates
- Kept Commit and Clear Queue actions intact
- Added tests to ensure discard is not rendered and commit controls remain

Verification checklist
- [x] No discard action visible in Issue preview
- [x] No discard action visible in generic preview
- [x] Return preview unchanged (no discard)
- [x] Commit actions still render and work
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
Template-only change. Backend /preview/discard route remains but is no longer reachable from UI.