### PR TITLE
Issue 26-31: add PDF export for admin report

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -15,11 +15,17 @@ import json
 import os
 import sqlite3
 import time
+from io import BytesIO
 from pathlib import Path
 from typing import Optional
 from datetime import datetime, timezone
 
 from flask import Flask, abort, flash, jsonify, redirect, render_template, request, send_file, session, url_for
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
 import assettrack.db as db_module
 from assettrack.assets import get_asset_table_columns
@@ -4008,6 +4014,184 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
         conn.close()
 
 
+def _build_admin_human_report_pdf(report_data: dict, db_path: str) -> bytes:
+    styles = getSampleStyleSheet()
+    body = styles["BodyText"]
+    heading = styles["Heading1"]
+    section_heading = styles["Heading2"]
+    title = styles["Title"]
+
+    def _p(value: object) -> Paragraph:
+        text = str(value or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        return Paragraph(text, body)
+
+    def _render_table(headers: list[str], rows: list[list[object]], column_widths: list[float]) -> Table:
+        data = [[Paragraph(f"<b>{header}</b>", body) for header in headers]]
+        for row in rows:
+            data.append([_p(value) for value in row])
+
+        table = Table(data, colWidths=column_widths, repeatRows=1)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#dbe7f3")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#c8d2dc")),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                    ("TOPPADDING", (0, 0), (-1, -1), 5),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+                ]
+            )
+        )
+        return table
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=letter,
+        leftMargin=0.5 * inch,
+        rightMargin=0.5 * inch,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+    )
+
+    story: list[object] = [
+        Paragraph("Admin Human-Readable Report", title),
+        Spacer(1, 0.15 * inch),
+        Paragraph("Read-only report. The raw SQLite database backup remains authoritative.", body),
+        Paragraph(f"Database path: {db_path}", body),
+        Paragraph("Recent events section: recent active events only.", body),
+        Spacer(1, 0.2 * inch),
+        Paragraph("Assets", heading),
+        Spacer(1, 0.08 * inch),
+        Paragraph(
+            (
+                f"Total assets: {report_data['asset_summary']['total_assets']} | "
+                f"In storage: {report_data['asset_summary']['storage_assets']} | "
+                f"In custody: {report_data['asset_summary']['in_custody_assets']} | "
+                f"Disposed: {report_data['asset_summary']['disposed_assets']}"
+            ),
+            body,
+        ),
+        Spacer(1, 0.1 * inch),
+        _render_table(
+            ["Asset Tag", "Type", "Make / Model", "Location Type", "Current Holder", "Home Slot"],
+            [
+                [
+                    row["asset_tag"],
+                    row["equipment_type"],
+                    f"{row['manufacturer']}{' / ' + row['model'] if row['model'] else ''}",
+                    row["location_type"],
+                    (
+                        f"{row['holder_name']} ({row['holder_organization']})"
+                        if row["holder_name"] and row["holder_organization"] and row["holder_organization"] != row["holder_name"]
+                        else row["holder_name"]
+                    ),
+                    row["home_slot"],
+                ]
+                for row in report_data["assets"]
+            ]
+            or [["No assets found.", "", "", "", "", ""]],
+            [1.1 * inch, 0.8 * inch, 1.4 * inch, 1.1 * inch, 1.6 * inch, 1.0 * inch],
+        ),
+        Spacer(1, 0.2 * inch),
+        Paragraph("Holders", section_heading),
+        Spacer(1, 0.08 * inch),
+        _render_table(
+            ["ID", "Type", "Name", "Organization", "Identifier", "Assets In Custody"],
+            [
+                [
+                    row["id"],
+                    row["holder_type"],
+                    row["name"],
+                    row["organization"],
+                    row["identifier"],
+                    row["assets_in_custody"],
+                ]
+                for row in report_data["holders"]
+            ]
+            or [["No holders found.", "", "", "", "", ""]],
+            [0.5 * inch, 0.9 * inch, 1.6 * inch, 1.5 * inch, 1.0 * inch, 0.9 * inch],
+        ),
+        Spacer(1, 0.2 * inch),
+        Paragraph("Organizations and Building Access", section_heading),
+        Spacer(1, 0.08 * inch),
+        _render_table(
+            ["Organization", "Mapped Buildings"],
+            [[row["name"], row["building_count"]] for row in report_data["organizations"]]
+            or [["No organizations found.", ""]],
+            [4.5 * inch, 2.0 * inch],
+        ),
+        Spacer(1, 0.08 * inch),
+        _render_table(
+            ["Organization", "Building"],
+            [
+                [row["organization_name"], row["building_name"]]
+                for row in report_data["organization_building_mappings"]
+            ]
+            or [["No organization-to-building mappings found.", ""]],
+            [3.5 * inch, 3.0 * inch],
+        ),
+        Spacer(1, 0.2 * inch),
+        Paragraph("Current Custody", section_heading),
+        Spacer(1, 0.08 * inch),
+        _render_table(
+            ["Holder", "Organization", "Asset Tag", "Type", "Current Location"],
+            [
+                [
+                    row["holder_name"],
+                    row["organization"],
+                    row["asset_tag"],
+                    row["equipment_type"],
+                    row["current_location"],
+                ]
+                for row in report_data["current_custody"]
+            ]
+            or [["No assets are currently in custody.", "", "", "", ""]],
+            [1.5 * inch, 1.5 * inch, 1.1 * inch, 0.8 * inch, 2.0 * inch],
+        ),
+        Spacer(1, 0.2 * inch),
+        Paragraph("Recent Active Events", section_heading),
+        Spacer(1, 0.08 * inch),
+        _render_table(
+            ["ID", "When", "Asset Tag", "Event Type", "Holder"],
+            [
+                [
+                    row["id"],
+                    row["event_date"],
+                    row["asset_tag"],
+                    row["event_type"],
+                    (
+                        f"{row['holder_name']} ({row['holder_organization']})"
+                        if row["holder_name"] and row["holder_organization"] and row["holder_organization"] != row["holder_name"]
+                        else row["holder_name"]
+                    ),
+                ]
+                for row in report_data["recent_active_events"]
+            ]
+            or [["No active events found.", "", "", "", ""]],
+            [0.5 * inch, 1.8 * inch, 1.1 * inch, 1.0 * inch, 2.6 * inch],
+        ),
+        Spacer(1, 0.2 * inch),
+        Paragraph("Location and Case Data", section_heading),
+        Spacer(1, 0.08 * inch),
+        _render_table(
+            ["Case", "Total Slots", "Occupied Slots"],
+            [
+                [row["case_name"], row["total_slots"], row["occupied_slots"]]
+                for row in report_data["cases"]
+            ]
+            or [["No case or slot data found.", "", ""]],
+            [3.5 * inch, 1.5 * inch, 1.5 * inch],
+        ),
+    ]
+
+    doc.build(story)
+    return buffer.getvalue()
+
+
 @app.route("/admin/reference-data", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
@@ -4094,6 +4278,27 @@ def admin_human_report():
         db_path=str(resolved_db_path),
         report_error=report_error,
         **report_data,
+    )
+
+
+@app.get("/admin/report/pdf")
+@require_login
+@require_role("admin")
+def admin_human_report_pdf():
+    resolved_db_path = _resolved_runtime_db_path()
+    try:
+        report_data = _load_admin_human_report_data(resolved_db_path)
+        pdf_bytes = _build_admin_human_report_pdf(report_data, str(resolved_db_path))
+    except sqlite3.Error as exc:
+        return f"Could not build admin PDF report: {exc}", 500
+
+    download_name = f"assettrack-human-report-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}.pdf"
+    return send_file(
+        BytesIO(pdf_bytes),
+        as_attachment=True,
+        download_name=download_name,
+        mimetype="application/pdf",
+        conditional=False,
     )
 
 

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -50,6 +50,7 @@
 {% block content %}
   <div class="report-actions">
     <a class="chip" href="{{ url_for('admin_system') }}">&larr; Back to System Health</a>
