### PR TITLE
Issue 26-15: fix dashboard spacing regression

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -27,12 +27,12 @@
 
     .grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: 1rem; }
     .grid > .card {
-      padding: 1.1rem;
+      padding: 0.9rem 1rem;
       display: flex;
       flex-direction: column;
-      gap: 0.1rem;
+      gap: 0.05rem;
     }
-    .metric { margin: 0.3rem 0; line-height: 1.45; }
+    .metric { margin: 0.15rem 0; line-height: 1.25; }
     .section { margin-top: 1rem; }
 
     .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
@@ -93,7 +93,7 @@
       width: 64px;
       background: #134e8a;
       border-radius: 999px;
-      margin: 0.35rem 0 0.85rem 0;
+      margin: 0.25rem 0 0.55rem 0;
     }
 
     @media (max-width: 900px) { .grid { grid-template-columns: 1fr; } }


### PR DESCRIPTION
## Summary
Tighten the dashboard summary cards so operators can scan more information without wasted vertical space.

## Related Issue
Closes #312 

## Changes
- reduced padding inside dashboard summary cards
- tightened inter-row spacing in the four summary sections
- reduced metric paragraph margin and line-height
- slightly tightened accent divider spacing
- kept dashboard structure, data, and behavior unchanged

## Verification checklist
- [x] `docker compose up -d --build`
- [x] Opened `/` in an incognito session
- [x] Confirmed tighter spacing in Inventory Summary
- [x] Confirmed tighter spacing in Slot Summary
- [x] Confirmed tighter spacing in Custody Summary
- [x] Confirmed tighter spacing in Exceptions Summary
- [x] Confirmed no clipping, overlap, or alignment issues

## Notes
UI-only change. No schema, auth, persistence, or workflow impact.