### PR TITLE
Issue 26-11: fix holder and reference data control sizing

### DIFF
--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -5,7 +5,7 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
     .grid { display: grid; grid-template-columns: repeat(2, minmax(260px, 1fr)); gap: 1rem; }
   </style>
 {% endblock %}

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -6,7 +6,7 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -6,7 +6,7 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"], select { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -6,7 +6,7 @@
 
 {% block extra_head %}
   <style>
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    input[type="text"] { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
     button { margin-left: 0.25rem; }
     th, td { border-bottom: 1px solid #eee; }
     .actions { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem; }

--- a/tests/test_admin_reference_data.py
+++ b/tests/test_admin_reference_data.py
@@ -37,6 +37,7 @@ class AdminReferenceDataTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Organizations", response.data)
         self.assertIn(b"Buildings", response.data)
+        self.assertIn(b"box-sizing: border-box;", response.data)
 
         create_org = self.client.post(
             "/admin/reference-data",

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -43,6 +43,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
         response = self.client.get("/holders/new")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Create Holder", response.data)
+        self.assertIn(b"box-sizing: border-box;", response.data)
         self.assertIn(b"novalidate", response.data)
         self.assertNotIn(b'name="organization_id" required', response.data)
 
@@ -169,6 +170,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
         edit_get = self.client.get(f"/holders/edit/{int(holder_row['id'])}")
         self.assertEqual(edit_get.status_code, 200)
         self.assertIn(b"Edit Holder", edit_get.data)
+        self.assertIn(b"box-sizing: border-box;", edit_get.data)
         self.assertIn(b"novalidate", edit_get.data)
         self.assertNotIn(b'name="organization_id" required', edit_get.data)
 


### PR DESCRIPTION
## Summary
Fixes undersized holder and reference-data form controls by applying the existing full-width sizing pattern consistently.

## Related Issue
Closes #306 

## Changes
- Applied consistent full-width control sizing across holder and reference-data templates
- Added missing box-sizing: border-box to align with the existing pattern
- Ensured inputs and selects render consistently across affected pages

## Verification checklist
- [x] Holder create form displays full-width controls
- [x] Holder search input is visually consistent
- [x] Admin reference-data controls are visually consistent
- [x] No behavior changes
- [x] Tests pass
- [x] Manual smoke test completed

## Notes
Presentation-only change using the existing sizing pattern. No logic or workflow impact.