### PR TITLE
Issue 26-55: route operator to receipt after commit

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2549,9 +2549,9 @@ def _insert_receipt_queue_row(
     commit_at: str,
     commit_operator_user_id: int,
     holder_id: Optional[int],
-) -> None:
+) -> int:
     now_iso = datetime.now(timezone.utc).isoformat()
-    conn.execute(
+    cursor = conn.execute(
         """
         INSERT INTO receipt_queue (
             receipt_key,
@@ -2578,6 +2578,7 @@ def _insert_receipt_queue_row(
             now_iso,
         ),
     )
+    return int(cursor.lastrowid)
 
 
 def _issue_batch(
@@ -2587,7 +2588,7 @@ def _issue_batch(
     responsibility_ack: dict[str, object],
     *,
     commit_operator_user_id: int,
-) -> int:
+) -> tuple[int, int]:
     if not asset_tags:
         raise ValueError("No assets in the queue to issue.")
 
@@ -2775,7 +2776,7 @@ def _issue_batch(
                 commit_at=now_iso,
                 commit_operator_user_id=commit_operator_user_id,
             )
-            _insert_receipt_queue_row(
+            receipt_id = _insert_receipt_queue_row(
                 conn,
                 receipt_type="ISSUE",
                 source_event_ids=event_ids,
@@ -2785,7 +2786,7 @@ def _issue_batch(
                 holder_id=holder_id,
             )
 
-            return len(canon_assets)
+            return len(canon_assets), receipt_id
     finally:
         conn.close()
 
@@ -2795,7 +2796,7 @@ def _return_batch(
     responsibility_ack: dict[str, object],
     *,
     commit_operator_user_id: int,
-) -> int:
+) -> tuple[int, int]:
     if not asset_tags:
         raise ValueError("No assets in the queue to return")
 
@@ -2965,7 +2966,7 @@ def _return_batch(
                 commit_at=now_iso,
                 commit_operator_user_id=commit_operator_user_id,
             )
-            _insert_receipt_queue_row(
+            receipt_id = _insert_receipt_queue_row(
                 conn,
                 receipt_type="RETURN",
                 source_event_ids=event_ids,
@@ -2975,7 +2976,7 @@ def _return_batch(
                 holder_id=snapshot.get("holder_id"),
             )
 
-            return len(validated_rows)
+            return len(validated_rows), receipt_id
     finally:
         conn.close()
 
@@ -3631,7 +3632,7 @@ def preview_commit():
     }
 
     try:
-        committed_count = _issue_batch(
+        committed_count, receipt_id = _issue_batch(
             asset_tags,
             holder["id"],
             issue_location_form,
@@ -3878,7 +3879,7 @@ def issue_commit():
     }
 
     try:
-        committed_count = _issue_batch(
+        committed_count, receipt_id = _issue_batch(
             asset_tags,
             holder["id"],
             issue_location_form,
@@ -3895,10 +3896,10 @@ def issue_commit():
     touch_session()
 
     if wants_json():
-        return {"ok": True, "committed": committed_count, "error": None}
+        return {"ok": True, "committed": committed_count, "receipt_id": receipt_id, "error": None}
 
     flash(f"Issued {committed_count} assets.", "success")
-    return redirect(url_for("issue", issued=committed_count))
+    return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
 
 @app.get("/return")
@@ -4025,7 +4026,7 @@ def return_commit():
     }
 
     try:
-        committed_count = _return_batch(
+        committed_count, receipt_id = _return_batch(
             asset_tags,
             responsibility_ack,
             commit_operator_user_id=int(user["id"]),
@@ -4046,7 +4047,7 @@ def return_commit():
     session["recent_return_cases"] = returned_cases
 
     if wants_json():
-        return {"ok": True, "committed": committed_count, "error": None}
+        return {"ok": True, "committed": committed_count, "receipt_id": receipt_id, "error": None}
 
     if committed_count == 1 and len(state["assets"]) == 1:
         returned_asset = state["assets"][0]
@@ -4059,7 +4060,7 @@ def return_commit():
         )
     else:
         flash(f"Returned {committed_count} assets.", "success")
-    return redirect(url_for("return_queue"))
+    return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
 @app.get("/lock")
 @require_login

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -188,8 +188,6 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     )
 
     assert commit_response.status_code == 302
-    assert (commit_response.headers.get("Location") or "").endswith("/issue?issued=2")
-    assert len(intake_app.SCAN_QUEUE) == 0
 
     conn = db.get_connection()
     rows = conn.execute(
@@ -202,7 +200,7 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     ).fetchall()
     receipt_row = conn.execute(
         """
-        SELECT receipt_type, holder_id, source_event_ids_json, snapshot_json, sent_at, last_attempt_at, last_error
+        SELECT id, receipt_type, holder_id, source_event_ids_json, snapshot_json, sent_at, last_attempt_at, last_error
         FROM receipt_queue
         ORDER BY id DESC
         LIMIT 1;
@@ -218,11 +216,13 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     ).fetchall()
     conn.close()
 
+    assert receipt_row is not None
+    assert (commit_response.headers.get("Location") or "").endswith(f"/receipts/{int(receipt_row['id'])}")
+    assert len(intake_app.SCAN_QUEUE) == 0
     assert [(str(row["asset_tag"]), str(row["event_type"]), int(row["holder_id"])) for row in rows] == [
         ("CI-400", "ISSUE", 1),
         ("CI-401", "ISSUE", 1),
     ]
-    assert receipt_row is not None
     assert str(receipt_row["receipt_type"]) == "ISSUE"
     assert int(receipt_row["holder_id"]) == 1
     source_event_ids = json.loads(str(receipt_row["source_event_ids_json"]))

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -196,7 +196,15 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     )
 
     assert commit.status_code == 302
