### PR TITLE
Issue 26-7: add-assets queue validation and clarity

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2292,6 +2292,18 @@ def intake():
             if 0 <= queue_index < len(SCAN_QUEUE):
                 SCAN_QUEUE.pop(queue_index)
 
+        should_validate_empty_scan = (
+            action == ""
+            and not scan_text
+            and return_to_path in {"", "/add-assets"}
+        )
+        if should_validate_empty_scan:
+            flash("Enter or scan an asset tag before adding it to the queue.", "error")
+            touch_session()
+            if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                return redirect(redirect_target)
+            return redirect(url_for("add_assets"))
+
         if scan_text:
             value = sanitize_scan(scan_text)
             if not value:
@@ -2466,6 +2478,17 @@ def add_assets():
         slot_options=slot_options,
         case_options=case_options,
     )
+
+
+@app.post("/add-assets/review")
+@require_login
+@require_role("admin")
+def add_assets_review():
+    if len(SCAN_QUEUE) == 0:
+        flash("Queue is empty. Add at least one asset to the queue before reviewing the batch.", "error")
+        return redirect(url_for("add_assets"))
+
+    return redirect(url_for("preview"))
 
 
 @app.route("/bootstrap/admin", methods=["GET", "POST"])

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -7,10 +7,31 @@
 {% block extra_head %}
   <style>
     input[type="text"], input[type="password"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
-    .queue-ts { color: #5b6878; font-size: 0.9rem; margin-right: 0.4rem; }
+    .queue-ts { color: #5b6878; font-size: 0.9rem; }
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    .queue-row { display: flex; align-items: center; gap: 0.45rem; flex-wrap: wrap; }
-    .queue-row form { margin: 0 0 0 auto; }
+    .queue-actions { display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: center; margin-top: 0.8rem; }
+    .queue-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.9rem; }
+    .queue-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1rem;
+      padding: 0.9rem 1rem;
+      border: 1px solid #d7deea;
+      border-radius: 12px;
+      background: #fff;
+    }
+    .queue-row-main { display: grid; gap: 0.45rem; min-width: 0; }
+    .queue-row-head { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; }
+    .queue-tag { font-size: 1rem; }
+    .queue-meta {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(150px, 1fr));
+      gap: 0.5rem 1rem;
+      color: #243447;
+    }
+    .queue-meta span { white-space: nowrap; }
+    .queue-row form { flex: 0 0 auto; margin: 0; align-self: center; }
     .queue-remove {
       padding: 0.25rem 0.5rem;
       border: 1px solid #d7deea;
@@ -19,6 +40,19 @@
       color: #243447;
       font-size: 0.85rem;
       cursor: pointer;
+    }
+    .queue-empty {
+      margin: 0;
+      padding: 0.85rem 1rem;
+      border: 1px dashed #c7d3e6;
+      border-radius: 12px;
+      color: #5b6878;
+      background: #f8fbff;
+    }
+    @media (max-width: 720px) {
+      .queue-row { flex-direction: column; }
+      .queue-row form { align-self: flex-start; }
+      .queue-meta { grid-template-columns: 1fr; }
     }
   </style>
 {% endblock %}
@@ -105,13 +139,13 @@
             autocomplete="off"
             data-timeout-lock-target
           />
-          <button id="submit-scan" type="submit" data-timeout-lock-target>Submit</button>
+          <button id="submit-scan" type="submit" data-timeout-lock-target>Add to queue</button>
           <button id="clear-queue" type="submit" name="action" value="clear" data-timeout-lock-target>Clear queue</button>
         </div>
       </form>
     {% endif %}
-    <form method="post" action="{{ url_for('preview_commit') }}" style="margin-top: 10px;">
-      <button id="add-to-db" type="submit" data-timeout-lock-target>Add to database</button>
+    <form method="post" action="{{ url_for('add_assets_review') }}" class="queue-actions">
+      <button id="review-batch" type="submit" data-timeout-lock-target>Review batch</button>
     </form>
   </div>
 
@@ -121,24 +155,34 @@
   </div>
 
   <div class="card">
