### PR TITLE
Issue 26-21: add icon to theme toggle

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -99,6 +99,9 @@
       button.theme-toggle:hover {
         background: var(--color-surface-soft);
       }
+      .theme-toggle-icon {
+        line-height: 1;
+      }
       .chip {
         display: inline-flex;
         align-items: center;
@@ -210,7 +213,8 @@
           aria-pressed="{{ 'true' if current_theme == 'dark' else 'false' }}"
           aria-label="Switch to {{ 'light' if current_theme == 'dark' else 'dark' }} mode"
         >
-          {{ "Light mode" if current_theme == "dark" else "Dark mode" }}
+          <span class="theme-toggle-icon" aria-hidden="true">{{ "☀️" if current_theme == "dark" else "🌙" }}</span>
+          <span class="theme-toggle-text">{{ "Light mode" if current_theme == "dark" else "Dark mode" }}</span>
         </button>
       </div>
       {% set heading = self.page_heading() | trim %}
@@ -250,7 +254,14 @@
 
         function syncThemeToggle() {
           const isDark = root.dataset.theme === "dark";
-          themeToggle.textContent = isDark ? "Light mode" : "Dark mode";
+          const icon = themeToggle.querySelector(".theme-toggle-icon");
+          const text = themeToggle.querySelector(".theme-toggle-text");
+          if (icon) {
+            icon.textContent = isDark ? "☀️" : "🌙";
+          }
+          if (text) {
+            text.textContent = isDark ? "Light mode" : "Dark mode";
+          }
           themeToggle.setAttribute("aria-pressed", isDark ? "true" : "false");
           themeToggle.setAttribute("aria-label", isDark ? "Switch to light mode" : "Switch to dark mode");
         }

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -50,6 +50,8 @@ def test_login_screen_renders_theme_toggle_without_persistence_storage(client_wi
     assert response.status_code == 200
     assert b'id="theme-toggle"' in response.data
     assert b"assettrack_theme" in response.data
+    assert b"theme-toggle-icon" in response.data
+    assert "🌙".encode("utf-8") in response.data
     assert b"Dark mode" in response.data
     assert b"localStorage" not in response.data
     assert b"sessionStorage" not in response.data
@@ -65,12 +67,16 @@ def test_dark_theme_cookie_persists_across_authenticated_navigation(client_with_
     assert b'<html lang="en" data-theme="dark">' in dashboard_response.data
     assert b'aria-pressed="true"' in dashboard_response.data
     assert b'aria-label="Switch to light mode"' in dashboard_response.data
+    assert "\u2600\ufe0f".encode("utf-8") in dashboard_response.data
+    assert b"Light mode" in dashboard_response.data
 
     asset_search_response = client_with_temp_db.get("/assets/search")
     assert asset_search_response.status_code == 200
     assert b'<html lang="en" data-theme="dark">' in asset_search_response.data
     assert b'aria-pressed="true"' in asset_search_response.data
     assert b'aria-label="Switch to light mode"' in asset_search_response.data
+    assert "\u2600\ufe0f".encode("utf-8") in asset_search_response.data
+    assert b"Light mode" in asset_search_response.data
 
 
 def test_inactive_user_login_fails(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Enhances the theme toggle by adding icon + text for clearer visual recognition.

## Related Issue
Closes #324 

## Changes
- Added ☀️ / 🌙 icons to theme toggle alongside existing text
- Preserved existing toggle behavior and cookie persistence
- Maintained accessibility with proper aria handling

## Verification checklist
- [x] Toggle shows icon + label clearly
- [x] Icon updates correctly when toggling theme
- [x] Works in light and dark mode
- [x] No behavior changes
- [x] Tests pass
- [x] Manual smoke test completed

## Notes
Presentation-only enhancement using inline Unicode icons. No logic or workflow impact.