### PR TITLE
Issue 26-1: wire issue-time current location

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1719,6 +1719,90 @@ def _selected_holder_from_session() -> Optional[dict]:
     return holder
 
 
+def _issue_location_form_from_session() -> dict[str, str]:
+    return {
+        "building": str(session.get("issue_building") or "").strip(),
+        "room": str(session.get("issue_room") or "").strip(),
+    }
+
+
+def _issue_location_context(selected_holder: Optional[dict], form: Optional[dict[str, str]] = None) -> dict:
+    normalized_form = {
+        "building": str((form or {}).get("building") or "").strip(),
+        "room": str((form or {}).get("room") or "").strip(),
+    }
+    all_building_names = [str(row.get("name") or "").strip() for row in list_buildings()]
+    all_building_names = [name for name in all_building_names if name]
+    allowed_building_names = list(all_building_names)
+    constrained_by_org = False
+
+    holder_org_id = None if not selected_holder else selected_holder.get("organization_id")
+    try:
+        normalized_holder_org_id = None if holder_org_id in {None, ""} else int(holder_org_id)
+    except (TypeError, ValueError):
+        normalized_holder_org_id = None
+
+    if normalized_holder_org_id is not None:
+        mapped_buildings = [
+            str(mapping.get("building_name") or "").strip()
+            for mapping in list_organization_building_mappings()
+            if int(mapping["organization_id"]) == normalized_holder_org_id
+        ]
+        mapped_buildings = [name for name in mapped_buildings if name]
+        if mapped_buildings:
+            constrained_by_org = True
+            allowed_building_names = mapped_buildings
+
+    return {
+        "form": normalized_form,
+        "building_options": allowed_building_names,
+        "has_reference_buildings": bool(all_building_names),
+        "constrained_by_org": constrained_by_org,
+    }
+
+
+def _validate_issue_location_form(selected_holder: Optional[dict], form: dict[str, str]) -> tuple[dict[str, str], list[str], dict]:
+    context = _issue_location_context(selected_holder, form)
+    normalized_form = context["form"]
+    errors: list[str] = []
+
+    if selected_holder is None:
+        errors.append("Select a holder before choosing the current location.")
+        return normalized_form, errors, context
+
+    building = normalized_form["building"]
+    room = normalized_form["room"]
+    building_options = list(context["building_options"])
+    building_name_map = {name.upper(): name for name in building_options}
+
+    if not building:
+        errors.append("Choose the current building.")
+    elif building_name_map:
+        matched_name = building_name_map.get(building.upper())
+        if matched_name is None:
+            if context["constrained_by_org"]:
+                errors.append("Choose a building allowed for the selected organization.")
+            else:
+                errors.append("Choose a valid building.")
+        else:
+            normalized_form["building"] = matched_name
+
+    if not room:
+        errors.append("Enter the current room or area.")
+
+    return normalized_form, errors, context
+
+
+def _issue_location_label(form: dict[str, str]) -> str:
+    building = str(form.get("building") or "").strip()
+    room = str(form.get("room") or "").strip()
+    if building and room:
+        return f"{building} / {room}"
+    if building:
+        return building
+    return ""
+
+
 def _queue_asset_tags() -> list[str]:
     tags: list[str] = []
     for s in SCAN_QUEUE:
@@ -1734,6 +1818,11 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
         identifier = (selected_holder.get("identifier") or "").strip()
         display_name = _holder_display_name(selected_holder)
         holder_label = display_name if not identifier else f"{display_name} ({identifier})"
+    issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
+        selected_holder,
+        _issue_location_form_from_session(),
+    )
+    issue_location_label = _issue_location_label(issue_location_form)
 
     assets: list[dict] = []
     unknown_tags: list[str] = []
@@ -1753,6 +1842,8 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
 
     if selected_holder is None:
         blocking_issues.append("No holder selected. Select a holder before issuing assets.")
+    for error in issue_location_errors:
+        blocking_issues.append(error)
 
     def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
         t = (scan_tag or "").strip()
