### PR TITLE
Issue 26-33: add receipt queue schema

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -5,7 +5,7 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-REQUIRED_TABLES = {"assets", "holders", "organizations", "buildings", "organization_buildings"}
+REQUIRED_TABLES = {"assets", "holders", "organizations", "buildings", "organization_buildings", "receipt_queue"}
 EVENT_TABLE_ALIASES = ("events", "asset_events")
 DEFAULT_AD_HOC_ORGANIZATION = "Ad Hoc"
 
@@ -423,6 +423,40 @@ def _create_schema(conn: sqlite3.Connection):
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS receipt_queue (
+            id INTEGER PRIMARY KEY,
+            receipt_key TEXT NOT NULL UNIQUE,
+            receipt_type TEXT NOT NULL CHECK(receipt_type IN ('ISSUE', 'RETURN')),
+            source_event_ids_json TEXT NOT NULL,
+            snapshot_json TEXT NOT NULL,
+            commit_at TEXT NOT NULL,
+            commit_operator_user_id INTEGER NOT NULL,
+            holder_id INTEGER NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            sent_at TEXT NULL,
+            last_attempt_at TEXT NULL,
+            last_error TEXT NULL
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_receipt_queue_commit_at
+            ON receipt_queue(commit_at);
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_receipt_queue_holder_id
+            ON receipt_queue(holder_id);
         """
     )
 

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -144,7 +144,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Return</a>" in dashboard_response.data
     assert b">Add Assets</a>" not in dashboard_response.data
     assert b">Users</a>" not in dashboard_response.data
-    assert b">System Health</a>" not in dashboard_response.data
+    assert b">Admin Tools</a>" not in dashboard_response.data
 
     preview_response = client_with_temp_db.get("/preview")
     assert preview_response.status_code == 200
@@ -159,7 +159,7 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
     assert dashboard_response.status_code == 200
     assert b">Add Assets</a>" in dashboard_response.data
     assert b">Users</a>" in dashboard_response.data
-    assert b">System Health</a>" in dashboard_response.data
+    assert b">Admin Tools</a>" in dashboard_response.data
 
 
 def test_bootstrap_only_when_empty(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Add the local receipt queue schema for deferred receipt storage.

## Related Issue
Closes #352 

## Changes
- added `receipt_queue` table to schema initialization
- added indexes for `commit_at` and `holder_id`
- added `receipt_queue` to required schema table checks
- updated stale admin navigation test wording to match the approved **Admin Tools** label

## Verification checklist
- [x] App starts cleanly after rebuild
- [x] `receipt_queue` schema initializes successfully
- [x] Required indexes are created
- [x] No route, workflow, auth, or commit behavior changes were introduced
- [x] Targeted regression tests passed

## Notes
- schema only
- no receipt creation logic yet
- no UI, PDF, or email behavior added
- no foreign keys were added in this issue by design