### PR TITLE
Issue 26-50: widen report page

### DIFF
--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -2,9 +2,13 @@
 
 {% block title %}Current Status Report{% endblock %}
 {% block page_heading %}Current Status Report{% endblock %}
+{% block page_class %} report-page{% endblock %}
 
 {% block extra_head %}
   <style>
+    .page.report-page {
+      max-width: 1320px;
+    }
     .report-actions {
       display: flex;
       gap: 0.5rem;


### PR DESCRIPTION
## Summary
Widen the current status report page so it uses more desktop width and feels less cramped.

## Related Issue
Closes #385 

## Changes
- add a page-local wrapper/class for the report page
- increase the local max-width for `/report`
- preserve existing layout, tables, and content

## Verification checklist
- [x] Manual browser verification passed
- [x] Report page uses more horizontal space
- [x] Tables and cards still align cleanly
- [x] No horizontal overflow beyond normal table scroll
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Presentation-only, page-local layout change aligned with 26-49 approach