### PR TITLE
Issue 26-42: improve receipts list readability and search UX

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4005,7 +4005,7 @@ def receipt_detail(receipt_id: int):
     )
 
 
-def _receipt_summary_from_row(row: sqlite3.Row) -> dict[str, object]:
+def _receipt_summary_from_row(row: sqlite3.Row, asset_tag_filter: str = "") -> dict[str, object]:
     snapshot = json.loads(str(row["snapshot_json"] or "{}"))
     if not isinstance(snapshot, dict):
         snapshot = {}
@@ -4040,7 +4040,7 @@ def _receipt_summary_from_row(row: sqlite3.Row) -> dict[str, object]:
     if location_context and str(location_context.get("building_room") or "").strip():
         location_summary = str(location_context.get("building_room") or "").strip()
     elif receipt_type == "RETURN":
-        location_summary = "Asset-specific return locations"
+        location_summary = "Return location varies by asset"
     else:
         location_summary = "Unknown"
 
@@ -4049,16 +4049,45 @@ def _receipt_summary_from_row(row: sqlite3.Row) -> dict[str, object]:
     else:
         committed_by = f"user_id {int(row['commit_operator_user_id'])}"
 
+    try:
+        commit_at_display = datetime.fromisoformat(commit_at).strftime("%Y-%m-%d %H:%M")
+    except ValueError:
+        commit_at_display = commit_at or "Unknown"
+
+    normalized_asset_tag_filter = asset_tag_filter.strip().upper()
+    matched_asset_tags: list[str] = []
+    asset_tags: list[str] = []
+    if normalized_asset_tag_filter:
+        for asset in asset_list:
+            if not isinstance(asset, dict):
+                continue
+            asset_tag = str(asset.get("asset_tag") or "").strip()
+            if asset_tag and normalized_asset_tag_filter in asset_tag.upper():
+                matched_asset_tags.append(asset_tag)
+    for asset in asset_list:
+        if not isinstance(asset, dict):
+            continue
+        asset_tag = str(asset.get("asset_tag") or "").strip()
+        if asset_tag:
+            asset_tags.append(asset_tag)
+
+    visible_asset_tags = matched_asset_tags or asset_tags[:1]
+    additional_asset_tag_count = max(len(asset_tags) - len(visible_asset_tags), 0)
+
     return {
         "id": int(row["id"]),
         "receipt_key": str(row["receipt_key"] or ""),
         "receipt_type": receipt_type,
         "commit_at": commit_at,
+        "commit_at_display": commit_at_display,
         "committed_by": committed_by,
         "holder_summary": holder_summary,
         "organization_summary": organization_summary,
         "location_summary": location_summary,
         "asset_count": len(asset_list),
+        "visible_asset_tags": visible_asset_tags,
+        "additional_asset_tag_count": additional_asset_tag_count,
+        "matched_asset_tags": matched_asset_tags,
     }
 
 
@@ -4146,7 +4175,7 @@ def receipts_list():
     finally:
         conn.close()
 
