### PR TITLE
Issue 26-5: add admin human-readable HTML report

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -45,7 +45,7 @@ from assettrack.reference_data import (
     list_organization_building_mappings,
     list_organizations,
 )
-from assettrack.audit import record_event
+from assettrack.audit import ACTIVE_EVENTS_WHERE, record_event
 from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
 from assettrack.users import (
     change_own_password,
@@ -3838,6 +3838,176 @@ def admin_system():
     )
 
 
+def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
+    conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+
+    try:
+        asset_summary_row = conn.execute(
+            """
+            SELECT
+                COUNT(*) AS total_assets,
+                SUM(CASE WHEN location_type = 'STORAGE' THEN 1 ELSE 0 END) AS storage_assets,
+                SUM(CASE WHEN location_type = 'IN_CUSTODY' THEN 1 ELSE 0 END) AS in_custody_assets,
+                SUM(CASE WHEN location_type = 'DISPOSED' THEN 1 ELSE 0 END) AS disposed_assets
+            FROM assets;
+            """
+        ).fetchone()
+
+        assets = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    a.asset_tag,
+                    COALESCE(a.equipment_type, '') AS equipment_type,
+                    COALESCE(a.manufacturer, '') AS manufacturer,
+                    COALESCE(a.model, '') AS model,
+                    COALESCE(a.location_type, '') AS location_type,
+                    COALESCE(h.name, '') AS holder_name,
+                    COALESCE(h.organization, '') AS holder_organization,
+                    COALESCE(s.case_name || ' / ' || s.slot_position, '') AS home_slot
+                FROM assets a
+                LEFT JOIN holders h
+                  ON h.id = a.current_holder_id
+                LEFT JOIN slots s
+                  ON s.id = a.home_slot_id
+                ORDER BY a.asset_tag COLLATE NOCASE ASC, a.id ASC;
+                """
+            ).fetchall()
+        ]
+
+        holders = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    h.id,
+                    h.holder_type,
+                    h.name,
+                    COALESCE(h.organization, '') AS organization,
+                    COALESCE(h.identifier, '') AS identifier,
+                    COUNT(a.id) AS assets_in_custody
+                FROM holders h
+                LEFT JOIN assets a
+                  ON a.current_holder_id = h.id
+                 AND a.location_type = 'IN_CUSTODY'
+                GROUP BY h.id, h.holder_type, h.name, h.organization, h.identifier
+                ORDER BY h.name COLLATE NOCASE ASC, h.id ASC;
+                """
+            ).fetchall()
+        ]
+
+        organizations = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    o.id,
+                    o.name,
+                    COUNT(DISTINCT ob.building_id) AS building_count
+                FROM organizations o
+                LEFT JOIN organization_buildings ob
+                  ON ob.organization_id = o.id
+                GROUP BY o.id, o.name
+                ORDER BY o.name COLLATE NOCASE ASC, o.id ASC;
+                """
+            ).fetchall()
+        ]
+
+        organization_building_mappings = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    o.name AS organization_name,
+                    b.name AS building_name
+                FROM organization_buildings ob
+                JOIN organizations o
+                  ON o.id = ob.organization_id
+                JOIN buildings b
+                  ON b.id = ob.building_id
+                ORDER BY o.name COLLATE NOCASE ASC, b.name COLLATE NOCASE ASC;
+                """
+            ).fetchall()
+        ]
+
+        current_custody = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    h.name AS holder_name,
+                    COALESCE(h.organization, '') AS organization,
+                    a.asset_tag,
+                    COALESCE(a.equipment_type, '') AS equipment_type,
+                    COALESCE(a.building_room, '') AS current_location
+                FROM assets a
+                JOIN holders h
+                  ON h.id = a.current_holder_id
+                WHERE a.location_type = 'IN_CUSTODY'
+                ORDER BY h.name COLLATE NOCASE ASC, a.asset_tag COLLATE NOCASE ASC, a.id ASC;
+                """
+            ).fetchall()
+        ]
+
+        recent_active_events = [
+            dict(row)
+            for row in conn.execute(
+                f"""
+                SELECT
+                    e.id,
+                    e.event_date,
+                    e.asset_tag,
+                    e.event_type,
+                    COALESCE(h.name, '') AS holder_name,
+                    COALESCE(h.organization, '') AS holder_organization
+                FROM asset_events e
+                LEFT JOIN holders h
+                  ON h.id = e.holder_id
+                WHERE {ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)}
+                ORDER BY e.id DESC
+                LIMIT 25;
+                """
+            ).fetchall()
+        ]
+
+        cases = [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT
+                    s.case_name,
+                    COUNT(*) AS total_slots,
+                    COUNT(DISTINCT so.slot_id) AS occupied_slots
+                FROM slots s
+                LEFT JOIN slot_occupancy so
+                  ON so.slot_id = s.id
+                GROUP BY s.case_name
+                ORDER BY s.case_name COLLATE NOCASE ASC;
+                """
+            ).fetchall()
+        ]
+
+        return {
+            "asset_summary": {
+                "total_assets": int(asset_summary_row["total_assets"] or 0),
+                "storage_assets": int(asset_summary_row["storage_assets"] or 0),
+                "in_custody_assets": int(asset_summary_row["in_custody_assets"] or 0),
+                "disposed_assets": int(asset_summary_row["disposed_assets"] or 0),
+            },
+            "assets": assets,
+            "holders": holders,
+            "organizations": organizations,
+            "organization_building_mappings": organization_building_mappings,
+            "current_custody": current_custody,
+            "recent_active_events": recent_active_events,
+            "cases": cases,
+        }
+    finally:
+        conn.close()
+
+
 @app.route("/admin/reference-data", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
@@ -3889,6 +4059,41 @@ def admin_db_export():
         download_name=download_name,
         mimetype="application/octet-stream",
         conditional=False,
+    )
+
+
+@app.get("/admin/report")
+@require_login
+@require_role("admin")
+def admin_human_report():
+    resolved_db_path = _resolved_runtime_db_path()
+    report_error: str | None = None
+    report_data = {
+        "asset_summary": {
+            "total_assets": 0,
+            "storage_assets": 0,
+            "in_custody_assets": 0,
+            "disposed_assets": 0,
+        },
+        "assets": [],
+        "holders": [],
+        "organizations": [],
+        "organization_building_mappings": [],
+        "current_custody": [],
+        "recent_active_events": [],
+        "cases": [],
+    }
+
+    try:
+        report_data = _load_admin_human_report_data(resolved_db_path)
+    except sqlite3.Error as exc:
+        report_error = f"Could not read admin report data: {exc}"
+
+    return render_template(
+        "admin_human_report.html",
+        db_path=str(resolved_db_path),
+        report_error=report_error,
+        **report_data,
     )
 
 

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -1,0 +1,274 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Human-Readable Report{% endblock %}
+{% block page_heading %}Admin: Human-Readable Report{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .report-actions {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .report-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.75rem;
+    }
+    .report-stat {
+      padding: 0.85rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 10px;
+      background: var(--color-surface-soft);
+    }
+    .report-stat strong {
+      display: block;
+      font-size: 1.35rem;
+      margin-top: 0.25rem;
+    }
+    .card h2 {
+      margin-top: 0;
+    }
+    .table-wrap {
+      overflow-x: auto;
+    }
+    @media print {
+      .page-tools,
+      .top-nav,
+      .report-actions {
+        display: none !important;
+      }
+      .card {
+        break-inside: avoid;
+        box-shadow: none;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="report-actions">
+    <a class="chip" href="{{ url_for('admin_system') }}">&larr; Back to System Health</a>
+    <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
+  </div>
+
+  {% if report_error %}
+    <div class="flash error">{{ report_error }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Report Scope</h2>
+    <p>This page is a read-only human-readable report for operators and admins. It does not replace the raw SQLite database backup.</p>
+    <p><strong>Database path:</strong> <code>{{ db_path }}</code></p>
+    <p><strong>Recent events section:</strong> showing recent active events only.</p>
+  </div>
+
+  <div class="card">
+    <h2>Assets</h2>
+    <div class="report-grid">
+      <div class="report-stat">Total assets<strong>{{ asset_summary.total_assets }}</strong></div>
+      <div class="report-stat">In storage<strong>{{ asset_summary.storage_assets }}</strong></div>
+      <div class="report-stat">In custody<strong>{{ asset_summary.in_custody_assets }}</strong></div>
+      <div class="report-stat">Disposed<strong>{{ asset_summary.disposed_assets }}</strong></div>
+    </div>
+    <div class="table-wrap" style="margin-top: 1rem;">
+      <table>
+        <thead>
+          <tr>
+            <th>Asset Tag</th>
+            <th>Type</th>
+            <th>Make / Model</th>
+            <th>Location Type</th>
+            <th>Current Holder</th>
+            <th>Home Slot</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in assets %}
+            <tr>
+              <td><code>{{ row.asset_tag }}</code></td>
+              <td>{{ row.equipment_type or "" }}</td>
+              <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
+              <td>{{ row.location_type or "" }}</td>
+              <td>
+                {% if row.holder_name %}
+                  {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                {% endif %}
+              </td>
+              <td>{{ row.home_slot or "" }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="6">No assets found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Holders</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>Type</th>
+            <th>Name</th>
+            <th>Organization</th>
+            <th>Identifier</th>
+            <th>Assets In Custody</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in holders %}
+            <tr>
+              <td><code>{{ row.id }}</code></td>
+              <td>{{ row.holder_type }}</td>
+              <td>{{ row.name }}</td>
+              <td>{{ row.organization }}</td>
+              <td>{{ row.identifier }}</td>
+              <td>{{ row.assets_in_custody }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="6">No holders found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Organizations and Building Access</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Organization</th>
+            <th>Mapped Buildings</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in organizations %}
+            <tr>
+              <td>{{ row.name }}</td>
+              <td>{{ row.building_count }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="2">No organizations found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="table-wrap" style="margin-top: 1rem;">
+      <table>
+        <thead>
+          <tr>
+            <th>Organization</th>
+            <th>Building</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in organization_building_mappings %}
+            <tr>
+              <td>{{ row.organization_name }}</td>
+              <td>{{ row.building_name }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="2">No organization-to-building mappings found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Current Custody</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Holder</th>
+            <th>Organization</th>
+            <th>Asset Tag</th>
+            <th>Type</th>
+            <th>Current Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in current_custody %}
+            <tr>
+              <td>{{ row.holder_name }}</td>
+              <td>{{ row.organization }}</td>
+              <td><code>{{ row.asset_tag }}</code></td>
+              <td>{{ row.equipment_type }}</td>
+              <td>{{ row.current_location }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5">No assets are currently in custody.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Recent Active Events</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>When</th>
+            <th>Asset Tag</th>
+            <th>Event Type</th>
+            <th>Holder</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in recent_active_events %}
+            <tr>
+              <td><code>{{ row.id }}</code></td>
+              <td>{{ row.event_date }}</td>
+              <td><code>{{ row.asset_tag }}</code></td>
+              <td>{{ row.event_type }}</td>
+              <td>
+                {% if row.holder_name %}
+                  {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                {% endif %}
+              </td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5">No active events found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card">
+    <h2>Location and Case Data</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Case</th>
+            <th>Total Slots</th>
+            <th>Occupied Slots</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in cases %}
+            <tr>
+              <td>{{ row.case_name }}</td>
+              <td>{{ row.total_slots }}</td>
+              <td>{{ row.occupied_slots }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="3">No case or slot data found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -13,6 +13,7 @@
   <div class="card">
     <h2>Database</h2>
     <p><a class="chip" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
+    <p><a class="chip" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
     <p><a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a></p>
     <table>
       <tbody>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -113,6 +113,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b'id="holder-count">1<' in response.data
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
+    assert b"Open Human-Readable Report" in response.data
     assert b"Download Database Backup" in response.data
 
 
@@ -121,6 +122,15 @@ def test_operator_is_forbidden_for_system_health(client_with_temp_db) -> None:
     login_session(client_with_temp_db, operator_id)
 
     response = client_with_temp_db.get("/admin/system")
+
+    assert response.status_code == 403
+
+
+def test_operator_is_forbidden_for_human_readable_report(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-report", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.get("/admin/report")
 
     assert response.status_code == 403
 
@@ -175,3 +185,140 @@ def test_system_health_renders_warning_when_assets_query_fails(
     assert response.status_code == 200
     assert b"Could not read system health data:" in response.data
     assert b'id="asset-count">N/A<' in response.data
+
+
+def test_admin_can_open_human_readable_report_with_data_sections(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-report", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    conn = db.get_connection()
+    _create_assets_table(conn)
+    conn.execute(
+        """
+        INSERT INTO organizations (name, created_at, updated_at)
+        VALUES ('Report Ops', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO buildings (name, created_at, updated_at)
+        VALUES ('Report HQ', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    organization_id = int(
+        conn.execute("SELECT id FROM organizations WHERE name = 'Report Ops' LIMIT 1;").fetchone()[0]
+    )
+    building_id = int(
+        conn.execute("SELECT id FROM buildings WHERE name = 'Report HQ' LIMIT 1;").fetchone()[0]
+    )
+    conn.execute(
+        """
+        INSERT INTO organization_buildings (organization_id, building_id, created_at)
+        VALUES (?, ?, '2026-01-01T00:00:00Z');
+        """
+        ,
+        (organization_id, building_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO holders (
+            id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+        )
+        VALUES (
+            1, 'PERSON', 'Jane Operator', 'Report Ops', ?, 'H-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+        );
+        """,
+        (organization_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (10, 'CASE-1', 1, 'AT-100');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (
+            'AT-100',
+            'SN-100',
+            'Dell',
+            'laptop',
+            'Report HQ',
+            '100',
+            'Latitude',
+            'LAT',
+            NULL,
+            'Report HQ/100',
+            'issued_to',
+            'accountable',
+            'serviceable',
+            '2026-01-01',
+            '2026-01-01T00:00:00Z',
+            'IN_CUSTODY',
+            1,
+            10
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        SELECT 10, id, '2026-01-01T00:00:00Z'
+        FROM assets
+        WHERE asset_tag = 'AT-100';
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (
+            'AT-100',
+            'ISSUE',
+            '2026-01-02T00:00:00Z',
+            'system',
+            NULL,
+            '{"to_location_type":"IN_CUSTODY"}',
+            1
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.get("/admin/report")
+
+    assert response.status_code == 200
+    assert b"Admin: Human-Readable Report" in response.data
+    assert b"This page is a read-only human-readable report" in response.data
+    assert b"Download Database Backup" in response.data
+    assert b"showing recent active events only" in response.data
+    assert b"Assets" in response.data
+    assert b"Holders" in response.data
+    assert b"Organizations and Building Access" in response.data
+    assert b"Current Custody" in response.data
+    assert b"Recent Active Events" in response.data
+    assert b"Location and Case Data" in response.data
+    assert b"AT-100" in response.data
+    assert b"Jane Operator" in response.data
+    assert b"Report Ops" in response.data
+    assert b"CASE-1" in response.data


### PR DESCRIPTION
## Summary
Add an admin-only human-readable HTML report to inspect system state alongside the raw database backup.

## Related Issue
Closes #297 

## Changes
- added `/admin/report` route (admin-only, read-only)
- added `admin_human_report.html` template
- added separate action on System Health page for readable report
- rendered sections for assets, holders, organizations, custody, recent active events, and location/case data
- preserved `/admin/db/export` as the authoritative backup

## Verification checklist
- [x] admin can open human-readable report
- [x] report renders all required sections
- [x] raw DB backup remains unchanged
- [x] admin-only access enforced
- [x] targeted tests pass
- [x] manual smoke test completed

## Notes
HTML chosen as the smallest safe first step. Report is read-only and not a backup. Designed to support future print/PDF export without expanding scope.