### PR TITLE
Issue 26-24: remove forced issue page scan jump

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -539,7 +539,7 @@ def _queue_redirect_target(return_to: str) -> str:
         return target
 
     path, sep, fragment = target.partition("#")
-    if path in {"/issue", "/return"} and not fragment:
+    if path == "/return" and not fragment:
         return f"{path}#queue-section"
     return target
 

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -76,7 +76,7 @@
 {% endblock %}
 
 {% block content %}
-  {% set queue_return_to = (return_to or url_for('return_queue')) ~ '#queue-section' %}
+  {% set queue_return_to = return_to or url_for('return_queue') %}
   {% set flashed_messages = get_flashed_messages(with_categories=true) %}
   {% set message_ns = namespace(global_messages=[], scan_messages=[], location_messages=[]) %}
   {% for category, message in flashed_messages %}
@@ -88,6 +88,8 @@
       {% set message_ns.global_messages = message_ns.global_messages + [(category, message)] %}
     {% endif %}
   {% endfor %}
+  {% set jump_to_scan_href = "#scan-input" %}
+  {% set jump_to_queue_href = "#queue-section" %}
   <p><a href="{{ url_for('dashboard') }}">← Back to dashboard</a></p>
 
   {% include "_timeout_status.html" %}
@@ -109,6 +111,10 @@
 
   {% if workflow_banner_title %}
     {% include "_workflow_context_banner.html" %}
+  {% endif %}
+
+  {% if issue_location_form is defined %}
+    <p><a class="chip" href="{{ jump_to_scan_href }}">Jump to scan</a></p>
   {% endif %}
 
   {% if issue_location_form is defined %}
@@ -172,6 +178,9 @@
         <div class="flash {{ category|e }}">{{ message }}</div>
       {% endfor %}
     {% endif %}
+    {% if queue_len > 0 %}
+      <p><a class="chip" href="{{ jump_to_queue_href }}">Jump to queue</a></p>
+    {% endif %}
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
       <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
@@ -180,7 +189,7 @@
         type="text"
         name="scan_text"
         placeholder="Scan here..."
-        autofocus
+        {% if issue_location_form is not defined %}autofocus{% endif %}
         data-timeout-lock-target
       />
       <button type="submit" data-timeout-lock-target>Submit</button>

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -56,7 +56,7 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
+    assert (response.headers.get("Location") or "").endswith("/issue")
     assert len(intake_app.SCAN_QUEUE) == 0
 
     with client_with_temp_db.session_transaction() as sess:
@@ -105,7 +105,7 @@ def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicate
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
+    assert (response.headers.get("Location") or "").endswith("/issue")
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DUP-TAG", "KEEP-TAG"]
 
     issue_page = client_with_temp_db.get("/issue")

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -110,6 +110,9 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert b"box-sizing: border-box;" in issue_page.data
     assert b"padding: 0.6rem;" in issue_page.data
     assert b"font-size: 1rem;" in issue_page.data
+    assert b'href="#scan-input"' in issue_page.data
+    assert b'id="scan-input"' in issue_page.data
+    assert b"autofocus" not in issue_page.data
     assert b"HQ North" in issue_page.data
     assert b"Warehouse West" not in issue_page.data
 
@@ -177,6 +180,7 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     assert scan_response.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
     assert b"Ready for preview. No blocking issues found." in scan_response.data
+    assert b'href="#queue-section"' in scan_response.data
 
     preview = client_with_temp_db.get("/issue/preview")
     assert preview.status_code == 200

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -83,7 +83,7 @@ def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: p
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
+    assert (response.headers.get("Location") or "").endswith("/issue")
     assert len(intake_app.SCAN_QUEUE) == 1
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 220
@@ -100,7 +100,7 @@ def test_queue_action_refreshes_last_seen(client_with_temp_db, monkeypatch: pyte
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue#queue-section")
+    assert (response.headers.get("Location") or "").endswith("/issue")
     assert len(intake_app.SCAN_QUEUE) == 0
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 230


### PR DESCRIPTION
## Summary
Removes forced auto-jump behavior on the Issue page so operators land at the top and navigate to scan/queue intentionally.

## Related Issue
Closes #332 

## Changes
- Removed automatic Issue-page jump behavior
- Preserved manual Jump to scan and Jump to queue controls
- Disabled Issue-specific scan input autofocus that was causing browser scroll-to-focus
- Kept Return behavior intact

## Verification checklist
- [x] `/issue` loads at the top of the page
- [x] Page does not auto-jump to scan or queue
- [x] Manual jump controls still work
- [x] Preview and commit flow still work
- [x] Return behavior remains correct
- [x] Tests pass
- [x] Manual smoke test completed

## Notes
Anchor behavior was partially fixed first, then completed by removing the remaining autofocus-driven scroll on the shared scan input.