+    <a class="chip" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
     <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
   </div>
 

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -135,6 +135,15 @@ def test_operator_is_forbidden_for_human_readable_report(client_with_temp_db) ->
     assert response.status_code == 403
 
 
+def test_operator_is_forbidden_for_human_readable_report_pdf(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-report-pdf", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.get("/admin/report/pdf")
+
+    assert response.status_code == 403
+
+
 def test_admin_can_download_database_export(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-export", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
@@ -310,6 +319,7 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     assert response.status_code == 200
     assert b"Admin: Human-Readable Report" in response.data
     assert b"This page is a read-only human-readable report" in response.data
+    assert b"Download PDF" in response.data
     assert b"Download Database Backup" in response.data
     assert b"showing recent active events only" in response.data
     assert b"Assets" in response.data
@@ -322,3 +332,131 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     assert b"Jane Operator" in response.data
     assert b"Report Ops" in response.data
     assert b"CASE-1" in response.data
+
+
+def test_admin_can_download_human_readable_report_pdf(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-report-pdf", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    conn = db.get_connection()
+    _create_assets_table(conn)
+    conn.execute(
+        """
+        INSERT INTO organizations (name, created_at, updated_at)
+        VALUES ('PDF Ops', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO buildings (name, created_at, updated_at)
+        VALUES ('PDF HQ', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    organization_id = int(
+        conn.execute("SELECT id FROM organizations WHERE name = 'PDF Ops' LIMIT 1;").fetchone()[0]
+    )
+    building_id = int(
+        conn.execute("SELECT id FROM buildings WHERE name = 'PDF HQ' LIMIT 1;").fetchone()[0]
+    )
+    conn.execute(
+        """
+        INSERT INTO organization_buildings (organization_id, building_id, created_at)
+        VALUES (?, ?, '2026-01-01T00:00:00Z');
+        """,
+        (organization_id, building_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO holders (
+            id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+        )
+        VALUES (
+            1, 'PERSON', 'PDF Operator', 'PDF Ops', ?, 'PDF-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+        );
+        """,
+        (organization_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (12, 'CASE-PDF', 1, 'PDF-100');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (
+            'PDF-100',
+            'SN-PDF',
+            'Dell',
+            'laptop',
+            'PDF HQ',
+            '200',
+            'Latitude',
+            'LAT',
+            NULL,
+            'PDF HQ/200',
+            'issued_to',
+            'accountable',
+            'serviceable',
+            '2026-01-01',
+            '2026-01-01T00:00:00Z',
+            'IN_CUSTODY',
+            1,
+            12
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        SELECT 12, id, '2026-01-01T00:00:00Z'
+        FROM assets
+        WHERE asset_tag = 'PDF-100';
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (
+            'PDF-100',
+            'ISSUE',
+            '2026-01-02T00:00:00Z',
+            'system',
+            NULL,
+            '{"to_location_type":"IN_CUSTODY"}',
+            1
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.get("/admin/report/pdf")
+
+    assert response.status_code == 200
+    disposition = response.headers.get("Content-Disposition") or ""
+    assert "attachment;" in disposition
+    assert "assettrack-human-report-" in disposition
+    assert ".pdf" in disposition
+    assert response.mimetype == "application/pdf"
+    assert response.data.startswith(b"%PDF-")


### PR DESCRIPTION
## Summary
Add an admin-only PDF export for the human-readable admin report.

## Related Issue
Closes #349 

## Changes
- added `/admin/report/pdf` as an admin-only PDF download route
- reused the existing admin report data loader so HTML and PDF stay aligned
- added a Download PDF action to the admin human-readable report page
- added test coverage for admin success, operator denial, and PDF response headers

## Verification checklist
- [x] Targeted tests passed
- [x] Admin can open `/admin/report`
- [x] Admin can download the PDF
- [x] PDF opens and matches the HTML report sections
- [x] Operator access to `/admin/report/pdf` is denied
- [x] No schema or persistence changes made

## Notes
- Raw DB backup remains separate at `/admin/db/export`
- PDF output is intentionally simple and readable