### PR TITLE
Issue 26-9: fix preview operator flow ordering

### DIFF
--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -41,51 +41,6 @@
         <span class="pill bad">not valid</span>
       {% endif %}
     </p>
-
-    <form method="post" action="{{ url_for('issue_commit') if issue_mode else url_for('preview_commit') }}" style="margin-top: 10px;">
-      <label style="display:block; margin-bottom: 10px;">
-        <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed">
-        I reviewed this batch and want to add it to the database.
-      </label>
-
-      <button id="add_btn" type="submit" disabled data-timeout-lock-target>{{ "Commit Issue" if issue_mode else "Add to database" }}</button>
-    </form>
-
-    <p style="margin-top: 10px;">
-      Tip: for raw JSON, open <code>/preview?json=1</code> or <code>/preview/validate</code>.
-    </p>
-  </div>
-
-  <div class="card">
-    <h2>Mode</h2>
-
-    <form method="post" action="{{ url_for('preview_mode') }}" style="margin-top: 10px;">
-      <label>
-        <input type="checkbox" name="issue_mode" value="on" {% if issue_mode %}checked{% endif %} />
-        Enable Issue mode (issue assets to a selected holder)
-      </label>
-      <br /><br />
-      <button type="submit">Save mode</button>
-    </form>
-
-    {% if issue_mode %}
-      <p style="margin-top: 12px;"><strong>Issue mode:</strong> ON</p>
-      {% if selected_holder %}
-        <p>
-          <strong>Selected holder:</strong>
-          {{ holder_display_name(selected_holder) }}
-          {% if selected_holder["identifier"] %}
-            ({{ selected_holder["identifier"] }})
-          {% endif %}
-        </p>
-      {% else %}
-        <p><strong>No holder selected.</strong></p>
-      {% endif %}
-      <p><a href="{{ url_for('holders_search') }}">Search/select holder</a></p>
-      <p><a href="{{ url_for('issue_preview') }}">Open Issue Assets Preview / Confirm</a></p>
-    {% else %}
-      <p style="margin-top: 12px;"><strong>Issue mode:</strong> OFF</p>
-    {% endif %}
   </div>
 
   <div class="card">
@@ -129,8 +84,46 @@
   </div>
 
   <div class="card">
-    <h2>Validation result</h2>
-    <pre>{{ validation | tojson(indent=2) }}</pre>
+    <form method="post" action="{{ url_for('issue_commit') if issue_mode else url_for('preview_commit') }}" style="margin-top: 10px;">
+      <label style="display:block; margin-bottom: 10px;">
+        <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed">
+        I reviewed this batch and want to add it to the database.
+      </label>
+
+      <button id="add_btn" type="submit" disabled data-timeout-lock-target>{{ "Commit Issue" if issue_mode else "Add to database" }}</button>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Mode</h2>
+
+    <form method="post" action="{{ url_for('preview_mode') }}" style="margin-top: 10px;">
+      <label>
+        <input type="checkbox" name="issue_mode" value="on" {% if issue_mode %}checked{% endif %} />
+        Enable Issue mode (issue assets to a selected holder)
+      </label>
+      <br /><br />
+      <button type="submit">Save mode</button>
+    </form>
+
+    {% if issue_mode %}
+      <p style="margin-top: 12px;"><strong>Issue mode:</strong> ON</p>
+      {% if selected_holder %}
+        <p>
+          <strong>Selected holder:</strong>
+          {{ holder_display_name(selected_holder) }}
+          {% if selected_holder["identifier"] %}
+            ({{ selected_holder["identifier"] }})
+          {% endif %}
+        </p>
+      {% else %}
+        <p><strong>No holder selected.</strong></p>
+      {% endif %}
+      <p><a href="{{ url_for('holders_search') }}">Search/select holder</a></p>
+      <p><a href="{{ url_for('issue_preview') }}">Open Issue Assets Preview / Confirm</a></p>
+    {% else %}
+      <p style="margin-top: 12px;"><strong>Issue mode:</strong> OFF</p>
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -204,6 +204,28 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Case:</strong> Unassigned", response.data)
         self.assertIn(b"Slot:</strong> Unassigned", response.data)
 
+    def test_preview_shows_parsed_rows_before_confirmation_and_hides_validation_json(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(
+            Scan(
+                asset_tag="AT-PREVIEW-1",
+                scanned_at=datetime(2026, 1, 1, 14, 5, 22, tzinfo=timezone.utc),
+                equipment_type="tablet",
+            )
+        )
+
+        response = self.client.get("/preview")
+
+        self.assertEqual(response.status_code, 200)
+        parsed_rows_heading = response.data.index(b"<h2>Parsed rows</h2>")
+        confirmation_text = response.data.index(b"I reviewed this batch and want to add it to the database.")
+        self.assertLess(parsed_rows_heading, confirmation_text)
+        self.assertIn(b'action="/preview/commit"', response.data)
+        self.assertIn(b'name="confirm_reviewed"', response.data)
+        self.assertIn(b">Add to database<", response.data)
+        self.assertNotIn(b"<h2>Validation result</h2>", response.data)
+        self.assertNotIn(b"/preview/validate", response.data)
+
     def test_blank_equipment_type_uses_default_and_missing_field_preserves_selection(self) -> None:
         intake_app.SCAN_QUEUE.clear()
 


### PR DESCRIPTION
## Summary
Fixed preview page flow so operators see parsed rows before confirming and committing.

## Related Issue
Closes #301 

## Changes
- Moved parsed rows above confirmation controls
- Moved commit controls below review content
- Removed raw validation JSON from operator view
- Preserved existing form structure and commit behavior

## Verification checklist
- [ ] Parsed rows appear before checkbox/button
- [ ] Commit button appears after review content
- [ ] No validation JSON visible
- [ ] Commit flow works end-to-end

## Notes
Template-only change. No schema or event logic impact.