@@ -1761,7 +1852,7 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
 
         rows = conn.execute(
             """
-            SELECT id, asset_tag, location_type, current_holder_id
+            SELECT id, asset_tag, location_type, current_holder_id, building_room, home_slot_id
             FROM assets
             WHERE UPPER(asset_tag) = UPPER(?)
                OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
@@ -1781,7 +1872,7 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
     conn = get_connection()
     try:
         asset_columns = get_asset_table_columns(conn)
-        required_columns = {"location_type", "current_holder_id"}
+        required_columns = {"location_type", "current_holder_id", "building_room"}
         missing_columns = sorted(required_columns - asset_columns)
         if missing_columns:
             blocking_issues.append(f"Assets table missing columns: {', '.join(missing_columns)}")
@@ -1799,10 +1890,12 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
                 "canonical_tag": None,
                 "before_location_type": "UNKNOWN",
                 "after_location_type": "IN_CUSTODY",
+                "before_current_location": "null",
+                "after_current_location": issue_location_label or "(choose current location)",
                 "before_holder": "null",
                 "after_holder": holder_label or "(select holder)",
-                "before_slot": "null",
-                "after_slot": "null",
+                "before_home_location": "null",
+                "after_home_location": "null",
                 "before_slot_occupancy": "unknown",
                 "after_slot_occupancy": "vacated",
                 "ready": False,
@@ -1822,6 +1915,7 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
 
             before_location = str(asset_row["location_type"] or "").strip().upper()
             row["before_location_type"] = before_location or "UNKNOWN"
+            row["before_current_location"] = str(asset_row["building_room"] or "").strip() or "null"
             if _is_terminal_location_type(before_location):
                 row["asset_issues"].append("Asset is retired/disposed")
                 retired_assets.append(canon_tag)
@@ -1831,9 +1925,20 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
 
             current_slot = _asset_current_slot(conn, int(asset_row["id"]), canon_tag)
             slotted = current_slot is not None
-            if current_slot is not None:
-                row["before_slot"] = f"{current_slot['case_name']} / {current_slot['slot_position']}"
+            home_slot_id = asset_row.get("home_slot_id")
+            if home_slot_id is not None:
+                home_slot = conn.execute(
+                    """
+                    SELECT case_name, slot_position
+                    FROM slots
+                    WHERE id = ?;
+                    """,
+                    (int(home_slot_id),),
+                ).fetchone()
+                if home_slot is not None:
+                    row["before_home_location"] = f"{home_slot['case_name']} / {home_slot['slot_position']}"
             row["before_slot_occupancy"] = "occupied" if slotted else "vacant"
+            row["after_home_location"] = row["before_home_location"]
 
             if before_location != "STORAGE":
                 row["asset_issues"].append("Asset is not in STORAGE")
@@ -2002,7 +2107,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
     return {"assets": assets, "ready_count": ready_count, "blocking_issues": blocking_issues}
 
 
-def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
+def _issue_batch(asset_tags: list[str], holder_id: int, issue_location: dict[str, str]) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to issue.")
 
@@ -2020,7 +2125,7 @@ def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
 
         rows = conn.execute(
             """
-            SELECT id, asset_tag, location_type
+            SELECT id, asset_tag, location_type, building_room, home_slot_id
             FROM assets
             WHERE UPPER(asset_tag) = UPPER(?)
                OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
@@ -2042,10 +2147,14 @@ def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
     try:
         with conn:
             asset_columns = get_asset_table_columns(conn)
-            required_columns = {"location_type", "current_holder_id"}
+            required_columns = {"location_type", "current_holder_id", "building_room"}
             missing_columns = sorted(required_columns - asset_columns)
             if missing_columns:
                 raise ValueError(f"Assets table missing columns: {', '.join(missing_columns)}")
+
+            building = str(issue_location.get("building") or "").strip()
+            room = str(issue_location.get("room") or "").strip()
+            building_room = f"{building}/{room}"
 
             unknown_tags: list[str] = []
             not_storage: list[str] = []
@@ -2053,7 +2162,7 @@ def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
             not_slotted: list[str] = []
 
             # Map scan tags -> canonical DB rows (so we update/vacate consistently)
-            canon_assets: list[tuple[int, str]] = []
+            canon_assets: list[tuple[int, str, Optional[int]]] = []
 
             for scan_tag in asset_tags:
                 asset_row = _canon_asset_row_for_scan_tag(conn, scan_tag)
@@ -2063,7 +2172,8 @@ def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
 
                 canon_tag = str(asset_row["asset_tag"])
                 asset_id = int(asset_row["id"])
-                canon_assets.append((asset_id, canon_tag))
+                home_slot_id = None if asset_row.get("home_slot_id") is None else int(asset_row["home_slot_id"])
+                canon_assets.append((asset_id, canon_tag, home_slot_id))
 
                 location_type = str(asset_row["location_type"] or "").strip().upper()
                 if _is_terminal_location_type(location_type):
@@ -2088,15 +2198,39 @@ def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
 
             now_iso = datetime.now(timezone.utc).isoformat()
 
-            for asset_id, canon_tag in canon_assets:
-                conn.execute(
+            for asset_id, canon_tag, home_slot_id in canon_assets:
+                asset_row = conn.execute(
                     """
+                    SELECT building_room
+                    FROM assets
+                    WHERE id = ?
+                    LIMIT 1;
+                    """,
+                    (asset_id,),
+                ).fetchone()
+                previous_building_room = "" if asset_row is None else str(asset_row["building_room"] or "").strip()
+
+                update_clauses = ["location_type = ?", "current_holder_id = ?"]
+                update_values: list[object] = ["IN_CUSTODY", holder_id]
+                if "building" in asset_columns:
+                    update_clauses.append("building = ?")
+                    update_values.append(building)
+                if "room" in asset_columns:
+                    update_clauses.append("room = ?")
+                    update_values.append(room)
+                if "building_room" in asset_columns:
+                    update_clauses.append("building_room = ?")
+                    update_values.append(building_room)
+                update_values.extend([canon_tag, canon_tag])
+
+                conn.execute(
+                    f"""
                     UPDATE assets
-                    SET location_type = ?, current_holder_id = ?
+                    SET {', '.join(update_clauses)}
                     WHERE UPPER(asset_tag) = UPPER(?)
                        OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?);
                     """,
-                    ("IN_CUSTODY", holder_id, canon_tag, canon_tag),
+                    tuple(update_values),
                 )
 
                 current_slot = _asset_current_slot(conn, asset_id, canon_tag)
@@ -2127,12 +2261,28 @@ def _issue_batch(asset_tags: list[str], holder_id: int) -> int:
                         event_date,
                         actor,
                         notes,
-                        payload,
-                        holder_id
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?);
-                    """,
-                    (canon_tag, ISSUE_EVENT_TYPE, now_iso, "system", None, None, holder_id),
+                    payload,
+                    holder_id
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?);
+                """,
+                    (
+                        canon_tag,
+                        ISSUE_EVENT_TYPE,
+                        now_iso,
+                        "system",
+                        None,
+                        json.dumps(
+                            {
+                                "from_location_type": "STORAGE",
+                                "to_location_type": "IN_CUSTODY",
+                                "from_building_room": previous_building_room,
+                                "to_building_room": building_room,
+                                "home_slot_id": home_slot_id,
+                            }
+                        ),
+                        holder_id,
+                    ),
                 )
 
             return len(canon_assets)
