### PR TITLE
Issue 26-41: add receipts navigation entry

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -229,6 +229,7 @@
           <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
           <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
           <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
+          <a class="chip {% if request.path.startswith('/receipts') %}active{% endif %}" href="{{ url_for('receipts_list') }}">Receipts</a>
           <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
           <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
           {% if authenticated_role == 'admin' %}

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -142,6 +142,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Preview</a>" not in dashboard_response.data
     assert b">Issue</a>" in dashboard_response.data
     assert b">Return</a>" in dashboard_response.data
+    assert b">Receipts</a>" in dashboard_response.data
     assert b">Add Assets</a>" not in dashboard_response.data
     assert b">Users</a>" not in dashboard_response.data
     assert b">Admin Tools</a>" not in dashboard_response.data
@@ -157,6 +158,7 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
     dashboard_response = client_with_temp_db.get("/dashboard")
 
     assert dashboard_response.status_code == 200
+    assert b">Receipts</a>" in dashboard_response.data
     assert b">Add Assets</a>" in dashboard_response.data
     assert b">Users</a>" in dashboard_response.data
     assert b">Admin Tools</a>" in dashboard_response.data


### PR DESCRIPTION
## Summary
Adds a Receipts navigation entry so authenticated users can reach the existing read-only receipts page from the normal UI.

## Related Issue
Closes #366 

## Changes
- Added a Receipts link to the shared authenticated navigation
- Made the link visible to both operator and admin users
- Updated auth/navigation coverage to verify visibility for both roles

## Verification checklist
- [x] Operator can see the Receipts link
- [x] Operator can open `/receipts` from the UI
- [x] Admin can see the Receipts link
- [x] Admin can open `/receipts` from the UI
- [x] Issue and Return navigation still behave normally
- [x] Tests pass
- [x] Manual browser smoke test completed

## Notes
This is a navigation-only change. No receipt logic, permissions, or workflow behavior changed.