### PR TITLE
Issue 26-53: prevent receipt PDF table cell wrapping

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from flask import Flask, abort, flash, jsonify, redirect, render_template, request, send_file, session, url_for
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
-from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
 from reportlab.pdfgen import canvas
 from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
@@ -4510,20 +4510,37 @@ def _receipt_acknowledgment_statement(receipt_type: str) -> str:
     return "Custody issue was reviewed and confirmed from the stored receipt record."
 
 
+def _receipt_pdf_location_type_label(value: object) -> str:
+    return str(value or "").strip().replace("_", " ")
+
+
 def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
     styles = getSampleStyleSheet()
     body = styles["BodyText"]
     heading = styles["Heading2"]
     title = styles["Title"]
+    table_body = ParagraphStyle(
+        "ReceiptPdfTableBody",
+        parent=body,
+        fontSize=8.5,
+        leading=10,
+        splitLongWords=False,
+        wordWrap="LTR",
+    )
+    table_header = ParagraphStyle(
+        "ReceiptPdfTableHeader",
+        parent=table_body,
+        fontName="Helvetica-Bold",
+    )
 
     def _text(value: object) -> str:
         return str(value or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
-    def _p(value: object) -> Paragraph:
-        return Paragraph(_text(value), body)
+    def _p(value: object, style: ParagraphStyle = table_body) -> Paragraph:
+        return Paragraph(_text(value), style)
 
     def _render_table(headers: list[str], rows: list[list[object]], column_widths: list[float]) -> Table:
-        data = [[Paragraph(f"<b>{_text(header)}</b>", body) for header in headers]]
+        data = [[Paragraph(_text(header), table_header) for header in headers]]
         for row in rows:
             data.append([_p(value) for value in row])
 
@@ -4576,8 +4593,8 @@ def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
                 str(asset.get("equipment_type") or "").strip(),
                 str(asset.get("serial_number") or "").strip(),
                 make_model,
-                str(asset.get("from_location_type") or "").strip(),
-                str(asset.get("to_location_type") or "").strip(),
+                _receipt_pdf_location_type_label(asset.get("from_location_type")),
+                _receipt_pdf_location_type_label(asset.get("to_location_type")),
             ]
         )
 
@@ -4612,7 +4629,7 @@ def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
         _render_table(
             ["Asset Tag", "Equipment", "Serial", "Make / Model", "From", "To"],
             asset_rows or [["No assets captured.", "", "", "", "", ""]],
-            [1.1 * inch, 1.0 * inch, 1.2 * inch, 2.0 * inch, 1.0 * inch, 1.0 * inch],
+            [1.15 * inch, 1.0 * inch, 1.25 * inch, 1.95 * inch, 0.95 * inch, 1.0 * inch],
         ),
     ]
 

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -581,6 +581,8 @@ def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_d
     assert "Initials: IH" in pdf_text
     assert "ISSUE-100" in pdf_text
     assert "Dell / Latitude (LAT-14)" in pdf_text
+    assert "IN CUSTODY" in pdf_text
+    assert "IN_CUSTODY" not in pdf_text
 
 
 def test_receipt_pdf_is_deterministic_for_same_snapshot(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Improve receipt PDF readability by preventing awkward table cell wrapping in the asset table.

## Related Issue
Closes #391 

## Changes
- adjust PDF table styling to reduce mid-word wrapping
- rebalance column widths for better readability
- render status values with safe spacing for cleaner wrapping
- keep all receipt data intact and aligned

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] PDF no longer shows awkward mid-word wrapping
- [x] Rows are readable and aligned
- [x] No content is truncated
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Presentation-only change within PDF generation
- No impact to receipt queue, delivery state, or persistence