@@ -2329,6 +2479,25 @@ def intake():
             return redirect(url_for("add_assets"))
 
         if scan_text:
+            if return_to_path == "/issue":
+                selected_holder = _selected_holder_from_session()
+                issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
+                    selected_holder,
+                    _issue_location_form_from_session(),
+                )
+                if selected_holder is None:
+                    flash("Select a holder before issuing assets.", "error")
+                    touch_session()
+                    return redirect(url_for("holders_search", return_to=url_for("issue")))
+                if issue_location_errors:
+                    flash(issue_location_errors[0], "error")
+                    touch_session()
+                    if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                        return redirect(redirect_target)
+                    return redirect(url_for("issue"))
+                session["issue_building"] = issue_location_form["building"]
+                session["issue_room"] = issue_location_form["room"]
+
             value = sanitize_scan(scan_text)
             if not value:
                 flash("Scan rejected. Enter a valid asset tag.", "error")
@@ -2882,10 +3051,20 @@ def preview_commit():
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("preview"))
 
+    issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
+        holder,
+        _issue_location_form_from_session(),
+    )
+    if issue_location_errors:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "; ".join(issue_location_errors)}, 400
+        flash("; ".join(issue_location_errors), "error")
+        return redirect(url_for("issue"))
+
     asset_tags = _queue_asset_tags()
 
     try:
-        committed_count = _issue_batch(asset_tags, holder["id"])
+        committed_count = _issue_batch(asset_tags, holder["id"], issue_location_form)
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400
@@ -2921,6 +3100,12 @@ def issue():
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("holders_search", return_to=url_for("issue")))
 
+    issue_location_form, issue_location_errors, issue_location_context = _validate_issue_location_form(
+        selected_holder,
+        _issue_location_form_from_session(),
+    )
+    session["issue_building"] = issue_location_form["building"]
+    session["issue_room"] = issue_location_form["room"]
     asset_tags = _queue_asset_tags()
     issue_state = _build_issue_preview_state(asset_tags, selected_holder)
     issued_count_raw = (request.args.get("issued") or "").strip()
@@ -2961,7 +3146,45 @@ def issue():
         ready_count=issue_state["ready_count"],
         blocking_issues=issue_state["blocking_issues"],
         selected_holder=selected_holder,
+        issue_location_form=issue_location_form,
+        issue_location_errors=issue_location_errors,
+        issue_location_building_options=issue_location_context["building_options"],
+        issue_location_constrained_by_org=issue_location_context["constrained_by_org"],
+        issue_location_ready=not issue_location_errors,
+        issue_location_label=_issue_location_label(issue_location_form),
     )
+
+
+@app.post("/issue/location")
+@require_login
+def issue_location_update():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("add_assets"))
+
+    selected_holder = _selected_holder_from_session()
+    if selected_holder is None:
+        flash("Select a holder before issuing assets.", "error")
+        return redirect(url_for("holders_search", return_to=url_for("issue")))
+
+    issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
+        selected_holder,
+        {
+            "building": (request.form.get("building") or "").strip(),
+            "room": (request.form.get("room") or "").strip(),
+        },
+    )
+    session["issue_building"] = issue_location_form["building"]
+    session["issue_room"] = issue_location_form["room"]
+    touch_session()
+
+    if issue_location_errors:
+        flash("; ".join(issue_location_errors), "error")
+    else:
+        flash(f"Current location set to {_issue_location_label(issue_location_form)}.", "success")
+
+    return redirect(url_for("issue"))
 
 
 @app.get("/issue/preview")
@@ -2973,6 +3196,12 @@ def issue_preview():
         return redirect(url_for("issue"))
 
     selected_holder = _selected_holder_from_session()
+    issue_location_form, issue_location_errors, issue_location_context = _validate_issue_location_form(
+        selected_holder,
+        _issue_location_form_from_session(),
+    )
+    session["issue_building"] = issue_location_form["building"]
+    session["issue_room"] = issue_location_form["room"]
     asset_tags = _queue_asset_tags()
     issue_preview_state = _build_issue_preview_state(asset_tags, selected_holder)
 
@@ -2988,6 +3217,11 @@ def issue_preview():
         blocking_issues=issue_preview_state["blocking_issues"],
         last_seen_age_seconds=seconds_since_last_seen(),
         timeout_seconds=INTAKE_TIMEOUT_SECONDS,
