### PR TITLE
Issue 26-49: widen receipt detail page

### DIFF
--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -2,9 +2,13 @@
 
 {% block title %}Receipt Detail{% endblock %}
 {% block page_heading %}Receipt {{ receipt.id }}{% endblock %}
+{% block page_class %} receipt-detail-page{% endblock %}
 
 {% block extra_head %}
   <style>
+    .page.receipt-detail-page {
+      max-width: 1320px;
+    }
     .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     .receipt-summary {
@@ -68,7 +72,7 @@
       background: color-mix(in srgb, var(--color-danger) 14%, white);
       color: var(--color-danger);
     }
-    @media (max-width: 860px) {
+    @media (max-width: 960px) {
       .receipt-summary {
         grid-template-columns: 1fr;
       }


### PR DESCRIPTION
## Summary
Widen the receipt detail page container so the page uses more desktop space and feels less cramped.

## Related Issue
Closes #381 

## Changes
- add a page-local wrapper/class for receipt detail
- increase the local max-width for `/receipts/<id>`
- slightly adjust the summary-grid collapse breakpoint to keep the wider layout balanced

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] Receipt detail page uses more horizontal space
- [x] Header groups still align cleanly
- [x] Lower cards/sections still align cleanly
- [x] No horizontal overflow
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Presentation-only, page-local layout change for receipt detail