### PR TITLE
Issue 26-12: standardize holder validation and redirects

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -552,6 +552,22 @@ def _return_to_path(return_to: str) -> str:
     return path
 
 
+def _safe_local_return_to(return_to: str) -> str | None:
+    target = str(return_to or "").strip()
+    if target.startswith("/") and not target.startswith("//"):
+        return target
+    return None
+
+
+def _holder_form_error_message(exc: ValueError) -> str:
+    message = str(exc)
+    if message == "organization is required":
+        return "Choose an organization for this holder."
+    if message == "name is required":
+        return "Enter a person or group name when using Ad Hoc."
+    return message
+
+
 def _holder_display_name(holder: Optional[dict]) -> str:
     if not holder:
         return ""
@@ -3237,11 +3253,16 @@ def holders_new():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
+    form = session.pop("holder_new_form", None)
+    if not isinstance(form, dict):
+        form = {"name": "", "organization_id": ""}
+
     return render_template(
         "holder_new.html",
-        form={"name": "", "organization_id": ""},
+        form=form,
+        return_to=return_to,
         organization_options=list_organizations(),
-        error_message=None,
     )
 
 
@@ -3253,6 +3274,7 @@ def holders_create():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    return_to = _safe_local_return_to(request.form.get("return_to") or "")
     name = (request.form.get("name") or "").strip()
     organization_id_raw = (request.form.get("organization_id") or "").strip()
     form = {"name": name, "organization_id": organization_id_raw}
@@ -3263,20 +3285,15 @@ def holders_create():
             organization_id=None if not organization_id_raw else int(organization_id_raw),
         )
     except ValueError as e:
-        return render_template(
-            "holder_new.html",
-            form=form,
-            organization_options=list_organizations(),
-            error_message=(
-                "Choose an organization for this holder."
-                if str(e) == "organization is required"
-                else "Enter a person or group name for Ad Hoc holders."
-                if str(e) == "name is required"
-                else str(e)
-            ),
-        )
+        session["holder_new_form"] = form
+        flash(_holder_form_error_message(e), "error")
+        if return_to is not None:
+            return redirect(url_for("holders_new", return_to=return_to))
+        return redirect(url_for("holders_new"))
 
     flash(f"Created holder: {_holder_display_name(created)}", "success")
+    if return_to is not None:
+        return redirect(return_to)
     return redirect(url_for("holders_search"))
 
 
@@ -3288,19 +3305,24 @@ def holders_edit(holder_id: int):
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     holder = get_holder(holder_id)
     if holder is None:
         abort(404)
 
+    form = session.pop(f"holder_edit_form:{holder_id}", None)
+    if not isinstance(form, dict):
+        form = {
+            "name": str(holder.get("name") or ""),
+            "organization_id": "" if holder.get("organization_id") is None else str(holder.get("organization_id")),
+        }
+
     return render_template(
         "holder_edit.html",
         holder=holder,
-        form={
-            "name": str(holder.get("name") or ""),
-            "organization_id": "" if holder.get("organization_id") is None else str(holder.get("organization_id")),
-        },
+        form=form,
+        return_to=return_to,
         organization_options=list_organizations(),
-        error_message=None,
     )
 
 
@@ -3312,6 +3334,7 @@ def holders_edit_submit(holder_id: int):
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    return_to = _safe_local_return_to(request.form.get("return_to") or "")
     form = {
         "name": (request.form.get("name") or "").strip(),
         "organization_id": (request.form.get("organization_id") or "").strip(),
@@ -3328,22 +3351,16 @@ def holders_edit_submit(holder_id: int):
             organization_id=None if not form["organization_id"] else int(form["organization_id"]),
         )
     except ValueError as e:
-        return render_template(
-            "holder_edit.html",
-            holder=holder,
-            form=form,
-            organization_options=list_organizations(),
-            error_message=(
-                "Choose an organization for this holder."
-                if str(e) == "organization is required"
-                else "Enter a person or group name for Ad Hoc holders."
-                if str(e) == "name is required"
-                else str(e)
-            ),
-        )
+        session[f"holder_edit_form:{holder_id}"] = form
+        flash(_holder_form_error_message(e), "error")
+        if return_to is not None:
+            return redirect(url_for("holders_edit", holder_id=holder_id, return_to=return_to))
+        return redirect(url_for("holders_edit", holder_id=holder_id))
 
     flash(f"Updated holder: {_holder_display_name(updated)}", "success")
-    return redirect(url_for("holders_search", q=_holder_display_name(updated)))
+    if return_to is not None:
+        return redirect(return_to)
+    return redirect(url_for("holders_search"))
 
 
 @app.post("/holders/select")

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -15,7 +15,11 @@
 {% block content %}
   <nav class="actions" aria-label="Holder navigation">
     <a class="chip" href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>