+        issue_location_form=issue_location_form,
+        issue_location_errors=issue_location_errors,
+        issue_location_building_options=issue_location_context["building_options"],
+        issue_location_constrained_by_org=issue_location_context["constrained_by_org"],
+        issue_location_label=_issue_location_label(issue_location_form),
     )
 
 
@@ -3026,6 +3260,16 @@ def issue_commit():
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("issue_preview"))
 
+    issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
+        holder,
+        _issue_location_form_from_session(),
+    )
+    if issue_location_errors:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "; ".join(issue_location_errors)}, 400
+        flash("; ".join(issue_location_errors), "error")
+        return redirect(url_for("issue"))
+
     asset_tags = _queue_asset_tags()
     if not asset_tags:
         if wants_json():
@@ -3034,7 +3278,7 @@ def issue_commit():
         return redirect(url_for("issue_preview"))
 
     try:
-        committed_count = _issue_batch(asset_tags, holder["id"])
+        committed_count = _issue_batch(asset_tags, holder["id"], issue_location_form)
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -92,6 +92,30 @@
   </div>
 
   <div class="card workflow-card">
+    <h2>Current Location</h2>
+    {% if issue_location_label and not issue_location_errors %}
+      <p class="holder-summary">
+        <strong>Current location:</strong> {{ issue_location_label }}
+      </p>
+    {% else %}
+      <p>No current location selected.</p>
+    {% endif %}
+    {% if issue_location_constrained_by_org %}
+      <p>Building choices are limited to the selected holder's organization.</p>
+    {% endif %}
+    {% if issue_location_errors %}
+      <ul>
+        {% for issue in issue_location_errors %}
+          <li>{{ issue }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    <div class="actions" style="margin-top: 0.75rem;">
+      <a class="chip" href="{{ url_for('issue') }}">Update current location</a>
+    </div>
+  </div>
+
+  <div class="card workflow-card">
     <h2>Validation Summary</h2>
     <p class="workflow-summary">
       <strong>Queued assets:</strong> {{ queued_count }}
@@ -133,16 +157,19 @@
         <tbody>
           {% for row in assets %}
             {% set before_holder_display = "Not assigned" if row.before_holder == "null" else row.before_holder %}
-            {% set before_slot_display = "Not assigned" if row.before_slot == "null" else row.before_slot %}
-            {% set after_slot_display = "Not assigned" if row.after_slot == "null" else row.after_slot %}
+            {% set before_current_location_display = "Not assigned" if row.before_current_location == "null" else row.before_current_location %}
+            {% set after_current_location_display = "Not assigned" if row.after_current_location == "null" else row.after_current_location %}
+            {% set before_home_location_display = "Not assigned" if row.before_home_location == "null" else row.before_home_location %}
+            {% set after_home_location_display = "Not assigned" if row.after_home_location == "null" else row.after_home_location %}
             <tr>
               <td><code>{{ row.asset_tag }}</code></td>
 
               <td>
                 <div class="state-block">
                   <strong>Location:</strong> <code>{{ row.before_location_type }}</code><br />
+                  <strong>Current location:</strong> <code>{{ before_current_location_display }}</code><br />
                   <strong>Issued to:</strong> <code>{{ before_holder_display }}</code><br />
-                  <strong>Home location:</strong> <code>{{ before_slot_display }}</code><br />
+                  <strong>Home location:</strong> <code>{{ before_home_location_display }}</code><br />
                   <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code>
                 </div>
               </td>
@@ -150,8 +177,9 @@
               <td>
                 <div class="state-block">
                   <strong>Location:</strong> <code>{{ row.after_location_type }}</code><br />
+                  <strong>Current location:</strong> <code>{{ after_current_location_display }}</code><br />
                   <strong>Issued to:</strong> <code>{{ row.after_holder }}</code><br />
-                  <strong>Home location:</strong> <code>{{ after_slot_display }}</code><br />
+                  <strong>Home location:</strong> <code>{{ after_home_location_display }}</code><br />
                   <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code> → <code>{{ row.after_slot_occupancy }}</code>
                 </div>
               </td>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -89,6 +89,48 @@
     {% include "_workflow_context_banner.html" %}
   {% endif %}
 
+  {% if issue_location_form is defined %}
+    <div class="card workflow-card">
+      <h2>Current Location Prerequisite</h2>
+      <p class="workflow-summary">
+        <strong>Current location:</strong>
+        {% if issue_location_ready %}
+          <code>{{ issue_location_label }}</code>
+        {% else %}
+          <span class="pill bad">required</span>
+        {% endif %}
+      </p>
+      {% if issue_location_constrained_by_org %}
+        <p>Building choices are limited to the selected holder's organization.</p>
+      {% endif %}
+      {% if issue_location_errors %}
+        <div class="validation-messages">
+          {% for issue in issue_location_errors %}
+            <p class="validation-message">{{ issue }}</p>
+          {% endfor %}
+        </div>
+      {% endif %}
+      <form method="post" action="{{ url_for('issue_location_update') }}" style="margin-top: 10px;">
+        <label for="issue-building"><strong>Current building</strong></label><br />
+        {% if issue_location_building_options %}
+          <select id="issue-building" name="building" data-timeout-lock-target>
+            <option value="">Choose building</option>
+            {% for building_name in issue_location_building_options %}
+              <option value="{{ building_name }}" {% if issue_location_form.building == building_name %}selected{% endif %}>{{ building_name }}</option>
+            {% endfor %}
+          </select>
+        {% else %}
+          <input id="issue-building" type="text" name="building" value="{{ issue_location_form.building }}" data-timeout-lock-target />
+        {% endif %}
+        <br /><br />
+        <label for="issue-room"><strong>Current room / area</strong></label><br />
+        <input id="issue-room" type="text" name="room" value="{{ issue_location_form.room }}" data-timeout-lock-target />
+        <br /><br />
+        <button type="submit" data-timeout-lock-target>Save current location</button>
+      </form>
+    </div>
+  {% endif %}
+
   <div class="card workflow-card">
     <h2>{{ scan_heading or "Scan returns" }}</h2>
     <p>Click the box once, then scan. The scanner "types" and hits Enter.</p>

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -86,6 +86,8 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     with client_with_temp_db.session_transaction() as sess:
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     issue_queue = client_with_temp_db.get("/issue")
     assert issue_queue.status_code == 200

--- a/tests/test_issue_23_1_active_queue_timestamps.py
+++ b/tests/test_issue_23_1_active_queue_timestamps.py
@@ -37,6 +37,8 @@ def test_issue_and_return_queue_pages_show_scan_timestamps(client_with_temp_db) 
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     scan = Scan(
         asset_tag="QUEUE-TAG-1",

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -72,6 +72,8 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.append(Scan.now("DDC4CY002645"))
 
@@ -88,8 +90,9 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Issued to:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data
     assert b"Queued:</strong> 1 asset" in issue_preview.data
+    assert b"Current location:</strong> <code>HQ North / 210</code>" in issue_preview.data
     assert b"Issued to:</strong> <code>Not assigned</code>" in issue_preview.data
-    assert b"Home location:</strong> <code>Not assigned</code>" in issue_preview.data
+    assert b"Home location:</strong> <code>CASE-1 / 1</code>" in issue_preview.data
     assert b"null" not in issue_preview.data
 
     commit = client_with_temp_db.post(
@@ -176,6 +179,8 @@ def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(clien
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.extend(
         [

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -34,6 +34,8 @@ def _login_issue_operator(client, username: str) -> None:
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
 
 def _insert_slot(conn, slot_id: int, case_name: str, slot_position: int) -> None:

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -45,6 +45,8 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.append(Scan.now("UNKNOWN-TAG"))
 
@@ -86,6 +88,8 @@ def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicate
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.extend(
         [
@@ -116,6 +120,8 @@ def test_operator_can_clear_queue_from_issue_preview_and_return_to_issue(client_
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.extend([Scan.now("TAG-1"), Scan.now("TAG-2")])
 
@@ -153,6 +159,8 @@ def test_issue_preview_discard_preserves_selected_holder_and_allows_rescan(clien
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.extend([Scan.now("TAG-1"), Scan.now("TAG-2")])
 
@@ -223,6 +231,8 @@ def test_issue_preview_discard_preserves_holder_through_rescan_preview_and_commi
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.extend([Scan.now("TAG-1"), Scan.now("TAG-2")])
 
@@ -290,6 +300,8 @@ def test_non_issue_preview_discard_still_clears_holder_selection(client_with_tem
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
         sess["equipment_type"] = "tablet"
 
     intake_app.SCAN_QUEUE.append(Scan.now("TAG-1"))
@@ -328,6 +340,8 @@ def test_issue_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_du
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     first = client_with_temp_db.post(
         "/",

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO organizations (name, created_at, updated_at)
+        VALUES ('Operations', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO buildings (name, created_at, updated_at)
+        VALUES
+            ('HQ North', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+            ('Warehouse West', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    organization_row = conn.execute(
+        "SELECT id FROM organizations WHERE name = 'Operations' LIMIT 1;"
+    ).fetchone()
+    hq_row = conn.execute(
+        "SELECT id FROM buildings WHERE name = 'HQ North' LIMIT 1;"
+    ).fetchone()
+    assert organization_row is not None
+    assert hq_row is not None
+    conn.execute(
+        """
+        INSERT INTO organization_buildings (organization_id, building_id, created_at)
+        VALUES (?, ?, '2026-01-01T00:00:00Z');
+        """
+        ,
+        (int(organization_row["id"]), int(hq_row["id"])),
+    )
+    conn.execute(
+        """
+        INSERT INTO holders (
+            id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+        )
+        VALUES (
+            1, 'PERSON', 'Issue Holder', 'Operations', ?, 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+        );
+        """,
+        (int(organization_row["id"]),),
+    )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (101, 'CASE-1', 1, 'ISSUE-100');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            id, asset_tag, serial_number, equipment_type, manufacturer, model,
+            building, room, building_room, location_type, current_holder_id, home_slot_id
+        )
+        VALUES (
+            501, 'ISSUE-100', 'SN-1', 'laptop', 'Dell', 'Latitude',
+            'Storage', 'A1', 'Storage/A1', 'STORAGE', NULL, 101
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (101, 501, '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_issue_operator(client) -> None:
+    operator_id = create_test_user(username="operator-issue-location", password="op-pass", role="operator")
+    with client.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+
+
+def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    issue_page = client_with_temp_db.get("/issue")
+
+    assert issue_page.status_code == 200
+    assert b"Current Location Prerequisite" in issue_page.data
+    assert b"HQ North" in issue_page.data
+    assert b"Warehouse West" not in issue_page.data
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert scan_response.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"Choose the current building." in scan_response.data
+
+
+def test_issue_commit_rejects_building_outside_selected_holder_org(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["issue_building"] = "Warehouse West"
+        sess["issue_room"] = "201"
+
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now("ISSUE-100"))
+
+    response = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+
+    conn = db.get_connection()
+    try:
+        asset_row = conn.execute(
+            "SELECT location_type, current_holder_id, building_room FROM assets WHERE id = 501 LIMIT 1;"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert asset_row is not None
+    assert str(asset_row["location_type"]) == "STORAGE"
+    assert asset_row["current_holder_id"] is None
+    assert str(asset_row["building_room"]) == "Storage/A1"
+
+
+def test_issue_commit_updates_current_location_and_preserves_home_location_context(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    location_response = client_with_temp_db.post(
+        "/issue/location",
+        data={"building": "HQ North", "room": "210"},
+        follow_redirects=True,
+    )
+    assert location_response.status_code == 200
+    assert b"Current location set to HQ North / 210." in location_response.data
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+    assert scan_response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
+
+    preview = client_with_temp_db.get("/issue/preview")
+    assert preview.status_code == 200
+    assert b"Current location:</strong> HQ North / 210" in preview.data
+    assert b"Current location:</strong> <code>HQ North / 210</code>" in preview.data
+    assert b"Home location:</strong> <code>CASE-1 / 1</code>" in preview.data
+    assert b"Home location:</strong> <code>Not assigned</code>" not in preview.data
+
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=False,
+    )
+
+    assert commit.status_code == 302
+    assert (commit.headers.get("Location") or "").endswith("/issue?issued=1")
+    assert len(intake_app.SCAN_QUEUE) == 0
+
+    conn = db.get_connection()
+    try:
+        asset_row = conn.execute(
+            """
+            SELECT location_type, current_holder_id, home_slot_id, building, room, building_room
+            FROM assets
+            WHERE id = 501
+            LIMIT 1;
+            """
+        ).fetchone()
+        event_row = conn.execute(
+            """
+            SELECT payload, holder_id
+            FROM asset_events
+            WHERE asset_tag = 'ISSUE-100' AND event_type = 'ISSUE'
+            ORDER BY id DESC
+            LIMIT 1;
+            """
+        ).fetchone()
+        occupancy = conn.execute(
+            "SELECT 1 FROM slot_occupancy WHERE asset_id = 501 LIMIT 1;"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert asset_row is not None
+    assert str(asset_row["location_type"]) == "IN_CUSTODY"
+    assert int(asset_row["current_holder_id"]) == 1
+    assert int(asset_row["home_slot_id"]) == 101
+    assert str(asset_row["building"]) == "HQ North"
+    assert str(asset_row["room"]) == "210"
+    assert str(asset_row["building_room"]) == "HQ North/210"
+    assert occupancy is None
+
+    assert event_row is not None
+    assert int(event_row["holder_id"]) == 1
+    payload = json.loads(str(event_row["payload"]))
+    assert payload["from_location_type"] == "STORAGE"
+    assert payload["to_location_type"] == "IN_CUSTODY"
+    assert payload["from_building_room"] == "Storage/A1"
+    assert payload["to_building_room"] == "HQ North/210"
+    assert int(payload["home_slot_id"]) == 101

--- a/tests/test_issue_slot_occupancy_consistency.py
+++ b/tests/test_issue_slot_occupancy_consistency.py
@@ -59,6 +59,8 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.append(Scan.now("DDC4CY002645"))
 
@@ -95,6 +97,8 @@ def test_issue_commit_redirect_shows_success_without_holder_warning(client_with_
         sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     intake_app.SCAN_QUEUE.append(Scan.now("DDC4CY002645"))
 

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -35,6 +35,8 @@ def _login(client, monkeypatch: pytest.MonkeyPatch, *, last_seen: int = 100) -> 
         sess["user_id"] = user_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
         sess["last_seen"] = last_seen
     return user_id
 


### PR DESCRIPTION
## Summary
Wire issue-time current location into the existing issue workflow using the current org/building model.

## Related Issue
Closes #293 

## Changes
- require current location before accepting issue scans
- constrain building choices by org when mappings exist
- carry current location through preview and commit
- update asset current location fields on issue commit
- keep current location and home location distinct in preview
- add regression coverage for issue location wiring and related issue-flow tests

## Verification checklist
- [x] `/issue` renders directly
- [x] holder/location prerequisite gates issue flow
- [x] scans are blocked until valid location is set
- [x] preview shows current location separate from home location
- [x] issue commit succeeds cleanly
- [x] asset updates to `IN_CUSTODY` with current location set
- [x] return page still renders normally
- [x] targeted tests pass

## Notes
- Follow-on UX friction noted during smoke test:
  - location requirement clarity needs improvement
  - denied scan feedback should appear closer to the blocked action
  - preview shows home location twice in the items block