### PR TITLE
Issue 26-30: add Codex skill support files

### DIFF
--- a/.codex/skills/assettrack-smoke-checker/smoke_checklist.md
+++ b/.codex/skills/assettrack-smoke-checker/smoke_checklist.md
@@ -1,0 +1,36 @@
+# AssetTrack Smoke Test Checklist
+
+## Required setup
+
+- Rebuild with Docker:
+  `docker compose up -d --build`
+- Use an incognito browser window
+
+## Core workflow seam
+
+`entry → prerequisite selection → scan queue → preview → commit`
+
+## Generic smoke sequence
+
+1. Log in
+2. Enter the affected workflow
+3. Perform the changed operator action
+4. Verify queue or workflow state changed correctly
+5. Open preview
+6. Verify preview content and messaging
+7. Commit
+8. Verify result/success path
+9. Verify queue clears
+10. Verify no obvious regression in nearby workflow if shared code changed
+
+## Pass/fail capture format
+
+- `Step X PASS`
+- `Step X FAIL: <plain-language reason>`
+
+## Failure rule
+
+If any step fails:
+- stop
+- describe what happened
+- identify the smallest safe next fix/test step

--- a/.codex/skills/assettrack-test-runner/run_tests.sh
+++ b/.codex/skills/assettrack-test-runner/run_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -eq 0 ]; then
+  python3 -m pytest -q
+else
+  python3 -m pytest "$@"
+fi


### PR DESCRIPTION
## Summary
Add supporting files for Codex skills to ensure deterministic test execution and consistent smoke validation.

## Related Issue
Closes #346 

## Changes
- added `run_tests.sh` to support assettrack-test-runner execution flow
- added `smoke_checklist.md` to document and reinforce smoke testing discipline

## Verification checklist
- [x] files added under `.codex/skills`
- [x] align with existing skill definitions
- [x] no application code changed
- [x] no runtime behavior changed

## Notes
These files support Codex skill behavior and operator workflow discipline. They do not affect application logic or persistence.