-    <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id) }}">Edit Holder</a>
+    {% if return_to %}
+      <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=return_to) }}">Edit Holder</a>
+    {% else %}
+      <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id) }}">Edit Holder</a>
+    {% endif %}
     <form method="post" action="{{ url_for('holders_select') }}">
       <input type="hidden" name="holder_id" value="{{ holder.id }}" />
       {% if return_to %}

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -6,12 +6,12 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
   </style>
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('holders_search') }}">&larr; Back to holders</a></p>
+  <p><a href="{{ return_to or url_for('holders_search') }}">&larr; Back to holders</a></p>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -21,21 +21,20 @@
     {% endif %}
   {% endwith %}
 
-  {% if error_message %}
-    <div class="flash error">{{ error_message }}</div>
-  {% endif %}
-
   <div class="card">
     <h2>Edit Holder</h2>
     <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
-    <form method="post" action="{{ url_for('holders_edit_submit', holder_id=holder.id) }}">
+    <form method="post" action="{{ url_for('holders_edit_submit', holder_id=holder.id) }}" novalidate>
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
       <div class="row">
         <label for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label><br />
         <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
         <label for="organization_id"><strong>Group / organization</strong></label><br />
-        <select id="organization_id" name="organization_id" required>
+        <select id="organization_id" name="organization_id">
           <option value="">Select organization</option>
           {% for organization in organization_options %}
             <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('holders_search') }}">&larr; Back to holders</a></p>
+  <p><a href="{{ return_to or url_for('holders_search') }}">&larr; Back to holders</a></p>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -21,21 +21,20 @@
     {% endif %}
   {% endwith %}
 
-  {% if error_message %}
-    <div class="flash error">{{ error_message }}</div>
-  {% endif %}
-
   <div class="card">
     <h2>New Holder</h2>
     <p class="muted">A holder can be a person or a group such as a shop, office, or team.</p>
-    <form method="post" action="{{ url_for('holders_create') }}">
+    <form method="post" action="{{ url_for('holders_create') }}" novalidate>
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
       <div class="row">
         <label for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label><br />
         <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
       <div class="row">
         <label for="organization_id"><strong>Group / organization</strong></label><br />
-        <select id="organization_id" name="organization_id" required>
+        <select id="organization_id" name="organization_id">
           <option value="">Select organization</option>
           {% for organization in organization_options %}
             <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -27,7 +27,11 @@
 
   <div class="card">
     <div class="actions" aria-label="Holder actions">
-      <a class="chip" href="{{ url_for('holders_new') }}">Add Holder</a>
+      {% if return_to %}
+        <a class="chip" href="{{ url_for('holders_new', return_to=return_to) }}">Add Holder</a>
+      {% else %}
+        <a class="chip" href="{{ url_for('holders_new') }}">Add Holder</a>
+      {% endif %}
       {% if query %}
         <a class="chip" href="{{ url_for('holders_search', return_to=return_to) }}">Clear Search</a>
       {% endif %}
@@ -97,7 +101,13 @@
               <td><code>{{ h["identifier"] or "" }}</code></td>
               <td>{{ h["contact_info"] or "" }}</td>
               <td>{{ h.get("asset_count", "") }}</td>
-              <td><a href="{{ url_for('holders_edit', holder_id=h['id']) }}">Edit</a></td>
+              <td>
+                {% if return_to %}
+                  <a href="{{ url_for('holders_edit', holder_id=h['id'], return_to=return_to) }}">Edit</a>
+                {% else %}
+                  <a href="{{ url_for('holders_edit', holder_id=h['id']) }}">Edit</a>
+                {% endif %}
+              </td>
               <td>
                 <form method="post" action="{{ url_for('holders_select') }}">
                   <input type="hidden" name="holder_id" value="{{ h['id'] }}" />

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -43,6 +43,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         response = self.client.get("/holders/new")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Create Holder", response.data)
+        self.assertIn(b"novalidate", response.data)
+        self.assertNotIn(b'name="organization_id" required', response.data)
 
     def test_get_holders_list_route_exists(self) -> None:
         response = self.client.get("/holders/list")
@@ -71,9 +73,15 @@ class HolderCreationViabilityTests(unittest.TestCase):
         response = self.client.post(
             "/holders/new",
             data={"name": "Named Holder", "organization_id": ""},
+            follow_redirects=False,
         )
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Choose an organization for this holder.", response.data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/holders/new"))
+
+        follow_up = self.client.get("/holders/new")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"Choose an organization for this holder.", follow_up.data)
+        self.assertIn(b'value="Named Holder"', follow_up.data)
 
         count = self.conn.execute("SELECT COUNT(*) AS c FROM holders;").fetchone()["c"]
         self.assertEqual(count, 0)
