### PR TITLE
Issue 26-3: persist responsibility acknowledgment on issue events

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2168,7 +2168,12 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
     return {"assets": assets, "ready_count": ready_count, "blocking_issues": blocking_issues}
 
 
-def _issue_batch(asset_tags: list[str], holder_id: int, issue_location: dict[str, str]) -> int:
+def _issue_batch(
+    asset_tags: list[str],
+    holder_id: int,
+    issue_location: dict[str, str],
+    responsibility_ack: dict[str, object],
+) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to issue.")
 
@@ -2340,6 +2345,7 @@ def _issue_batch(asset_tags: list[str], holder_id: int, issue_location: dict[str
                                 "from_building_room": previous_building_room,
                                 "to_building_room": building_room,
                                 "home_slot_id": home_slot_id,
+                                "responsibility_ack": responsibility_ack,
                             }
                         ),
                         holder_id,
@@ -3320,11 +3326,30 @@ def issue_commit():
         flash("Please confirm you reviewed the batch before adding it.", "error")
         return redirect(url_for("issue_preview"))
 
+    acknowledged = (request.form.get("confirm_responsibility_ack") or "").strip().lower() in {"on", "true", "1", "yes"}
+    if not acknowledged:
+        if wants_json():
+            return {
+                "ok": False,
+                "committed": 0,
+                "error": "Confirm responsibility acknowledgment before issuing assets.",
+            }, 400
+        flash("Confirm responsibility acknowledgment before issuing assets.", "error")
+        preview_response = issue_preview()
+        return preview_response, 400
+
     holder = _selected_holder_from_session()
     if holder is None:
         if wants_json():
             return {"ok": False, "committed": 0, "error": "Select a holder before issuing assets."}, 400
         flash("Select a holder before issuing assets.", "error")
+        return redirect(url_for("issue_preview"))
+
+    user = current_user()
+    if user is None:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "Authenticated operator not found."}, 400
+        flash("Authenticated operator not found.", "error")
         return redirect(url_for("issue_preview"))
 
     issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
@@ -3344,8 +3369,16 @@ def issue_commit():
         flash("No assets in the queue to issue..", "error")
         return redirect(url_for("issue_preview"))
 
+    responsibility_ack = {
+        "acknowledged": True,
+        "ack_holder_id": int(holder["id"]),
+        "ack_operator_user_id": int(user["id"]),
+        "ack_at": datetime.now(timezone.utc).isoformat(),
+        "ack_scope": "batch",
+    }
+
     try:
-        committed_count = _issue_batch(asset_tags, holder["id"], issue_location_form)
+        committed_count = _issue_batch(asset_tags, holder["id"], issue_location_form, responsibility_ack)
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -212,26 +212,20 @@
         <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
         I reviewed this batch and want to add it to the database.
       </label>
-      <button id="issue_btn" type="submit" disabled data-timeout-lock-target>Commit Issue</button>
+      <label style="display:block; margin-bottom: 10px;">
+        <input type="checkbox" id="confirm_responsibility_ack" name="confirm_responsibility_ack" />
+        I confirm the selected holder accepted responsibility for this issue batch.
+      </label>
+      <button id="issue_btn" type="submit" data-timeout-lock-target>Commit Issue</button>
     </form>
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
       <input type="hidden" name="action" value="clear" />
       <input type="hidden" name="return_to" value="{{ url_for('issue') }}" />
       <button type="submit" data-timeout-lock-target>Clear Queue</button>
     </form>
-    <p style="margin-top: 10px;">{{ url_for('issue_commit') }}?json=1</p>
   </div>
 {% endblock %}
 
 {% block extra_scripts %}
-  <script>
-    const cb = document.getElementById('confirm_reviewed');
-    const btn = document.getElementById('issue_btn');
-    if (cb && btn) {
-      const sync = () => { btn.disabled = !cb.checked; };
-      cb.addEventListener('change', sync);
-      sync();
-    }
-  </script>
   {% include "_timeout_lock_script.html" %}
 {% endblock %}

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -93,11 +93,15 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Current location:</strong> <code>HQ North / 210</code>" in issue_preview.data
     assert b"Issued to:</strong> <code>Not assigned</code>" in issue_preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in issue_preview.data
