### PR TITLE
Issue 26-10: require holder organization

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 REQUIRED_TABLES = {"assets", "holders", "organizations", "buildings", "organization_buildings"}
 EVENT_TABLE_ALIASES = ("events", "asset_events")
+DEFAULT_AD_HOC_ORGANIZATION = "Ad Hoc"
 
 
 def _table_exists(conn: sqlite3.Connection, table_name: str) -> bool:
@@ -546,6 +547,13 @@ def _create_schema(conn: sqlite3.Connection):
         cursor.execute(
             """
             INSERT OR IGNORE INTO organizations (name, created_at, updated_at)
+            VALUES (?, ?, ?);
+            """,
+            (DEFAULT_AD_HOC_ORGANIZATION, now_iso, now_iso),
+        )
+        cursor.execute(
+            """
+            INSERT OR IGNORE INTO organizations (name, created_at, updated_at)
             SELECT DISTINCT TRIM(organization), ?, ?
             FROM holders
             WHERE TRIM(COALESCE(organization, '')) <> '';
@@ -564,6 +572,19 @@ def _create_schema(conn: sqlite3.Connection):
             WHERE organization_id IS NULL
               AND TRIM(COALESCE(organization, '')) <> '';
             """
+        )
+        cursor.execute(
+            """
+            UPDATE holders
+            SET organization_id = (
+                SELECT o.id
+                FROM organizations o
+                WHERE UPPER(o.name) = UPPER(?)
+                LIMIT 1
+            )
+            WHERE organization_id IS NULL;
+            """,
+            (DEFAULT_AD_HOC_ORGANIZATION,),
         )
         cursor.execute(
             """

--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from assettrack.db import get_connection
+from assettrack.db import DEFAULT_AD_HOC_ORGANIZATION, get_connection
 from assettrack.reference_data import get_organization
 
 
@@ -87,24 +87,24 @@ def create_holder(
     name: str,
     *,
     holder_type: str = "PERSON",
-    organization: str | None = None,
-    organization_id: int | None = None,
+    organization_id: int,
     identifier: str | None = None,
     contact_info: str | None = None,
 ) -> dict:
     normalized_name = (name or "").strip()
-    normalized_organization = (organization or "").strip() or None
-    normalized_organization_id: int | None = None
-    if organization_id not in {None, ""}:
-        organization_row = get_organization(int(organization_id))
-        if organization_row is None:
-            raise ValueError("organization not found")
-        normalized_organization_id = int(organization_row["id"])
-        normalized_organization = str(organization_row["name"] or "").strip() or None
-    if not normalized_name and not normalized_organization:
-        raise ValueError("name or organization is required")
+    if organization_id in {None, ""}:
+        raise ValueError("organization is required")
+    organization_row = get_organization(int(organization_id))
+    if organization_row is None:
+        raise ValueError("organization not found")
+    normalized_organization_id = int(organization_row["id"])
+    normalized_organization = str(organization_row["name"] or "").strip() or None
+    if not normalized_organization:
+        raise ValueError("organization not found")
+    if not normalized_name and normalized_organization == DEFAULT_AD_HOC_ORGANIZATION:
+        raise ValueError("name is required")
     normalized_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else holder_type
-    persisted_name = normalized_name or str(normalized_organization or "").strip()
+    persisted_name = normalized_name or normalized_organization
 
     now_iso = datetime.now(timezone.utc).isoformat()
     conn = get_connection()
@@ -143,8 +143,7 @@ def update_holder(
     holder_id: int,
     *,
     name: str,
-    organization: str | None = None,
-    organization_id: int | None = None,
+    organization_id: int,
 ) -> dict:
     try:
         normalized_id = int(holder_id)
@@ -152,17 +151,18 @@ def update_holder(
         raise ValueError("holder_id is required") from e
 
     normalized_name = (name or "").strip()
-    normalized_organization = (organization or "").strip() or None
-    normalized_organization_id: int | None = None
-    if organization_id not in {None, ""}:
-        organization_row = get_organization(int(organization_id))
-        if organization_row is None:
-            raise ValueError("organization not found")
-        normalized_organization_id = int(organization_row["id"])
-        normalized_organization = str(organization_row["name"] or "").strip() or None
-    if not normalized_name and not normalized_organization:
-        raise ValueError("name or organization is required")
-    persisted_name = normalized_name or str(normalized_organization or "").strip()
+    if organization_id in {None, ""}:
+        raise ValueError("organization is required")
+    organization_row = get_organization(int(organization_id))
+    if organization_row is None:
+        raise ValueError("organization not found")
+    normalized_organization_id = int(organization_row["id"])
+    normalized_organization = str(organization_row["name"] or "").strip() or None
+    if not normalized_organization:
+        raise ValueError("organization not found")
+    if not normalized_name and normalized_organization == DEFAULT_AD_HOC_ORGANIZATION:
+        raise ValueError("name is required")
+    persisted_name = normalized_name or normalized_organization
     persisted_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else "PERSON"
     now_iso = datetime.now(timezone.utc).isoformat()
 

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -3259,13 +3259,11 @@ def holders_create():
 
     name = (request.form.get("name") or "").strip()
     organization_id_raw = (request.form.get("organization_id") or "").strip()
-    organization_text = (request.form.get("organization") or "").strip()
     form = {"name": name, "organization_id": organization_id_raw}
 
     try:
         created = create_holder(
             name,
-            organization=organization_text or None,
             organization_id=None if not organization_id_raw else int(organization_id_raw),
         )
     except ValueError as e:
@@ -3274,8 +3272,10 @@ def holders_create():
             form=form,
             organization_options=list_organizations(),
             error_message=(
-                "Enter a person or group name, or enter a group / organization."
-                if str(e) == "name or organization is required"
+                "Choose an organization for this holder."
+                if str(e) == "organization is required"
+                else "Enter a person or group name for Ad Hoc holders."
+                if str(e) == "name is required"
                 else str(e)
             ),
         )
@@ -3320,7 +3320,6 @@ def holders_edit_submit(holder_id: int):
         "name": (request.form.get("name") or "").strip(),
         "organization_id": (request.form.get("organization_id") or "").strip(),
     }
-    organization_text = (request.form.get("organization") or "").strip()
 
     holder = get_holder(holder_id)
     if holder is None:
@@ -3330,7 +3329,6 @@ def holders_edit_submit(holder_id: int):
         updated = update_holder(
             holder_id,
             name=form["name"],
-            organization=organization_text or None,
             organization_id=None if not form["organization_id"] else int(form["organization_id"]),
         )
     except ValueError as e:
@@ -3340,8 +3338,10 @@ def holders_edit_submit(holder_id: int):
             form=form,
             organization_options=list_organizations(),
             error_message=(
-                "Enter a person or group name, or enter a group / organization."
-                if str(e) == "name or organization is required"
+                "Choose an organization for this holder."
+                if str(e) == "organization is required"
+                else "Enter a person or group name for Ad Hoc holders."
+                if str(e) == "name is required"
                 else str(e)
             ),
         )

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -30,13 +30,13 @@
     <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
     <form method="post" action="{{ url_for('holders_edit_submit', holder_id=holder.id) }}">
       <div class="row">
-        <label for="name"><strong>Person or group name</strong> (optional if a group / organization is selected)</label><br />
+        <label for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label><br />
         <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
-        <label for="organization_id"><strong>Group / organization</strong> (optional)</label><br />
-        <select id="organization_id" name="organization_id">
-          <option value="">No organization</option>
+        <label for="organization_id"><strong>Group / organization</strong></label><br />
+        <select id="organization_id" name="organization_id" required>
+          <option value="">Select organization</option>
           {% for organization in organization_options %}
             <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>
           {% endfor %}

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -30,13 +30,13 @@
     <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
     <form method="post" action="{{ url_for('holders_create') }}">
       <div class="row">
-        <label for="name"><strong>Person or group name</strong> (optional if a group / organization is selected)</label><br />
+        <label for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label><br />
         <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
-        <label for="organization_id"><strong>Group / organization</strong> (optional)</label><br />
-        <select id="organization_id" name="organization_id">
-          <option value="">No organization</option>
+        <label for="organization_id"><strong>Group / organization</strong></label><br />
+        <select id="organization_id" name="organization_id" required>
+          <option value="">Select organization</option>
           {% for organization in organization_options %}
             <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>
           {% endfor %}

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -63,6 +63,21 @@ def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> N
     assert "organization_buildings" in tables
 
 
+def test_initialize_schema_creates_default_ad_hoc_organization(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        ad_hoc = conn.execute(
+            "SELECT id, name FROM organizations WHERE name = 'Ad Hoc';"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert ad_hoc is not None
+
+
 def test_initialize_schema_backfills_holder_organization_ids(tmp_path: Path) -> None:
     db_path = tmp_path / "assettrack.db"
     conn = sqlite3.connect(db_path)
@@ -129,6 +144,74 @@ def test_initialize_schema_backfills_holder_organization_ids(tmp_path: Path) -> 
     assert holder is not None
     assert holder[0] == "Ops Alpha"
     assert holder[1] == organization[0]
+
+
+def test_initialize_schema_creates_ad_hoc_and_backfills_null_holder_organizations(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                identifier TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+            VALUES (1, 'PERSON', 'Jane Holder', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        holder = conn.execute(
+            "SELECT organization, organization_id FROM holders WHERE id = 1;"
+        ).fetchone()
+        ad_hoc = conn.execute(
+            "SELECT id, name FROM organizations WHERE name = 'Ad Hoc';"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert ad_hoc is not None
+    assert holder is not None
+    assert holder[0] == "Ad Hoc"
+    assert holder[1] == ad_hoc[0]
 
 
 def test_initialize_if_missing_or_empty_does_not_mask_invalid_nonempty_db(tmp_path: Path) -> None:

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -23,6 +23,22 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.conn.close()
         self.temp_dir.cleanup()
 
+    def _create_org(self, name: str) -> int:
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO organizations (name, created_at, updated_at)
+            VALUES (?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (name,),
+        )
+        self.conn.commit()
+        row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = ?;",
+            (name,),
+        ).fetchone()
+        assert row is not None
+        return int(row["id"])
+
     def test_get_holders_new_route_exists(self) -> None:
         response = self.client.get("/holders/new")
         self.assertEqual(response.status_code, 200)
@@ -35,16 +51,10 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
     def test_post_holders_new_persists_holder(self) -> None:
         holder_name = "Viability Gate Holder"
-        org = self.conn.execute(
-            """
-            INSERT INTO organizations (name, created_at, updated_at)
-            VALUES ('Alpha Org', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
-            """
-        )
-        self.conn.commit()
+        org_id = self._create_org("Alpha Org")
         response = self.client.post(
             "/holders/new",
-            data={"name": holder_name, "organization_id": str(org.lastrowid)},
+            data={"name": holder_name, "organization_id": str(org_id)},
         )
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.headers["Location"].endswith("/holders"))
@@ -55,23 +65,24 @@ class HolderCreationViabilityTests(unittest.TestCase):
         ).fetchone()
         self.assertIsNotNone(row)
         self.assertEqual(row["organization"], "Alpha Org")
-        self.assertEqual(int(row["organization_id"]), int(org.lastrowid))
+        self.assertEqual(int(row["organization_id"]), org_id)
 
-    def test_post_holders_new_rejects_blank_name(self) -> None:
+    def test_post_holders_new_rejects_missing_organization(self) -> None:
         response = self.client.post(
             "/holders/new",
-            data={"name": "   ", "organization": "   "},
+            data={"name": "Named Holder", "organization_id": ""},
         )
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Enter a person or group name, or enter a group / organization.", response.data)
+        self.assertIn(b"Choose an organization for this holder.", response.data)
 
         count = self.conn.execute("SELECT COUNT(*) AS c FROM holders;").fetchone()["c"]
         self.assertEqual(count, 0)
 
     def test_post_holders_new_allows_group_only_holder(self) -> None:
+        organization_id = self._create_org("Maintenance Shop")
         response = self.client.post(
             "/holders/new",
-            data={"name": "", "organization": "Maintenance Shop"},
+            data={"name": "", "organization_id": str(organization_id)},
             follow_redirects=True,
         )
         self.assertEqual(response.status_code, 200)
@@ -86,12 +97,24 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(row["holder_type"], "ORGANIZATION")
         self.assertEqual(row["organization"], "Maintenance Shop")
 
+    def test_post_holders_new_rejects_blank_name_for_ad_hoc(self) -> None:
+        organization_id = self._create_org("Ad Hoc")
+
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "", "organization_id": str(organization_id)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Enter a person or group name for Ad Hoc holders.", response.data)
+
     def test_create_search_and_select_holder_workflow(self) -> None:
         holder_name = "ZZ Test Holder 21-4"
+        organization_id = self._create_org("Bravo Org")
 
         create_response = self.client.post(
             "/holders/new",
-            data={"name": holder_name, "organization": "Bravo Org"},
+            data={"name": holder_name, "organization_id": str(organization_id)},
         )
         self.assertEqual(create_response.status_code, 302)
         self.assertTrue(create_response.headers["Location"].endswith("/holders"))
@@ -120,21 +143,10 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Bravo Org", select_response.data)
 
     def test_edit_holder_updates_organization(self) -> None:
-        org_one = self.conn.execute(
-            """
-            INSERT INTO organizations (name, created_at, updated_at)
-            VALUES ('Org One', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
-            """
-        )
-        org_two = self.conn.execute(
-            """
-            INSERT INTO organizations (name, created_at, updated_at)
-            VALUES ('Org Two', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
-            """
-        )
-        self.conn.commit()
+        org_one_id = self._create_org("Org One")
+        org_two_id = self._create_org("Org Two")
 
-        self.client.post("/holders/new", data={"name": "Editable Holder", "organization_id": str(org_one.lastrowid)})
+        self.client.post("/holders/new", data={"name": "Editable Holder", "organization_id": str(org_one_id)})
         holder_row = self.conn.execute(
             "SELECT id FROM holders WHERE name = ?;",
             ("Editable Holder",),
@@ -147,7 +159,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
         edit_post = self.client.post(
             f"/holders/edit/{int(holder_row['id'])}",
-            data={"name": "Editable Holder", "organization_id": str(org_two.lastrowid)},
+            data={"name": "Editable Holder", "organization_id": str(org_two_id)},
             follow_redirects=True,
         )
         self.assertEqual(edit_post.status_code, 200)
@@ -158,11 +170,29 @@ class HolderCreationViabilityTests(unittest.TestCase):
             (int(holder_row["id"]),),
         ).fetchone()
         self.assertEqual(updated["organization"], "Org Two")
-        self.assertEqual(int(updated["organization_id"]), int(org_two.lastrowid))
+        self.assertEqual(int(updated["organization_id"]), org_two_id)
+
+    def test_edit_holder_rejects_missing_organization(self) -> None:
+        org_id = self._create_org("Org One")
+        self.client.post("/holders/new", data={"name": "Editable Holder", "organization_id": str(org_id)})
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Editable Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        edit_post = self.client.post(
+            f"/holders/edit/{int(holder_row['id'])}",
+            data={"name": "Editable Holder", "organization_id": ""},
+        )
+
+        self.assertEqual(edit_post.status_code, 200)
+        self.assertIn(b"Choose an organization for this holder.", edit_post.data)
 
     def test_holders_list_shows_holders_and_asset_count(self) -> None:
         holder_name = "Holder List Person"
-        self.client.post("/holders/new", data={"name": holder_name})
+        organization_id = self._create_org("Ad Hoc")
+        self.client.post("/holders/new", data={"name": holder_name, "organization_id": str(organization_id)})
         holder_row = self.conn.execute(
             "SELECT id FROM holders WHERE name = ?;",
             (holder_name,),
@@ -183,8 +213,9 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(f'href="/holders/{holder_id}"'.encode("utf-8"), response.data)
 
     def test_holders_directory_loads_by_default_without_search(self) -> None:
-        self.client.post("/holders/new", data={"name": "Alpha Holder"})
-        self.client.post("/holders/new", data={"name": "Bravo Holder"})
+        organization_id = self._create_org("Ad Hoc")
+        self.client.post("/holders/new", data={"name": "Alpha Holder", "organization_id": str(organization_id)})
+        self.client.post("/holders/new", data={"name": "Bravo Holder", "organization_id": str(organization_id)})
 
         response = self.client.get("/holders")
 
@@ -195,7 +226,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Search by person name, group, organization, or identifier", response.data)
 
     def test_holder_detail_shows_metadata_and_assigned_assets(self) -> None:
-        self.client.post("/holders/new", data={"name": "Detail Holder", "organization": "Org Detail"})
+        organization_id = self._create_org("Org Detail")
+        self.client.post("/holders/new", data={"name": "Detail Holder", "organization_id": str(organization_id)})
         holder_row = self.conn.execute(
             "SELECT id FROM holders WHERE name = ?;",
             ("Detail Holder",),
@@ -222,7 +254,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(f'href="/holders/edit/{holder_id}"'.encode("utf-8"), response.data)
 
     def test_holder_detail_shows_zero_assets_state(self) -> None:
-        self.client.post("/holders/new", data={"name": "Empty Holder", "organization": "None"})
+        organization_id = self._create_org("Ad Hoc")
+        self.client.post("/holders/new", data={"name": "Empty Holder", "organization_id": str(organization_id)})
         holder_row = self.conn.execute(
             "SELECT id FROM holders WHERE name = ?;",
             ("Empty Holder",),
@@ -236,7 +269,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"No assigned assets.", response.data)
 
     def test_holder_detail_displays_group_holder_cleanly(self) -> None:
-        self.client.post("/holders/new", data={"name": "", "organization": "Ops Section"})
+        organization_id = self._create_org("Ops Section")
+        self.client.post("/holders/new", data={"name": "", "organization_id": str(organization_id)})
         holder_row = self.conn.execute(
             "SELECT id FROM holders WHERE name = ?;",
             ("Ops Section",),

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -24,6 +24,8 @@ class HoldersTests(unittest.TestCase):
         self,
         holder_type: str,
         name: str,
+        organization: str | None = None,
+        organization_id: int | None = None,
         identifier: str | None = None,
         contact_info: str | None = None,
     ) -> int:
@@ -31,18 +33,38 @@ class HoldersTests(unittest.TestCase):
         cursor = self.conn.execute(
             """
             INSERT INTO holders (
-                holder_type, name, identifier, contact_info, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?);
+                holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
             """,
-            (holder_type, name, identifier, contact_info, now, now),
+            (holder_type, name, organization, organization_id, identifier, contact_info, now, now),
         )
         self.conn.commit()
         return int(cursor.lastrowid)
 
+    def _insert_organization(self, name: str) -> int:
+        now = datetime.now(timezone.utc).isoformat()
+        self.conn.execute(
+            """
+            INSERT OR IGNORE INTO organizations (name, created_at, updated_at)
+            VALUES (?, ?, ?);
+            """,
+            (name, now, now),
+        )
+        self.conn.commit()
+        row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = ?;",
+            (name,),
+        ).fetchone()
+        assert row is not None
+        return int(row["id"])
+
     def test_holders_insert_and_get(self) -> None:
+        organization_id = self._insert_organization("Ad Hoc")
         holder_id = self._insert_holder(
             holder_type="Person",
             name="Jane Doe",
+            organization="Ad Hoc",
+            organization_id=organization_id,
             identifier="ID-123",
             contact_info="jane@example.org",
         )
@@ -50,13 +72,13 @@ class HoldersTests(unittest.TestCase):
         self.assertIsNotNone(holder)
         self.assertEqual(holder["name"], "Jane Doe")
         self.assertEqual(holder["identifier"], "ID-123")
-        self.assertIsNone(holder["organization"])
+        self.assertEqual(holder["organization"], "Ad Hoc")
 
     def test_search_holders_by_name_and_identifier(self) -> None:
-        self._insert_holder("Person", "Alpha User", "A-001", None)
-        self._insert_holder("Organization", "Bravo Org", "BR-77", "contact@bravo.org")
-        self.conn.execute("UPDATE holders SET organization = 'Bravo Group' WHERE name = 'Bravo Org';")
-        self.conn.commit()
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+        bravo_org_id = self._insert_organization("Bravo Group")
+        self._insert_holder("Person", "Alpha User", "Ad Hoc", ad_hoc_id, "A-001", None)
+        self._insert_holder("Organization", "Bravo Org", "Bravo Group", bravo_org_id, "BR-77", "contact@bravo.org")
 
         by_name = search_holders("Alpha")
         self.assertEqual(len(by_name), 1)
@@ -71,8 +93,9 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual(by_organization[0]["name"], "Bravo Org")
 
     def test_list_holders_includes_asset_count(self) -> None:
-        alpha_id = self._insert_holder("Person", "Alpha User", "A-001", None)
-        self._insert_holder("Organization", "Bravo Org", "BR-77", "contact@bravo.org")
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+        alpha_id = self._insert_holder("Person", "Alpha User", "Ad Hoc", ad_hoc_id, "A-001", None)
+        self._insert_holder("Organization", "Bravo Org", "Ad Hoc", ad_hoc_id, "BR-77", "contact@bravo.org")
 
         self.conn.execute(
             "INSERT INTO assets (asset_tag, current_holder_id) VALUES (?, ?);",
@@ -90,10 +113,12 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual(int(rows[1]["asset_count"]), 0)
 
     def test_create_and_update_holder_organization(self) -> None:
-        created = create_holder("Org Holder", organization="Alpha Org")
+        alpha_org_id = self._insert_organization("Alpha Org")
+        bravo_org_id = self._insert_organization("Bravo Org")
+        created = create_holder("Org Holder", organization_id=alpha_org_id)
         self.assertEqual(created["organization"], "Alpha Org")
 
-        updated = update_holder(int(created["id"]), name="Org Holder", organization="Bravo Org")
+        updated = update_holder(int(created["id"]), name="Org Holder", organization_id=bravo_org_id)
         self.assertEqual(updated["organization"], "Bravo Org")
 
         fetched = get_holder(int(created["id"]))
@@ -101,23 +126,26 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual(fetched["organization"], "Bravo Org")
 
     def test_create_holder_with_organization_id_sets_denormalized_text(self) -> None:
-        now = datetime.now(timezone.utc).isoformat()
-        cursor = self.conn.execute(
-            """
-            INSERT INTO organizations (name, created_at, updated_at)
-            VALUES (?, ?, ?);
-            """,
-            ("Support Org", now, now),
-        )
-        self.conn.commit()
+        organization_id = self._insert_organization("Support Org")
 
-        created = create_holder("Mapped Holder", organization_id=int(cursor.lastrowid))
+        created = create_holder("Mapped Holder", organization_id=organization_id)
 
         self.assertEqual(created["organization"], "Support Org")
-        self.assertEqual(int(created["organization_id"]), int(cursor.lastrowid))
+        self.assertEqual(int(created["organization_id"]), organization_id)
 
     def test_create_holder_allows_org_only_holder(self) -> None:
-        created = create_holder("", organization="Field Team")
+        organization_id = self._insert_organization("Field Team")
+        created = create_holder("", organization_id=organization_id)
         self.assertEqual(created["holder_type"], "ORGANIZATION")
         self.assertEqual(created["name"], "Field Team")
         self.assertEqual(created["organization"], "Field Team")
+
+    def test_create_holder_requires_organization_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "organization is required"):
+            create_holder("Missing Org", organization_id=None)  # type: ignore[arg-type]
+
+    def test_create_holder_requires_name_for_ad_hoc(self) -> None:
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+
+        with self.assertRaisesRegex(ValueError, "name is required"):
+            create_holder("", organization_id=ad_hoc_id)


### PR DESCRIPTION
## Summary
Require organizations for all holders and add an idempotent Ad Hoc fallback organization for one-off cases.

## Related Issue
Closes #305 

## Changes
- ensured Ad Hoc organization exists during schema init
- backfilled holders with null organization_id to Ad Hoc
- kept holder organization text synced from canonical organization name
- made organization required in holder create/edit flows
- required an explicit holder name when using Ad Hoc
- added test coverage for startup backfill, holder validation, and holder UI flow

## Verification checklist
- [x] rebuilt with `docker compose up -d --build`
- [x] verified holder create blocks missing organization selection
- [x] verified Ad Hoc with blank holder name is blocked
- [x] created valid Ad Hoc holder successfully
- [x] verified holder detail shows Ad Hoc correctly
- [x] edited existing holder to Ad Hoc successfully
- [x] confirmed `/issue` and `/return` still load normally

## Notes
- browser-native required-field validation currently appears before app-level messaging for missing organization selection
- holder edit redirect felt slightly inconsistent during smoke testing and should be reviewed separately