### PR TITLE
Issue 26-34: queue receipt snapshots on custody commit

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2174,11 +2174,128 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
     return {"assets": assets, "ready_count": ready_count, "blocking_issues": blocking_issues}
 
 
+def _receipt_key(receipt_type: str, source_event_ids: list[int]) -> str:
+    return f"{receipt_type}:{'-'.join(str(event_id) for event_id in source_event_ids)}"
+
+
+def _receipt_holder_snapshot(conn, holder_id: Optional[int]) -> Optional[dict]:
+    if holder_id is None:
+        return None
+
+    row = conn.execute(
+        """
+        SELECT id, holder_type, name, organization, organization_id, identifier, contact_info
+        FROM holders
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (int(holder_id),),
+    ).fetchone()
+    if row is None:
+        return None
+
+    return {
+        "id": int(row["id"]),
+        "holder_type": str(row["holder_type"] or ""),
+        "name": str(row["name"] or ""),
+        "organization": str(row["organization"] or ""),
+        "organization_id": None if row["organization_id"] is None else int(row["organization_id"]),
+        "identifier": str(row["identifier"] or ""),
+        "contact_info": str(row["contact_info"] or ""),
+    }
+
+
+def _receipt_operator_snapshot(conn, user_id: int) -> Optional[dict]:
+    row = conn.execute(
+        """
+        SELECT id, username, role, active
+        FROM users
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (int(user_id),),
+    ).fetchone()
+    if row is None:
+        return None
+
+    return {
+        "id": int(row["id"]),
+        "username": str(row["username"] or ""),
+        "role": str(row["role"] or ""),
+        "active": bool(int(row["active"] or 0)),
+    }
+
+
+def _receipt_slot_snapshot(conn, slot_id: Optional[int]) -> Optional[dict]:
+    if slot_id is None:
+        return None
+
+    row = conn.execute(
+        """
+        SELECT id, case_name, slot_position
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (int(slot_id),),
+    ).fetchone()
+    if row is None:
+        return None
+
+    return {
+        "slot_id": int(row["id"]),
+        "case_name": str(row["case_name"] or ""),
+        "slot_position": int(row["slot_position"]),
+    }
+
+
+def _insert_receipt_queue_row(
+    conn,
+    *,
+    receipt_type: str,
+    source_event_ids: list[int],
+    snapshot: dict[str, object],
+    commit_at: str,
+    commit_operator_user_id: int,
+    holder_id: Optional[int],
+) -> None:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT INTO receipt_queue (
+            receipt_key,
+            receipt_type,
+            source_event_ids_json,
+            snapshot_json,
+            commit_at,
+            commit_operator_user_id,
+            holder_id,
+            created_at,
+            updated_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            _receipt_key(receipt_type, source_event_ids),
+            receipt_type,
+            json.dumps(source_event_ids),
+            json.dumps(snapshot),
+            commit_at,
+            int(commit_operator_user_id),
+            None if holder_id is None else int(holder_id),
+            now_iso,
+            now_iso,
+        ),
+    )
+
+
 def _issue_batch(
     asset_tags: list[str],
     holder_id: int,
     issue_location: dict[str, str],
     responsibility_ack: dict[str, object],
+    *,
+    commit_operator_user_id: int,
 ) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to issue.")
@@ -2269,11 +2386,15 @@ def _issue_batch(
                 raise ValueError("; ".join(parts))
 
             now_iso = datetime.now(timezone.utc).isoformat()
+            event_ids: list[int] = []
+            asset_snapshots: list[dict[str, object]] = []
+            holder_snapshot = _receipt_holder_snapshot(conn, holder_id)
+            commit_operator_snapshot = _receipt_operator_snapshot(conn, commit_operator_user_id)
 
             for asset_id, canon_tag, home_slot_id in canon_assets:
                 asset_row = conn.execute(
                     """
-                    SELECT building_room
+                    SELECT serial_number, equipment_type, manufacturer, model, model_code, notes, building_room
                     FROM assets
                     WHERE id = ?
                     LIMIT 1;
@@ -2281,6 +2402,7 @@ def _issue_batch(
                     (asset_id,),
                 ).fetchone()
                 previous_building_room = "" if asset_row is None else str(asset_row["building_room"] or "").strip()
+                home_slot_snapshot = _receipt_slot_snapshot(conn, home_slot_id)
 
                 update_clauses = ["location_type = ?", "current_holder_id = ?"]
                 update_values: list[object] = ["IN_CUSTODY", holder_id]
@@ -2325,7 +2447,7 @@ def _issue_batch(
                     (int(current_slot["slot_id"]),),
                 )
 
-                conn.execute(
+                event_cursor = conn.execute(
                     """
                     INSERT INTO asset_events (
                         asset_tag,
@@ -2357,13 +2479,68 @@ def _issue_batch(
                         holder_id,
                     ),
                 )
+                event_ids.append(int(event_cursor.lastrowid))
+                asset_snapshots.append(
+                    {
+                        "asset_id": asset_id,
+                        "asset_tag": canon_tag,
+                        "serial_number": "" if asset_row is None else str(asset_row["serial_number"] or ""),
+                        "equipment_type": "" if asset_row is None else str(asset_row["equipment_type"] or ""),
+                        "manufacturer": "" if asset_row is None else str(asset_row["manufacturer"] or ""),
+                        "model": "" if asset_row is None else str(asset_row["model"] or ""),
+                        "model_code": "" if asset_row is None else str(asset_row["model_code"] or ""),
+                        "notes": "" if asset_row is None else str(asset_row["notes"] or ""),
+                        "from_location_type": "STORAGE",
+                        "to_location_type": "IN_CUSTODY",
+                        "from_building_room": previous_building_room,
+                        "to_building_room": building_room,
+                        "holder_id": int(holder_id),
+                        "holder_snapshot": holder_snapshot,
+                        "home_slot": home_slot_snapshot,
+                    }
+                )
+
+            snapshot = {
+                "receipt_type": "ISSUE",
+                "commit_at": now_iso,
+                "commit_operator_user_id": int(commit_operator_user_id),
+                "commit_operator": commit_operator_snapshot,
+                "holder_id": int(holder_id),
+                "holder_snapshot": holder_snapshot,
+                "organization_snapshot": None if holder_snapshot is None else {
+                    "organization": str(holder_snapshot.get("organization") or ""),
+                    "organization_id": holder_snapshot.get("organization_id"),
+                },
+                "acknowledgment": dict(responsibility_ack),
+                "location_context": {
+                    "building": building,
+                    "room": room,
+                    "building_room": building_room,
+                },
+                "assets": asset_snapshots,
+                "source_event_ids": event_ids,
+            }
+            _insert_receipt_queue_row(
+                conn,
+                receipt_type="ISSUE",
+                source_event_ids=event_ids,
+                snapshot=snapshot,
+                commit_at=now_iso,
+                commit_operator_user_id=commit_operator_user_id,
+                holder_id=holder_id,
+            )
 
             return len(canon_assets)
     finally:
         conn.close()
 
 
-def _return_batch(asset_tags: list[str], responsibility_ack: dict[str, object]) -> int:
+def _return_batch(
+    asset_tags: list[str],
+    responsibility_ack: dict[str, object],
+    *,
+    commit_operator_user_id: int,
+) -> int:
     if not asset_tags:
         raise ValueError("No assets in the queue to return")
 
@@ -2464,11 +2641,29 @@ def _return_batch(asset_tags: list[str], responsibility_ack: dict[str, object]) 
                 raise ValueError("; ".join(parts))
 
             now_iso = datetime.now(timezone.utc).isoformat()
+            event_ids: list[int] = []
+            asset_snapshots: list[dict[str, object]] = []
+            batch_holder_ids: set[int] = set()
+            commit_operator_snapshot = _receipt_operator_snapshot(conn, commit_operator_user_id)
 
             for row in validated_rows:
                 canon_tag = row["asset_tag"]
                 home_slot_id = row["home_slot_id"]
                 current_holder_id = row["current_holder_id"]
+                if current_holder_id is not None:
+                    batch_holder_ids.add(int(current_holder_id))
+                asset_row = conn.execute(
+                    """
+                    SELECT id, serial_number, equipment_type, manufacturer, model, model_code, notes, building_room
+                    FROM assets
+                    WHERE UPPER(asset_tag) = UPPER(?)
+                       OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
+                    LIMIT 1;
+                    """,
+                    (canon_tag, canon_tag),
+                ).fetchone()
+                holder_snapshot = _receipt_holder_snapshot(conn, current_holder_id)
+                home_slot_snapshot = _receipt_slot_snapshot(conn, home_slot_id)
 
                 conn.execute(
                     """
@@ -2491,7 +2686,7 @@ def _return_batch(asset_tags: list[str], responsibility_ack: dict[str, object]) 
                 if cursor.rowcount != 1:
                     raise ValueError(f"Home slot became occupied for {canon_tag}")
 
-                conn.execute(
+                event_cursor = conn.execute(
                     """
                     INSERT INTO asset_events (
                         asset_tag,
@@ -2524,6 +2719,54 @@ def _return_batch(asset_tags: list[str], responsibility_ack: dict[str, object]) 
                         None,
                     ),
                 )
+                event_ids.append(int(event_cursor.lastrowid))
+                asset_snapshots.append(
+                    {
+                        "asset_id": None if asset_row is None else int(asset_row["id"]),
+                        "asset_tag": canon_tag,
+                        "serial_number": "" if asset_row is None else str(asset_row["serial_number"] or ""),
+                        "equipment_type": "" if asset_row is None else str(asset_row["equipment_type"] or ""),
+                        "manufacturer": "" if asset_row is None else str(asset_row["manufacturer"] or ""),
+                        "model": "" if asset_row is None else str(asset_row["model"] or ""),
+                        "model_code": "" if asset_row is None else str(asset_row["model_code"] or ""),
+                        "notes": "" if asset_row is None else str(asset_row["notes"] or ""),
+                        "from_location_type": "IN_CUSTODY",
+                        "to_location_type": "STORAGE",
+                        "from_holder_id": current_holder_id,
+                        "from_holder_snapshot": holder_snapshot,
+                        "to_holder_id": None,
+                        "from_building_room": "" if asset_row is None else str(asset_row["building_room"] or ""),
+                        "to_building_room": "" if asset_row is None else str(asset_row["building_room"] or ""),
+                        "home_slot": home_slot_snapshot,
+                    }
+                )
+
+            batch_holder_id = next(iter(batch_holder_ids)) if len(batch_holder_ids) == 1 else None
+            batch_holder_snapshot = _receipt_holder_snapshot(conn, batch_holder_id)
+            snapshot = {
+                "receipt_type": "RETURN",
+                "commit_at": now_iso,
+                "commit_operator_user_id": int(commit_operator_user_id),
+                "commit_operator": commit_operator_snapshot,
+                "holder_id": batch_holder_id,
+                "holder_snapshot": batch_holder_snapshot,
+                "organization_snapshot": None if batch_holder_snapshot is None else {
+                    "organization": str(batch_holder_snapshot.get("organization") or ""),
+                    "organization_id": batch_holder_snapshot.get("organization_id"),
+                },
+                "acknowledgment": dict(responsibility_ack),
+                "assets": asset_snapshots,
+                "source_event_ids": event_ids,
+            }
+            _insert_receipt_queue_row(
+                conn,
+                receipt_type="RETURN",
+                source_event_ids=event_ids,
+                snapshot=snapshot,
+                commit_at=now_iso,
+                commit_operator_user_id=commit_operator_user_id,
+                holder_id=batch_holder_id,
+            )
 
             return len(validated_rows)
     finally:
@@ -3166,9 +3409,28 @@ def preview_commit():
         return redirect(url_for("issue"))
 
     asset_tags = _queue_asset_tags()
+    user = current_user()
+    if user is None:
+        if wants_json():
+            return {"ok": False, "committed": 0, "error": "Authenticated operator not found."}, 400
+        flash("Authenticated operator not found.", "error")
+        return redirect(url_for("preview"))
+    responsibility_ack = {
+        "acknowledged": True,
+        "ack_holder_id": int(holder["id"]),
+        "ack_operator_user_id": int(user["id"]),
+        "ack_at": datetime.now(timezone.utc).isoformat(),
+        "ack_scope": "batch",
+    }
 
     try:
-        committed_count = _issue_batch(asset_tags, holder["id"], issue_location_form)
+        committed_count = _issue_batch(
+            asset_tags,
+            holder["id"],
+            issue_location_form,
+            responsibility_ack,
+            commit_operator_user_id=int(user["id"]),
+        )
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400
@@ -3409,7 +3671,13 @@ def issue_commit():
     }
 
     try:
-        committed_count = _issue_batch(asset_tags, holder["id"], issue_location_form, responsibility_ack)
+        committed_count = _issue_batch(
+            asset_tags,
+            holder["id"],
+            issue_location_form,
+            responsibility_ack,
+            commit_operator_user_id=int(user["id"]),
+        )
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400
@@ -3550,7 +3818,11 @@ def return_commit():
     }
 
     try:
-        committed_count = _return_batch(asset_tags, responsibility_ack)
+        committed_count = _return_batch(
+            asset_tags,
+            responsibility_ack,
+            commit_operator_user_id=int(user["id"]),
+        )
     except ValueError as e:
         if wants_json():
             return {"ok": False, "committed": 0, "error": str(e)}, 400

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -211,6 +211,7 @@ class AdminRetireAssetTests(unittest.TestCase):
                     "ack_at": "2026-03-28T00:00:00Z",
                     "ack_scope": "batch",
                 },
+                commit_operator_user_id=1,
             )
 
         with self.assertRaisesRegex(ValueError, "Retired/disposed"):
@@ -222,6 +223,7 @@ class AdminRetireAssetTests(unittest.TestCase):
                     "ack_at": "2026-03-28T00:00:00Z",
                     "ack_scope": "batch",
                 },
+                commit_operator_user_id=1,
             )
 
     def test_admin_assign_slot_refuses_retired_asset(self) -> None:

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -193,12 +194,20 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     conn = db.get_connection()
     rows = conn.execute(
         """
-        SELECT asset_tag, event_type, holder_id
+        SELECT id, asset_tag, event_type, holder_id
         FROM asset_events
         WHERE event_type = 'ISSUE'
         ORDER BY asset_tag ASC;
         """
     ).fetchall()
+    receipt_row = conn.execute(
+        """
+        SELECT receipt_type, holder_id, source_event_ids_json, snapshot_json
+        FROM receipt_queue
+        ORDER BY id DESC
+        LIMIT 1;
+        """
+    ).fetchone()
     asset_rows = conn.execute(
         """
         SELECT asset_tag, location_type, current_holder_id
@@ -213,6 +222,14 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
         ("CI-400", "ISSUE", 1),
         ("CI-401", "ISSUE", 1),
     ]
+    assert receipt_row is not None
+    assert str(receipt_row["receipt_type"]) == "ISSUE"
+    assert int(receipt_row["holder_id"]) == 1
+    source_event_ids = json.loads(str(receipt_row["source_event_ids_json"]))
+    assert source_event_ids == [int(rows[0]["id"]), int(rows[1]["id"])]
+    receipt_snapshot = json.loads(str(receipt_row["snapshot_json"]))
+    assert receipt_snapshot["source_event_ids"] == source_event_ids
+    assert len(receipt_snapshot["assets"]) == 2
     assert [(str(row["asset_tag"]), str(row["location_type"]), int(row["current_holder_id"])) for row in asset_rows] == [
         ("CI-400", "IN_CUSTODY", 1),
         ("CI-401", "IN_CUSTODY", 1),

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -211,9 +211,17 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
         ).fetchone()
         event_row = conn.execute(
             """
-            SELECT payload, holder_id
+            SELECT id, payload, holder_id
             FROM asset_events
             WHERE asset_tag = 'ISSUE-100' AND event_type = 'ISSUE'
+            ORDER BY id DESC
+            LIMIT 1;
+            """
+        ).fetchone()
+        receipt_row = conn.execute(
+            """
+            SELECT receipt_type, commit_operator_user_id, holder_id, source_event_ids_json, snapshot_json
+            FROM receipt_queue
             ORDER BY id DESC
             LIMIT 1;
             """
@@ -246,6 +254,23 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     assert int(payload["responsibility_ack"]["ack_operator_user_id"]) > 0
     assert payload["responsibility_ack"]["ack_at"]
     assert payload["responsibility_ack"]["ack_scope"] == "batch"
+    assert receipt_row is not None
+    assert str(receipt_row["receipt_type"]) == "ISSUE"
+    assert int(receipt_row["commit_operator_user_id"]) > 0
+    assert int(receipt_row["holder_id"]) == 1
+    assert json.loads(str(receipt_row["source_event_ids_json"])) == [int(event_row["id"])]
+    receipt_snapshot = json.loads(str(receipt_row["snapshot_json"]))
+    assert receipt_snapshot["receipt_type"] == "ISSUE"
+    assert receipt_snapshot["holder_id"] == 1
+    assert receipt_snapshot["source_event_ids"] == [int(event_row["id"])]
+    assert receipt_snapshot["location_context"]["building"] == "HQ North"
+    assert receipt_snapshot["location_context"]["room"] == "210"
+    assert receipt_snapshot["location_context"]["building_room"] == "HQ North/210"
+    assert receipt_snapshot["acknowledgment"]["ack_scope"] == "batch"
+    assert len(receipt_snapshot["assets"]) == 1
+    assert receipt_snapshot["assets"][0]["asset_tag"] == "ISSUE-100"
+    assert receipt_snapshot["assets"][0]["from_location_type"] == "STORAGE"
+    assert receipt_snapshot["assets"][0]["to_location_type"] == "IN_CUSTODY"
 
 
 def test_issue_commit_requires_responsibility_acknowledgment(client_with_temp_db) -> None:
@@ -273,11 +298,14 @@ def test_issue_commit_requires_responsibility_acknowledgment(client_with_temp_db
         event_count = conn.execute(
             "SELECT COUNT(*) AS c FROM asset_events WHERE asset_tag = 'ISSUE-100' AND event_type = 'ISSUE';"
         ).fetchone()
+        receipt_count = conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
     finally:
         conn.close()
 
     assert event_count is not None
     assert int(event_count["c"]) == 0
+    assert receipt_count is not None
+    assert int(receipt_count["c"]) == 0
 
 
 def test_issue_commit_missing_ack_shows_visible_message_on_issue_preview(client_with_temp_db) -> None:

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -166,12 +166,20 @@ class ReturnBatchTests(unittest.TestCase):
 
         event_row = self.conn.execute(
             """
-            SELECT event_type, payload FROM asset_events
+            SELECT id, event_type, payload FROM asset_events
             WHERE asset_tag = ?
             ORDER BY id DESC
             LIMIT 1;
             """,
             ("TAG-OK",),
+        ).fetchone()
+        receipt_row = self.conn.execute(
+            """
+            SELECT receipt_type, commit_operator_user_id, holder_id, source_event_ids_json, snapshot_json
+            FROM receipt_queue
+            ORDER BY id DESC
+            LIMIT 1;
+            """
         ).fetchone()
         self.assertIsNotNone(event_row)
         self.assertEqual(event_row["event_type"], "RETURN")
@@ -184,6 +192,19 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertGreater(int(payload["responsibility_ack"]["ack_operator_user_id"]), 0)
         self.assertTrue(payload["responsibility_ack"]["ack_at"])
         self.assertEqual(payload["responsibility_ack"]["ack_scope"], "batch")
+        self.assertIsNotNone(receipt_row)
+        self.assertEqual(receipt_row["receipt_type"], "RETURN")
+        self.assertGreater(int(receipt_row["commit_operator_user_id"]), 0)
+        self.assertEqual(int(receipt_row["holder_id"]), 9)
+        self.assertEqual(json.loads(str(receipt_row["source_event_ids_json"])), [int(event_row["id"])])
+        receipt_snapshot = json.loads(str(receipt_row["snapshot_json"]))
+        self.assertEqual(receipt_snapshot["receipt_type"], "RETURN")
+        self.assertEqual(receipt_snapshot["holder_id"], 9)
+        self.assertEqual(receipt_snapshot["source_event_ids"], [int(event_row["id"])])
+        self.assertEqual(len(receipt_snapshot["assets"]), 1)
+        self.assertEqual(receipt_snapshot["assets"][0]["asset_tag"], "TAG-OK")
+        self.assertEqual(receipt_snapshot["assets"][0]["from_location_type"], "IN_CUSTODY")
+        self.assertEqual(receipt_snapshot["assets"][0]["to_location_type"], "STORAGE")
 
     def test_return_commit_missing_ack_redirects_back_to_preview_with_message(self) -> None:
         self._insert_slot(21, "C", 3, None)
@@ -205,6 +226,8 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(follow.status_code, 200)
         self.assertIn(b"Confirm responsibility acknowledgment before returning assets.", follow.data)
         self.assertEqual(len(intake_app.SCAN_QUEUE), 1)
+        receipt_count = self.conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+        self.assertEqual(int(receipt_count["c"]), 0)
 
     def test_single_asset_return_success_message_shows_final_location(self) -> None:
         self._insert_slot(30, "CASE-13", 6, None)


### PR DESCRIPTION
## Summary
Queue one local receipt snapshot per successful custody batch commit.

## Related Issue
Closes #353 

## Changes
- added receipt queue creation inside the existing issue and return batch transaction
- store one `receipt_queue` row per successful batch commit
- capture commit-time `snapshot_json` and `source_event_ids_json`
- store receipt type, commit timestamp, commit operator, and holder context when available
- added targeted tests for successful issue/return receipt creation and failed-commit no-row behavior

## Verification checklist
- [x] Issue commit creates one receipt row per batch
- [x] Return commit creates one receipt row per batch
- [x] Failed commit creates no receipt row
- [x] Stored receipt contains expected receipt type and source event IDs
- [x] App rebuilds and runs cleanly
- [x] Manual issue workflow passes
- [x] Manual return workflow passes
- [x] No UI, route, auth, or schema changes introduced

## Notes
- local receipt storage only
- no email, PDF, or send-attempt behavior added
- receipt creation stays secondary to custody commit