+    assert b'name="confirm_responsibility_ack"' in issue_preview.data
+    assert b"accepted responsibility for this issue batch" in issue_preview.data
+    assert b'id="issue_btn" type="submit" data-timeout-lock-target' in issue_preview.data
+    assert b"/issue/commit?json=1" not in issue_preview.data
     assert b"null" not in issue_preview.data
 
     commit = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=True,
     )
 
@@ -209,7 +213,7 @@ def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(clien
 
     commit = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=True,
     )
 

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -182,7 +182,7 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
 
     commit_response = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=False,
     )
 

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -264,7 +264,7 @@ def test_issue_preview_discard_preserves_holder_through_rescan_preview_and_commi
 
     commit = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=True,
     )
 

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -139,7 +139,7 @@ def test_issue_commit_rejects_building_outside_selected_holder_org(client_with_t
 
     response = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=False,
     )
 
@@ -191,7 +191,7 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
 
     commit = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=False,
     )
 
@@ -241,3 +241,62 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     assert payload["from_building_room"] == "Storage/A1"
     assert payload["to_building_room"] == "HQ North/210"
     assert int(payload["home_slot_id"]) == 101
+    assert payload["responsibility_ack"]["acknowledged"] is True
+    assert int(payload["responsibility_ack"]["ack_holder_id"]) == 1
+    assert int(payload["responsibility_ack"]["ack_operator_user_id"]) > 0
+    assert payload["responsibility_ack"]["ack_at"]
+    assert payload["responsibility_ack"]["ack_scope"] == "batch"
+
+
+def test_issue_commit_requires_responsibility_acknowledgment(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+    assert scan_response.status_code == 200
+
+    blocked = client_with_temp_db.post(
+        "/issue/commit?json=1",
+        data={"confirm_reviewed": "on"},
+    )
+
+    assert blocked.status_code == 400
+    assert blocked.json["ok"] is False
+    assert blocked.json["committed"] == 0
+    assert blocked.json["error"] == "Confirm responsibility acknowledgment before issuing assets."
+
+    conn = db.get_connection()
+    try:
+        event_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM asset_events WHERE asset_tag = 'ISSUE-100' AND event_type = 'ISSUE';"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert event_count is not None
+    assert int(event_count["c"]) == 0
+
+
+def test_issue_commit_missing_ack_shows_visible_message_on_issue_preview(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+    assert scan_response.status_code == 200
+
+    blocked = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on"},
+        follow_redirects=False,
+    )
+
+    assert blocked.status_code == 400
+    assert b"Issue Assets \xe2\x80\x94 Preview / Confirm" in blocked.data
+    assert b"Confirm responsibility acknowledgment before issuing assets." in blocked.data
+    assert len(intake_app.SCAN_QUEUE) == 1

--- a/tests/test_issue_slot_occupancy_consistency.py
+++ b/tests/test_issue_slot_occupancy_consistency.py
@@ -69,7 +69,10 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
     assert b"Not currently slotted: DDC4CY002645" not in preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in preview.data
 
-    commit = client_with_temp_db.post("/issue/commit", data={"confirm_reviewed": "on"})
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+    )
     assert commit.status_code == 302
     assert (commit.headers.get("Location") or "").endswith("/issue?issued=1")
 
@@ -104,7 +107,7 @@ def test_issue_commit_redirect_shows_success_without_holder_warning(client_with_
 
     commit_response = client_with_temp_db.post(
         "/issue/commit",
-        data={"confirm_reviewed": "on"},
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
         follow_redirects=True,
     )
 


### PR DESCRIPTION
## Summary
Adds responsibility acknowledgment to the issue workflow and persists it on each emitted ISSUE event, while keeping the existing issue workflow seam intact.

## Related Issue
Closes #295 

## Changes
- added explicit responsibility acknowledgment to issue preview
- required acknowledgment at /issue/commit alongside review confirmation
- persisted responsibility_ack on each ISSUE event payload
- rendered visible correction feedback when acknowledgment is missing
- removed client-side submit gating that blocked the server correction path
- removed stray issue preview debug text

## Verification checklist
- [x] Manual smoke test performed
- [x] Missing acknowledgment blocks issue commit
- [x] Visible correction message appears on issue preview
- [x] Successful issue still works when both confirmations are checked
- [x] Responsibility acknowledgment is persisted on ISSUE events
- [x] No schema or migration changes
- [x] No invariant violations

## Notes
Current acknowledgment is operator-confirmed only. A future issue can add holder-entered name or initials for direct acknowledgment.