-    receipts = [_receipt_summary_from_row(row) for row in rows]
+    receipts = [_receipt_summary_from_row(row, asset_tag_filter=asset_tag) for row in rows]
 
     return render_template(
         "receipts_list.html",

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -204,7 +204,7 @@
     {% block extra_head %}{% endblock %}
   </head>
   <body>
-    <div class="page">
+    <div class="page{% block page_class %}{% endblock %}">
       <div class="page-tools">
         <button
           type="button"

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -2,9 +2,13 @@
 
 {% block title %}Receipts{% endblock %}
 {% block page_heading %}Receipts{% endblock %}
+{% block page_class %} receipts-page{% endblock %}
 
 {% block extra_head %}
   <style>
+    .page.receipts-page {
+      max-width: 1440px;
+    }
     .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
     .filters {
       display: grid;
@@ -12,8 +16,69 @@
       gap: 0.75rem;
       align-items: end;
     }
+    .filter-actions {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      flex-wrap: wrap;
+    }
     .filters .row {
       margin: 0;
+    }
+    .receipts-table {
+      table-layout: fixed;
+    }
+    .receipts-table th:nth-child(1) { width: 29%; }
+    .receipts-table th:nth-child(2) { width: 21%; }
+    .receipts-table th:nth-child(3) { width: 14%; }
+    .receipts-table th:nth-child(4) { width: 20%; }
+    .receipts-table th:nth-child(5) { width: 16%; }
+    .receipts-table th,
+    .receipts-table td {
+      vertical-align: top;
+      padding-block: 0.9rem;
+    }
+    .receipt-primary {
+      display: grid;
+      gap: 0.2rem;
+    }
+    .receipt-title {
+      font-weight: 600;
+    }
+    .receipt-link {
+      display: inline-block;
+      color: var(--color-primary);
+      font-weight: 600;
+      text-decoration: underline;
+      text-underline-offset: 0.12em;
+      cursor: pointer;
+    }
+    .asset-tag-line {
+      font-weight: 600;
+    }
+    .receipt-meta,
+    .location-note {
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+    }
+    .asset-tag-line,
+    .asset-tag-extra,
+    .asset-tag-match {
+      font-size: 0.95rem;
+    }
+    .asset-tag-extra {
+      color: var(--color-text-muted);
+    }
+    .asset-tag-match {
+      color: var(--color-primary);
+      font-weight: 600;
+    }
+    .commit-cell {
+      white-space: nowrap;
+    }
+    .commit-stamp {
+      font-size: 0.95rem;
+      font-variant-numeric: tabular-nums;
     }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     .muted-cell { color: var(--color-text-muted); }
@@ -43,7 +108,12 @@
           <input id="building_room" name="building_room" type="text" value="{{ filters.building_room }}" />
         </div>
         <div class="row">
-          <button type="submit">Search</button>
+          <div class="filter-actions">
+            <button type="submit">Search</button>
+            {% if filters.asset_tag or filters.holder_name or filters.building_room %}
+              <a href="{{ url_for('receipts_list') }}">Clear search</a>
+            {% endif %}
+          </div>
         </div>
       </div>
     </form>
@@ -51,40 +121,71 @@
 
   <section class="card">
     <h2>Receipt Results ({{ receipts|length }})</h2>
-    <table>
+    <table class="receipts-table">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Receipt Key</th>
-          <th>Type</th>
-          <th>Committed At</th>
-          <th>Committed By</th>
+          <th>Receipt</th>
+          <th>Asset Tag</th>
+          <th>Commit</th>
           <th>Holder</th>
-          <th>Organization</th>
           <th>Location</th>
-          <th>Assets</th>
-          <th>Detail</th>
         </tr>
       </thead>
       <tbody>
         {% for receipt in receipts %}
           <tr>
-            <td class="mono">{{ receipt.id }}</td>
-            <td class="mono">{{ receipt.receipt_key }}</td>
-            <td>{{ receipt.receipt_type }}</td>
-            <td>{{ receipt.commit_at or "Unknown" }}</td>
-            <td>{{ receipt.committed_by }}</td>
-            <td>{{ receipt.holder_summary }}</td>
-            <td>{{ receipt.organization_summary or "" }}</td>
-            <td class="{{ 'muted-cell' if receipt.location_summary in ['Unknown', 'Asset-specific return locations'] else '' }}">
-              {{ receipt.location_summary }}
+            <td>
+              <div class="receipt-primary">
+                <div class="receipt-title">{{ receipt.receipt_type }}</div>
+                <div class="receipt-meta mono">{{ receipt.receipt_key }}</div>
+                <div><a class="receipt-link mono" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Receipt ID {{ receipt.id }}</a></div>
+                <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
+                {% if receipt.matched_asset_tags %}
+                  <div class="receipt-meta">Matched by asset tag search</div>
+                {% endif %}
+              </div>
             </td>
-            <td>{{ receipt.asset_count }}</td>
-            <td><a href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Open</a></td>
+            <td>
+              <div class="receipt-primary">
+                {% if receipt.visible_asset_tags %}
+                  {% for asset_tag in receipt.visible_asset_tags %}
+                    <div class="asset-tag-line mono">{{ asset_tag }}</div>
+                  {% endfor %}
+                {% else %}
+                  <div class="asset-tag-line muted-cell">No asset tag</div>
+                {% endif %}
+                {% if receipt.matched_asset_tags %}
+                  <div class="asset-tag-match">Matched asset tag</div>
+                {% elif receipt.additional_asset_tag_count > 0 %}
+                  <div class="asset-tag-extra">+{{ receipt.additional_asset_tag_count }} more asset{% if receipt.additional_asset_tag_count != 1 %}s{% endif %}</div>
+                {% endif %}
+              </div>
+            </td>
+            <td class="commit-cell">
+              <div class="receipt-primary">
+                <div class="commit-stamp mono">{{ receipt.commit_at_display }}</div>
+              </div>
+            </td>
+            <td>
+              <div class="receipt-primary">
+                <div>{{ receipt.holder_summary }}</div>
+                {% if receipt.organization_summary %}
+                  <div class="receipt-meta">{{ receipt.organization_summary }}</div>
+                {% endif %}
+              </div>
+            </td>
+            <td class="{{ 'muted-cell' if receipt.location_summary in ['Unknown', 'Return location varies by asset'] else '' }}">
+              <div class="receipt-primary">
+                <div>{{ receipt.location_summary }}</div>
+                {% if receipt.location_summary == "Return location varies by asset" %}
+                  <div class="location-note">See the receipt details for each asset's return location.</div>
+                {% endif %}
+              </div>
+            </td>
           </tr>
         {% else %}
           <tr>
-            <td colspan="10">No receipts matched the current search.</td>
+            <td colspan="5">No receipts matched the current search.</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -32,7 +32,10 @@ def test_receipts_list_asset_tag_search_returns_expected_receipt(client_with_tem
 
     assert response.status_code == 200
     assert f'href="/receipts/{return_receipt_id}"'.encode("utf-8") in response.data
-    assert response.data.count(b'">Open</a>') == 1
+    assert b"Matched asset tag" in response.data
+    assert b"Matched by asset tag search" in response.data
+    assert b"RETURN-200" in response.data
+    assert response.data.count(b'href="/receipts/') == 1
 
 
 def test_receipts_list_holder_name_search_returns_expected_receipt(client_with_temp_db) -> None:
@@ -44,7 +47,7 @@ def test_receipts_list_holder_name_search_returns_expected_receipt(client_with_t
     assert response.status_code == 200
     assert f'href="/receipts/{issue_receipt_id}"'.encode("utf-8") in response.data
     assert b"Issue Holder" in response.data
-    assert response.data.count(b'">Open</a>') == 1
+    assert response.data.count(b'href="/receipts/') == 1
 
 
 def test_receipts_list_building_room_search_returns_expected_receipt(client_with_temp_db) -> None:
@@ -55,7 +58,7 @@ def test_receipts_list_building_room_search_returns_expected_receipt(client_with
 
     assert response.status_code == 200
     assert f'href="/receipts/{mixed_return_receipt_id}"'.encode("utf-8") in response.data
-    assert response.data.count(b'">Open</a>') == 1
+    assert response.data.count(b'href="/receipts/') == 1
 
 
 def test_mixed_holder_return_renders_multiple_holders_summary(client_with_temp_db) -> None:
@@ -66,6 +69,27 @@ def test_mixed_holder_return_renders_multiple_holders_summary(client_with_temp_d
     assert response.status_code == 200
     assert f'href="/receipts/{mixed_return_receipt_id}"'.encode("utf-8") in response.data
     assert b"Multiple holders" in response.data
+    assert b"Return location varies by asset" in response.data
+
+
+def test_receipts_list_shows_asset_tag_in_default_results(client_with_temp_db) -> None:
+    _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert b"Asset Tag" in response.data
+    assert b"ISSUE-100" in response.data
+
+
+def test_receipts_list_renders_clear_search_link_when_filters_are_active(client_with_temp_db) -> None:
+    _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts?holder_name=Issue%20Holder")
+
+    assert response.status_code == 200
+    assert b'href="/receipts"' in response.data
+    assert b"Clear search" in response.data
 
 
 @pytest.mark.parametrize("role", ["operator", "admin"])
@@ -110,6 +134,8 @@ def test_receipts_list_links_to_existing_receipt_detail(client_with_temp_db) -> 
 
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
+    assert f"Receipt ID {receipt_id}".encode("utf-8") in response.data
+    assert b"Detail" not in response.data
 
     detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert detail_response.status_code == 200


### PR DESCRIPTION
## Summary
Improves receipts list readability and search UX by simplifying the layout, making receipt access clearer, and surfacing asset tag matches directly in the results.

## Related Issue
Closes #368 

## Changes
- Removed Detail column and made Receipt ID the primary clickable link
- Added Asset Tag column for immediate scanability
- Simplified Commit display to a compact timestamp
- Widened receipts page container locally for better readability
- Improved asset-tag search visibility with in-row match cues
- Added clear search control when filters are active

## Verification checklist
- [x] Receipts page is wider and easier to scan
- [x] Receipt ID is clearly clickable
- [x] Commit column no longer wraps awkwardly
- [x] Asset tags are visible and easy to scan
- [x] Asset-tag search clearly shows match context
- [x] Tests pass
- [x] Manual browser verification completed

## Notes
Follow-on improvements for responsive layout and stronger match highlighting are tracked in Issue 26-43.