### PR TITLE
Issue 26-44: extend search match highlighting across receipts filters

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4005,7 +4005,12 @@ def receipt_detail(receipt_id: int):
     )
 
 
-def _receipt_summary_from_row(row: sqlite3.Row, asset_tag_filter: str = "") -> dict[str, object]:
+def _receipt_summary_from_row(
+    row: sqlite3.Row,
+    asset_tag_filter: str = "",
+    holder_name_filter: str = "",
+    building_room_filter: str = "",
+) -> dict[str, object]:
     snapshot = json.loads(str(row["snapshot_json"] or "{}"))
     if not isinstance(snapshot, dict):
         snapshot = {}
@@ -4054,22 +4059,61 @@ def _receipt_summary_from_row(row: sqlite3.Row, asset_tag_filter: str = "") -> d
     except ValueError:
         commit_at_display = commit_at or "Unknown"
 
+    def _append_unique(values: list[str], value: object) -> None:
+        text = str(value or "").strip()
+        if text and text not in values:
+            values.append(text)
+
     normalized_asset_tag_filter = asset_tag_filter.strip().upper()
+    normalized_holder_name_filter = holder_name_filter.strip().upper()
+    normalized_building_room_filter = building_room_filter.strip().upper()
     matched_asset_tags: list[str] = []
     asset_tags: list[str] = []
+    matched_holder_names: list[str] = []
+    matched_locations: list[str] = []
     if normalized_asset_tag_filter:
         for asset in asset_list:
             if not isinstance(asset, dict):
                 continue
             asset_tag = str(asset.get("asset_tag") or "").strip()
             if asset_tag and normalized_asset_tag_filter in asset_tag.upper():
-                matched_asset_tags.append(asset_tag)
+                _append_unique(matched_asset_tags, asset_tag)
+
+    if normalized_holder_name_filter:
+        if holder_summary != "Unknown" and normalized_holder_name_filter in holder_summary.upper():
+            _append_unique(matched_holder_names, holder_summary)
+        for asset in asset_list:
+            if not isinstance(asset, dict):
+                continue
+            _append_unique(
+                matched_holder_names,
+                asset.get("holder_snapshot", {}).get("name") if isinstance(asset.get("holder_snapshot"), dict) else "",
+            )
+            _append_unique(
+                matched_holder_names,
+                asset.get("from_holder_snapshot", {}).get("name")
+                if isinstance(asset.get("from_holder_snapshot"), dict)
+                else "",
+            )
+        matched_holder_names = [
+            value for value in matched_holder_names if normalized_holder_name_filter in value.upper()
+        ]
+
+    if normalized_building_room_filter:
+        _append_unique(matched_locations, location_summary if location_summary != "Unknown" else "")
+        for asset in asset_list:
+            if not isinstance(asset, dict):
+                continue
+            _append_unique(matched_locations, asset.get("from_building_room"))
+            _append_unique(matched_locations, asset.get("to_building_room"))
+        matched_locations = [value for value in matched_locations if normalized_building_room_filter in value.upper()]
+
     for asset in asset_list:
         if not isinstance(asset, dict):
             continue
         asset_tag = str(asset.get("asset_tag") or "").strip()
         if asset_tag:
-            asset_tags.append(asset_tag)
+            _append_unique(asset_tags, asset_tag)
 
     visible_asset_tags = matched_asset_tags or asset_tags[:1]
     additional_asset_tag_count = max(len(asset_tags) - len(visible_asset_tags), 0)
@@ -4088,6 +4132,8 @@ def _receipt_summary_from_row(row: sqlite3.Row, asset_tag_filter: str = "") -> d
         "visible_asset_tags": visible_asset_tags,
         "additional_asset_tag_count": additional_asset_tag_count,
         "matched_asset_tags": matched_asset_tags,
+        "matched_holder_names": matched_holder_names,
+        "matched_locations": matched_locations,
     }
 
 
@@ -4175,7 +4221,15 @@ def receipts_list():
     finally:
         conn.close()
 
