### PR TITLE
Issue 25-13: hide admin actions from operator UI

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -127,9 +127,9 @@
           {% if authenticated_role == 'admin' %}
             <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
             <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">System Health</a>
+            <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Add Assets</a>
           {% endif %}
           <a class="chip {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
-          <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Add Assets</a>
           {% if authenticated_role == 'admin' %}
             <span class="chip mode-badge" aria-label="Admin mode">ADMIN</span>
           {% endif %}

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -103,9 +103,24 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Preview</a>" not in dashboard_response.data
     assert b">Issue</a>" in dashboard_response.data
     assert b">Return</a>" in dashboard_response.data
+    assert b">Add Assets</a>" not in dashboard_response.data
+    assert b">Users</a>" not in dashboard_response.data
+    assert b">System Health</a>" not in dashboard_response.data
 
     preview_response = client_with_temp_db.get("/preview")
     assert preview_response.status_code == 200
+
+
+def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
+    create_user("admin", "admin-pass", "admin", True)
+    _login(client_with_temp_db, "admin", "admin-pass")
+
+    dashboard_response = client_with_temp_db.get("/dashboard")
+
+    assert dashboard_response.status_code == 200
+    assert b">Add Assets</a>" in dashboard_response.data
+    assert b">Users</a>" in dashboard_response.data
+    assert b">System Health</a>" in dashboard_response.data
 
 
 def test_bootstrap_only_when_empty(client_with_temp_db) -> None:


### PR DESCRIPTION
Summary
Hide admin-only actions from operator UI.

Related Issue
Closes #25-13

Changes
- Gated Add Assets with existing admin-only nav items in base template
- Ensured operator sessions do not render admin links
- Added tests to verify role-based nav visibility

Verification checklist
- [x] Operator nav hides Add Assets, Users, System Health
- [x] Admin nav shows all admin controls
- [x] No layout regressions
- [x] Targeted tests pass locally
- [x] Manual smoke test passed

Notes
Template-only UI enforcement. Backend auth unchanged.