### PR TITLE
Issue 26-4: finalize deferred email receipt queue

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2249,6 +2249,244 @@ def _receipt_slot_snapshot(conn, slot_id: Optional[int]) -> Optional[dict]:
     }
 
 
+def _receipt_delivery_snapshot(
+    *,
+    state: str = "pending",
+    sent_at: Optional[str] = None,
+    last_attempt_at: Optional[str] = None,
+    last_error: Optional[str] = None,
+) -> dict[str, Optional[str]]:
+    normalized_state = str(state or "").strip().lower()
+    if normalized_state not in {"pending", "sent", "failed"}:
+        normalized_state = "pending"
+    return {
+        "state": normalized_state,
+        "sent_at": sent_at,
+        "last_attempt_at": last_attempt_at,
+        "last_error": last_error,
+    }
+
+
+def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) -> dict[str, Optional[str]]:
+    snapshot_delivery = snapshot.get("delivery")
+    if not isinstance(snapshot_delivery, dict):
+        snapshot_delivery = {}
+
+    sent_at = str(row["sent_at"] or snapshot_delivery.get("sent_at") or "").strip() or None
+    last_attempt_at = str(row["last_attempt_at"] or snapshot_delivery.get("last_attempt_at") or "").strip() or None
+    last_error = str(row["last_error"] or snapshot_delivery.get("last_error") or "").strip() or None
+
+    if sent_at:
+        state = "sent"
+    elif last_error:
+        state = "failed"
+    else:
+        state = str(snapshot_delivery.get("state") or "pending").strip().lower() or "pending"
+
+    return _receipt_delivery_snapshot(
+        state=state,
+        sent_at=sent_at,
+        last_attempt_at=last_attempt_at,
+        last_error=last_error,
+    )
+
+
+def _receipt_asset_row_snapshot(conn, asset_tag: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT id, asset_tag, serial_number, equipment_type, manufacturer, model, model_code, notes, building_room
+        FROM assets
+        WHERE UPPER(asset_tag) = UPPER(?)
+           OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_tag, asset_tag),
+    ).fetchone()
+
+
+def _receipt_event_rows(conn, source_event_ids: list[int]) -> list[sqlite3.Row]:
+    if not source_event_ids:
+        raise ValueError("Receipt queue rows require at least one source event.")
+
+    placeholders = ", ".join("?" for _ in source_event_ids)
+    rows = conn.execute(
+        f"""
+        SELECT id, asset_tag, payload, holder_id
+        FROM asset_events
+        WHERE id IN ({placeholders});
+        """,
+        tuple(int(event_id) for event_id in source_event_ids),
+    ).fetchall()
+    rows_by_id = {int(row["id"]): row for row in rows}
+    ordered_rows = [rows_by_id[int(event_id)] for event_id in source_event_ids if int(event_id) in rows_by_id]
+    if len(ordered_rows) != len(source_event_ids):
+        raise ValueError("Receipt queue rows must be derived from stored event history.")
+    return ordered_rows
+
+
+def _receipt_location_context_from_building_room(building_room: str) -> dict[str, str]:
+    normalized = str(building_room or "").strip()
+    if not normalized:
+        return {"building": "", "room": "", "building_room": ""}
+    building, separator, room = normalized.partition("/")
+    return {
+        "building": building,
+        "room": room if separator else "",
+        "building_room": normalized,
+    }
+
+
+def _build_receipt_snapshot_from_stored_facts(
+    conn,
+    *,
+    receipt_type: str,
+    source_event_ids: list[int],
+    commit_at: str,
+    commit_operator_user_id: int,
+) -> dict[str, object]:
+    event_rows = _receipt_event_rows(conn, source_event_ids)
+    commit_operator_snapshot = _receipt_operator_snapshot(conn, commit_operator_user_id)
+    asset_snapshots: list[dict[str, object]] = []
+
+    if receipt_type == "ISSUE":
+        holder_ids = {
+            int(row["holder_id"])
+            for row in event_rows
+            if row["holder_id"] is not None
+        }
+        batch_holder_id = next(iter(holder_ids)) if len(holder_ids) == 1 else None
+        batch_holder_snapshot = _receipt_holder_snapshot(conn, batch_holder_id)
+        first_payload: dict[str, object] = {}
+
+        for event_row in event_rows:
+            payload = json.loads(str(event_row["payload"] or "{}"))
+            if not isinstance(payload, dict):
+                payload = {}
+            if not first_payload:
+                first_payload = payload
+
+            asset_tag = str(event_row["asset_tag"] or "").strip()
+            asset_row = _receipt_asset_row_snapshot(conn, asset_tag)
+            holder_id = None if event_row["holder_id"] is None else int(event_row["holder_id"])
+            home_slot_id = payload.get("home_slot_id")
+            asset_snapshots.append(
+                {
+                    "asset_id": None if asset_row is None else int(asset_row["id"]),
+                    "asset_tag": str(asset_row["asset_tag"] if asset_row is not None else asset_tag),
+                    "serial_number": "" if asset_row is None else str(asset_row["serial_number"] or ""),
+                    "equipment_type": "" if asset_row is None else str(asset_row["equipment_type"] or ""),
+                    "manufacturer": "" if asset_row is None else str(asset_row["manufacturer"] or ""),
+                    "model": "" if asset_row is None else str(asset_row["model"] or ""),
+                    "model_code": "" if asset_row is None else str(asset_row["model_code"] or ""),
+                    "notes": "" if asset_row is None else str(asset_row["notes"] or ""),
+                    "from_location_type": str(payload.get("from_location_type") or ""),
+                    "to_location_type": str(payload.get("to_location_type") or ""),
+                    "from_building_room": str(payload.get("from_building_room") or ""),
+                    "to_building_room": str(payload.get("to_building_room") or ""),
+                    "holder_id": holder_id,
+                    "holder_snapshot": _receipt_holder_snapshot(conn, holder_id),
+                    "home_slot": _receipt_slot_snapshot(
+                        conn,
+                        int(home_slot_id) if home_slot_id is not None else None,
+                    ),
+                }
+            )
+
+        location_context = _receipt_location_context_from_building_room(str(first_payload.get("to_building_room") or ""))
+        return {
+            "receipt_type": "ISSUE",
+            "commit_at": commit_at,
+            "commit_operator_user_id": int(commit_operator_user_id),
+            "commit_operator": commit_operator_snapshot,
+            "holder_id": batch_holder_id,
+            "holder_snapshot": batch_holder_snapshot,
+            "organization_snapshot": None if batch_holder_snapshot is None else {
+                "organization": str(batch_holder_snapshot.get("organization") or ""),
+                "organization_id": batch_holder_snapshot.get("organization_id"),
+            },
+            "acknowledgment": (
+                dict(first_payload.get("responsibility_ack"))
+                if isinstance(first_payload.get("responsibility_ack"), dict)
+                else None
+            ),
+            "location_context": location_context,
+            "assets": asset_snapshots,
+            "source_event_ids": list(source_event_ids),
+            "delivery": _receipt_delivery_snapshot(),
+        }
+
+    if receipt_type != "RETURN":
+        raise ValueError(f"Unsupported receipt type: {receipt_type}")
+
+    holder_ids: set[int] = set()
+    top_level_ack: Optional[dict[str, object]] = None
+
+    for event_row in event_rows:
+        payload = json.loads(str(event_row["payload"] or "{}"))
+        if not isinstance(payload, dict):
+            payload = {}
+        responsibility_ack = payload.get("responsibility_ack")
+        if not isinstance(responsibility_ack, dict):
+            responsibility_ack = {}
+        if top_level_ack is None:
+            top_level_ack = dict(responsibility_ack)
+
+        from_holder_id = responsibility_ack.get("ack_holder_id")
+        normalized_holder_id = int(from_holder_id) if from_holder_id is not None else None
+        if normalized_holder_id is not None:
+            holder_ids.add(normalized_holder_id)
+
+        asset_tag = str(event_row["asset_tag"] or "").strip()
+        asset_row = _receipt_asset_row_snapshot(conn, asset_tag)
+        home_slot_id = payload.get("home_slot_id")
+        building_room = "" if asset_row is None else str(asset_row["building_room"] or "")
+        asset_snapshots.append(
+            {
+                "asset_id": None if asset_row is None else int(asset_row["id"]),
+                "asset_tag": str(asset_row["asset_tag"] if asset_row is not None else asset_tag),
+                "serial_number": "" if asset_row is None else str(asset_row["serial_number"] or ""),
+                "equipment_type": "" if asset_row is None else str(asset_row["equipment_type"] or ""),
+                "manufacturer": "" if asset_row is None else str(asset_row["manufacturer"] or ""),
+                "model": "" if asset_row is None else str(asset_row["model"] or ""),
+                "model_code": "" if asset_row is None else str(asset_row["model_code"] or ""),
+                "notes": "" if asset_row is None else str(asset_row["notes"] or ""),
+                "from_location_type": str(payload.get("from_location_type") or ""),
+                "to_location_type": str(payload.get("to_location_type") or ""),
+                "from_holder_id": normalized_holder_id,
+                "from_holder_snapshot": _receipt_holder_snapshot(conn, normalized_holder_id),
+                "to_holder_id": None,
+                "from_building_room": building_room,
+                "to_building_room": building_room,
+                "home_slot": _receipt_slot_snapshot(
+                    conn,
+                    int(home_slot_id) if home_slot_id is not None else None,
+                ),
+            }
+        )
+
+    batch_holder_id = next(iter(holder_ids)) if len(holder_ids) == 1 else None
+    batch_holder_snapshot = _receipt_holder_snapshot(conn, batch_holder_id)
+    if top_level_ack is not None and len(holder_ids) != 1:
+        top_level_ack.pop("ack_holder_id", None)
+
+    return {
+        "receipt_type": "RETURN",
+        "commit_at": commit_at,
+        "commit_operator_user_id": int(commit_operator_user_id),
+        "commit_operator": commit_operator_snapshot,
+        "holder_id": batch_holder_id,
+        "holder_snapshot": batch_holder_snapshot,
+        "organization_snapshot": None if batch_holder_snapshot is None else {
+            "organization": str(batch_holder_snapshot.get("organization") or ""),
+            "organization_id": batch_holder_snapshot.get("organization_id"),
+        },
+        "acknowledgment": top_level_ack,
+        "assets": asset_snapshots,
+        "source_event_ids": list(source_event_ids),
+        "delivery": _receipt_delivery_snapshot(),
+    }
+
+
 def _insert_receipt_queue_row(
     conn,
     *,
@@ -2279,7 +2517,7 @@ def _insert_receipt_queue_row(
             _receipt_key(receipt_type, source_event_ids),
             receipt_type,
             json.dumps(source_event_ids),
-            json.dumps(snapshot),
+            json.dumps(snapshot, sort_keys=True),
             commit_at,
             int(commit_operator_user_id),
             None if holder_id is None else int(holder_id),
@@ -2387,9 +2625,6 @@ def _issue_batch(
 
             now_iso = datetime.now(timezone.utc).isoformat()
             event_ids: list[int] = []
-            asset_snapshots: list[dict[str, object]] = []
-            holder_snapshot = _receipt_holder_snapshot(conn, holder_id)
-            commit_operator_snapshot = _receipt_operator_snapshot(conn, commit_operator_user_id)
 
             for asset_id, canon_tag, home_slot_id in canon_assets:
                 asset_row = conn.execute(
@@ -2480,46 +2715,13 @@ def _issue_batch(
                     ),
                 )
                 event_ids.append(int(event_cursor.lastrowid))
-                asset_snapshots.append(
-                    {
-                        "asset_id": asset_id,
-                        "asset_tag": canon_tag,
-                        "serial_number": "" if asset_row is None else str(asset_row["serial_number"] or ""),
-                        "equipment_type": "" if asset_row is None else str(asset_row["equipment_type"] or ""),
-                        "manufacturer": "" if asset_row is None else str(asset_row["manufacturer"] or ""),
-                        "model": "" if asset_row is None else str(asset_row["model"] or ""),
-                        "model_code": "" if asset_row is None else str(asset_row["model_code"] or ""),
-                        "notes": "" if asset_row is None else str(asset_row["notes"] or ""),
-                        "from_location_type": "STORAGE",
-                        "to_location_type": "IN_CUSTODY",
-                        "from_building_room": previous_building_room,
-                        "to_building_room": building_room,
-                        "holder_id": int(holder_id),
-                        "holder_snapshot": holder_snapshot,
-                        "home_slot": home_slot_snapshot,
-                    }
-                )
-
-            snapshot = {
-                "receipt_type": "ISSUE",
-                "commit_at": now_iso,
-                "commit_operator_user_id": int(commit_operator_user_id),
-                "commit_operator": commit_operator_snapshot,
-                "holder_id": int(holder_id),
-                "holder_snapshot": holder_snapshot,
-                "organization_snapshot": None if holder_snapshot is None else {
-                    "organization": str(holder_snapshot.get("organization") or ""),
-                    "organization_id": holder_snapshot.get("organization_id"),
-                },
-                "acknowledgment": dict(responsibility_ack),
-                "location_context": {
-                    "building": building,
-                    "room": room,
-                    "building_room": building_room,
-                },
-                "assets": asset_snapshots,
-                "source_event_ids": event_ids,
-            }
+            snapshot = _build_receipt_snapshot_from_stored_facts(
+                conn,
+                receipt_type="ISSUE",
+                source_event_ids=event_ids,
+                commit_at=now_iso,
+                commit_operator_user_id=commit_operator_user_id,
+            )
             _insert_receipt_queue_row(
                 conn,
                 receipt_type="ISSUE",
@@ -2642,28 +2844,11 @@ def _return_batch(
 
             now_iso = datetime.now(timezone.utc).isoformat()
             event_ids: list[int] = []
-            asset_snapshots: list[dict[str, object]] = []
-            batch_holder_ids: set[int] = set()
-            commit_operator_snapshot = _receipt_operator_snapshot(conn, commit_operator_user_id)
 
             for row in validated_rows:
                 canon_tag = row["asset_tag"]
                 home_slot_id = row["home_slot_id"]
                 current_holder_id = row["current_holder_id"]
-                if current_holder_id is not None:
-                    batch_holder_ids.add(int(current_holder_id))
-                asset_row = conn.execute(
-                    """
-                    SELECT id, serial_number, equipment_type, manufacturer, model, model_code, notes, building_room
-                    FROM assets
-                    WHERE UPPER(asset_tag) = UPPER(?)
-                       OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
-                    LIMIT 1;
-                    """,
-                    (canon_tag, canon_tag),
-                ).fetchone()
-                holder_snapshot = _receipt_holder_snapshot(conn, current_holder_id)
-                home_slot_snapshot = _receipt_slot_snapshot(conn, home_slot_id)
 
                 conn.execute(
                     """
@@ -2720,44 +2905,13 @@ def _return_batch(
                     ),
                 )
                 event_ids.append(int(event_cursor.lastrowid))
-                asset_snapshots.append(
-                    {
-                        "asset_id": None if asset_row is None else int(asset_row["id"]),
-                        "asset_tag": canon_tag,
-                        "serial_number": "" if asset_row is None else str(asset_row["serial_number"] or ""),
-                        "equipment_type": "" if asset_row is None else str(asset_row["equipment_type"] or ""),
-                        "manufacturer": "" if asset_row is None else str(asset_row["manufacturer"] or ""),
-                        "model": "" if asset_row is None else str(asset_row["model"] or ""),
-                        "model_code": "" if asset_row is None else str(asset_row["model_code"] or ""),
-                        "notes": "" if asset_row is None else str(asset_row["notes"] or ""),
-                        "from_location_type": "IN_CUSTODY",
-                        "to_location_type": "STORAGE",
-                        "from_holder_id": current_holder_id,
-                        "from_holder_snapshot": holder_snapshot,
-                        "to_holder_id": None,
-                        "from_building_room": "" if asset_row is None else str(asset_row["building_room"] or ""),
-                        "to_building_room": "" if asset_row is None else str(asset_row["building_room"] or ""),
-                        "home_slot": home_slot_snapshot,
-                    }
-                )
-
-            batch_holder_id = next(iter(batch_holder_ids)) if len(batch_holder_ids) == 1 else None
-            batch_holder_snapshot = _receipt_holder_snapshot(conn, batch_holder_id)
-            snapshot = {
-                "receipt_type": "RETURN",
-                "commit_at": now_iso,
-                "commit_operator_user_id": int(commit_operator_user_id),
-                "commit_operator": commit_operator_snapshot,
-                "holder_id": batch_holder_id,
-                "holder_snapshot": batch_holder_snapshot,
-                "organization_snapshot": None if batch_holder_snapshot is None else {
-                    "organization": str(batch_holder_snapshot.get("organization") or ""),
-                    "organization_id": batch_holder_snapshot.get("organization_id"),
-                },
-                "acknowledgment": dict(responsibility_ack),
-                "assets": asset_snapshots,
-                "source_event_ids": event_ids,
-            }
+            snapshot = _build_receipt_snapshot_from_stored_facts(
+                conn,
+                receipt_type="RETURN",
+                source_event_ids=event_ids,
+                commit_at=now_iso,
+                commit_operator_user_id=commit_operator_user_id,
+            )
             _insert_receipt_queue_row(
                 conn,
                 receipt_type="RETURN",
@@ -2765,7 +2919,7 @@ def _return_batch(
                 snapshot=snapshot,
                 commit_at=now_iso,
                 commit_operator_user_id=commit_operator_user_id,
-                holder_id=batch_holder_id,
+                holder_id=snapshot.get("holder_id"),
             )
 
             return len(validated_rows)
@@ -3937,7 +4091,10 @@ def receipt_detail(receipt_id: int):
                 snapshot_json,
                 commit_at,
                 commit_operator_user_id,
-                holder_id
+                holder_id,
+                sent_at,
+                last_attempt_at,
+                last_error
             FROM receipt_queue
             WHERE id = ?
             LIMIT 1;
@@ -3973,6 +4130,7 @@ def receipt_detail(receipt_id: int):
 
     snapshot_commit_at = str(snapshot.get("commit_at") or "").strip()
     commit_at = snapshot_commit_at or str(row["commit_at"] or "")
+    delivery = _receipt_delivery_from_row(row, snapshot)
 
     snapshot_operator_id = snapshot.get("commit_operator_user_id")
     commit_operator_user_id = (
@@ -3993,6 +4151,7 @@ def receipt_detail(receipt_id: int):
         "organization_snapshot": (
             snapshot.get("organization_snapshot") if isinstance(snapshot.get("organization_snapshot"), dict) else None
         ),
+        "delivery": delivery,
         "acknowledgment": acknowledgment,
         "location_context": location_context,
         "assets": assets,
@@ -4027,6 +4186,7 @@ def _receipt_summary_from_row(
     receipt_type = str(snapshot.get("receipt_type") or row["receipt_type"] or "").strip().upper()
     commit_at = str(snapshot.get("commit_at") or row["commit_at"] or "")
     holder_id = snapshot.get("holder_id") if snapshot.get("holder_id") is not None else row["holder_id"]
+    delivery = _receipt_delivery_from_row(row, snapshot)
 
     if holder_snapshot and str(holder_snapshot.get("name") or "").strip():
         holder_summary = str(holder_snapshot.get("name") or "").strip()
@@ -4122,6 +4282,7 @@ def _receipt_summary_from_row(
         "id": int(row["id"]),
         "receipt_key": str(row["receipt_key"] or ""),
         "receipt_type": receipt_type,
+        "delivery_state": str(delivery.get("state") or "pending"),
         "commit_at": commit_at,
         "commit_at_display": commit_at_display,
         "committed_by": committed_by,
@@ -4211,7 +4372,10 @@ def receipts_list():
                 snapshot_json,
                 commit_at,
                 commit_operator_user_id,
-                holder_id
+                holder_id,
+                sent_at,
+                last_attempt_at,
+                last_error
             FROM receipt_queue
             {where_sql}
             ORDER BY commit_at DESC, id DESC;

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -15,6 +15,28 @@
     .meta-grid p {
       margin: 0;
     }
+    .status-chip {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+      font-weight: 700;
+      text-transform: capitalize;
+      background: var(--color-surface-soft);
+    }
+    .status-chip[data-state="pending"] {
+      background: var(--color-warning-soft);
+      color: var(--color-primary);
+    }
+    .status-chip[data-state="sent"] {
+      background: color-mix(in srgb, var(--color-success) 16%, white);
+      color: var(--color-success);
+    }
+    .status-chip[data-state="failed"] {
+      background: color-mix(in srgb, var(--color-danger) 14%, white);
+      color: var(--color-danger);
+    }
   </style>
 {% endblock %}
 
@@ -32,6 +54,10 @@
       <p><strong>Receipt ID:</strong> <span class="mono">{{ receipt.id }}</span></p>
       <p><strong>Receipt key:</strong> <span class="mono">{{ receipt.receipt_key }}</span></p>
       <p><strong>Receipt type:</strong> {{ receipt.receipt_type or "Unknown" }}</p>
+      <p>
+        <strong>Delivery state:</strong>
+        <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ receipt.delivery.state }}</span>
+      </p>
       <p><strong>Committed at:</strong> {{ receipt.commit_at or "Unknown" }}</p>
       <p>
         <strong>Committed by:</strong>
@@ -58,6 +84,15 @@
           {{ organization.organization or "Unknown" }}
           {% if organization.organization_id is not none %}(org_id {{ organization.organization_id }}){% endif %}
         </p>
+      {% endif %}
+      {% if receipt.delivery.last_attempt_at %}
+        <p><strong>Last delivery attempt:</strong> {{ receipt.delivery.last_attempt_at }}</p>
+      {% endif %}
+      {% if receipt.delivery.sent_at %}
+        <p><strong>Delivered at:</strong> {{ receipt.delivery.sent_at }}</p>
+      {% endif %}
+      {% if receipt.delivery.last_error %}
+        <p><strong>Last delivery error:</strong> {{ receipt.delivery.last_error }}</p>
       {% endif %}
     </div>
   </section>

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -69,6 +69,29 @@
     .asset-tag-match {
       font-size: 0.95rem;
     }
+    .receipt-status {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      padding: 0.18rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.88rem;
+      font-weight: 700;
+      text-transform: capitalize;
+      background: var(--color-surface-soft);
+    }
+    .receipt-status[data-state="pending"] {
+      background: var(--color-warning-soft);
+      color: var(--color-primary);
+    }
+    .receipt-status[data-state="sent"] {
+      background: color-mix(in srgb, var(--color-success) 16%, white);
+      color: var(--color-success);
+    }
+    .receipt-status[data-state="failed"] {
+      background: color-mix(in srgb, var(--color-danger) 14%, white);
+      color: var(--color-danger);
+    }
     .match-values {
       display: flex;
       flex-wrap: wrap;
@@ -214,6 +237,7 @@
                 <div class="receipt-meta mono">{{ receipt.receipt_key }}</div>
                 <div><a class="receipt-link mono" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Receipt ID {{ receipt.id }}</a></div>
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
+                <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ receipt.delivery_state }}</div>
                 {% if receipt.matched_asset_tags %}
                   <div class="asset-tag-match match-label">Asset tag search match</div>
                 {% endif %}

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -202,7 +202,7 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     ).fetchall()
     receipt_row = conn.execute(
         """
-        SELECT receipt_type, holder_id, source_event_ids_json, snapshot_json
+        SELECT receipt_type, holder_id, source_event_ids_json, snapshot_json, sent_at, last_attempt_at, last_error
         FROM receipt_queue
         ORDER BY id DESC
         LIMIT 1;
@@ -229,7 +229,11 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     assert source_event_ids == [int(rows[0]["id"]), int(rows[1]["id"])]
     receipt_snapshot = json.loads(str(receipt_row["snapshot_json"]))
     assert receipt_snapshot["source_event_ids"] == source_event_ids
+    assert receipt_snapshot["delivery"]["state"] == "pending"
     assert len(receipt_snapshot["assets"]) == 2
+    assert receipt_row["sent_at"] is None
+    assert receipt_row["last_attempt_at"] is None
+    assert receipt_row["last_error"] is None
     assert [(str(row["asset_tag"]), str(row["location_type"]), int(row["current_holder_id"])) for row in asset_rows] == [
         ("CI-400", "IN_CUSTODY", 1),
         ("CI-401", "IN_CUSTODY", 1),

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -220,7 +220,7 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
         ).fetchone()
         receipt_row = conn.execute(
             """
-            SELECT receipt_type, commit_operator_user_id, holder_id, source_event_ids_json, snapshot_json
+            SELECT receipt_type, commit_operator_user_id, holder_id, source_event_ids_json, snapshot_json, sent_at, last_attempt_at, last_error
             FROM receipt_queue
             ORDER BY id DESC
             LIMIT 1;
@@ -267,10 +267,17 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     assert receipt_snapshot["location_context"]["room"] == "210"
     assert receipt_snapshot["location_context"]["building_room"] == "HQ North/210"
     assert receipt_snapshot["acknowledgment"]["ack_scope"] == "batch"
+    assert receipt_snapshot["delivery"]["state"] == "pending"
+    assert receipt_snapshot["delivery"]["sent_at"] is None
+    assert receipt_snapshot["delivery"]["last_attempt_at"] is None
+    assert receipt_snapshot["delivery"]["last_error"] is None
     assert len(receipt_snapshot["assets"]) == 1
     assert receipt_snapshot["assets"][0]["asset_tag"] == "ISSUE-100"
     assert receipt_snapshot["assets"][0]["from_location_type"] == "STORAGE"
     assert receipt_snapshot["assets"][0]["to_location_type"] == "IN_CUSTODY"
+    assert receipt_row["sent_at"] is None
+    assert receipt_row["last_attempt_at"] is None
+    assert receipt_row["last_error"] is None
 
 
 def test_issue_commit_requires_responsibility_acknowledgment(client_with_temp_db) -> None:

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -280,6 +281,75 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     assert b"iPad" in response.data
     assert b"CASE-20 / 1" in response.data
     assert b"Source Events" in response.data
+
+
+def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_json
+            FROM receipt_queue
+            WHERE id = ?;
+            """,
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "pending",
+            "sent_at": None,
+            "last_attempt_at": "2026-03-29T12:00:00+00:00",
+            "last_error": "smtp offline",
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = NULL, last_attempt_at = ?, last_error = ?
+            WHERE id = ?;
+            """,
+            (
+                json.dumps(snapshot, sort_keys=True),
+                "2026-03-29T12:00:00+00:00",
+                "smtp offline",
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    failed_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert failed_response.status_code == 200
+    assert b"Delivery state:</strong>" in failed_response.data
+    assert b">failed<" in failed_response.data
+    assert b"Last delivery attempt:</strong> 2026-03-29T12:00:00+00:00" in failed_response.data
+    assert b"Last delivery error:</strong> smtp offline" in failed_response.data
+
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET sent_at = ?, last_attempt_at = ?, last_error = NULL
+            WHERE id = ?;
+            """,
+            (
+                "2026-03-29T12:05:00+00:00",
+                "2026-03-29T12:04:00+00:00",
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    sent_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert sent_response.status_code == 200
+    assert b">sent<" in sent_response.data
+    assert b"Delivered at:</strong> 2026-03-29T12:05:00+00:00" in sent_response.data
 
 
 def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import assettrack.db as db
 import pytest
 
 from assettrack.intake import app as intake_app
@@ -83,6 +84,35 @@ def test_receipts_list_shows_asset_tag_in_default_results(client_with_temp_db) -
     assert response.status_code == 200
     assert b"Asset Tag" in response.data
     assert b"ISSUE-100" in response.data
+    assert b">pending<" in response.data
+
+
+def test_receipts_list_shows_failed_delivery_state_from_persisted_queue_metadata(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET last_attempt_at = ?, last_error = ?
+            WHERE id = ?;
+            """,
+            (
+                "2026-03-29T12:00:00+00:00",
+                "smtp offline",
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
+    assert b">failed<" in response.data
 
 
 def test_receipts_list_renders_clear_search_link_when_filters_are_active(client_with_temp_db) -> None:

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -175,7 +175,7 @@ class ReturnBatchTests(unittest.TestCase):
         ).fetchone()
         receipt_row = self.conn.execute(
             """
-            SELECT receipt_type, commit_operator_user_id, holder_id, source_event_ids_json, snapshot_json
+            SELECT receipt_type, commit_operator_user_id, holder_id, source_event_ids_json, snapshot_json, sent_at, last_attempt_at, last_error
             FROM receipt_queue
             ORDER BY id DESC
             LIMIT 1;
@@ -201,10 +201,14 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(receipt_snapshot["receipt_type"], "RETURN")
         self.assertEqual(receipt_snapshot["holder_id"], 9)
         self.assertEqual(receipt_snapshot["source_event_ids"], [int(event_row["id"])])
+        self.assertEqual(receipt_snapshot["delivery"]["state"], "pending")
         self.assertEqual(len(receipt_snapshot["assets"]), 1)
         self.assertEqual(receipt_snapshot["assets"][0]["asset_tag"], "TAG-OK")
         self.assertEqual(receipt_snapshot["assets"][0]["from_location_type"], "IN_CUSTODY")
         self.assertEqual(receipt_snapshot["assets"][0]["to_location_type"], "STORAGE")
+        self.assertIsNone(receipt_row["sent_at"])
+        self.assertIsNone(receipt_row["last_attempt_at"])
+        self.assertIsNone(receipt_row["last_error"])
 
     def test_return_commit_missing_ack_redirects_back_to_preview_with_message(self) -> None:
         self._insert_slot(21, "C", 3, None)


### PR DESCRIPTION
## Summary
Finalize the deferred email receipt queue so custody commits create durable queued receipt records from stored facts, persist delivery state, and keep email delivery fully secondary to custody success.

## Related Issue
Closes #296 

## Changes
- rebuild queued receipt snapshots from stored asset events and persisted DB rows after custody writes succeed
- persist delivery metadata for queued receipts with default pending state
- update receipt read paths to resolve pending, sent, and failed from persisted queue fields
- surface delivery state in receipts list and receipt detail views
- add/update tests for successful ISSUE and RETURN queue creation, failed commit behavior, default pending state, and persisted state read behavior

## Verification checklist
- [x] Targeted pytest passed
- [x] ISSUE smoke test passed
- [x] RETURN smoke test passed
- [x] New queued receipts showed pending after commit
- [x] Failed commit still creates no queue row
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Follow-on bug found in smoke test: historical non-queued receipts are being displayed as pending. That needs a separate issue so queued vs historical receipt status stays cleanly modeled.