-    <h2>Queue ({{ queue_len }})</h2>
-    <ul id="queue-list" role="list">
-      {% for s in queue %}
-        <li class="queue-row" data-asset-tag="{{ s.asset_tag }}">
-          <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }}</time>
-          <code>{{ s.asset_tag }}</code>
-          {% if s.case_name and s.slot_position is not none %}
-            <span class="muted">→ {{ s.case_name }} / Slot {{ s.slot_position }}</span>
-          {% endif %}
-          <form method="post" action="{{ url_for('intake') }}">
-            <input type="hidden" name="return_to" value="{{ url_for('add_assets') }}" />
-            <input type="hidden" name="action" value="remove" />
-            <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
-            <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>
-          </form>
-        </li>
-      {% endfor %}
-    </ul>
+    <h2 id="queue-section">Queue ({{ queue_len }})</h2>
+    {% if queue %}
+      <ul id="queue-list" class="queue-list" role="list">
+        {% for s in queue %}
+          <li class="queue-row" data-asset-tag="{{ s.asset_tag }}">
+            <div class="queue-row-main">
+              <div class="queue-row-head">
+                <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }}</time>
+                <code class="queue-tag">{{ s.asset_tag }}</code>
+              </div>
+              <div class="queue-meta">
+                <span><strong>Equipment type:</strong> {{ s.equipment_type or "Not set" }}</span>
+                <span><strong>Case:</strong> {{ s.case_name or "Unassigned" }}</span>
+                <span><strong>Slot:</strong> {% if s.slot_position is not none %}Slot {{ s.slot_position }}{% else %}Unassigned{% endif %}</span>
+              </div>
+            </div>
+            <form method="post" action="{{ url_for('intake') }}">
+              <input type="hidden" name="return_to" value="{{ url_for('add_assets') }}" />
+              <input type="hidden" name="action" value="remove" />
+              <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
+              <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>
+            </form>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="queue-empty">No assets are queued yet. Scan or enter an asset tag, then add it to the queue for review.</p>
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -122,6 +122,34 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b'name="case_name"', response.data)
         self.assertIn(b'name="slot_id"', response.data)
         self.assertIn(b"CASE-LIVE", response.data)
+        self.assertIn(b"Add to queue", response.data)
+        self.assertIn(b"Review batch", response.data)
+        self.assertNotIn(b"Add to database", response.data)
+
+    def test_add_assets_empty_scan_submission_shows_validation_message(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "", "equipment_type": "tablet", "return_to": "/add-assets"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Enter or scan an asset tag before adding it to the queue.", response.data)
+        self.assertEqual(len(intake_app.SCAN_QUEUE), 0)
+
+    def test_add_assets_review_blocks_empty_queue_with_clear_message(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+
+        response = self.client.post(
+            "/add-assets/review",
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Queue is empty. Add at least one asset to the queue before reviewing the batch.", response.data)
+        self.assertIn(b"No assets are queued yet.", response.data)
 
     def test_scans_keep_equipment_type_captured_at_scan_time(self) -> None:
         intake_app.SCAN_QUEUE.clear()
@@ -145,6 +173,36 @@ class AdminAddAssetUiTests(unittest.TestCase):
         rows = preview.json["rows"]
         self.assertEqual(rows[0]["equipment_type"], "tablet")
         self.assertEqual(rows[1]["equipment_type"], "laptop")
+
+    def test_add_assets_queue_rows_show_operator_verification_details(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(
+            Scan(
+                asset_tag="AT-VERIFY-1",
+                scanned_at=datetime(2026, 1, 1, 14, 3, 22, tzinfo=timezone.utc),
+                equipment_type="tablet",
+                case_name="CASE-V",
+                slot_position=3,
+            )
+        )
+        intake_app.SCAN_QUEUE.append(
+            Scan(
+                asset_tag="AT-VERIFY-2",
+                scanned_at=datetime(2026, 1, 1, 14, 4, 22, tzinfo=timezone.utc),
+                equipment_type="laptop",
+            )
+        )
+
+        response = self.client.get("/add-assets")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"AT-VERIFY-1", response.data)
+        self.assertIn(b"Equipment type:</strong> tablet", response.data)
+        self.assertIn(b"Case:</strong> CASE-V", response.data)
+        self.assertIn(b"Slot:</strong> Slot 3", response.data)
+        self.assertIn(b"AT-VERIFY-2", response.data)
+        self.assertIn(b"Case:</strong> Unassigned", response.data)
+        self.assertIn(b"Slot:</strong> Unassigned", response.data)
 
     def test_blank_equipment_type_uses_default_and_missing_field_preserves_selection(self) -> None:
         intake_app.SCAN_QUEUE.clear()


### PR DESCRIPTION
## Summary
Tightened Add Assets workflow to prevent silent failures and improve operator clarity.

## Related Issue
Closes #299 

## Changes
- Added validation for empty scan submission
- Blocked preview when queue is empty
- Updated button wording to match workflow (queue → review → commit)
- Improved queue row detail (asset tag, equipment type, case, slot)
- Improved queue row layout and remove control alignment

## Verification checklist
- [ ] Empty scan shows validation message
- [ ] Empty queue cannot proceed to preview
- [ ] Queue rows display full detail
- [ ] Layout is readable and aligned
- [ ] Happy path still reaches preview and commit

## Notes
No schema or event model changes. UI/behavior only.