### PR TITLE
Issue 26-47: clarify receipt email status wording

### DIFF
--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -44,6 +44,7 @@
   {% set operator = receipt.commit_operator %}
   {% set holder = receipt.holder_snapshot %}
   {% set organization = receipt.organization_snapshot %}
+  {% set email_status_label = "Queued" if receipt.delivery.state == "pending" else receipt.delivery.state %}
   <nav class="actions" aria-label="Receipt navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="chip" href="{{ url_for('human_report') }}">Open Current Status Report</a>
@@ -56,8 +57,8 @@
       <p><strong>Receipt type:</strong> {{ receipt.receipt_type or "Unknown" }}</p>
       {% if receipt.delivery.state %}
         <p>
-          <strong>Delivery state:</strong>
-          <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ receipt.delivery.state }}</span>
+          <strong>Receipt email status:</strong>
+          <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ email_status_label }}</span>
         </p>
       {% endif %}
       <p><strong>Committed at:</strong> {{ receipt.commit_at or "Unknown" }}</p>

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -230,6 +230,7 @@
       </thead>
       <tbody>
         {% for receipt in receipts %}
+          {% set email_status_label = "Queued" if receipt.delivery_state == "pending" else receipt.delivery_state %}
           <tr>
             <td data-label="Receipt">
               <div class="receipt-primary">
@@ -238,7 +239,7 @@
                 <div><a class="receipt-link mono" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Receipt ID {{ receipt.id }}</a></div>
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
                 {% if receipt.delivery_state %}
-                  <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ receipt.delivery_state }}</div>
+                  <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ email_status_label }}</div>
                 {% endif %}
                 {% if receipt.matched_asset_tags %}
                   <div class="asset-tag-match match-label">Asset tag search match</div>

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -323,7 +323,7 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
 
     failed_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert failed_response.status_code == 200
-    assert b"Delivery state:</strong>" in failed_response.data
+    assert b"Receipt email status:</strong>" in failed_response.data
     assert b">failed<" in failed_response.data
     assert b"Last delivery attempt:</strong> 2026-03-29T12:00:00+00:00" in failed_response.data
     assert b"Last delivery error:</strong> smtp offline" in failed_response.data
@@ -386,7 +386,7 @@ def test_receipt_detail_hides_delivery_state_for_historical_nonqueued_receipt(cl
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Delivery state:</strong>" not in response.data
+    assert b"Receipt email status:</strong>" not in response.data
     assert b">pending<" not in response.data
 
 

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -85,7 +85,7 @@ def test_receipts_list_shows_asset_tag_in_default_results(client_with_temp_db) -
     assert response.status_code == 200
     assert b"Asset Tag" in response.data
     assert b"ISSUE-100" in response.data
-    assert b">pending<" in response.data
+    assert b">Queued<" in response.data
 
 
 def test_receipts_list_shows_failed_delivery_state_from_persisted_queue_metadata(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Clarify receipt email delivery wording so operators can distinguish email status from asset custody state.

## Related Issue
Closes #378 

## Changes
- update label from "Delivery state" to "Receipt email status"
- update "Pending" to "Queued" in receipt list and detail views
- keep "Sent" and "Failed" unchanged
- update tests to reflect new wording

## Verification checklist
- [x] Targeted pytest passed
- [x] Receipts list shows "Queued" instead of "Pending"
- [x] Receipt detail shows "Receipt email status"
- [x] Sent and Failed states unchanged
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- UI-only change to improve operator clarity between custody state and email delivery state