### PR TITLE
Issue 26-45: distinguish queued vs historical receipt delivery state

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2269,12 +2269,21 @@ def _receipt_delivery_snapshot(
 
 def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) -> dict[str, Optional[str]]:
     snapshot_delivery = snapshot.get("delivery")
-    if not isinstance(snapshot_delivery, dict):
+    has_snapshot_delivery = isinstance(snapshot_delivery, dict)
+    if not has_snapshot_delivery:
         snapshot_delivery = {}
 
     sent_at = str(row["sent_at"] or snapshot_delivery.get("sent_at") or "").strip() or None
     last_attempt_at = str(row["last_attempt_at"] or snapshot_delivery.get("last_attempt_at") or "").strip() or None
     last_error = str(row["last_error"] or snapshot_delivery.get("last_error") or "").strip() or None
+
+    if not has_snapshot_delivery and not sent_at and not last_attempt_at and not last_error:
+        return {
+            "state": None,
+            "sent_at": None,
+            "last_attempt_at": None,
+            "last_error": None,
+        }
 
     if sent_at:
         state = "sent"
@@ -4282,7 +4291,7 @@ def _receipt_summary_from_row(
         "id": int(row["id"]),
         "receipt_key": str(row["receipt_key"] or ""),
         "receipt_type": receipt_type,
-        "delivery_state": str(delivery.get("state") or "pending"),
+        "delivery_state": delivery.get("state"),
         "commit_at": commit_at,
         "commit_at_display": commit_at_display,
         "committed_by": committed_by,

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -54,10 +54,12 @@
       <p><strong>Receipt ID:</strong> <span class="mono">{{ receipt.id }}</span></p>
       <p><strong>Receipt key:</strong> <span class="mono">{{ receipt.receipt_key }}</span></p>
       <p><strong>Receipt type:</strong> {{ receipt.receipt_type or "Unknown" }}</p>
-      <p>
-        <strong>Delivery state:</strong>
-        <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ receipt.delivery.state }}</span>
-      </p>
+      {% if receipt.delivery.state %}
+        <p>
+          <strong>Delivery state:</strong>
+          <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ receipt.delivery.state }}</span>
+        </p>
+      {% endif %}
       <p><strong>Committed at:</strong> {{ receipt.commit_at or "Unknown" }}</p>
       <p>
         <strong>Committed by:</strong>

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -237,7 +237,9 @@
                 <div class="receipt-meta mono">{{ receipt.receipt_key }}</div>
                 <div><a class="receipt-link mono" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Receipt ID {{ receipt.id }}</a></div>
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
-                <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ receipt.delivery_state }}</div>
+                {% if receipt.delivery_state %}
+                  <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ receipt.delivery_state }}</div>
+                {% endif %}
                 {% if receipt.matched_asset_tags %}
                   <div class="asset-tag-match match-label">Asset tag search match</div>
                 {% endif %}

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -352,6 +352,44 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
     assert b"Delivered at:</strong> 2026-03-29T12:05:00+00:00" in sent_response.data
 
 
+def test_receipt_detail_hides_delivery_state_for_historical_nonqueued_receipt(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_json
+            FROM receipt_queue
+            WHERE id = ?;
+            """,
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot.pop("delivery", None)
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = NULL, last_attempt_at = NULL, last_error = NULL
+            WHERE id = ?;
+            """,
+            (
+                json.dumps(snapshot, sort_keys=True),
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Delivery state:</strong>" not in response.data
+    assert b">pending<" not in response.data
+
+
 def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:
     receipt_id = _create_return_receipt(client_with_temp_db, mixed_holders=True)
 

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import assettrack.db as db
+import json
 import pytest
 
 from assettrack.intake import app as intake_app
@@ -113,6 +114,46 @@ def test_receipts_list_shows_failed_delivery_state_from_persisted_queue_metadata
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
     assert b">failed<" in response.data
+
+
+def test_receipts_list_hides_delivery_state_for_historical_nonqueued_receipt(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_json
+            FROM receipt_queue
+            WHERE id = ?;
+            """,
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot.pop("delivery", None)
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = NULL, last_attempt_at = NULL, last_error = NULL
+            WHERE id = ?;
+            """,
+            (
+                json.dumps(snapshot, sort_keys=True),
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
+    assert b">pending<" not in response.data
+    assert b">sent<" not in response.data
+    assert b">failed<" not in response.data
 
 
 def test_receipts_list_renders_clear_search_link_when_filters_are_active(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Fix receipt delivery state so only queued receipts display a delivery status, and historical non-queued receipts are no longer incorrectly labeled as pending.

## Related Issue
Closes #375 

## Changes
- update receipt delivery-state resolution to require actual queue metadata or send-attempt fields
- remove fallback that treated missing metadata as pending
- update receipt list and detail templates to render delivery state only when present
- add tests for historical (non-queued) vs queued receipt behavior

## Verification checklist
- [x] Targeted pytest passed
- [x] Historical receipts no longer show pending
- [x] New queued receipts show pending
- [x] Sent/failed states still resolve correctly
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- This is a read/display-only correction. Queue creation behavior from 26-4 is unchanged.