### PR TITLE
Issue 26-48: reduce receipt detail header density

### DIFF
--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -7,13 +7,44 @@
   <style>
     .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-    .meta-grid {
+    .receipt-summary {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 0.75rem;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 1rem;
     }
-    .meta-grid p {
+    .summary-group {
+      display: grid;
+      gap: 0.55rem;
+      padding: 0.95rem 1rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 12px;
+      background: var(--color-surface-bg);
+    }
+    .summary-group p {
       margin: 0;
+    }
+    .summary-group-title {
+      margin: 0;
+      color: var(--color-text-muted);
+      font-size: 0.8rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .summary-value {
+      display: grid;
+      gap: 0.18rem;
+    }
+    .summary-label {
+      color: var(--color-text-muted);
+      font-size: 0.86rem;
+      font-weight: 600;
+    }
+    .summary-copy {
+      line-height: 1.4;
+    }
+    .summary-status {
+      align-content: start;
     }
     .status-chip {
       display: inline-flex;
@@ -37,6 +68,11 @@
       background: color-mix(in srgb, var(--color-danger) 14%, white);
       color: var(--color-danger);
     }
+    @media (max-width: 860px) {
+      .receipt-summary {
+        grid-template-columns: 1fr;
+      }
+    }
   </style>
 {% endblock %}
 
@@ -51,52 +87,96 @@
   </nav>
 
   <section class="card">
-    <div class="meta-grid">
-      <p><strong>Receipt ID:</strong> <span class="mono">{{ receipt.id }}</span></p>
-      <p><strong>Receipt key:</strong> <span class="mono">{{ receipt.receipt_key }}</span></p>
-      <p><strong>Receipt type:</strong> {{ receipt.receipt_type or "Unknown" }}</p>
-      {% if receipt.delivery.state %}
-        <p>
-          <strong>Receipt email status:</strong>
-          <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ email_status_label }}</span>
-        </p>
-      {% endif %}
-      <p><strong>Committed at:</strong> {{ receipt.commit_at or "Unknown" }}</p>
-      <p>
-        <strong>Committed by:</strong>
-        {% if operator and operator.username %}
-          {{ operator.username }}{% if operator.role %} ({{ operator.role }}){% endif %} [user_id {{ operator.id }}]
-        {% else %}
-          user_id {{ receipt.commit_operator_user_id }}
+    <div class="receipt-summary">
+      <section class="summary-group">
+        <h2 class="summary-group-title">Identity</h2>
+        <div class="summary-value">
+          <div class="summary-label">Receipt ID</div>
+          <div class="summary-copy mono">{{ receipt.id }}</div>
+        </div>
+        <div class="summary-value">
+          <div class="summary-label">Receipt type</div>
+          <div class="summary-copy">{{ receipt.receipt_type or "Unknown" }}</div>
+        </div>
+        <div class="summary-value">
+          <div class="summary-label">Receipt key</div>
+          <div class="summary-copy mono">{{ receipt.receipt_key }}</div>
+        </div>
+      </section>
+
+      <section class="summary-group summary-status">
+        <h2 class="summary-group-title">Email</h2>
+        {% if receipt.delivery.state %}
+          <div class="summary-value">
+            <div class="summary-label">Receipt email status</div>
+            <div class="summary-copy">
+              <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ email_status_label }}</span>
+            </div>
+          </div>
         {% endif %}
-      </p>
-      {% if holder or receipt.holder_id is not none %}
-        <p>
-          <strong>Receipt holder:</strong>
-          {% if holder and holder.name %}
-            {{ holder.name }}
-            {% if holder.identifier %}(ID {{ holder.identifier }}){% endif %}
-          {% else %}
-            holder_id {{ receipt.holder_id }}
-          {% endif %}
-        </p>
-      {% endif %}
-      {% if organization %}
-        <p>
-          <strong>Organization:</strong>
-          {{ organization.organization or "Unknown" }}
-          {% if organization.organization_id is not none %}(org_id {{ organization.organization_id }}){% endif %}
-        </p>
-      {% endif %}
-      {% if receipt.delivery.last_attempt_at %}
-        <p><strong>Last delivery attempt:</strong> {{ receipt.delivery.last_attempt_at }}</p>
-      {% endif %}
-      {% if receipt.delivery.sent_at %}
-        <p><strong>Delivered at:</strong> {{ receipt.delivery.sent_at }}</p>
-      {% endif %}
-      {% if receipt.delivery.last_error %}
-        <p><strong>Last delivery error:</strong> {{ receipt.delivery.last_error }}</p>
-      {% endif %}
+        {% if receipt.delivery.last_attempt_at %}
+          <div class="summary-value">
+            <div class="summary-label">Last delivery attempt</div>
+            <div class="summary-copy">{{ receipt.delivery.last_attempt_at }}</div>
+          </div>
+        {% endif %}
+        {% if receipt.delivery.sent_at %}
+          <div class="summary-value">
+            <div class="summary-label">Delivered at</div>
+            <div class="summary-copy">{{ receipt.delivery.sent_at }}</div>
+          </div>
+        {% endif %}
+        {% if receipt.delivery.last_error %}
+          <div class="summary-value">
+            <div class="summary-label">Last delivery error</div>
+            <div class="summary-copy">{{ receipt.delivery.last_error }}</div>
+          </div>
+        {% endif %}
+      </section>
+
+      <section class="summary-group">
+        <h2 class="summary-group-title">Actor</h2>
+        <div class="summary-value">
+          <div class="summary-label">Committed by</div>
+          <div class="summary-copy">
+            {% if operator and operator.username %}
+              {{ operator.username }}{% if operator.role %} ({{ operator.role }}){% endif %} [user_id {{ operator.id }}]
+            {% else %}
+              user_id {{ receipt.commit_operator_user_id }}
+            {% endif %}
+          </div>
+        </div>
+        {% if holder or receipt.holder_id is not none %}
+          <div class="summary-value">
+            <div class="summary-label">Receipt holder</div>
+            <div class="summary-copy">
+              {% if holder and holder.name %}
+                {{ holder.name }}
+                {% if holder.identifier %}(ID {{ holder.identifier }}){% endif %}
+              {% else %}
+                holder_id {{ receipt.holder_id }}
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
+      </section>
+
+      <section class="summary-group">
+        <h2 class="summary-group-title">Context</h2>
+        <div class="summary-value">
+          <div class="summary-label">Committed at</div>
+          <div class="summary-copy">{{ receipt.commit_at or "Unknown" }}</div>
+        </div>
+        {% if organization %}
+          <div class="summary-value">
+            <div class="summary-label">Organization</div>
+            <div class="summary-copy">
+              {{ organization.organization or "Unknown" }}
+              {% if organization.organization_id is not none %}(org_id {{ organization.organization_id }}){% endif %}
+            </div>
+          </div>
+        {% endif %}
+      </section>
     </div>
   </section>
 

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -249,12 +249,13 @@ def test_issue_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None
     assert response.status_code == 200
     assert b"Receipt Detail" in response.data
     assert f"Receipt {receipt_id}".encode("utf-8") in response.data
