### PR TITLE
Issue 26-16: restore issue entry workflow from holders

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2953,12 +2953,8 @@ def issue():
 def issue_preview():
     issue_mode = bool(session.get("issue_mode"))
     if not issue_mode:
-        flash("Enable issue mode before using Issue Assets.", "error")
-        return render_template(
-            "issue_preview.html",
-            blocking_issues=[],
-            assets=[],
-        )
+        flash("Use the Issue workflow before opening Issue Assets Preview.", "error")
+        return redirect(url_for("issue"))
 
     selected_holder = _selected_holder_from_session()
     asset_tags = _queue_asset_tags()

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('preview') }}">← Back to preview</a> | <a href="{{ url_for('issue_preview') }}">Issue Assets Preview</a></p>
+  <p><a href="{{ url_for('preview') }}">← Back to preview</a> | <a href="{{ url_for('issue') }}">Issue Assets</a></p>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -64,6 +64,45 @@ def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     assert b"Open Issue Assets Preview / Confirm" in issue_page.data
 
 
+def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_holder(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-holders-issue-nav", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+
+    holders_page = client_with_temp_db.get("/holders")
+    assert holders_page.status_code == 200
+    assert b'href="/issue"' in holders_page.data
+    assert b'href="/issue/preview"' not in holders_page.data
+
+    select_response = client_with_temp_db.post(
+        "/holders/select",
+        data={"holder_id": "1"},
+    )
+    assert select_response.status_code == 302
+    assert (select_response.headers.get("Location") or "").endswith("/holders")
+
+    issue_page = client_with_temp_db.get("/issue")
+    assert issue_page.status_code == 200
+    assert b"Issuing Assets" in issue_page.data
+    assert b"Issue Holder (Issue Org)" in issue_page.data
+    assert b"Enable issue mode before using Issue Assets." not in issue_page.data
+
+
+def test_issue_preview_without_issue_mode_redirects_to_issue_entry(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-issue-preview-redirect", password="op-pass", role="operator")
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = False
+
+    response = client_with_temp_db.get("/issue/preview")
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+
+
 def test_issue_with_selected_holder_still_loads_normally(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-selected", password="op-pass", role="operator")
 


### PR DESCRIPTION
## Summary
Restore the correct issue workflow seam from the holders page so operators enter `/issue` with holder context instead of falling into an invalid preview state.

## Related Issue
Closes #314 

## Changes
- changed holders page issue-related navigation to target `/issue` instead of `/issue/preview`
- updated `/issue/preview` guard behavior to redirect back to `/issue` when reached without valid issue workflow context
- added regression coverage for holder-to-issue navigation and invalid direct preview access

## Verification checklist
- [x] `pytest -q tests/test_issue_holder_prerequisite.py tests/test_issue_23_2_preview_commit_seam.py tests/test_issue_22_2_timeout_ui_lock.py tests/test_holder_creation_viability.py`
- [x] `docker compose up -d --build`
- [x] Opened app in an incognito session
- [x] Selected a holder from `/holders`
- [x] Confirmed issue-related navigation lands on `/issue`
- [x] Confirmed selected holder context is preserved
- [x] Confirmed no misleading “Enable issue mode before using Issue Assets” dead-end appears
- [x] Confirmed direct `/issue/preview` access redirects back to `/issue`

## Notes
Behavior fix only. No schema, auth, persistence, or event model changes.