### PR TITLE
Issue 26-54: use human-readable receipt PDF filename

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4445,6 +4445,14 @@ def _receipt_display_title(receipt_type: str, holder_name: str, display_date: st
     return f"{_receipt_type_label(receipt_type)} — {holder_name or 'Unknown Holder'} — {display_date or 'Unknown Date'}"
 
 
+def _receipt_pdf_download_name(receipt: dict[str, object]) -> str:
+    title = str(receipt.get("display_title") or "").strip() or "Receipt"
+    sanitized = title.replace(" — ", " - ")
+    sanitized = re.sub(r'[<>:"/\\|?*]', " ", sanitized)
+    sanitized = re.sub(r"\s+", " ", sanitized).strip().rstrip(". ")
+    return f"{sanitized or 'Receipt'}.pdf"
+
+
 def _receipt_pdf_ack_name(receipt: dict[str, object]) -> str:
     holder_snapshot = receipt.get("holder_snapshot")
     if isinstance(holder_snapshot, dict):
@@ -4794,8 +4802,7 @@ def receipt_pdf(receipt_id: int):
 
     receipt = _receipt_from_queue_row(row)
     pdf_bytes = _build_receipt_pdf(receipt)
-    receipt_type = str(receipt.get("receipt_type") or "").strip().lower() or "acknowledgment"
-    download_name = f"receipt-{receipt['id']}-{receipt_type}.pdf"
+    download_name = _receipt_pdf_download_name(receipt)
     return send_file(
         BytesIO(pdf_bytes),
         as_attachment=True,

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -568,7 +568,7 @@ def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_d
     assert response.mimetype == "application/pdf"
     disposition = response.headers.get("Content-Disposition") or ""
     assert "attachment;" in disposition
-    assert f"receipt-{receipt_id}-issue.pdf" in disposition
+    assert "Issue Receipt - Issue Holder - Mar 29, 2026.pdf" in disposition
 
     pdf_text = _extract_pdf_text(response.data)
     assert "Custody Acknowledgment Receipt" in pdf_text
@@ -583,6 +583,17 @@ def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_d
     assert "Dell / Latitude (LAT-14)" in pdf_text
     assert "IN CUSTODY" in pdf_text
     assert "IN_CUSTODY" not in pdf_text
+
+
+def test_return_receipt_pdf_download_uses_human_readable_filename(client_with_temp_db) -> None:
+    receipt_id = _create_return_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}/pdf")
+
+    assert response.status_code == 200
+    disposition = response.headers.get("Content-Disposition") or ""
+    assert "attachment;" in disposition
+    assert "Return Receipt - Return Holder One - Mar 29, 2026.pdf" in disposition
 
 
 def test_receipt_pdf_is_deterministic_for_same_snapshot(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Use a human-readable filename when downloading receipt PDFs so files are clear and usable outside the system.

## Related Issue
Closes #394 

## Changes
- replace internal PDF filename with human-readable format
- align filename with receipt display naming
- sanitize filename for filesystem safety
- keep filename deterministic from stored receipt data

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] Downloaded PDF filename is human-readable
- [x] Issue and Return receipts labeled correctly
- [x] Filename is OS-safe
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- Presentation-only change to response headers
- No impact to receipt content, queue, or delivery state