### PR TITLE
Issue 26-25: filter return case expansion to in-custody assets

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -324,6 +324,67 @@ def _find_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
     }
 
 
+def _find_return_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
+    t = (scan_tag or "").strip()
+    if not t:
+        return None
+
+    slot_rows = conn.execute(
+        """
+        SELECT id, case_name, slot_position
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+           OR REPLACE(UPPER(case_name), '-', '') = UPPER(?)
+        ORDER BY slot_position ASC, id ASC;
+        """,
+        (t, t),
+    ).fetchall()
+    if not slot_rows:
+        return None
+
+    case_names = {str(row["case_name"] or "").strip().upper() for row in slot_rows if str(row["case_name"] or "").strip()}
+    if len(case_names) > 1:
+        raise ValueError(f"Ambiguous case match for scan '{t}'")
+
+    case_name = str(slot_rows[0]["case_name"] or "").strip().upper()
+    assets: list[dict] = []
+    seen_asset_tags: set[str] = set()
+
+    for slot_row in slot_rows:
+        slot_id = int(slot_row["id"])
+        slot_position = int(slot_row["slot_position"])
+        asset_rows = conn.execute(
+            """
+            SELECT asset_tag
+            FROM assets
+            WHERE home_slot_id = ?
+              AND UPPER(COALESCE(location_type, '')) = 'IN_CUSTODY'
+            ORDER BY UPPER(asset_tag) ASC, id ASC;
+            """,
+            (slot_id,),
+        ).fetchall()
+
+        for asset_row in asset_rows:
+            asset_tag = sanitize_scan(str(asset_row["asset_tag"] or ""))
+            if not asset_tag or asset_tag in seen_asset_tags:
+                continue
+
+            seen_asset_tags.add(asset_tag)
+            assets.append(
+                {
+                    "asset_tag": asset_tag,
+                    "home_slot_id": slot_id,
+                    "case_name": case_name,
+                    "slot_position": slot_position,
+                }
+            )
+
+    return {
+        "case_name": case_name,
+        "assets": assets,
+    }
+
+
 def _asset_current_slot(conn, asset_id: int, asset_tag: str) -> Optional[dict]:
     occupancy_row = conn.execute(
         """
@@ -2518,9 +2579,12 @@ def intake():
                 conn = get_connection()
                 try:
                     case_match = None
-                    if return_to_path == "/issue":
+                    if return_to_path in {"/issue", "/return"}:
                         try:
-                            case_match = _find_case_assets_for_scan_tag(conn, value)
+                            if return_to_path == "/issue":
+                                case_match = _find_case_assets_for_scan_tag(conn, value)
+                            else:
+                                case_match = _find_return_case_assets_for_scan_tag(conn, value)
                         except ValueError as e:
                             flash(str(e), "error")
                             touch_session()

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -252,6 +252,89 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"KEEP-ME", preview.data)
         self.assertNotIn(b"REMOVE-ME", preview.data)
 
+    def test_return_case_scan_expands_assets_by_home_case(self) -> None:
+        self._insert_slot(70, "CASE-2", 1, None)
+        self._insert_slot(71, "CASE-2", 2, None)
+        self._insert_slot(72, "CASE-2", 3, None)
+        self._insert_asset("RT-100", location_type="IN_CUSTODY", holder_id=5, home_slot_id=70)
+        self._insert_asset("RT-101", location_type="IN_CUSTODY", holder_id=6, home_slot_id=71)
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "case-2", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT100", "RT101"])
+        self.assertIn(b"Case CASE-2 added 2 assets to queue.", response.data)
+        self.assertIn(b"Queue (2)", response.data)
+        self.assertNotIn(b"CASE2", response.data)
+
+    def test_return_case_scan_excludes_assets_already_returned_to_storage(self) -> None:
+        self._insert_slot(73, "CASE-3", 1, current_asset_tag="RT-300")
+        self._insert_slot(74, "CASE-3", 2, None)
+        self._insert_asset("RT-300", location_type="STORAGE", holder_id=None, home_slot_id=73)
+        self._insert_asset("RT-301", location_type="IN_CUSTODY", holder_id=6, home_slot_id=74)
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "CASE-3", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT301"])
+        self.assertIn(b"Case CASE-3 added 1 asset to queue.", response.data)
+        self.assertNotIn(b"RT300", response.data)
+
+    def test_return_case_scan_skips_assets_already_queued(self) -> None:
+        self._insert_slot(80, "CASE-20", 1, None)
+        self._insert_slot(81, "CASE-20", 2, None)
+        self._insert_asset("RT-200", location_type="IN_CUSTODY", holder_id=5, home_slot_id=80)
+        self._insert_asset("RT-201", location_type="IN_CUSTODY", holder_id=6, home_slot_id=81)
+
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now("RT200"))
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "CASE20", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT200", "RT201"])
+        self.assertIn(b"Case CASE-20 added 1 asset to queue. Skipped 1 already queued.", response.data)
+
+    def test_return_case_scan_allows_selective_removal_before_preview(self) -> None:
+        self._insert_slot(90, "CASE-30", 1, None)
+        self._insert_slot(91, "CASE-30", 2, None)
+        self._insert_asset("RT-300", location_type="IN_CUSTODY", holder_id=5, home_slot_id=90)
+        self._insert_asset("RT-301", location_type="IN_CUSTODY", holder_id=6, home_slot_id=91)
+
+        scanned = self.client.post(
+            "/",
+            data={"scan_text": "CASE-30", "return_to": "/return"},
+            follow_redirects=True,
+        )
+        self.assertEqual(scanned.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT300", "RT301"])
+
+        removed = self.client.post(
+            "/",
+            data={"action": "remove", "queue_index": "0", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(removed.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT301"])
+        self.assertIn(b"Queue (1)", removed.data)
+
+        preview = self.client.get("/return/preview")
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"RT301", preview.data)
+        self.assertNotIn(b"RT300", preview.data)
+
     def test_return_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_duplicate(self) -> None:
         self._insert_slot(26, "CASE-RT", 2, None)
         self._insert_asset("RT200", location_type="IN_CUSTODY", holder_id=9, home_slot_id=26)


### PR DESCRIPTION
## Summary
Adds case-based return expansion so scanning a case in the Return workflow enqueues only assets that are currently in custody, allowing fast batch returns with selective removal before preview.

## Related Issue
Closes #335 

## Changes
- added return-only case scan expansion based on home case
- filtered expansion to include only IN_CUSTODY assets
- prevented already-returned assets from being queued
- preserved per-asset queue entries and selective removal
- left preview and commit behavior unchanged

## Verification checklist
- [x] Targeted tests updated
- [x] Manual smoke test performed
- [x] Case scan enqueues only returnable assets
- [x] Already-returned assets excluded
- [x] Selective removal works before preview
- [x] Preview and commit behavior unchanged
- [x] No schema, auth, or event changes
- [x] No invariant violations

## Notes
Improves high-volume return workflow by eliminating one-by-one scanning while preserving control and audit integrity.