### PR TITLE
Issue 26-46: fix asset search layout and clear

### DIFF
--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -2,13 +2,40 @@
 
 {% block title %}Asset Search{% endblock %}
 {% block page_heading %}Asset Search{% endblock %}
+{% block page_class %} asset-search-page{% endblock %}
 
 {% block extra_head %}
   <style>
-    .search-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
+    .search-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.75rem 1rem; }
+    .asset-search-page .search-grid .row { min-width: 0; }
+    .asset-search-page input[type="text"] {
+      width: 100%;
+      max-width: none;
+      min-width: 0;
+      box-sizing: border-box;
+      padding: 0.6rem;
+      font-size: 1rem;
+    }
+    .search-actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-top: 0.25rem;
+    }
+    .search-clear {
+      display: inline-flex;
+      align-items: center;
+      color: var(--color-text-muted);
+      font-weight: 600;
+    }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .results-table code { white-space: nowrap; }
+    @media (max-width: 720px) {
+      .search-grid {
+        grid-template-columns: 1fr;
+      }
+    }
   </style>
 {% endblock %}
 
@@ -31,7 +58,12 @@
           <input type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" />
         </div>
       </div>
-      <button type="submit">Search</button>
+      <div class="search-actions">
+        <button type="submit">Search</button>
+        {% if form.asset_tag or form.serial_number %}
+          <a class="search-clear" href="{{ url_for('asset_search') }}">Clear</a>
+        {% endif %}
+      </div>
     </form>
   </div>
 

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -82,6 +82,7 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Asset Search", response.data)
         self.assertIn(b"Search by asset tag or serial number", response.data)
+        self.assertNotIn(b">Clear<", response.data)
 
     def test_search_finds_asset_by_asset_tag(self) -> None:
         self._insert_holder(1, "Alex Holder", "Field Ops")
@@ -148,6 +149,32 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Asset not found.", response.data)
         self.assertNotIn(b"Asset Found", response.data)
+        self.assertIn(b'href="/assets/search"', response.data)
+        self.assertIn(b">Clear<", response.data)
+
+    def test_search_page_renders_clear_link_when_any_field_is_filled(self) -> None:
+        response = self.client.get("/assets/search?asset_tag=AT-100&serial_number=SER-100")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'value="AT-100"', response.data)
+        self.assertIn(b'value="SER-100"', response.data)
+        self.assertIn(b'href="/assets/search"', response.data)
+        self.assertIn(b">Clear<", response.data)
+
+    def test_clean_search_route_resets_both_fields_and_results(self) -> None:
+        self._insert_asset("AT-300", serial_number="SER-300", location_type="STORAGE", home_slot_id=None)
+
+        searched = self.client.get("/assets/search?asset_tag=AT-300&serial_number=SER-300")
+        self.assertEqual(searched.status_code, 200)
+        self.assertIn(b"Asset Found", searched.data)
+        self.assertIn(b'value="AT-300"', searched.data)
+        self.assertIn(b'value="SER-300"', searched.data)
+
+        cleared = self.client.get("/assets/search")
+        self.assertEqual(cleared.status_code, 200)
+        self.assertNotIn(b"Asset Found", cleared.data)
+        self.assertIn(b'value=""', cleared.data)
+        self.assertNotIn(b">Clear<", cleared.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fix the asset search form layout so inputs stay inside the container and add a clear control to reset the form cleanly.

## Related Issue
Closes #26-46

## Changes
- adjust the `/assets/search` form layout so asset tag and serial number inputs stay within the page container
- add a GET-safe Clear control that returns to the clean `/assets/search` route
- add UI test coverage for the clear control and reset behavior

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] Inputs stay inside the container
- [x] Clear resets both fields
- [x] Asset tag search still works
- [x] Serial number search still works
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Presentation-only plus form reset UX improvement; no search logic changes