-    receipts = [_receipt_summary_from_row(row, asset_tag_filter=asset_tag) for row in rows]
+    receipts = [
+        _receipt_summary_from_row(
+            row,
+            asset_tag_filter=asset_tag,
+            holder_name_filter=holder_name,
+            building_room_filter=building_room,
+        )
+        for row in rows
+    ]
 
     return render_template(
         "receipts_list.html",

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -69,6 +69,11 @@
     .asset-tag-match {
       font-size: 0.95rem;
     }
+    .match-values {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+    }
     .asset-tag-extra {
       color: var(--color-text-muted);
     }
@@ -93,6 +98,9 @@
       color: var(--color-primary);
       font-weight: 700;
       letter-spacing: 0.01em;
+    }
+    .match-label {
+      margin-top: 0.15rem;
     }
     .commit-cell {
       white-space: nowrap;
@@ -207,21 +215,23 @@
                 <div><a class="receipt-link mono" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Receipt ID {{ receipt.id }}</a></div>
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
                 {% if receipt.matched_asset_tags %}
-                  <div class="asset-tag-match">Asset tag search match</div>
+                  <div class="asset-tag-match match-label">Asset tag search match</div>
                 {% endif %}
               </div>
             </td>
             <td data-label="Asset Tag">
               <div class="receipt-primary">
                 {% if receipt.visible_asset_tags %}
-                  {% for asset_tag in receipt.visible_asset_tags %}
-                    <div class="asset-tag-line mono{% if receipt.matched_asset_tags and asset_tag in receipt.matched_asset_tags %} matched-tag{% endif %}">{{ asset_tag }}</div>
-                  {% endfor %}
+                  <div class="match-values">
+                    {% for asset_tag in receipt.visible_asset_tags %}
+                      <div class="asset-tag-line mono{% if receipt.matched_asset_tags and asset_tag in receipt.matched_asset_tags %} matched-tag{% endif %}">{{ asset_tag }}</div>
+                    {% endfor %}
+                  </div>
                 {% else %}
                   <div class="asset-tag-line muted-cell">No asset tag</div>
                 {% endif %}
                 {% if receipt.matched_asset_tags %}
-                  <div class="asset-tag-match">Matched asset tag</div>
+                  <div class="asset-tag-match match-label">Matched asset tag</div>
                 {% elif receipt.additional_asset_tag_count > 0 %}
                   <div class="asset-tag-extra">+{{ receipt.additional_asset_tag_count }} more asset{% if receipt.additional_asset_tag_count != 1 %}s{% endif %}</div>
                 {% endif %}
@@ -234,17 +244,37 @@
             </td>
             <td data-label="Holder">
               <div class="receipt-primary">
-                <div>{{ receipt.holder_summary }}</div>
+                <div{% if receipt.matched_holder_names and receipt.holder_summary in receipt.matched_holder_names %} class="matched-tag"{% endif %}>{{ receipt.holder_summary }}</div>
                 {% if receipt.organization_summary %}
                   <div class="receipt-meta">{{ receipt.organization_summary }}</div>
+                {% endif %}
+                {% if receipt.matched_holder_names %}
+                  <div class="asset-tag-match match-label">Holder search match</div>
+                  <div class="match-values">
+                    {% for holder_name in receipt.matched_holder_names %}
+                      {% if holder_name != receipt.holder_summary %}
+                        <div class="matched-tag">{{ holder_name }}</div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
                 {% endif %}
               </div>
             </td>
             <td data-label="Location" class="{{ 'muted-cell' if receipt.location_summary in ['Unknown', 'Return location varies by asset'] else '' }}">
               <div class="receipt-primary">
-                <div>{{ receipt.location_summary }}</div>
+                <div{% if receipt.matched_locations and receipt.location_summary in receipt.matched_locations %} class="matched-tag"{% endif %}>{{ receipt.location_summary }}</div>
                 {% if receipt.location_summary == "Return location varies by asset" %}
                   <div class="location-note">See the receipt details for each asset's return location.</div>
+                {% endif %}
+                {% if receipt.matched_locations %}
+                  <div class="asset-tag-match match-label">Location search match</div>
+                  <div class="match-values">
+                    {% for location in receipt.matched_locations %}
+                      {% if location != receipt.location_summary %}
+                        <div class="matched-tag">{{ location }}</div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
                 {% endif %}
               </div>
             </td>

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -47,6 +47,7 @@ def test_receipts_list_holder_name_search_returns_expected_receipt(client_with_t
     assert response.status_code == 200
     assert f'href="/receipts/{issue_receipt_id}"'.encode("utf-8") in response.data
     assert b"Issue Holder" in response.data
+    assert b"Holder search match" in response.data
     assert response.data.count(b'href="/receipts/') == 1
 
 
@@ -58,6 +59,8 @@ def test_receipts_list_building_room_search_returns_expected_receipt(client_with
 
     assert response.status_code == 200
     assert f'href="/receipts/{mixed_return_receipt_id}"'.encode("utf-8") in response.data
+    assert b"Location search match" in response.data
+    assert b"HQ North/211" in response.data
     assert response.data.count(b'href="/receipts/') == 1
 
 
@@ -149,3 +152,5 @@ def test_receipts_list_building_room_search_matches_issue_location_summary(clien
 
     assert response.status_code == 200
     assert f'href="/receipts/{issue_receipt_id}"'.encode("utf-8") in response.data
+    assert b"Location search match" in response.data
+    assert b"HQ North/210" in response.data


### PR DESCRIPTION
## Summary
Extends receipts list match highlighting to all supported search filters so results clearly show why they matched.

## Related Issue
Closes #372 

## Changes
- Added match highlighting for holder name and location filters
- Reused existing badge/pill pattern from asset-tag highlighting
- Displayed matched values directly in result rows
- Added consistent match reason badges for each filter type
- Supported multiple matches per row without breaking layout

## Verification checklist
- [x] Asset-tag search highlights matched tags clearly
- [x] Holder search highlights matching holder names
- [x] Location search highlights matching locations
- [x] Multiple matches remain readable and uncluttered
- [x] No-search state remains clean
- [x] Tests pass
- [x] Manual browser smoke test completed

## Notes
Builds on Issue 26-43 by extending the same visual language to all existing receipts search filters.