### PR TITLE
Issue 26-14: apply root color palette

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -6,13 +6,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}AssetTrack{% endblock %}</title>
     <style>
+      :root {
+        --color-bg: #EBE4D1;
+        --color-surface: #B4B4B3;
+        --color-primary: #26577C;
+        --color-accent: #E55604;
+        --color-text: #12202f;
+        --color-surface-soft: rgba(180, 180, 179, 0.24);
+        --color-primary-soft: rgba(38, 87, 124, 0.12);
+        --color-accent-soft: rgba(229, 86, 4, 0.14);
+      }
       body {
         font-family: system-ui, -apple-system, Arial, sans-serif;
         margin: 0;
-        color: #12202f;
-        background: #f7f9fc;
+        color: var(--color-text);
+        background: var(--color-bg);
       }
-      a { color: #134e8a; text-decoration: none; }
+      a { color: var(--color-primary); text-decoration: none; }
       a:hover { text-decoration: underline; }
       .page {
         max-width: 1100px;
@@ -33,21 +43,23 @@
         gap: 0.35rem;
         padding: 0.4rem 0.6rem;
         border-radius: 999px;
-        background: #eef3fb;
-        border: 1px solid #d7deea;
+        background: var(--color-primary-soft);
+        border: 1px solid var(--color-surface);
+        color: var(--color-primary);
         font-weight: 600;
         font-size: 0.95rem;
         white-space: nowrap;
       }
       .chip.active {
-        background-color: #1f2937;
-        color: white;
+        background-color: var(--color-primary);
+        border-color: var(--color-primary);
+        color: #fff;
         font-weight: 600;
       }
       .chip.mode-badge {
-        background: #f8f1e3;
-        border-color: #dfcfac;
-        color: #5a4b2c;
+        background: var(--color-accent-soft);
+        border-color: var(--color-accent);
+        color: var(--color-accent);
         letter-spacing: 0.04em;
         font-size: 0.8rem;
         text-transform: uppercase;
@@ -55,35 +67,35 @@
       .card {
         margin-top: 1rem;
         padding: 1rem;
-        border: 1px solid #d7deea;
+        border: 1px solid var(--color-surface);
         border-radius: 10px;
-        background: #fff;
+        background: rgba(255, 255, 255, 0.52);
       }
       .flash {
         padding: 0.75rem 1rem;
         border-radius: 10px;
         margin: 0.75rem 0;
       }
-      .flash.error { background: #ffe8e8; border: 1px solid #f2b8b8; }
-      .flash.success { background: #eaffea; border: 1px solid #bfe8bf; }
+      .flash.error { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
+      .flash.success { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
       table { width: 100%; border-collapse: collapse; }
-      th, td { text-align: left; border-bottom: 1px solid #e8edf6; padding: 0.5rem; vertical-align: top; }
-      th { background: #eef3fb; }
-      code { background: #f6f6f6; padding: 0.15rem 0.3rem; border-radius: 4px; }
-      button { padding: 0.6rem 1rem; font-size: 1rem; }
+      th, td { text-align: left; border-bottom: 1px solid var(--color-surface); padding: 0.5rem; vertical-align: top; }
+      th { background: var(--color-primary-soft); }
+      code { background: var(--color-surface-soft); padding: 0.15rem 0.3rem; border-radius: 4px; }
+      button { padding: 0.6rem 1rem; font-size: 1rem; background: var(--color-primary); color: #fff; border: 1px solid var(--color-primary); border-radius: 8px; }
       .row { margin: 0.75rem 0; }
-      .muted { color: #555; }
+      .muted { color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text)); }
       .timeout-panel {
         margin: 0 0 1rem 0;
         padding: 0.75rem 1rem;
-        border: 1px solid #d7deea;
+        border: 1px solid var(--color-surface);
         border-radius: 10px;
-        background: #eef3fb;
+        background: var(--color-primary-soft);
       }
       .timeout-panel.locked {
-        background: #fff1f1;
-        border-color: #e0b4b4;
-        color: #7a1f1f;
+        background: var(--color-accent-soft);
+        border-color: var(--color-accent);
+        color: var(--color-accent);
       }
       @keyframes timeoutWarningPulse {
         0%, 100% { opacity: 1; }
@@ -93,7 +105,7 @@
         font-weight: inherit;
       }
       .timeout-countdown.timeout-warning {
-        color: #a54a16;
+        color: var(--color-accent);
         animation: timeoutWarningPulse 1s ease-in-out infinite;
       }
       .locked-control {
@@ -101,7 +113,7 @@
         cursor: not-allowed;
       }
       a.locked-control {
-        color: #6b7280;
+        color: color-mix(in srgb, var(--color-surface) 68%, var(--color-text));
         pointer-events: none;
         text-decoration: none;
       }

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -11,7 +11,7 @@
       font-size: 1.08rem;
       line-height: 1.3;
     }
-    .muted { color: #5b6878; }
+    .muted { color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text)); }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 
     .topbar { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 0.75rem; }
@@ -23,7 +23,7 @@
       gap: 0.5rem;
       margin: 0.75rem 0 1rem 0;
     }
-    .chip.secondary { background: #fff; }
+    .chip.secondary { background: rgba(255, 255, 255, 0.52); }
 
     .grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: 1rem; }
     .grid > .card {
@@ -35,11 +35,11 @@
     .metric { margin: 0.15rem 0; line-height: 1.25; }
     .section { margin-top: 1rem; }
 
-    .table-wrap { background: #fff; border: 1px solid #d7deea; border-radius: 10px; overflow: hidden; }
+    .table-wrap { background: rgba(255, 255, 255, 0.52); border: 1px solid var(--color-surface); border-radius: 10px; overflow: hidden; }
     table { width: 100%; border-collapse: collapse; }
-    th, td { text-align: left; padding: 0.7rem 0.75rem; border-bottom: 1px solid #e8edf6; vertical-align: top; }
+    th, td { text-align: left; padding: 0.7rem 0.75rem; border-bottom: 1px solid var(--color-surface); vertical-align: top; }
     th {
-      background: #eef3fb;
+      background: var(--color-primary-soft);
       font-size: 0.88rem;
       font-weight: 700;
       line-height: 1.25;
@@ -47,8 +47,8 @@
     tr:last-child td { border-bottom: 0; }
 
     details.collapsible {
-      background: #fff;
-      border: 1px solid #d7deea;
+      background: rgba(255, 255, 255, 0.52);
+      border: 1px solid var(--color-surface);
       border-radius: 10px;
       overflow: hidden;
       margin-top: 1rem;
@@ -57,7 +57,7 @@
       cursor: pointer;
       list-style: none;
       padding: 0.9rem 1rem;
-      background: #f3f7ff;
+      background: var(--color-primary-soft);
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -65,7 +65,7 @@
       font-weight: 700;
     }
     details.collapsible summary::-webkit-details-marker { display: none; }
-    .summary-hint { font-weight: 500; font-size: 0.9rem; color: #5b6878; }
+    .summary-hint { font-weight: 500; font-size: 0.9rem; color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text)); }
     .collapsible-body { padding: 0.9rem 1rem 1rem 1rem; }
     .collapsible-body .table-wrap { margin-top: 0.25rem; }
     .status-cell { white-space: nowrap; }
@@ -83,15 +83,15 @@
       border: 1px solid rgba(18, 32, 47, 0.18);
       flex: 0 0 auto;
     }
-    .status-dot.full { background: #12b76a; }
-    .status-dot.low { background: #f79009; }
-    .status-dot.open { background: #b42318; }
+    .status-dot.full { background: var(--color-primary); }
+    .status-dot.low { background: var(--color-surface); }
+    .status-dot.open { background: var(--color-accent); }
 
     .section-title { margin-top: 1.5rem; }
     .accent {
       height: 3px;
       width: 64px;
-      background: #134e8a;
+      background: var(--color-accent);
       border-radius: 999px;
       margin: 0.25rem 0 0.55rem 0;
     }

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -7,7 +7,7 @@
 {% block extra_head %}
   <style>
     input[type="text"], input[type="password"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
-    .queue-ts { color: #5b6878; font-size: 0.9rem; }
+    .queue-ts { color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text)); font-size: 0.9rem; }
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .queue-actions { display: flex; gap: 0.6rem; flex-wrap: wrap; align-items: center; margin-top: 0.8rem; }
     .queue-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.9rem; }
@@ -17,9 +17,9 @@
       align-items: flex-start;
       gap: 1rem;
       padding: 0.9rem 1rem;
-      border: 1px solid #d7deea;
+      border: 1px solid var(--color-surface);
       border-radius: 12px;
-      background: #fff;
+      background: rgba(255, 255, 255, 0.52);
     }
     .queue-row-main { display: grid; gap: 0.45rem; min-width: 0; }
     .queue-row-head { display: flex; align-items: center; gap: 0.65rem; flex-wrap: wrap; }
@@ -28,26 +28,26 @@
       display: grid;
       grid-template-columns: repeat(3, minmax(150px, 1fr));
       gap: 0.5rem 1rem;
-      color: #243447;
+      color: var(--color-text);
     }
     .queue-meta span { white-space: nowrap; }
     .queue-row form { flex: 0 0 auto; margin: 0; align-self: center; }
     .queue-remove {
       padding: 0.25rem 0.5rem;
-      border: 1px solid #d7deea;
+      border: 1px solid var(--color-surface);
       border-radius: 999px;
-      background: #fff;
-      color: #243447;
+      background: rgba(255, 255, 255, 0.52);
+      color: var(--color-text);
       font-size: 0.85rem;
       cursor: pointer;
     }
     .queue-empty {
       margin: 0;
       padding: 0.85rem 1rem;
-      border: 1px dashed #c7d3e6;
+      border: 1px dashed var(--color-surface);
       border-radius: 12px;
-      color: #5b6878;
-      background: #f8fbff;
+      color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text));
+      background: var(--color-primary-soft);
     }
     @media (max-width: 720px) {
       .queue-row { flex-direction: column; }

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -7,14 +7,14 @@
 {% block extra_head %}
   <style>
     .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
-    .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
-    .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
+    .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
+    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
     ul { margin: 0.5rem 0 0 1.25rem; }
     .workflow-card h2 { margin: 0 0 0.55rem 0; }
     .workflow-summary { margin: 0; line-height: 1.55; }
     .holder-summary { margin: 0; line-height: 1.55; }
     .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-    .workflow-table td strong { color: #344054; }
+    .workflow-table td strong { color: var(--color-primary); }
     .workflow-table code {
       font-size: 0.94rem;
       font-weight: 600;
@@ -28,15 +28,15 @@
     .state-block + .state-block {
       margin-top: 0.55rem;
       padding-top: 0.55rem;
-      border-top: 1px solid #e8edf6;
+      border-top: 1px solid var(--color-surface);
     }
     .review-signal {
-      border-left: 4px solid #2f6f3e;
-      background: #f4fbf5;
+      border-left: 4px solid var(--color-primary);
+      background: var(--color-primary-soft);
     }
     .review-signal.blocked {
-      border-left-color: #9f3a38;
-      background: #fff5f5;
+      border-left-color: var(--color-accent);
+      background: var(--color-accent-soft);
     }
   </style>
 {% endblock %}

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -8,8 +8,8 @@
   <style>
     pre { white-space: pre-wrap; word-break: break-word; }
     .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
-    .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
-    .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
+    .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
+    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -7,13 +7,13 @@
 {% block extra_head %}
   <style>
     .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
-    .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
-    .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
+    .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
+    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
     ul { margin: 0.5rem 0 0 1.25rem; }
     .workflow-card h2 { margin: 0 0 0.55rem 0; }
     .workflow-summary { margin: 0; line-height: 1.55; }
     .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-    .workflow-table td strong { color: #344054; }
+    .workflow-table td strong { color: var(--color-primary); }
     .workflow-table code {
       font-size: 0.94rem;
       font-weight: 600;
@@ -27,15 +27,15 @@
     .state-block + .state-block {
       margin-top: 0.55rem;
       padding-top: 0.55rem;
-      border-top: 1px solid #e8edf6;
+      border-top: 1px solid var(--color-surface);
     }
     .review-signal {
-      border-left: 4px solid #2f6f3e;
-      background: #f4fbf5;
+      border-left: 4px solid var(--color-primary);
+      background: var(--color-primary-soft);
     }
     .review-signal.blocked {
-      border-left-color: #9f3a38;
-      background: #fff5f5;
+      border-left-color: var(--color-accent);
+      background: var(--color-accent-soft);
     }
   </style>
 {% endblock %}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -7,19 +7,19 @@
 {% block extra_head %}
   <style>
     .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
-    .pill.good { background: #eaffea; border: 1px solid #bfe8bf; }
-    .pill.bad { background: #ffe8e8; border: 1px solid #f2b8b8; }
+    .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
+    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
     input[type="text"] { padding: 0.6rem; font-size: 1rem; width: 420px; }
     .validation-messages { margin-top: 0.5rem; }
     .validation-message { margin: 0.35rem 0; }
     .queue-ts {
-      color: #5b6878;
+      color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text));
       font-size: 0.82rem;
       margin-right: 0.25rem;
       padding: 0.2rem 0.45rem;
       border-radius: 999px;
-      background: #eef3fb;
-      border: 1px solid #d7deea;
+      background: var(--color-primary-soft);
+      border: 1px solid var(--color-surface);
       white-space: nowrap;
     }
     .workflow-card h2 { margin: 0 0 0.55rem 0; }
@@ -39,9 +39,9 @@
       gap: 0.45rem;
       flex-wrap: wrap;
       padding: 0.6rem 0.7rem;
-      border: 1px solid #d7deea;
+      border: 1px solid var(--color-surface);
       border-radius: 12px;
-      background: #f8fbff;
+      background: var(--color-primary-soft);
     }
     .queue-item code {
       font-size: 0.95rem;
@@ -52,10 +52,10 @@
     }
     .queue-remove {
       padding: 0.3rem 0.55rem;
-      border: 1px solid #d7deea;
+      border: 1px solid var(--color-surface);
       border-radius: 999px;
-      background: #fff;
-      color: #243447;
+      background: rgba(255, 255, 255, 0.52);
+      color: var(--color-text);
       font-size: 0.85rem;
       cursor: pointer;
     }

--- a/assettrack/intake/templates/splash.html
+++ b/assettrack/intake/templates/splash.html
@@ -13,7 +13,7 @@
       align-items: center;
       gap: 1.25rem;
       padding: 1.75rem 0 1.5rem;
-      background: #fbfbf8;
+      background: var(--color-bg);
       overflow-x: clip;
     }
 
@@ -23,15 +23,15 @@
       font-weight: 900;
       letter-spacing: 0.03em;
       font-size: clamp(1.6rem, 2.4vw, 2.2rem);
-      color: #12151c;
+      color: var(--color-text);
       margin-top: 0.35rem;
     }
 
     .card {
       width: min(480px, 100%);
       max-width: 92vw;
-      background: #fff;
-      border: 1px solid #e2e7f0;
+      background: rgba(255, 255, 255, 0.52);
+      border: 1px solid var(--color-surface);
       border-radius: 16px;
       box-shadow: 0 14px 30px rgba(16, 24, 40, 0.10);
       padding: 1.5rem 1.35rem 1.25rem;
@@ -49,7 +49,7 @@
       font-weight: 800;
       letter-spacing: 0.20em;
       margin: 0 0 1rem 0;
-      color: #243447;
+      color: var(--color-primary);
       font-size: 1.05rem;
     }
 
@@ -63,7 +63,7 @@
       font-weight: 800;
       letter-spacing: 0.20em;
       margin: 0 0 0.4rem 0;
-      color: #1f2a37;
+      color: var(--color-text);
       font-size: 0.85rem;
     }
 
@@ -71,7 +71,7 @@
       height: 2px;
       width: 118px;
       margin: 0 auto 0.75rem auto;
-      background: #ff4b1f;
+      background: var(--color-accent);
       border-radius: 999px;
     }
 
@@ -81,16 +81,16 @@
       font-size: 1rem;
       padding: 0.85rem 0.95rem;
       border-radius: 10px;
-      border: 1px solid #d9e0eb;
+      border: 1px solid var(--color-surface);
       outline: none;
-      background: #fbfcfe;
-      color: #14202f;
+      background: rgba(255, 255, 255, 0.52);
+      color: var(--color-text);
     }
-    .splash-input::placeholder { color: #98a4b3; }
+    .splash-input::placeholder { color: color-mix(in srgb, var(--color-surface) 72%, var(--color-text)); }
     .splash-input:focus {
-      border-color: #b8c7df;
-      box-shadow: 0 0 0 3px rgba(19, 78, 138, 0.08);
-      background: #fff;
+      border-color: var(--color-primary);
+      box-shadow: 0 0 0 3px var(--color-primary-soft);
+      background: rgba(255, 255, 255, 0.72);
     }
 
     .splash-button {
@@ -102,17 +102,17 @@
       font-weight: 900;
       letter-spacing: 0.18em;
       color: #fff;
-      background: #ff4b1f;
+      background: var(--color-primary);
       border: 0;
       border-radius: 10px;
       cursor: pointer;
-      box-shadow: 0 10px 18px rgba(255, 75, 31, 0.22);
+      box-shadow: 0 10px 18px rgba(38, 87, 124, 0.22);
       display: flex;
       align-items: center;
       justify-content: center;
       gap: 0.75rem;
     }
-    .splash-button:hover { background: #f24319; }
+    .splash-button:hover { background: color-mix(in srgb, var(--color-primary) 88%, black); }
     .splash-button .btn_label {
       flex: 1 1 auto;
       text-align: center;
@@ -131,9 +131,9 @@
       margin: 0 0 0.9rem 0;
       padding: 0.55rem 0.75rem;
       border-radius: 8px;
-      border: 1px solid #f2c2bc;
-      background: #fff1ef;
-      color: #8b2417;
+      border: 1px solid var(--color-accent);
+      background: var(--color-accent-soft);
+      color: var(--color-accent);
       font-size: 0.9rem;
       text-align: center;
     }
@@ -145,8 +145,8 @@
       width: min(820px, 100%);
       max-width: 94vw;
       box-sizing: border-box;
-      background: #ffffff;
-      border: 1px solid #e7e7e2;
+      background: rgba(255, 255, 255, 0.52);
+      border: 1px solid var(--color-surface);
       border-radius: 16px;
       box-shadow: 0 10px 24px rgba(18, 21, 28, 0.08);
       padding: 1rem 1.1rem;
@@ -174,7 +174,7 @@
       right: 0;
       bottom: 0.1rem;
       height: 1px;
-      background: #cfd6e0;
+      background: var(--color-surface);
       opacity: 0.28;
     }
 
@@ -198,7 +198,7 @@
     .bottom_left .wordmark_asset {
       font-size: clamp(0.68rem, 0.95vw, 0.78rem);
       font-weight: 400;
-      color: #626b78;
+      color: color-mix(in srgb, var(--color-primary) 44%, var(--color-text));
       letter-spacing: 0.02em;
       text-transform: none;
       margin: 0;
@@ -221,8 +221,8 @@
       border-radius: 10px;
       background-image: linear-gradient(
         90deg,
-        #ff4a1a 0%,
-        #8e4a26 100%
+        var(--color-accent) 0%,
+        var(--color-primary) 100%
       );
       background-repeat: no-repeat;
       box-shadow: inset 0 1px 0 rgba(255,255,255,0.22);


### PR DESCRIPTION
## Summary
Apply the new root color palette across the shared shell and core workflow screens to improve visual consistency and operator readability.

## Related Issue
Closes #311 

## Changes
- added root color variables in `assettrack/intake/templates/base.html`
- applied the palette to shared shell elements including background, cards, nav chips, links, buttons, tables, flash banners, and timeout panels
- updated core dashboard, intake, preview, return, and login templates to replace legacy hardcoded colors
- removed bright green success styling from the updated core UI and used the blue/orange system instead

## Verification checklist
- [x] `docker compose up -d --build`
- [x] Opened key screens in an incognito session
- [x] Confirmed warm base background displays correctly
- [x] Confirmed cards and panels remain distinct and readable
- [x] Confirmed blue is the primary system color
- [x] Confirmed orange is used only for attention states
- [x] Confirmed no bright green success styling remains in updated core UI
- [x] Confirmed no workflow behavior changed

## Notes
UI-only change. No schema, auth, persistence, routing, or workflow impact.