### PR TITLE
Issue 26-28: define Codex skills baseline

### DIFF
--- a/.codex/skills/assettrack-smoke-checker/SKILL.md
+++ b/.codex/skills/assettrack-smoke-checker/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: assettrack-smoke-checker
+description: Enforce AssetTrack manual smoke-test discipline for workflow, queue, preview, and commit behavior.
+---
+
+# AssetTrack Smoke Checker
+
+Use this skill when a change affects navigation, redirects, forms, queues, preview pages, commit behavior, workflow state, or operator flow.
+
+## Purpose
+
+Make sure workflow changes are manually validated through the real operator path.
+
+## Rules
+
+- Always require Docker rebuild before smoke testing:
+  `docker compose up -d --build`
+- Always use an incognito browser session.
+- Walk the operator through the real workflow seam:
+  `entry → prerequisite selection → scan queue → preview → commit`
+- Do not mark a workflow issue done without a manual smoke test.
+- Default to exactly two smoke-test steps at a time.
+- Report exactly which smoke steps passed or failed.
+- Every smoke response must include explicit `PASS` or `FAIL` capture for each step.
+- If a step fails, stop and report the smallest safe next step.
+- Keep instructions short and linear.
+
+## Minimum smoke test
+
+1. Log in
+2. Enter the target workflow
+3. Perform the operator action
+4. Verify queue/state change
+5. Verify preview
+6. Verify commit
+7. Verify queue clears
+
+## Output format
+
+Return:
+
+1. Smoke test scope
+2. Step-by-step checklist
+3. Pass/fail capture format using explicit `PASS` / `FAIL`
+4. Smallest safe next step if anything fails
+
+## Usage examples
+
+- "Use the assettrack-smoke-checker skill for this issue workflow change."
+- "Use the assettrack-smoke-checker skill to produce a two-step smoke test for the return workflow."

--- a/.codex/skills/assettrack-test-runner/SKILL.md
+++ b/.codex/skills/assettrack-test-runner/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: assettrack-test-runner
+description: Run AssetTrack tests in a disciplined way, starting with targeted pytest and expanding only when needed.
+---
+
+# AssetTrack Test Runner
+
+Use this skill when the task involves validating AssetTrack changes with tests.
+
+## Purpose
+
+Run tests with the smallest safe scope first, then widen only if needed.
+
+## Rules
+
+- Prefer targeted pytest for changed files first.
+- If template or shared workflow code changed, run related regression tests next.
+- Run broader scope only after targeted and related tests.
+- Run the full suite only when requested, when the task exit criteria requires it, or when narrower coverage is insufficient.
+- Do not claim tests passed unless they actually passed.
+- Report exactly what was run.
+- If dependencies or environment are missing, say so plainly.
+- Do not add or remove tests unless the task requires it.
+- For workflow-affecting changes, remind the operator that Docker rebuild + incognito smoke test is still required.
+- Prefer the minimum execution needed to prove the change.
+
+## Standard order
+
+1. Run targeted tests for changed files.
+2. Run nearby regression tests if shared workflow code was touched.
+3. Run broader related scope if needed.
+4. Run the full `pytest -q` suite only when required by the task or when narrower runs do not establish confidence.
+5. Summarize failures briefly and plainly.
+
+## Output format
+
+Return:
+
+1. Tests run
+2. Result
+3. Failures, if any
+4. Smallest safe next test step
+
+## Command helper
+
+Use the bundled script when appropriate:
+
+`bash .codex/skills/assettrack-test-runner/run_tests.sh <pytest args>`
+
+Examples:
+
+- `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_return_batch.py -q`
+- `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_location_wiring.py -q`
+- `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_location_wiring.py tests/test_return_batch.py -q`
+- `bash .codex/skills/assettrack-test-runner/run_tests.sh -q`


### PR DESCRIPTION
## Summary
Tighten the AssetTrack Codex skills baseline so test execution and smoke testing are deterministic and consistent.

## Related Issue
Closes #341 

## Changes
- updated `assettrack-test-runner` to enforce minimal-first test execution
- updated `assettrack-smoke-checker` to enforce 2-step smoke testing
- documented Docker rebuild, incognito usage, and PASS / FAIL reporting in the smoke skill

## Verification checklist
- [x] Codex lists both AssetTrack skills
- [x] `assettrack-test-runner` responds with targeted-first, broader-next, full-only-when-needed strategy
- [x] `assettrack-smoke-checker` responds with exactly 2 steps and PASS / FAIL expectations
- [x] no runtime behavior changed

## Notes
This is a tooling-only change under `.codex/skills`. No application code, schema, or runtime behavior was modified.