### PR TITLE
Issue 26-52: improve receipt naming for operator clarity

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4179,6 +4179,9 @@ def _receipt_from_queue_row(row: sqlite3.Row) -> dict[str, object]:
 
     snapshot_assets = snapshot.get("assets")
     assets = snapshot_assets if isinstance(snapshot_assets, list) else []
+    holder_snapshot = snapshot.get("holder_snapshot")
+    if not isinstance(holder_snapshot, dict):
+        holder_snapshot = None
     location_context = snapshot.get("location_context")
     if not isinstance(location_context, dict):
         location_context = None
@@ -4200,16 +4203,27 @@ def _receipt_from_queue_row(row: sqlite3.Row) -> dict[str, object]:
         if snapshot_operator_id is not None
         else int(row["commit_operator_user_id"])
     )
+    holder_display_name = _receipt_display_holder_name(
+        holder_snapshot,
+        holder_id=snapshot.get("holder_id") if snapshot.get("holder_id") is not None else row["holder_id"],
+        receipt_type=receipt_type,
+        assets=assets,
+    )
+    display_date = _receipt_display_date(commit_at)
 
     return {
         "id": int(row["id"]),
         "receipt_key": str(row["receipt_key"] or ""),
         "receipt_type": receipt_type,
+        "receipt_type_label": _receipt_type_label(receipt_type),
+        "holder_display_name": holder_display_name,
         "commit_at": commit_at,
+        "display_date": display_date,
+        "display_title": _receipt_display_title(receipt_type, holder_display_name, display_date),
         "commit_operator_user_id": commit_operator_user_id,
         "commit_operator": snapshot.get("commit_operator") if isinstance(snapshot.get("commit_operator"), dict) else None,
         "holder_id": snapshot.get("holder_id") if snapshot.get("holder_id") is not None else row["holder_id"],
-        "holder_snapshot": snapshot.get("holder_snapshot") if isinstance(snapshot.get("holder_snapshot"), dict) else None,
+        "holder_snapshot": holder_snapshot,
         "organization_snapshot": (
             snapshot.get("organization_snapshot") if isinstance(snapshot.get("organization_snapshot"), dict) else None
         ),
@@ -4270,6 +4284,14 @@ def _receipt_summary_from_row(
         committed_by = str(operator.get("username") or "").strip()
     else:
         committed_by = f"user_id {int(row['commit_operator_user_id'])}"
+
+    display_date = _receipt_display_date(commit_at)
+    display_holder_name = _receipt_display_holder_name(
+        holder_snapshot,
+        holder_id=holder_id,
+        receipt_type=receipt_type,
+        assets=asset_list,
+    )
 
     try:
         commit_at_display = datetime.fromisoformat(commit_at).strftime("%Y-%m-%d %H:%M")
@@ -4339,11 +4361,15 @@ def _receipt_summary_from_row(
         "id": int(row["id"]),
         "receipt_key": str(row["receipt_key"] or ""),
         "receipt_type": receipt_type,
+        "receipt_type_label": _receipt_type_label(receipt_type),
+        "display_title": _receipt_display_title(receipt_type, display_holder_name, display_date),
+        "display_date": display_date,
         "delivery_state": delivery.get("state"),
         "commit_at": commit_at,
         "commit_at_display": commit_at_display,
         "committed_by": committed_by,
         "holder_summary": holder_summary,
+        "holder_display_name": display_holder_name,
         "organization_summary": organization_summary,
         "location_summary": location_summary,
         "asset_count": len(asset_list),
@@ -4353,6 +4379,70 @@ def _receipt_summary_from_row(
         "matched_holder_names": matched_holder_names,
         "matched_locations": matched_locations,
     }
+
+
+def _receipt_type_label(receipt_type: str) -> str:
+    normalized = str(receipt_type or "").strip().upper()
+    if normalized == "ISSUE":
+        return "Issue Receipt"
+    if normalized == "RETURN":
+        return "Return Receipt"
+    return "Receipt"
+
+
+def _receipt_display_date(commit_at: str) -> str:
+    value = str(commit_at or "").strip()
+    if not value:
+        return "Unknown Date"
+
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        return value
+
+    month = parsed.strftime("%b")
+    day = parsed.day
+    year = parsed.year
+    return f"{month} {day}, {year}"
+
+
+def _receipt_display_holder_name(
+    holder_snapshot: Optional[dict[str, object]],
+    *,
+    holder_id: object,
+    receipt_type: str,
+    assets: list[object],
+) -> str:
+    if isinstance(holder_snapshot, dict):
+        holder_name = str(holder_snapshot.get("name") or "").strip()
+        if holder_name:
+            return holder_name
+
+    unique_names: list[str] = []
+    for asset in assets:
+        if not isinstance(asset, dict):
+            continue
+        for field_name in ("holder_snapshot", "from_holder_snapshot"):
+            snapshot = asset.get(field_name)
+            if not isinstance(snapshot, dict):
+                continue
+            holder_name = str(snapshot.get("name") or "").strip()
+            if holder_name and holder_name not in unique_names:
+                unique_names.append(holder_name)
+
+    if len(unique_names) == 1:
+        return unique_names[0]
+    if len(unique_names) > 1:
+        return "Multiple Holders"
+    if holder_id is not None:
+        return f"Holder {holder_id}"
+    if str(receipt_type or "").strip().upper() == "RETURN":
+        return "Returning Holder"
+    return "Unknown Holder"
+
+
+def _receipt_display_title(receipt_type: str, holder_name: str, display_date: str) -> str:
+    return f"{_receipt_type_label(receipt_type)} — {holder_name or 'Unknown Holder'} — {display_date or 'Unknown Date'}"
 
 
 def _receipt_pdf_ack_name(receipt: dict[str, object]) -> str:

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Receipt Detail{% endblock %}
-{% block page_heading %}Receipt {{ receipt.id }}{% endblock %}
+{% block title %}{{ receipt.display_title }}{% endblock %}
+{% block page_heading %}{{ receipt.display_title }}{% endblock %}
 {% block page_class %} receipt-detail-page{% endblock %}
 
 {% block extra_head %}
@@ -92,6 +92,7 @@
   </nav>
 
   <section class="card">
+    <p class="summary-label">Internal receipt ID {{ receipt.id }}</p>
     <div class="receipt-summary">
       <section class="summary-group">
         <h2 class="summary-group-title">Identity</h2>
@@ -100,8 +101,8 @@
           <div class="summary-copy mono">{{ receipt.id }}</div>
         </div>
         <div class="summary-value">
-          <div class="summary-label">Receipt type</div>
-          <div class="summary-copy">{{ receipt.receipt_type or "Unknown" }}</div>
+          <div class="summary-label">Receipt title</div>
+          <div class="summary-copy">{{ receipt.display_title }}</div>
         </div>
         <div class="summary-value">
           <div class="summary-label">Receipt key</div>

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -234,9 +234,11 @@
           <tr>
             <td data-label="Receipt">
               <div class="receipt-primary">
-                <div class="receipt-title">{{ receipt.receipt_type }}</div>
+                <div class="receipt-title">
+                  <a class="receipt-link" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">{{ receipt.display_title }}</a>
+                </div>
                 <div class="receipt-meta mono">{{ receipt.receipt_key }}</div>
-                <div><a class="receipt-link mono" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">Receipt ID {{ receipt.id }}</a></div>
+                <div class="receipt-meta">Internal receipt ID <span class="mono">{{ receipt.id }}</span></div>
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
                 {% if receipt.delivery_state %}
                   <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ email_status_label }}</div>

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -254,12 +254,12 @@ def test_issue_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt Detail" in response.data
-    assert f"Receipt {receipt_id}".encode("utf-8") in response.data
+    assert b"Issue Receipt" in response.data
+    assert b"Issue Receipt \xe2\x80\x94 Issue Holder \xe2\x80\x94 Mar 29, 2026" in response.data
+    assert f"Internal receipt ID {receipt_id}".encode("utf-8") in response.data
     assert b"Receipt key" in response.data
     assert b"ISSUE:" in response.data
-    assert b"Receipt type" in response.data
-    assert b"ISSUE" in response.data
+    assert b"Receipt title" in response.data
     assert b"Committed by" in response.data
     assert b"issue-operator" in response.data
     assert b"Receipt holder" in response.data
@@ -281,8 +281,8 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt type" in response.data
-    assert b"RETURN" in response.data
+    assert b"Return Receipt" in response.data
+    assert b"Return Receipt \xe2\x80\x94 Return Holder One \xe2\x80\x94 Mar 29, 2026" in response.data
     assert b"RETURN:" in response.data
     assert b"Return Holder One" in response.data
     assert b"RETURN-200" in response.data
@@ -408,8 +408,8 @@ def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt type" in response.data
-    assert b"RETURN" in response.data
+    assert b"Receipt title" in response.data
+    assert b"Return Receipt \xe2\x80\x94 Multiple Holders \xe2\x80\x94 Mar 29, 2026" in response.data
     assert b"Receipt holder" not in response.data
     assert b"Return Holder One" in response.data
     assert b"Return Holder Two" in response.data
@@ -518,6 +518,45 @@ def test_receipt_detail_links_to_receipt_pdf(client_with_temp_db) -> None:
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}/pdf"'.encode("utf-8") in response.data
     assert b"Download Receipt PDF" in response.data