-    assert (commit.headers.get("Location") or "").endswith("/issue?issued=1")
+    conn = db.get_connection()
+    try:
+        receipt_row = conn.execute(
+            "SELECT id FROM receipt_queue ORDER BY id DESC LIMIT 1;"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert receipt_row is not None
+    assert (commit.headers.get("Location") or "").endswith(f"/receipts/{int(receipt_row['id'])}")
     assert len(intake_app.SCAN_QUEUE) == 0
 
     conn = db.get_connection()
@@ -313,6 +321,41 @@ def test_issue_commit_requires_responsibility_acknowledgment(client_with_temp_db
     assert int(event_count["c"]) == 0
     assert receipt_count is not None
     assert int(receipt_count["c"]) == 0
+
+
+def test_issue_commit_json_returns_exact_created_receipt_id(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+    with client_with_temp_db.session_transaction() as sess:
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+    assert scan_response.status_code == 200
+
+    commit = client_with_temp_db.post(
+        "/issue/commit?json=1",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+    )
+
+    assert commit.status_code == 200
+    assert commit.json["ok"] is True
+    assert commit.json["committed"] == 1
+    assert isinstance(commit.json["receipt_id"], int)
+
+    conn = db.get_connection()
+    try:
+        receipt_row = conn.execute(
+            "SELECT id FROM receipt_queue ORDER BY id DESC LIMIT 1;"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert receipt_row is not None
+    assert int(receipt_row["id"]) == int(commit.json["receipt_id"])
 
 
 def test_issue_commit_missing_ack_shows_visible_message_on_issue_preview(client_with_temp_db) -> None:

--- a/tests/test_issue_slot_occupancy_consistency.py
+++ b/tests/test_issue_slot_occupancy_consistency.py
@@ -74,10 +74,11 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
         data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
     )
     assert commit.status_code == 302
-    assert (commit.headers.get("Location") or "").endswith("/issue?issued=1")
-
     conn = db.get_connection()
     try:
+        receipt_row = conn.execute(
+            "SELECT id FROM receipt_queue ORDER BY id DESC LIMIT 1;"
+        ).fetchone()
         occupancy = conn.execute(
             "SELECT 1 FROM slot_occupancy WHERE asset_id = 501 LIMIT 1;"
         ).fetchone()
@@ -86,6 +87,8 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
         ).fetchone()
     finally:
         conn.close()
+    assert receipt_row is not None
+    assert (commit.headers.get("Location") or "").endswith(f"/receipts/{int(receipt_row['id'])}")
 
     assert occupancy is None
     assert asset is not None
@@ -112,8 +115,7 @@ def test_issue_commit_redirect_shows_success_without_holder_warning(client_with_
     )
 
     assert commit_response.status_code == 200
-    assert b"Issued 1 assets." in commit_response.data
     assert b"Select a holder before issuing assets." not in commit_response.data
-    assert b"Status:</strong> Issued 1 asset successfully." in commit_response.data
-    assert b"Queued:</strong> 0 assets" not in commit_response.data
+    assert b"Issue Receipt" in commit_response.data
+    assert b"Internal receipt ID" in commit_response.data
     assert len(intake_app.SCAN_QUEUE) == 0

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -148,6 +148,7 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(success.status_code, 200)
         self.assertTrue(success.json["ok"])
         self.assertEqual(success.json["committed"], 1)
+        self.assertIsInstance(success.json["receipt_id"], int)
         self.assertEqual(success.json["error"], None)
         self.assertEqual(len(intake_app.SCAN_QUEUE), 0)
 
@@ -247,11 +248,9 @@ class ReturnBatchTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Returned MVPLAPTOP02.", response.data)
-        self.assertIn(b"Location: STORAGE.", response.data)
-        self.assertIn(b"Slot: CASE-13 / 6.", response.data)
-        self.assertIn(b"Verify home slots:", response.data)
-        self.assertIn(b'href="/dashboard/cases/CASE-13"', response.data)
+        self.assertIn(b"Return Receipt", response.data)
+        self.assertIn(b"MVPLAPTOP02", response.data)
+        self.assertIn(b"CASE-13 / 6", response.data)
 
         asset_after = self.conn.execute(
             "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
@@ -260,6 +259,26 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIsNotNone(asset_after)
         self.assertEqual(asset_after["location_type"], "STORAGE")
         self.assertIsNone(asset_after["current_holder_id"])
+
+    def test_return_commit_redirects_to_exact_created_receipt(self) -> None:
+        self._insert_slot(31, "CASE-14", 2, None)
+        self._insert_asset("RETURN-REDIRECT", location_type="IN_CUSTODY", holder_id=12, home_slot_id=31)
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-REDIRECT", equipment_type="laptop"))
+
+        response = self.client.post(
+            "/return/commit",
+            data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        receipt_row = self.conn.execute(
+            "SELECT id FROM receipt_queue ORDER BY id DESC LIMIT 1;"
+        ).fetchone()
+        self.assertIsNotNone(receipt_row)
+        self.assertTrue((response.headers.get("Location") or "").endswith(f"/receipts/{int(receipt_row['id'])}"))
 
     def test_multi_asset_return_same_case_shows_one_case_drilldown_link(self) -> None:
         self._insert_slot(40, "CASE-SAME", 1, None)
@@ -278,9 +297,9 @@ class ReturnBatchTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Returned 2 assets.", response.data)
-        self.assertIn(b"Verify home slots:", response.data)
-        self.assertEqual(response.data.count(b'href="/dashboard/cases/CASE-SAME"'), 1)
+        self.assertIn(b"Return Receipt", response.data)
+        self.assertIn(b"SAME-1", response.data)
+        self.assertIn(b"SAME-2", response.data)
 
     def test_multi_asset_return_different_cases_shows_one_link_per_case(self) -> None:
         self._insert_slot(50, "CASE-X", 1, None)
@@ -299,10 +318,9 @@ class ReturnBatchTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Returned 2 assets.", response.data)
-        self.assertIn(b"Verify home slots:", response.data)
-        self.assertEqual(response.data.count(b'href="/dashboard/cases/CASE-X"'), 1)
-        self.assertEqual(response.data.count(b'href="/dashboard/cases/CASE-Y"'), 1)
+        self.assertIn(b"Return Receipt", response.data)
+        self.assertIn(b"DIFF-1", response.data)
+        self.assertIn(b"DIFF-2", response.data)
 
     def test_return_queue_can_remove_one_item_and_preview_only_remaining_items(self) -> None:
         intake_app.SCAN_QUEUE.clear()


### PR DESCRIPTION
## Summary
Route successful Issue and Return commits directly to the exact created receipt so operators do not have to hunt through the Receipts page.

## Related Issue
Closes #397 

## Changes
- carry the exact created receipt id through Issue and Return commit success paths
- redirect successful non-JSON commits directly to receipt detail
- include receipt_id in successful JSON commit responses
- update targeted tests for Issue and Return commit behavior

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed
- [x] Issue commit lands on the created receipt detail page
- [x] Return commit lands on the created receipt detail page
- [x] Receipt remains easy to navigate away from
- [x] No schema or migration changes
- [x] No workflow seam changes before commit

## Notes
- Reuses the exact receipt row already created in the existing commit transaction
- No impact to receipt queue creation, delivery state, or persistence