### PR TITLE
Issue 26-13: fix holder organization dropdown sizing

### DIFF
--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -6,7 +6,7 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
Make the holder organization dropdown full width so it matches the other form inputs on the new holder page.

## Related Issue
Closes #308 

## Changes
- updated the local form selector in `assettrack/intake/templates/holder_new.html`
- applied the existing input styling to the organization `<select>`
- kept behavior, validation, routes, and workflow unchanged

## Verification checklist
- [x] `docker compose up -d --build`
- [x] Opened `/holders/new` in an incognito session
- [x] Confirmed organization dropdown is full width
- [x] Confirmed dropdown matches adjacent input styling
- [x] Confirmed no layout regression

## Notes
UI-only change. No schema, auth, persistence, or workflow impact.