+
+
+def test_receipt_detail_uses_stable_holder_fallback_when_snapshot_name_is_missing(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_json
+            FROM receipt_queue
+            WHERE id = ?;
+            """,
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["holder_snapshot"]["name"] = ""
+        asset_holder = snapshot["assets"][0]["holder_snapshot"]
+        asset_holder["name"] = ""
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?
+            WHERE id = ?;
+            """,
+            (
+                json.dumps(snapshot, sort_keys=True),
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Issue Receipt \xe2\x80\x94 Holder 1 \xe2\x80\x94 Mar 29, 2026" in response.data
 
 
 def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_db) -> None:

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -73,6 +73,7 @@ def test_mixed_holder_return_renders_multiple_holders_summary(client_with_temp_d
 
     assert response.status_code == 200
     assert f'href="/receipts/{mixed_return_receipt_id}"'.encode("utf-8") in response.data
+    assert b"Return Receipt \xe2\x80\x94 Multiple Holders \xe2\x80\x94 Mar 29, 2026" in response.data
     assert b"Multiple holders" in response.data
     assert b"Return location varies by asset" in response.data
 
@@ -208,11 +209,62 @@ def test_receipts_list_links_to_existing_receipt_detail(client_with_temp_db) -> 
 
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
-    assert f"Receipt ID {receipt_id}".encode("utf-8") in response.data
+    assert b"Issue Receipt \xe2\x80\x94 Issue Holder \xe2\x80\x94 Mar 29, 2026" in response.data
+    assert b"Internal receipt ID" in response.data
+    assert f">{receipt_id}<".encode("utf-8") in response.data
     assert b"Detail" not in response.data
 
     detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert detail_response.status_code == 200
+
+
+def test_receipts_list_renders_distinct_issue_and_return_titles(client_with_temp_db) -> None:
+    _create_issue_receipt(client_with_temp_db)
+    _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert b"Issue Receipt \xe2\x80\x94 Issue Holder \xe2\x80\x94 Mar 29, 2026" in response.data
+    assert b"Return Receipt \xe2\x80\x94 Return Holder One \xe2\x80\x94 Mar 29, 2026" in response.data
+
+
+def test_receipts_list_uses_stable_holder_fallback_when_snapshot_name_is_missing(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_json
+            FROM receipt_queue
+            WHERE id = ?;
+            """,
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["holder_snapshot"]["name"] = ""
+        snapshot["assets"][0]["holder_snapshot"]["name"] = ""
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?
+            WHERE id = ?;
+            """,
+            (
+                json.dumps(snapshot, sort_keys=True),
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/receipts")
+
+    assert response.status_code == 200
+    assert b"Issue Receipt \xe2\x80\x94 Holder 1 \xe2\x80\x94 Mar 29, 2026" in response.data
 
 
 def test_receipts_list_building_room_search_matches_issue_location_summary(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Replace internal receipt naming with human-readable titles so operators and holders can quickly understand what the receipt represents.

## Related Issue
Closes #390 

## Changes
- replace "Receipt <id>" primary label with human-readable format
- add Issue Receipt / Return Receipt labeling based on receipt type
- include holder name and date in primary title
- keep internal receipt ID as secondary text
- reuse stored receipt snapshot data for deterministic naming
- update tests for receipt list and detail rendering

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] Receipt list shows human-readable titles
- [x] Receipt detail shows same title format
- [x] Issue and Return receipts display correct labels
- [x] Internal ID remains visible as secondary text
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Display-only change using existing stored receipt data
- No impact to receipt queue, delivery state, or persistence