### PR TITLE
Issue 26-2: add org and building reference data

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -2,9 +2,10 @@
 import os
 import sqlite3
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
-REQUIRED_TABLES = {"assets", "holders"}
+REQUIRED_TABLES = {"assets", "holders", "organizations", "buildings", "organization_buildings"}
 EVENT_TABLE_ALIASES = ("events", "asset_events")
 
 
@@ -317,6 +318,39 @@ def _create_schema(conn: sqlite3.Connection):
 
     cursor.execute(
         """
+        CREATE TABLE IF NOT EXISTS organizations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS buildings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS organization_buildings (
+            organization_id INTEGER NOT NULL REFERENCES organizations(id),
+            building_id INTEGER NOT NULL REFERENCES buildings(id),
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (organization_id, building_id)
+        );
+        """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS slots (
             id INTEGER PRIMARY KEY,
             case_name TEXT NOT NULL,
@@ -368,6 +402,7 @@ def _create_schema(conn: sqlite3.Connection):
             holder_type TEXT NOT NULL,
             name TEXT NOT NULL,
             organization TEXT NULL,
+            organization_id INTEGER NULL REFERENCES organizations(id),
             identifier TEXT NULL,
             contact_info TEXT NULL,
             created_at TEXT NOT NULL,
@@ -417,6 +452,13 @@ def _create_schema(conn: sqlite3.Connection):
             """
             ALTER TABLE holders
             ADD COLUMN organization TEXT NULL;
+            """
+        )
+    if _table_exists(conn, "holders") and not _column_exists(conn, "holders", "organization_id"):
+        cursor.execute(
+            """
+            ALTER TABLE holders
+            ADD COLUMN organization_id INTEGER NULL REFERENCES organizations(id);
             """
         )
 
@@ -498,6 +540,43 @@ def _create_schema(conn: sqlite3.Connection):
                 ADD COLUMN building_room TEXT NULL;
                 """
             )
+
+    if _table_exists(conn, "holders") and _table_exists(conn, "organizations"):
+        now_iso = datetime.now(timezone.utc).isoformat()
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO organizations (name, created_at, updated_at)
+            SELECT DISTINCT TRIM(organization), ?, ?
+            FROM holders
+            WHERE TRIM(COALESCE(organization, '')) <> '';
+            """,
+            (now_iso, now_iso),
+        )
+        cursor.execute(
+            """
+            UPDATE holders
+            SET organization_id = (
+                SELECT o.id
+                FROM organizations o
+                WHERE UPPER(o.name) = UPPER(holders.organization)
+                LIMIT 1
+            )
+            WHERE organization_id IS NULL
+              AND TRIM(COALESCE(organization, '')) <> '';
+            """
+        )
+        cursor.execute(
+            """
+            UPDATE holders
+            SET organization = (
+                SELECT o.name
+                FROM organizations o
+                WHERE o.id = holders.organization_id
+                LIMIT 1
+            )
+            WHERE organization_id IS NOT NULL;
+            """
+        )
 
     if _table_exists(conn, "assets"):
         cursor.execute(

--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from assettrack.db import get_connection
+from assettrack.reference_data import get_organization
 
 
 def search_holders(query: str, limit: int = 20) -> list[dict]:
@@ -87,11 +88,19 @@ def create_holder(
     *,
     holder_type: str = "PERSON",
     organization: str | None = None,
+    organization_id: int | None = None,
     identifier: str | None = None,
     contact_info: str | None = None,
 ) -> dict:
     normalized_name = (name or "").strip()
     normalized_organization = (organization or "").strip() or None
+    normalized_organization_id: int | None = None
+    if organization_id not in {None, ""}:
+        organization_row = get_organization(int(organization_id))
+        if organization_row is None:
+            raise ValueError("organization not found")
+        normalized_organization_id = int(organization_row["id"])
+        normalized_organization = str(organization_row["name"] or "").strip() or None
     if not normalized_name and not normalized_organization:
         raise ValueError("name or organization is required")
     normalized_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else holder_type
@@ -102,10 +111,19 @@ def create_holder(
     try:
         cursor = conn.execute(
             """
-            INSERT INTO holders (holder_type, name, organization, identifier, contact_info, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?);
+            INSERT INTO holders (holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?);
             """,
-            (normalized_holder_type, persisted_name, normalized_organization, identifier, contact_info, now_iso, now_iso),
+            (
+                normalized_holder_type,
+                persisted_name,
+                normalized_organization,
+                normalized_organization_id,
+                identifier,
+                contact_info,
+                now_iso,
+                now_iso,
+            ),
         )
         conn.commit()
         created_id = int(cursor.lastrowid)
@@ -126,6 +144,7 @@ def update_holder(
     *,
     name: str,
     organization: str | None = None,
+    organization_id: int | None = None,
 ) -> dict:
     try:
         normalized_id = int(holder_id)
@@ -134,6 +153,13 @@ def update_holder(
 
     normalized_name = (name or "").strip()
     normalized_organization = (organization or "").strip() or None
+    normalized_organization_id: int | None = None
+    if organization_id not in {None, ""}:
+        organization_row = get_organization(int(organization_id))
+        if organization_row is None:
+            raise ValueError("organization not found")
+        normalized_organization_id = int(organization_row["id"])
+        normalized_organization = str(organization_row["name"] or "").strip() or None
     if not normalized_name and not normalized_organization:
         raise ValueError("name or organization is required")
     persisted_name = normalized_name or str(normalized_organization or "").strip()
@@ -145,10 +171,17 @@ def update_holder(
         cursor = conn.execute(
             """
             UPDATE holders
-            SET holder_type = ?, name = ?, organization = ?, updated_at = ?
+            SET holder_type = ?, name = ?, organization = ?, organization_id = ?, updated_at = ?
             WHERE id = ?;
             """,
-            (persisted_holder_type, persisted_name, normalized_organization, now_iso, normalized_id),
+            (
+                persisted_holder_type,
+                persisted_name,
+                normalized_organization,
+                normalized_organization_id,
+                now_iso,
+                normalized_id,
+            ),
         )
         if cursor.rowcount != 1:
             raise ValueError("holder not found")

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -24,7 +24,7 @@ from flask import Flask, abort, flash, jsonify, redirect, render_template, reque
 import assettrack.db as db_module
 from assettrack.assets import get_asset_table_columns
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
-from assettrack.db import assert_schema_present, get_connection, initialize_if_missing_or_empty
+from assettrack.db import assert_schema_present, get_connection, initialize_schema
 from assettrack.drilldowns import (
     get_case_slot_detail,
     get_holder_custody_detail,
@@ -37,6 +37,14 @@ from assettrack.intake.scan import Scan
 from assettrack.intake.to_ingest import scan_to_ingest_row
 from assettrack.auth import current_user, require_login, require_role
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, update_holder
+from assettrack.reference_data import (
+    create_building,
+    create_organization,
+    create_organization_building_mapping,
+    list_buildings,
+    list_organization_building_mappings,
+    list_organizations,
+)
 from assettrack.audit import record_event
 from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
 from assettrack.users import (
@@ -56,7 +64,7 @@ from assettrack.users import (
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
 
-initialize_if_missing_or_empty(db_module.DB_PATH)
+initialize_schema(db_module.DB_PATH)
 assert_schema_present(db_module.DB_PATH)
 
 # In-memory only: wiped on restart
@@ -3235,7 +3243,8 @@ def holders_new():
 
     return render_template(
         "holder_new.html",
-        form={"name": "", "organization": ""},
+        form={"name": "", "organization_id": ""},
+        organization_options=list_organizations(),
         error_message=None,
     )
 
@@ -3249,16 +3258,26 @@ def holders_create():
         return redirect(url_for("intake"))
 
     name = (request.form.get("name") or "").strip()
-    organization = (request.form.get("organization") or "").strip()
-    form = {"name": name, "organization": organization}
+    organization_id_raw = (request.form.get("organization_id") or "").strip()
+    organization_text = (request.form.get("organization") or "").strip()
+    form = {"name": name, "organization_id": organization_id_raw}
 
     try:
-        created = create_holder(name, organization=organization)
-    except ValueError:
+        created = create_holder(
+            name,
+            organization=organization_text or None,
+            organization_id=None if not organization_id_raw else int(organization_id_raw),
+        )
+    except ValueError as e:
         return render_template(
             "holder_new.html",
             form=form,
-            error_message="Enter a person or group name, or enter a group / organization.",
+            organization_options=list_organizations(),
+            error_message=(
+                "Enter a person or group name, or enter a group / organization."
+                if str(e) == "name or organization is required"
+                else str(e)
+            ),
         )
 
     flash(f"Created holder: {_holder_display_name(created)}", "success")
@@ -3282,8 +3301,9 @@ def holders_edit(holder_id: int):
         holder=holder,
         form={
             "name": str(holder.get("name") or ""),
-            "organization": str(holder.get("organization") or ""),
+            "organization_id": "" if holder.get("organization_id") is None else str(holder.get("organization_id")),
         },
+        organization_options=list_organizations(),
         error_message=None,
     )
 
@@ -3298,8 +3318,9 @@ def holders_edit_submit(holder_id: int):
 
     form = {
         "name": (request.form.get("name") or "").strip(),
-        "organization": (request.form.get("organization") or "").strip(),
+        "organization_id": (request.form.get("organization_id") or "").strip(),
     }
+    organization_text = (request.form.get("organization") or "").strip()
 
     holder = get_holder(holder_id)
     if holder is None:
@@ -3309,13 +3330,15 @@ def holders_edit_submit(holder_id: int):
         updated = update_holder(
             holder_id,
             name=form["name"],
-            organization=form["organization"],
+            organization=organization_text or None,
+            organization_id=None if not form["organization_id"] else int(form["organization_id"]),
         )
     except ValueError as e:
         return render_template(
             "holder_edit.html",
             holder=holder,
             form=form,
+            organization_options=list_organizations(),
             error_message=(
                 "Enter a person or group name, or enter a group / organization."
                 if str(e) == "name or organization is required"
@@ -3405,6 +3428,41 @@ def admin_system():
         holder_count=holder_count,
         asset_count=asset_count,
         schema_warning=schema_warning,
+    )
+
+
+@app.route("/admin/reference-data", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_reference_data():
+    error_message: str | None = None
+
+    if request.method == "POST":
+        action = (request.form.get("action") or "").strip().lower()
+        try:
+            if action == "create_organization":
+                create_organization((request.form.get("organization_name") or "").strip())
+                flash("Created organization.", "success")
+            elif action == "create_building":
+                create_building((request.form.get("building_name") or "").strip())
+                flash("Created building.", "success")
+            elif action == "map_organization_building":
+                create_organization_building_mapping(
+                    int((request.form.get("organization_id") or "").strip()),
+                    int((request.form.get("building_id") or "").strip()),
+                )
+                flash("Created organization to building mapping.", "success")
+            else:
+                error_message = "Unknown action."
+        except ValueError as e:
+            error_message = str(e)
+
+    return render_template(
+        "admin_reference_data.html",
+        organizations=list_organizations(),
+        buildings=list_buildings(),
+        mappings=list_organization_building_mappings(),
+        error_message=error_message,
     )
 
 

--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -1,0 +1,144 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Reference Data{% endblock %}
+{% block page_heading %}Admin: Organizations and Buildings{% endblock %}
+
+{% block extra_head %}
+  <style>
+    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(260px, 1fr)); gap: 1rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p><a href="{{ url_for('admin_system') }}">&larr; Back to system health</a></p>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <div class="grid">
+    <div class="card">
+      <h2>Organizations</h2>
+      <form method="post" action="{{ url_for('admin_reference_data') }}">
+        <input type="hidden" name="action" value="create_organization" />
+        <div class="row">
+          <label for="organization_name"><strong>Organization name</strong></label><br />
+          <input type="text" id="organization_name" name="organization_name" autocomplete="off" />
+        </div>
+        <button type="submit">Create organization</button>
+      </form>
+
+      <table style="margin-top: 1rem;">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for organization in organizations %}
+            <tr>
+              <td><code>{{ organization.id }}</code></td>
+              <td>{{ organization.name }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="2">No organizations yet.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h2>Buildings</h2>
+      <form method="post" action="{{ url_for('admin_reference_data') }}">
+        <input type="hidden" name="action" value="create_building" />
+        <div class="row">
+          <label for="building_name"><strong>Building name</strong></label><br />
+          <input type="text" id="building_name" name="building_name" autocomplete="off" />
+        </div>
+        <button type="submit">Create building</button>
+      </form>
+
+      <table style="margin-top: 1rem;">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for building in buildings %}
+            <tr>
+              <td><code>{{ building.id }}</code></td>
+              <td>{{ building.name }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="2">No buildings yet.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Organization to Building Mapping</h2>
+    <form method="post" action="{{ url_for('admin_reference_data') }}">
+      <input type="hidden" name="action" value="map_organization_building" />
+      <div class="grid">
+        <div class="row">
+          <label for="organization_id"><strong>Organization</strong></label><br />
+          <select id="organization_id" name="organization_id">
+            <option value="">Select organization</option>
+            {% for organization in organizations %}
+              <option value="{{ organization.id }}">{{ organization.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+        <div class="row">
+          <label for="building_id"><strong>Building</strong></label><br />
+          <select id="building_id" name="building_id">
+            <option value="">Select building</option>
+            {% for building in buildings %}
+              <option value="{{ building.id }}">{{ building.name }}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <button type="submit">Create mapping</button>
+    </form>
+
+    <table style="margin-top: 1rem;">
+      <thead>
+        <tr>
+          <th>Organization</th>
+          <th>Building</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for mapping in mappings %}
+          <tr>
+            <td>{{ mapping.organization_name }}</td>
+            <td>{{ mapping.building_name }}</td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="2">No mappings yet.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -12,6 +12,7 @@
 
   <div class="card">
     <h2>Database</h2>
+    <p><a class="chip" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
     <p><a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a></p>
     <table>
       <tbody>

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -30,12 +30,17 @@
     <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
     <form method="post" action="{{ url_for('holders_edit_submit', holder_id=holder.id) }}">
       <div class="row">
-        <label for="name"><strong>Person or group name</strong> (optional if group / organization is entered)</label><br />
+        <label for="name"><strong>Person or group name</strong> (optional if a group / organization is selected)</label><br />
         <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
-        <label for="organization"><strong>Group / organization</strong> (optional)</label><br />
-        <input type="text" id="organization" name="organization" value="{{ form.organization or '' }}" />
+        <label for="organization_id"><strong>Group / organization</strong> (optional)</label><br />
+        <select id="organization_id" name="organization_id">
+          <option value="">No organization</option>
+          {% for organization in organization_options %}
+            <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>
+          {% endfor %}
+        </select>
       </div>
       <button type="submit">Save Holder</button>
     </form>

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -30,12 +30,17 @@
     <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
     <form method="post" action="{{ url_for('holders_create') }}">
       <div class="row">
-        <label for="name"><strong>Person or group name</strong> (optional if group / organization is entered)</label><br />
+        <label for="name"><strong>Person or group name</strong> (optional if a group / organization is selected)</label><br />
         <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
-        <label for="organization"><strong>Group / organization</strong> (optional)</label><br />
-        <input type="text" id="organization" name="organization" value="{{ form.organization or '' }}" />
+        <label for="organization_id"><strong>Group / organization</strong> (optional)</label><br />
+        <select id="organization_id" name="organization_id">
+          <option value="">No organization</option>
+          {% for organization in organization_options %}
+            <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>
+          {% endfor %}
+        </select>
       </div>
       <button type="submit">Create Holder</button>
     </form>

--- a/assettrack/reference_data.py
+++ b/assettrack/reference_data.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+
+from assettrack.db import get_connection
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_name(name: str) -> str:
+    normalized = (name or "").strip()
+    if not normalized:
+        raise ValueError("name is required")
+    return normalized
+
+
+def list_organizations() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM organizations
+            ORDER BY name COLLATE NOCASE ASC, id ASC;
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_organization(organization_id: int) -> dict | None:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM organizations
+            WHERE id = ?;
+            """,
+            (int(organization_id),),
+        ).fetchone()
+        return None if row is None else dict(row)
+    finally:
+        conn.close()
+
+
+def create_organization(name: str) -> dict:
+    normalized_name = _normalize_name(name)
+    now_iso = _utc_now_iso()
+
+    conn = get_connection()
+    try:
+        existing = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM organizations
+            WHERE UPPER(name) = UPPER(?)
+            LIMIT 1;
+            """,
+            (normalized_name,),
+        ).fetchone()
+        if existing is not None:
+            raise ValueError("organization already exists")
+
+        cursor = conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES (?, ?, ?);
+            """,
+            (normalized_name, now_iso, now_iso),
+        )
+        conn.commit()
+        created_id = int(cursor.lastrowid)
+        return dict(
+            conn.execute(
+                """
+                SELECT id, name, created_at, updated_at
+                FROM organizations
+                WHERE id = ?;
+                """,
+                (created_id,),
+            ).fetchone()
+        )
+    finally:
+        conn.close()
+
+
+def list_buildings() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM buildings
+            ORDER BY name COLLATE NOCASE ASC, id ASC;
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def get_building(building_id: int) -> dict | None:
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM buildings
+            WHERE id = ?;
+            """,
+            (int(building_id),),
+        ).fetchone()
+        return None if row is None else dict(row)
+    finally:
+        conn.close()
+
+
+def create_building(name: str) -> dict:
+    normalized_name = _normalize_name(name)
+    now_iso = _utc_now_iso()
+
+    conn = get_connection()
+    try:
+        existing = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM buildings
+            WHERE UPPER(name) = UPPER(?)
+            LIMIT 1;
+            """,
+            (normalized_name,),
+        ).fetchone()
+        if existing is not None:
+            raise ValueError("building already exists")
+
+        cursor = conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES (?, ?, ?);
+            """,
+            (normalized_name, now_iso, now_iso),
+        )
+        conn.commit()
+        created_id = int(cursor.lastrowid)
+        return dict(
+            conn.execute(
+                """
+                SELECT id, name, created_at, updated_at
+                FROM buildings
+                WHERE id = ?;
+                """,
+                (created_id,),
+            ).fetchone()
+        )
+    finally:
+        conn.close()
+
+
+def list_organization_building_mappings() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                ob.organization_id,
+                o.name AS organization_name,
+                ob.building_id,
+                b.name AS building_name,
+                ob.created_at
+            FROM organization_buildings ob
+            JOIN organizations o
+              ON o.id = ob.organization_id
+            JOIN buildings b
+              ON b.id = ob.building_id
+            ORDER BY o.name COLLATE NOCASE ASC, b.name COLLATE NOCASE ASC, ob.organization_id ASC, ob.building_id ASC;
+            """
+        ).fetchall()
+        return [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+
+def create_organization_building_mapping(organization_id: int, building_id: int) -> dict:
+    now_iso = _utc_now_iso()
+
+    conn = get_connection()
+    try:
+        organization = conn.execute(
+            "SELECT id, name FROM organizations WHERE id = ?;",
+            (int(organization_id),),
+        ).fetchone()
+        if organization is None:
+            raise ValueError("organization not found")
+
+        building = conn.execute(
+            "SELECT id, name FROM buildings WHERE id = ?;",
+            (int(building_id),),
+        ).fetchone()
+        if building is None:
+            raise ValueError("building not found")
+
+        existing = conn.execute(
+            """
+            SELECT 1
+            FROM organization_buildings
+            WHERE organization_id = ? AND building_id = ?
+            LIMIT 1;
+            """,
+            (int(organization_id), int(building_id)),
+        ).fetchone()
+        if existing is not None:
+            raise ValueError("mapping already exists")
+
+        conn.execute(
+            """
+            INSERT INTO organization_buildings (organization_id, building_id, created_at)
+            VALUES (?, ?, ?);
+            """,
+            (int(organization_id), int(building_id), now_iso),
+        )
+        conn.commit()
+        return {
+            "organization_id": int(organization["id"]),
+            "organization_name": str(organization["name"]),
+            "building_id": int(building["id"]),
+            "building_name": str(building["name"]),
+            "created_at": now_iso,
+        }
+    finally:
+        conn.close()

--- a/tests/test_admin_reference_data.py
+++ b/tests/test_admin_reference_data.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+class AdminReferenceDataTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        db.DB_PATH = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = db.get_connection()
+        intake_app.app.testing = True
+        self.client = intake_app.app.test_client()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def test_operator_cannot_access_admin_reference_data(self) -> None:
+        operator_id = create_test_user(username="operator-ref", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.get("/admin/reference-data")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_admin_can_create_organization_building_and_mapping(self) -> None:
+        admin_id = create_test_user(username="admin-ref", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+
+        response = self.client.get("/admin/reference-data")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Organizations", response.data)
+        self.assertIn(b"Buildings", response.data)
+
+        create_org = self.client.post(
+            "/admin/reference-data",
+            data={"action": "create_organization", "organization_name": "Operations"},
+            follow_redirects=True,
+        )
+        self.assertEqual(create_org.status_code, 200)
+        self.assertIn(b"Created organization.", create_org.data)
+
+        create_building = self.client.post(
+            "/admin/reference-data",
+            data={"action": "create_building", "building_name": "HQ North"},
+            follow_redirects=True,
+        )
+        self.assertEqual(create_building.status_code, 200)
+        self.assertIn(b"Created building.", create_building.data)
+
+        org_row = self.conn.execute(
+            "SELECT id, name FROM organizations WHERE name = ?;",
+            ("Operations",),
+        ).fetchone()
+        self.assertIsNotNone(org_row)
+
+        building_row = self.conn.execute(
+            "SELECT id, name FROM buildings WHERE name = ?;",
+            ("HQ North",),
+        ).fetchone()
+        self.assertIsNotNone(building_row)
+
+        create_map = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "map_organization_building",
+                "organization_id": str(org_row["id"]),
+                "building_id": str(building_row["id"]),
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(create_map.status_code, 200)
+        self.assertIn(b"Created organization to building mapping.", create_map.data)
+        self.assertIn(b"Operations", create_map.data)
+        self.assertIn(b"HQ North", create_map.data)
+
+        mapping = self.conn.execute(
+            """
+            SELECT organization_id, building_id
+            FROM organization_buildings
+            WHERE organization_id = ? AND building_id = ?;
+            """,
+            (org_row["id"], building_row["id"]),
+        ).fetchone()
+        self.assertIsNotNone(mapping)

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -80,6 +80,9 @@ def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:
     export_response = client_with_temp_db.get("/admin/db/export")
     assert export_response.status_code == 403
 
+    reference_data_response = client_with_temp_db.get("/admin/reference-data")
+    assert reference_data_response.status_code == 403
+
 def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     create_user("admin", "admin-pass", "admin", True)
     _login(client_with_temp_db, "admin", "admin-pass")
@@ -87,6 +90,8 @@ def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     assert response.status_code == 200
     edit_response = client_with_temp_db.get("/admin/assets/edit")
     assert edit_response.status_code == 200
+    reference_data_response = client_with_temp_db.get("/admin/reference-data")
+    assert reference_data_response.status_code == 200
 
 
 def test_asset_search_requires_login(client_with_temp_db) -> None:

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -52,10 +52,83 @@ def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> N
     conn = sqlite3.connect(db_path)
     try:
         columns = {row[1] for row in conn.execute("PRAGMA table_info(holders);").fetchall()}
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table';").fetchall()}
     finally:
         conn.close()
 
     assert "organization" in columns
+    assert "organization_id" in columns
+    assert "organizations" in tables
+    assert "buildings" in tables
+    assert "organization_buildings" in tables
+
+
+def test_initialize_schema_backfills_holder_organization_ids(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                identifier TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+            VALUES (1, 'PERSON', 'Jane Holder', 'Ops Alpha', NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        holder = conn.execute(
+            "SELECT organization, organization_id FROM holders WHERE id = 1;"
+        ).fetchone()
+        organization = conn.execute(
+            "SELECT id, name FROM organizations WHERE name = 'Ops Alpha';"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert organization is not None
+    assert holder is not None
+    assert holder[0] == "Ops Alpha"
+    assert holder[1] == organization[0]
 
 
 def test_initialize_if_missing_or_empty_does_not_mask_invalid_nonempty_db(tmp_path: Path) -> None:

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -35,19 +35,27 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
     def test_post_holders_new_persists_holder(self) -> None:
         holder_name = "Viability Gate Holder"
+        org = self.conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES ('Alpha Org', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
         response = self.client.post(
             "/holders/new",
-            data={"name": holder_name, "organization": "Alpha Org"},
+            data={"name": holder_name, "organization_id": str(org.lastrowid)},
         )
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.headers["Location"].endswith("/holders"))
 
         row = self.conn.execute(
-            "SELECT id, name, organization FROM holders WHERE name = ?;",
+            "SELECT id, name, organization, organization_id FROM holders WHERE name = ?;",
             (holder_name,),
         ).fetchone()
         self.assertIsNotNone(row)
         self.assertEqual(row["organization"], "Alpha Org")
+        self.assertEqual(int(row["organization_id"]), int(org.lastrowid))
 
     def test_post_holders_new_rejects_blank_name(self) -> None:
         response = self.client.post(
@@ -112,7 +120,21 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Bravo Org", select_response.data)
 
     def test_edit_holder_updates_organization(self) -> None:
-        self.client.post("/holders/new", data={"name": "Editable Holder", "organization": "Org One"})
+        org_one = self.conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES ('Org One', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        org_two = self.conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES ('Org Two', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
+
+        self.client.post("/holders/new", data={"name": "Editable Holder", "organization_id": str(org_one.lastrowid)})
         holder_row = self.conn.execute(
             "SELECT id FROM holders WHERE name = ?;",
             ("Editable Holder",),
@@ -125,17 +147,18 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
         edit_post = self.client.post(
             f"/holders/edit/{int(holder_row['id'])}",
-            data={"name": "Editable Holder", "organization": "Org Two"},
+            data={"name": "Editable Holder", "organization_id": str(org_two.lastrowid)},
             follow_redirects=True,
         )
         self.assertEqual(edit_post.status_code, 200)
         self.assertIn(b"Updated holder: Editable Holder", edit_post.data)
 
         updated = self.conn.execute(
-            "SELECT organization FROM holders WHERE id = ?;",
+            "SELECT organization, organization_id FROM holders WHERE id = ?;",
             (int(holder_row["id"]),),
         ).fetchone()
         self.assertEqual(updated["organization"], "Org Two")
+        self.assertEqual(int(updated["organization_id"]), int(org_two.lastrowid))
 
     def test_holders_list_shows_holders_and_asset_count(self) -> None:
         holder_name = "Holder List Person"

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -100,6 +100,22 @@ class HoldersTests(unittest.TestCase):
         self.assertIsNotNone(fetched)
         self.assertEqual(fetched["organization"], "Bravo Org")
 
+    def test_create_holder_with_organization_id_sets_denormalized_text(self) -> None:
+        now = datetime.now(timezone.utc).isoformat()
+        cursor = self.conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES (?, ?, ?);
+            """,
+            ("Support Org", now, now),
+        )
+        self.conn.commit()
+
+        created = create_holder("Mapped Holder", organization_id=int(cursor.lastrowid))
+
+        self.assertEqual(created["organization"], "Support Org")
+        self.assertEqual(int(created["organization_id"]), int(cursor.lastrowid))
+
     def test_create_holder_allows_org_only_holder(self) -> None:
         created = create_holder("", organization="Field Team")
         self.assertEqual(created["holder_type"], "ORGANIZATION")


### PR DESCRIPTION
## Summary
Add normalized organization and building reference data with admin-only management and holder organization support.

## Related Issue
Closes #294 

## Changes
- added organizations, buildings, and organization_buildings foundation
- added holder organization_id support with startup backfill from existing holder organization text
- added admin-only reference-data page for organization, building, and mapping management
- updated holder create/edit flows to use normalized organization selection
- kept asset building text fields unchanged to avoid workflow and event drift
- added test coverage for auth, schema/init, holder flows, and reference-data CRUD/mapping

## Verification checklist
- [x] rebuilt with `docker compose up -d --build`
- [x] logged in as admin in incognito
- [x] opened Admin System and reference-data page
- [x] created organization
- [x] created building
- [x] created org-to-building mapping
- [x] confirmed duplicate mapping is blocked
- [x] created holder with organization selection
- [x] edited holder organization successfully
- [x] confirmed holder search/detail still shows organization correctly
- [x] confirmed add-assets / preview / return pages still load and behave normally

## Notes
- holder organization is now required in practice; use an **Ad Hoc** organization for one-off cases
- follow-up UI polish is still needed for reference-data form sizing and holder organization dropdown sizing