### PR TITLE
Issue 26-40: Add read-only receipts list and search page

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4005,6 +4005,160 @@ def receipt_detail(receipt_id: int):
     )
 
 
+def _receipt_summary_from_row(row: sqlite3.Row) -> dict[str, object]:
+    snapshot = json.loads(str(row["snapshot_json"] or "{}"))
+    if not isinstance(snapshot, dict):
+        snapshot = {}
+
+    assets = snapshot.get("assets")
+    asset_list = assets if isinstance(assets, list) else []
+    operator = snapshot.get("commit_operator") if isinstance(snapshot.get("commit_operator"), dict) else None
+    holder_snapshot = snapshot.get("holder_snapshot") if isinstance(snapshot.get("holder_snapshot"), dict) else None
+    organization_snapshot = (
+        snapshot.get("organization_snapshot") if isinstance(snapshot.get("organization_snapshot"), dict) else None
+    )
+    location_context = snapshot.get("location_context") if isinstance(snapshot.get("location_context"), dict) else None
+
+    receipt_type = str(snapshot.get("receipt_type") or row["receipt_type"] or "").strip().upper()
+    commit_at = str(snapshot.get("commit_at") or row["commit_at"] or "")
+    holder_id = snapshot.get("holder_id") if snapshot.get("holder_id") is not None else row["holder_id"]
+
+    if holder_snapshot and str(holder_snapshot.get("name") or "").strip():
+        holder_summary = str(holder_snapshot.get("name") or "").strip()
+    elif holder_id is not None:
+        holder_summary = f"holder_id {holder_id}"
+    elif receipt_type == "RETURN" and len(asset_list) > 1:
+        holder_summary = "Multiple holders"
+    else:
+        holder_summary = "Unknown"
+
+    if organization_snapshot and str(organization_snapshot.get("organization") or "").strip():
+        organization_summary = str(organization_snapshot.get("organization") or "").strip()
+    else:
+        organization_summary = ""
+
+    if location_context and str(location_context.get("building_room") or "").strip():
+        location_summary = str(location_context.get("building_room") or "").strip()
+    elif receipt_type == "RETURN":
+        location_summary = "Asset-specific return locations"
+    else:
+        location_summary = "Unknown"
+
+    if operator and str(operator.get("username") or "").strip():
+        committed_by = str(operator.get("username") or "").strip()
+    else:
+        committed_by = f"user_id {int(row['commit_operator_user_id'])}"
+
+    return {
+        "id": int(row["id"]),
+        "receipt_key": str(row["receipt_key"] or ""),
+        "receipt_type": receipt_type,
+        "commit_at": commit_at,
+        "committed_by": committed_by,
+        "holder_summary": holder_summary,
+        "organization_summary": organization_summary,
+        "location_summary": location_summary,
+        "asset_count": len(asset_list),
+    }
+
+
+@app.get("/receipts")
+@require_login
+def receipts_list():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    asset_tag = (request.args.get("asset_tag") or "").strip()
+    holder_name = (request.args.get("holder_name") or "").strip()
+    building_room = (request.args.get("building_room") or "").strip()
+
+    clauses: list[str] = []
+    params: list[object] = []
+
+    if asset_tag:
+        clauses.append(
+            """
+            EXISTS (
+                SELECT 1
+                FROM json_each(receipt_queue.snapshot_json, '$.assets') AS asset
+                WHERE UPPER(COALESCE(json_extract(asset.value, '$.asset_tag'), '')) LIKE UPPER(?)
+            )
+            """
+        )
+        params.append(f"%{asset_tag}%")
+
+    if holder_name:
+        clauses.append(
+            """
+            (
+                UPPER(COALESCE(json_extract(receipt_queue.snapshot_json, '$.holder_snapshot.name'), '')) LIKE UPPER(?)
+                OR EXISTS (
+                    SELECT 1
+                    FROM json_each(receipt_queue.snapshot_json, '$.assets') AS asset
+                    WHERE UPPER(COALESCE(json_extract(asset.value, '$.holder_snapshot.name'), '')) LIKE UPPER(?)
+                       OR UPPER(COALESCE(json_extract(asset.value, '$.from_holder_snapshot.name'), '')) LIKE UPPER(?)
+                )
+            )
+            """
+        )
+        like_value = f"%{holder_name}%"
+        params.extend([like_value, like_value, like_value])
+
+    if building_room:
+        clauses.append(
+            """
+            (
+                UPPER(COALESCE(json_extract(receipt_queue.snapshot_json, '$.location_context.building_room'), '')) LIKE UPPER(?)
+                OR EXISTS (
+                    SELECT 1
+                    FROM json_each(receipt_queue.snapshot_json, '$.assets') AS asset
+                    WHERE UPPER(COALESCE(json_extract(asset.value, '$.from_building_room'), '')) LIKE UPPER(?)
+                       OR UPPER(COALESCE(json_extract(asset.value, '$.to_building_room'), '')) LIKE UPPER(?)
+                )
+            )
+            """
+        )
+        like_value = f"%{building_room}%"
+        params.extend([like_value, like_value, like_value])
+
+    where_sql = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            f"""
+            SELECT
+                id,
+                receipt_key,
+                receipt_type,
+                snapshot_json,
+                commit_at,
+                commit_operator_user_id,
+                holder_id
+            FROM receipt_queue
+            {where_sql}
+            ORDER BY commit_at DESC, id DESC;
+            """,
+            tuple(params),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    receipts = [_receipt_summary_from_row(row) for row in rows]
+
+    return render_template(
+        "receipts_list.html",
+        receipts=receipts,
+        filters={
+            "asset_tag": asset_tag,
+            "holder_name": holder_name,
+            "building_room": building_room,
+        },
+    )
+
+
 @app.get("/holders/new")
 @require_login
 def holders_new():

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -1,0 +1,93 @@
+{% extends "base.html" %}
+
+{% block title %}Receipts{% endblock %}
+{% block page_heading %}Receipts{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
+    .filters {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.75rem;
+      align-items: end;
+    }
+    .filters .row {
+      margin: 0;
+    }
+    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .muted-cell { color: var(--color-text-muted); }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="actions" aria-label="Receipt navigation">
+    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a class="chip" href="{{ url_for('human_report') }}">Open Current Status Report</a>
+  </nav>
+
+  <section class="card">
+    <h2>Search Receipts</h2>
+    <form method="get" action="{{ url_for('receipts_list') }}">
+      <div class="filters">
+        <div class="row">
+          <label for="asset_tag">Asset Tag</label>
+          <input id="asset_tag" name="asset_tag" type="text" value="{{ filters.asset_tag }}" />
+        </div>
+        <div class="row">
+          <label for="holder_name">Holder Name</label>
+          <input id="holder_name" name="holder_name" type="text" value="{{ filters.holder_name }}" />
+        </div>
+        <div class="row">
+          <label for="building_room">Building / Room</label>
+          <input id="building_room" name="building_room" type="text" value="{{ filters.building_room }}" />
+        </div>
+        <div class="row">
+          <button type="submit">Search</button>
+        </div>
+      </div>
+    </form>
+  </section>
+
+  <section class="card">
+    <h2>Receipt Results ({{ receipts|length }})</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Receipt Key</th>
+          <th>Type</th>
+          <th>Committed At</th>
+          <th>Committed By</th>
+          <th>Holder</th>
+          <th>Organization</th>
+          <th>Location</th>
+          <th>Assets</th>
+          <th>Detail</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for receipt in receipts %}
+          <tr>
+            <td class="mono">{{ receipt.id }}</td>
+            <td class="mono">{{ receipt.receipt_key }}</td>
+            <td>{{ receipt.receipt_type }}</td>
+            <td>{{ receipt.commit_at or "Unknown" }}</td>
+            <td>{{ receipt.committed_by }}</td>
+            <td>{{ receipt.holder_summary }}</td>
+            <td>{{ receipt.organization_summary or "" }}</td>
+            <td class="{{ 'muted-cell' if receipt.location_summary in ['Unknown', 'Asset-specific return locations'] else '' }}">
+              {{ receipt.location_summary }}
+            </td>
+            <td>{{ receipt.asset_count }}</td>
+            <td><a href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Open</a></td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="10">No receipts matched the current search.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+{% endblock %}

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import pytest
+
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user
+from tests.test_receipt_detail import (
+    _create_issue_receipt,
+    _create_return_receipt,
+    _login_user,
+    client_with_temp_db,
+)
+
+
+def test_receipts_list_renders_newest_first(client_with_temp_db) -> None:
+    older_receipt_id = _create_issue_receipt(client_with_temp_db)
+    newer_receipt_id = _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert response.data.find(f"/receipts/{newer_receipt_id}".encode("utf-8")) < response.data.find(
+        f"/receipts/{older_receipt_id}".encode("utf-8")
+    )
+
+
+def test_receipts_list_asset_tag_search_returns_expected_receipt(client_with_temp_db) -> None:
+    _create_issue_receipt(client_with_temp_db)
+    return_receipt_id = _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts?asset_tag=RETURN-200")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{return_receipt_id}"'.encode("utf-8") in response.data
+    assert response.data.count(b'">Open</a>') == 1
+
+
+def test_receipts_list_holder_name_search_returns_expected_receipt(client_with_temp_db) -> None:
+    issue_receipt_id = _create_issue_receipt(client_with_temp_db)
+    _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts?holder_name=Issue%20Holder")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{issue_receipt_id}"'.encode("utf-8") in response.data
+    assert b"Issue Holder" in response.data
+    assert response.data.count(b'">Open</a>') == 1
+
+
+def test_receipts_list_building_room_search_returns_expected_receipt(client_with_temp_db) -> None:
+    _create_issue_receipt(client_with_temp_db)
+    mixed_return_receipt_id = _create_return_receipt(client_with_temp_db, mixed_holders=True)
+
+    response = client_with_temp_db.get("/receipts?building_room=HQ%20North/211")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{mixed_return_receipt_id}"'.encode("utf-8") in response.data
+    assert response.data.count(b'">Open</a>') == 1
+
+
+def test_mixed_holder_return_renders_multiple_holders_summary(client_with_temp_db) -> None:
+    mixed_return_receipt_id = _create_return_receipt(client_with_temp_db, mixed_holders=True)
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{mixed_return_receipt_id}"'.encode("utf-8") in response.data
+    assert b"Multiple holders" in response.data
+
+
+@pytest.mark.parametrize("role", ["operator", "admin"])
+def test_receipts_list_allows_operator_and_admin(client_with_temp_db, role: str) -> None:
+    _create_issue_receipt(client_with_temp_db)
+    _login_user(client_with_temp_db, username=f"{role}-list-viewer", role=role)
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+
+
+def test_receipts_list_requires_login(client_with_temp_db) -> None:
+    _create_issue_receipt(client_with_temp_db)
+    with client_with_temp_db.session_transaction() as sess:
+        sess.clear()
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 403
+    assert response.json == {"ok": False, "error": "Forbidden"}
+
+
+def test_receipts_list_timeout_matches_existing_readonly_pattern(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _create_issue_receipt(client_with_temp_db)
+    _login_user(client_with_temp_db, username="timeout-list-operator", role="operator")
+    monkeypatch.setattr(intake_app, "auth_enabled", lambda: True)
+    monkeypatch.setattr(intake_app, "enforce_inactivity_timeout", lambda: False)
+
+    response = client_with_temp_db.get("/receipts", follow_redirects=False)
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/")
+
+
+def test_receipts_list_links_to_existing_receipt_detail(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
+
+    detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert detail_response.status_code == 200
+
+
+def test_receipts_list_building_room_search_matches_issue_location_summary(client_with_temp_db) -> None:
+    issue_receipt_id = _create_issue_receipt(client_with_temp_db)
+    _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts?building_room=HQ%20North/210")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{issue_receipt_id}"'.encode("utf-8") in response.data


### PR DESCRIPTION
## Summary
Adds a read-only receipts list page with bounded search for asset tag, holder name, and building / room.

## Related Issue
Closes #365 

## Changes
- Added GET /receipts read-only list page
- Lists receipts newest first
- Added bounded search for asset tag, holder name, and building / room
- Keeps results tied to stored receipt snapshot data only
- Links each result to the existing receipt detail page
- Added focused route tests for list/search behavior

## Verification checklist
- [x] `/receipts` renders for authenticated users
- [x] Receipts list newest first
- [x] Asset tag search works
- [x] Holder name search works
- [x] Building / room search works
- [x] Receipt detail links still work
- [x] Page remains read-only
- [x] Operator access verified
- [x] Admin access verified
- [x] Unauthenticated access blocked

## Notes
This keeps search bounded to MVP scope and uses stored receipt data only, with no live-table reconstruction.