@@ -103,10 +111,15 @@ class HolderCreationViabilityTests(unittest.TestCase):
         response = self.client.post(
             "/holders/new",
             data={"name": "", "organization_id": str(organization_id)},
+            follow_redirects=False,
         )
 
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Enter a person or group name for Ad Hoc holders.", response.data)
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/holders/new"))
+
+        follow_up = self.client.get("/holders/new")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"Enter a person or group name when using Ad Hoc.", follow_up.data)
 
     def test_create_search_and_select_holder_workflow(self) -> None:
         holder_name = "ZZ Test Holder 21-4"
@@ -156,6 +169,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         edit_get = self.client.get(f"/holders/edit/{int(holder_row['id'])}")
         self.assertEqual(edit_get.status_code, 200)
         self.assertIn(b"Edit Holder", edit_get.data)
+        self.assertIn(b"novalidate", edit_get.data)
+        self.assertNotIn(b'name="organization_id" required', edit_get.data)
 
         edit_post = self.client.post(
             f"/holders/edit/{int(holder_row['id'])}",
@@ -184,10 +199,61 @@ class HolderCreationViabilityTests(unittest.TestCase):
         edit_post = self.client.post(
             f"/holders/edit/{int(holder_row['id'])}",
             data={"name": "Editable Holder", "organization_id": ""},
+            follow_redirects=False,
         )
 
-        self.assertEqual(edit_post.status_code, 200)
-        self.assertIn(b"Choose an organization for this holder.", edit_post.data)
+        self.assertEqual(edit_post.status_code, 302)
+        self.assertTrue((edit_post.headers["Location"]).endswith(f"/holders/edit/{int(holder_row['id'])}"))
+
+        follow_up = self.client.get(f"/holders/edit/{int(holder_row['id'])}")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"Choose an organization for this holder.", follow_up.data)
+        self.assertIn(b'value="Editable Holder"', follow_up.data)
+
+    def test_create_holder_respects_return_to_after_success(self) -> None:
+        organization_id = self._create_org("Issue Org")
+
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "Workflow Holder", "organization_id": str(organization_id), "return_to": "/issue"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/issue"))
+
+    def test_create_holder_preserves_return_to_on_validation_redirect(self) -> None:
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "Workflow Holder", "organization_id": "", "return_to": "/issue"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/holders/new?return_to=/issue"))
+
+        follow_up = self.client.get("/holders/new?return_to=/issue")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b'name="return_to" value="/issue"', follow_up.data)
+        self.assertIn(b"Choose an organization for this holder.", follow_up.data)
+
+    def test_edit_holder_respects_return_to_after_success(self) -> None:
+        organization_id = self._create_org("Issue Org")
+        self.client.post("/holders/new", data={"name": "Workflow Holder", "organization_id": str(organization_id)})
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Workflow Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        response = self.client.post(
+            f"/holders/edit/{int(holder_row['id'])}",
+            data={"name": "Workflow Holder", "organization_id": str(organization_id), "return_to": "/issue"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/issue"))
 
     def test_holders_list_shows_holders_and_asset_count(self) -> None:
         holder_name = "Holder List Person"


### PR DESCRIPTION
## Summary
Standardize holder create/edit validation and redirect behavior so operators always see app-controlled messages and return to the right workflow path.

## Related Issue
Closes #309 

## Changes
- disabled browser-native validation on holder create/edit forms
- standardized server-side validation messages for organization selection and Ad Hoc naming
- changed invalid create/edit POST handling to PRG with flashed app messages
- preserved entered form values across validation redirects
- preserved valid `return_to` through holder create/edit flows
- updated holder search/detail links to carry workflow return intent into add/edit actions

## Verification checklist
- [x] `pytest -q tests/test_holder_creation_viability.py tests/test_issue_holder_prerequisite.py tests/test_holders.py`
- [x] `pytest -q tests/test_issue_23_2_preview_commit_seam.py tests/test_issue_clear_queue.py tests/test_issue_22_2_timeout_ui_lock.py`
- [x] `docker compose up -d --build`
- [x] Opened app in an incognito session
- [x] Confirmed create validation shows app-controlled message with no browser-native popup
- [x] Confirmed Ad Hoc validation shows app-controlled message and preserves entered values
- [x] Confirmed edit validation shows app-controlled message and preserves values
- [x] Confirmed workflow-driven holder create/edit returns to `/issue` when entered from that path

## Notes
Behavior fix only. No schema, auth, persistence, or event model changes.