### PR TITLE
Issue 26-38: Add read-only receipt detail view

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -3917,6 +3917,94 @@ def holder_detail(holder_id: int):
     )
 
 
+@app.get("/receipts/<int:receipt_id>")
+@require_login
+def receipt_detail(receipt_id: int):
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    conn = get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT
+                id,
+                receipt_key,
+                receipt_type,
+                source_event_ids_json,
+                snapshot_json,
+                commit_at,
+                commit_operator_user_id,
+                holder_id
+            FROM receipt_queue
+            WHERE id = ?
+            LIMIT 1;
+            """,
+            (receipt_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        abort(404)
+
+    source_event_ids = json.loads(str(row["source_event_ids_json"] or "[]"))
+    if not isinstance(source_event_ids, list):
+        source_event_ids = []
+
+    snapshot = json.loads(str(row["snapshot_json"] or "{}"))
+    if not isinstance(snapshot, dict):
+        snapshot = {}
+
+    snapshot_assets = snapshot.get("assets")
+    assets = snapshot_assets if isinstance(snapshot_assets, list) else []
+    location_context = snapshot.get("location_context")
+    if not isinstance(location_context, dict):
+        location_context = None
+    acknowledgment = snapshot.get("acknowledgment")
+    if not isinstance(acknowledgment, dict):
+        acknowledgment = None
+
+    snapshot_receipt_type = str(snapshot.get("receipt_type") or "").strip().upper()
+    row_receipt_type = str(row["receipt_type"] or "").strip().upper()
+    receipt_type = snapshot_receipt_type or row_receipt_type
+
+    snapshot_commit_at = str(snapshot.get("commit_at") or "").strip()
+    commit_at = snapshot_commit_at or str(row["commit_at"] or "")
+
+    snapshot_operator_id = snapshot.get("commit_operator_user_id")
+    commit_operator_user_id = (
+        int(snapshot_operator_id)
+        if snapshot_operator_id is not None
+        else int(row["commit_operator_user_id"])
+    )
+
+    receipt = {
+        "id": int(row["id"]),
+        "receipt_key": str(row["receipt_key"] or ""),
+        "receipt_type": receipt_type,
+        "commit_at": commit_at,
+        "commit_operator_user_id": commit_operator_user_id,
+        "commit_operator": snapshot.get("commit_operator") if isinstance(snapshot.get("commit_operator"), dict) else None,
+        "holder_id": snapshot.get("holder_id") if snapshot.get("holder_id") is not None else row["holder_id"],
+        "holder_snapshot": snapshot.get("holder_snapshot") if isinstance(snapshot.get("holder_snapshot"), dict) else None,
+        "organization_snapshot": (
+            snapshot.get("organization_snapshot") if isinstance(snapshot.get("organization_snapshot"), dict) else None
+        ),
+        "acknowledgment": acknowledgment,
+        "location_context": location_context,
+        "assets": assets,
+        "source_event_ids": source_event_ids,
+    }
+
+    return render_template(
+        "receipt_detail.html",
+        receipt=receipt,
+    )
+
+
 @app.get("/holders/new")
 @require_login
 def holders_new():

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -1,0 +1,178 @@
+{% extends "base.html" %}
+
+{% block title %}Receipt Detail{% endblock %}
+{% block page_heading %}Receipt {{ receipt.id }}{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .meta-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem;
+    }
+    .meta-grid p {
+      margin: 0;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  {% set operator = receipt.commit_operator %}
+  {% set holder = receipt.holder_snapshot %}
+  {% set organization = receipt.organization_snapshot %}
+  <nav class="actions" aria-label="Receipt navigation">
+    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a class="chip" href="{{ url_for('human_report') }}">Open Current Status Report</a>
+  </nav>
+
+  <section class="card">
+    <div class="meta-grid">
+      <p><strong>Receipt ID:</strong> <span class="mono">{{ receipt.id }}</span></p>
+      <p><strong>Receipt key:</strong> <span class="mono">{{ receipt.receipt_key }}</span></p>
+      <p><strong>Receipt type:</strong> {{ receipt.receipt_type or "Unknown" }}</p>
+      <p><strong>Committed at:</strong> {{ receipt.commit_at or "Unknown" }}</p>
+      <p>
+        <strong>Committed by:</strong>
+        {% if operator and operator.username %}
+          {{ operator.username }}{% if operator.role %} ({{ operator.role }}){% endif %} [user_id {{ operator.id }}]
+        {% else %}
+          user_id {{ receipt.commit_operator_user_id }}
+        {% endif %}
+      </p>
+      {% if holder or receipt.holder_id is not none %}
+        <p>
+          <strong>Receipt holder:</strong>
+          {% if holder and holder.name %}
+            {{ holder.name }}
+            {% if holder.identifier %}(ID {{ holder.identifier }}){% endif %}
+          {% else %}
+            holder_id {{ receipt.holder_id }}
+          {% endif %}
+        </p>
+      {% endif %}
+      {% if organization %}
+        <p>
+          <strong>Organization:</strong>
+          {{ organization.organization or "Unknown" }}
+          {% if organization.organization_id is not none %}(org_id {{ organization.organization_id }}){% endif %}
+        </p>
+      {% endif %}
+    </div>
+  </section>
+
+  {% if receipt.acknowledgment %}
+    <section class="card">
+      <h2>Acknowledgment</h2>
+      <p>
+        <strong>Acknowledged:</strong> {{ "Yes" if receipt.acknowledgment.get("acknowledged") else "No" }}<br />
+        {% if receipt.acknowledgment.get("ack_scope") %}
+          <strong>Scope:</strong> {{ receipt.acknowledgment.get("ack_scope") }}<br />
+        {% endif %}
+        {% if receipt.acknowledgment.get("ack_at") %}
+          <strong>Captured at:</strong> {{ receipt.acknowledgment.get("ack_at") }}<br />
+        {% endif %}
+        {% if receipt.acknowledgment.get("ack_operator_user_id") is not none %}
+          <strong>Operator user ID:</strong> {{ receipt.acknowledgment.get("ack_operator_user_id") }}<br />
+        {% endif %}
+        {% if receipt.acknowledgment.get("ack_holder_id") is not none %}
+          <strong>Holder ID:</strong> {{ receipt.acknowledgment.get("ack_holder_id") }}
+        {% endif %}
+      </p>
+    </section>
+  {% endif %}
+
+  {% if receipt.location_context %}
+    <section class="card">
+      <h2>Issue Location</h2>
+      <p>
+        <strong>Building:</strong> {{ receipt.location_context.get("building") or "Unknown" }}<br />
+        <strong>Room:</strong> {{ receipt.location_context.get("room") or "Unknown" }}<br />
+        <strong>Combined location:</strong> {{ receipt.location_context.get("building_room") or "Unknown" }}
+      </p>
+    </section>
+  {% endif %}
+
+  <section class="card">
+    <h2>Assets ({{ receipt.assets|length }})</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Asset Tag</th>
+          <th>Equipment</th>
+          <th>Serial</th>
+          <th>Make / Model</th>
+          <th>From</th>
+          <th>To</th>
+          <th>Holder</th>
+          <th>Home Slot</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for asset in receipt.assets %}
+          {% set issue_holder = asset.get("holder_snapshot") if asset.get("holder_snapshot") is mapping else None %}
+          {% set return_holder = asset.get("from_holder_snapshot") if asset.get("from_holder_snapshot") is mapping else None %}
+          {% set home_slot = asset.get("home_slot") if asset.get("home_slot") is mapping else None %}
+          <tr>
+            <td class="mono">{{ asset.get("asset_tag") or "" }}</td>
+            <td>{{ asset.get("equipment_type") or "" }}</td>
+            <td class="mono">{{ asset.get("serial_number") or "" }}</td>
+            <td>
+              {{ asset.get("manufacturer") or "" }}
+              {% if asset.get("model") %} / {{ asset.get("model") }}{% endif %}
+              {% if asset.get("model_code") %} ({{ asset.get("model_code") }}){% endif %}
+            </td>
+            <td>{{ asset.get("from_location_type") or "" }}{% if asset.get("from_building_room") %}<br />{{ asset.get("from_building_room") }}{% endif %}</td>
+            <td>{{ asset.get("to_location_type") or "" }}{% if asset.get("to_building_room") %}<br />{{ asset.get("to_building_room") }}{% endif %}</td>
+            <td>
+              {% if receipt.receipt_type == "ISSUE" %}
+                {% if issue_holder and issue_holder.get("name") %}
+                  {{ issue_holder.get("name") }}
+                  {% if issue_holder.get("identifier") %}<br />ID {{ issue_holder.get("identifier") }}{% endif %}
+                {% elif asset.get("holder_id") is not none %}
+                  holder_id {{ asset.get("holder_id") }}
+                {% else %}
+                  Unknown
+                {% endif %}
+              {% else %}
+                {% if return_holder and return_holder.get("name") %}
+                  {{ return_holder.get("name") }}
+                  {% if return_holder.get("identifier") %}<br />ID {{ return_holder.get("identifier") }}{% endif %}
+                {% elif asset.get("from_holder_id") is not none %}
+                  holder_id {{ asset.get("from_holder_id") }}
+                {% else %}
+                  None
+                {% endif %}
+              {% endif %}
+            </td>
+            <td>
+              {% if home_slot %}
+                {{ home_slot.get("case_name") or "Unknown" }} / {{ home_slot.get("slot_position") if home_slot.get("slot_position") is not none else "Unknown" }}
+              {% else %}
+                Unknown
+              {% endif %}
+            </td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="8">No assets were captured in this receipt snapshot.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+
+  <section class="card">
+    <h2>Source Events</h2>
+    <p>
+      {% if receipt.source_event_ids %}
+        {% for event_id in receipt.source_event_ids %}
+          <span class="mono">{{ event_id }}</span>{% if not loop.last %}, {% endif %}
+        {% endfor %}
+      {% else %}
+        None recorded.
+      {% endif %}
+    </p>
+  </section>
+{% endblock %}

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _insert_holder(
+    holder_id: int,
+    *,
+    name: str,
+    identifier: str,
+    organization: str = "",
+    organization_id: int | None = None,
+) -> None:
+    conn = db.get_connection()
+    try:
+        if organization_id is not None:
+            conn.execute(
+                """
+                INSERT INTO organizations (id, name, created_at, updated_at)
+                VALUES (?, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                """,
+                (organization_id, organization or f"Organization {organization_id}"),
+            )
+        conn.execute(
+            """
+            INSERT INTO holders (
+                id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+            )
+            VALUES (?, 'PERSON', ?, ?, ?, ?, '', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (holder_id, name, organization, organization_id, identifier),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_slot(slot_id: int, case_name: str, slot_position: int) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, NULL);
+            """,
+            (slot_id, case_name, slot_position),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_asset(
+    asset_id: int,
+    asset_tag: str,
+    *,
+    location_type: str,
+    home_slot_id: int | None,
+    current_holder_id: int | None = None,
+    building_room: str = "",
+    serial_number: str = "",
+    equipment_type: str = "",
+    manufacturer: str = "",
+    model: str = "",
+    model_code: str = "",
+    notes: str = "",
+) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO assets (
+                id, asset_tag, serial_number, equipment_type, manufacturer, model, model_code, notes,
+                location_type, current_holder_id, home_slot_id, building_room
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                asset_id,
+                asset_tag,
+                serial_number,
+                equipment_type,
+                manufacturer,
+                model,
+                model_code,
+                notes,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                building_room,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _occupy_slot(slot_id: int, asset_id: int) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, '2026-01-01T00:00:00Z');
+            """,
+            (slot_id, asset_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _login_issue_operator(client, *, username: str = "issue-operator") -> int:
+    operator_id = create_test_user(username=username, password="op-pass", role="operator")
+    with client.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
+    return operator_id
+
+
+def _login_user(client, *, username: str, role: str) -> int:
+    user_id = create_test_user(username=username, password="op-pass", role=role)
+    with client.session_transaction() as sess:
+        sess["user_id"] = user_id
+    return user_id
+
+
+def _latest_receipt_id() -> int:
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT id
+            FROM receipt_queue
+            ORDER BY id DESC
+            LIMIT 1;
+            """
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return int(row["id"])
+
+
+def _create_issue_receipt(client) -> int:
+    _insert_holder(1, name="Issue Holder", identifier="IH-1", organization="Operations", organization_id=9)
+    _insert_slot(10, "CASE-10", 1)
+    _insert_asset(
+        100,
+        "ISSUE-100",
+        location_type="STORAGE",
+        home_slot_id=10,
+        building_room="Storage/A1",
+        serial_number="SN-ISSUE-100",
+        equipment_type="Laptop",
+        manufacturer="Dell",
+        model="Latitude",
+        model_code="LAT-14",
+        notes="Original issue note",
+    )
+    _occupy_slot(10, 100)
+    _login_issue_operator(client)
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="ISSUE-100", equipment_type="laptop"))
+
+    response = client.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    return _latest_receipt_id()
+
+
+def _create_return_receipt(client, *, mixed_holders: bool = False) -> int:
+    _insert_holder(7, name="Return Holder One", identifier="RH-7")
+    _insert_holder(8, name="Return Holder Two", identifier="RH-8")
+    _insert_slot(20, "CASE-20", 1)
+    _insert_slot(21, "CASE-20", 2)
+    _insert_asset(
+        200,
+        "RETURN-200",
+        location_type="IN_CUSTODY",
+        current_holder_id=7,
+        home_slot_id=20,
+        building_room="HQ North/210",
+        serial_number="SN-RETURN-200",
+        equipment_type="Tablet",
+        manufacturer="Apple",
+        model="iPad",
+        model_code="IP-1",
+        notes="Return note one",
+    )
+    if mixed_holders:
+        _insert_asset(
+            201,
+            "RETURN-201",
+            location_type="IN_CUSTODY",
+            current_holder_id=8,
+            home_slot_id=21,
+            building_room="HQ North/211",
+            serial_number="SN-RETURN-201",
+            equipment_type="Laptop",
+            manufacturer="Lenovo",
+            model="ThinkPad",
+            model_code="TP-2",
+            notes="Return note two",
+        )
+    _login_user(client, username="return-operator", role="operator")
+
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-200", equipment_type="tablet"))
+    if mixed_holders:
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-201", equipment_type="laptop"))
+
+    response = client.post(
+        "/return/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    return _latest_receipt_id()
+
+
+def test_issue_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Receipt Detail" in response.data
+    assert f"Receipt {receipt_id}".encode("utf-8") in response.data
+    assert b"Receipt key:" in response.data
+    assert b"ISSUE:" in response.data
+    assert b"Receipt type:</strong> ISSUE" in response.data
+    assert b"Committed by:</strong>" in response.data
+    assert b"issue-operator" in response.data
+    assert b"Receipt holder:</strong>" in response.data
+    assert b"Issue Holder" in response.data
+    assert b"Issue Location" in response.data
+    assert b"HQ North" in response.data
+    assert b"210" in response.data
+    assert b"HQ North/210" in response.data
+    assert b"ISSUE-100" in response.data
+    assert b"Dell" in response.data
+    assert b"Latitude" in response.data
+    assert b"CASE-10 / 1" in response.data
+    assert b"Source Events" in response.data
+
+
+def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None:
+    receipt_id = _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Receipt type:</strong> RETURN" in response.data
+    assert b"RETURN:" in response.data
+    assert b"Return Holder One" in response.data
+    assert b"RETURN-200" in response.data
+    assert b"Apple" in response.data
+    assert b"iPad" in response.data
+    assert b"CASE-20 / 1" in response.data
+    assert b"Source Events" in response.data
+
+
+def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:
+    receipt_id = _create_return_receipt(client_with_temp_db, mixed_holders=True)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Receipt type:</strong> RETURN" in response.data
+    assert b"Receipt holder:" not in response.data
+    assert b"Return Holder One" in response.data
+    assert b"Return Holder Two" in response.data
+    assert b"RETURN-200" in response.data
+    assert b"RETURN-201" in response.data
+
+
+def test_missing_receipt_returns_404(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="missing-operator", password="op-pass", role="operator")
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = operator_id
+
+    response = client_with_temp_db.get("/receipts/9999")
+
+    assert response.status_code == 404
+
+
+@pytest.mark.parametrize("role", ["operator", "admin"])
+def test_receipt_detail_allows_operator_and_admin(client_with_temp_db, role: str) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    _login_user(client_with_temp_db, username=f"{role}-viewer", role=role)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+
+
+def test_receipt_detail_requires_login(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    with client_with_temp_db.session_transaction() as sess:
+        sess.clear()
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 403
+    assert response.json == {"ok": False, "error": "Forbidden"}
+
+
+def test_receipt_detail_timeout_matches_existing_readonly_pattern(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    _login_user(client_with_temp_db, username="timeout-operator", role="operator")
+    monkeypatch.setattr(intake_app, "auth_enabled", lambda: True)
+    monkeypatch.setattr(intake_app, "enforce_inactivity_timeout", lambda: False)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/")
+
+
+def test_receipt_detail_uses_snapshot_truth_not_live_tables(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            UPDATE holders
+            SET name = ?, identifier = ?
+            WHERE id = 1;
+            """,
+            ("Mutated Holder", "IH-CHANGED"),
+        )
+        conn.execute(
+            """
+            UPDATE assets
+            SET manufacturer = ?, model = ?, notes = ?
+            WHERE id = 100;
+            """,
+            ("Changed Maker", "Changed Model", "Changed note"),
+        )
+        conn.execute(
+            """
+            UPDATE users
+            SET username = ?
+            WHERE username = ?;
+            """,
+            ("mutated-operator", "issue-operator"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Issue Holder" in response.data
+    assert b"IH-1" in response.data
+    assert b"Dell" in response.data
+    assert b"Latitude" in response.data
+    assert b"issue-operator" in response.data
+    assert b"Mutated Holder" not in response.data
+    assert b"IH-CHANGED" not in response.data
+    assert b"Changed Maker" not in response.data
+    assert b"Changed Model" not in response.data
+    assert b"mutated-operator" not in response.data


### PR DESCRIPTION
## Summary
Adds a read-only receipt detail page backed by stored snapshot data.

## Related Issue
Closes #362 

## Changes
- Added GET /receipts/<id> route
- Renders receipt from snapshot_json only
- Supports ISSUE and RETURN receipts
- Handles mixed-holder returns safely
- Added focused tests for receipt detail behavior

## Verification checklist
- [x] Issue receipt renders with correct data
- [x] Return receipt renders with correct data
- [x] Mixed-holder return handled correctly
- [x] Page is read-only
- [x] Snapshot data is preserved independent of live DB changes
- [x] Operator and admin access verified
- [x] Unauthenticated access blocked

## Notes
Receipt detail uses snapshot truth and does not join to live tables to preserve audit integrity.