-    assert b"Receipt key:" in response.data
+    assert b"Receipt key" in response.data
     assert b"ISSUE:" in response.data
-    assert b"Receipt type:</strong> ISSUE" in response.data
-    assert b"Committed by:</strong>" in response.data
+    assert b"Receipt type" in response.data
+    assert b"ISSUE" in response.data
+    assert b"Committed by" in response.data
     assert b"issue-operator" in response.data
-    assert b"Receipt holder:</strong>" in response.data
+    assert b"Receipt holder" in response.data
     assert b"Issue Holder" in response.data
     assert b"Issue Location" in response.data
     assert b"HQ North" in response.data
@@ -273,7 +274,8 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt type:</strong> RETURN" in response.data
+    assert b"Receipt type" in response.data
+    assert b"RETURN" in response.data
     assert b"RETURN:" in response.data
     assert b"Return Holder One" in response.data
     assert b"RETURN-200" in response.data
@@ -323,10 +325,12 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
 
     failed_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert failed_response.status_code == 200
-    assert b"Receipt email status:</strong>" in failed_response.data
+    assert b"Receipt email status" in failed_response.data
     assert b">failed<" in failed_response.data
-    assert b"Last delivery attempt:</strong> 2026-03-29T12:00:00+00:00" in failed_response.data
-    assert b"Last delivery error:</strong> smtp offline" in failed_response.data
+    assert b"Last delivery attempt" in failed_response.data
+    assert b"2026-03-29T12:00:00+00:00" in failed_response.data
+    assert b"Last delivery error" in failed_response.data
+    assert b"smtp offline" in failed_response.data
 
     conn = db.get_connection()
     try:
@@ -349,7 +353,8 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
     sent_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert sent_response.status_code == 200
     assert b">sent<" in sent_response.data
-    assert b"Delivered at:</strong> 2026-03-29T12:05:00+00:00" in sent_response.data
+    assert b"Delivered at" in sent_response.data
+    assert b"2026-03-29T12:05:00+00:00" in sent_response.data
 
 
 def test_receipt_detail_hides_delivery_state_for_historical_nonqueued_receipt(client_with_temp_db) -> None:
@@ -386,7 +391,7 @@ def test_receipt_detail_hides_delivery_state_for_historical_nonqueued_receipt(cl
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt email status:</strong>" not in response.data
+    assert b"Receipt email status" not in response.data
     assert b">pending<" not in response.data
 
 
@@ -396,8 +401,9 @@ def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt type:</strong> RETURN" in response.data
-    assert b"Receipt holder:" not in response.data
+    assert b"Receipt type" in response.data
+    assert b"RETURN" in response.data
+    assert b"Receipt holder" not in response.data
     assert b"Return Holder One" in response.data
     assert b"Return Holder Two" in response.data
     assert b"RETURN-200" in response.data


### PR DESCRIPTION
## Summary
Reduce visual density in the receipt detail header so operators can scan key receipt information more easily.

## Related Issue
Closes #380 

## Changes
- regroup the top receipt summary into clearer sections
- add spacing and section labels to improve scan order
- keep all existing receipt facts visible
- update receipt detail tests to match the new header structure

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] Receipt ID and type still visible
- [x] Receipt email status still visible
- [x] Committed by and holder still visible
- [x] Organization and timestamp still visible
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Presentation-only change to improve readability in the receipt detail top block