### PR TITLE
Issue 26-35: send queued receipts and update delivery state

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -16,7 +16,10 @@ import json
 import os
 import re
 import sqlite3
+import smtplib
 import time
+from email.message import EmailMessage
+from email.utils import getaddresses
 from io import BytesIO
 from pathlib import Path
 from typing import Optional
@@ -2344,6 +2347,36 @@ def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) ->
     )
 
 
+def _receipt_row_snapshot(row: sqlite3.Row) -> dict[str, object]:
+    snapshot = json.loads(str(row["snapshot_json"] or "{}"))
+    if not isinstance(snapshot, dict):
+        snapshot = {}
+    return snapshot
+
+
+def _receipt_queue_row_by_id(conn, receipt_id: int) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT
+            id,
+            receipt_key,
+            receipt_type,
+            source_event_ids_json,
+            snapshot_json,
+            commit_at,
+            commit_operator_user_id,
+            holder_id,
+            sent_at,
+            last_attempt_at,
+            last_error
+        FROM receipt_queue
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (int(receipt_id),),
+    ).fetchone()
+
+
 def _receipt_asset_row_snapshot(conn, asset_tag: str) -> Optional[sqlite3.Row]:
     return conn.execute(
         """
@@ -4446,12 +4479,96 @@ def _receipt_display_title(receipt_type: str, holder_name: str, display_date: st
     return f"{_receipt_type_label(receipt_type)} — {holder_name or 'Unknown Holder'} — {display_date or 'Unknown Date'}"
 
 
+def _receipt_email_recipients(receipt: dict[str, object]) -> list[str]:
+    contact_values: list[str] = []
+
+    def _append_contact(snapshot: object) -> None:
+        if not isinstance(snapshot, dict):
+            return
+        contact_info = str(snapshot.get("contact_info") or "").strip()
+        if contact_info:
+            contact_values.append(contact_info)
+
+    _append_contact(receipt.get("holder_snapshot"))
+    for asset in receipt.get("assets", []):
+        if not isinstance(asset, dict):
+            continue
+        _append_contact(asset.get("holder_snapshot"))
+        _append_contact(asset.get("from_holder_snapshot"))
+
+    recipients: list[str] = []
+    for _, email_address in getaddresses(contact_values):
+        normalized = str(email_address or "").strip()
+        if normalized and "@" in normalized and normalized not in recipients:
+            recipients.append(normalized)
+
+    return recipients
+
+
 def _receipt_pdf_download_name(receipt: dict[str, object]) -> str:
     title = str(receipt.get("display_title") or "").strip() or "Receipt"
     sanitized = title.replace(" — ", " - ")
     sanitized = re.sub(r'[<>:"/\\|?*]', " ", sanitized)
     sanitized = re.sub(r"\s+", " ", sanitized).strip().rstrip(". ")
     return f"{sanitized or 'Receipt'}.pdf"
+
+
+def _build_receipt_email_body(receipt: dict[str, object]) -> str:
+    asset_tags: list[str] = []
+    for asset in receipt.get("assets", []):
+        if not isinstance(asset, dict):
+            continue
+        asset_tag = str(asset.get("asset_tag") or "").strip()
+        if asset_tag:
+            asset_tags.append(asset_tag)
+
+    asset_lines = "\n".join(f"- {asset_tag}" for asset_tag in asset_tags) or "- None recorded"
+    return (
+        f"{receipt.get('display_title')}\n\n"
+        f"Receipt key: {receipt.get('receipt_key')}\n"
+        f"Committed at: {receipt.get('commit_at')}\n"
+        f"Holder: {receipt.get('holder_display_name')}\n"
+        f"Assets:\n{asset_lines}\n"
+    )
+
+
+def _send_receipt_email(receipt: dict[str, object]) -> list[str]:
+    recipients = _receipt_email_recipients(receipt)
+    if not recipients:
+        raise ValueError("Receipt has no stored email recipient.")
+
+    smtp_host = str(os.getenv("ASSETTRACK_SMTP_HOST") or "").strip()
+    if not smtp_host:
+        raise ValueError("Receipt email delivery is not configured.")
+
+    smtp_port = int(str(os.getenv("ASSETTRACK_SMTP_PORT") or "25").strip() or "25")
+    smtp_username = str(os.getenv("ASSETTRACK_SMTP_USERNAME") or "").strip()
+    smtp_password = str(os.getenv("ASSETTRACK_SMTP_PASSWORD") or "")
+    smtp_starttls = str(os.getenv("ASSETTRACK_SMTP_STARTTLS") or "").strip().lower() in {"1", "true", "yes", "on"}
+    smtp_use_ssl = str(os.getenv("ASSETTRACK_SMTP_USE_SSL") or "").strip().lower() in {"1", "true", "yes", "on"}
+    from_address = str(os.getenv("ASSETTRACK_RECEIPT_FROM_EMAIL") or "assettrack@local").strip() or "assettrack@local"
+
+    message = EmailMessage()
+    message["Subject"] = str(receipt.get("display_title") or "AssetTrack Receipt")
+    message["From"] = from_address
+    message["To"] = ", ".join(recipients)
+    message.set_content(_build_receipt_email_body(receipt))
+    message.add_attachment(
+        _build_receipt_pdf(receipt),
+        maintype="application",
+        subtype="pdf",
+        filename=_receipt_pdf_download_name(receipt),
+    )
+
+    smtp_cls = smtplib.SMTP_SSL if smtp_use_ssl else smtplib.SMTP
+    with smtp_cls(smtp_host, smtp_port, timeout=10) as smtp:
+        if smtp_starttls and not smtp_use_ssl:
+            smtp.starttls()
+        if smtp_username:
+            smtp.login(smtp_username, smtp_password)
+        smtp.send_message(message)
+
+    return recipients
 
 
 def _receipt_pdf_ack_name(receipt: dict[str, object]) -> str:
@@ -4657,6 +4774,89 @@ def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
     )
 
 
+def _update_receipt_delivery_state(
+    conn,
+    *,
+    receipt_id: int,
+    snapshot: dict[str, object],
+    state: str,
+    last_attempt_at: Optional[str],
+    sent_at: Optional[str],
+    last_error: Optional[str],
+) -> None:
+    updated_snapshot = dict(snapshot)
+    updated_snapshot["delivery"] = _receipt_delivery_snapshot(
+        state=state,
+        sent_at=sent_at,
+        last_attempt_at=last_attempt_at,
+        last_error=last_error,
+    )
+    conn.execute(
+        """
+        UPDATE receipt_queue
+        SET snapshot_json = ?, sent_at = ?, last_attempt_at = ?, last_error = ?
+        WHERE id = ?;
+        """,
+        (
+            json.dumps(updated_snapshot, sort_keys=True),
+            sent_at,
+            last_attempt_at,
+            last_error,
+            int(receipt_id),
+        ),
+    )
+
+
+def _send_queued_receipt(receipt_id: int) -> dict[str, object]:
+    conn = get_connection()
+    try:
+        row = _receipt_queue_row_by_id(conn, receipt_id)
+        if row is None:
+            raise ValueError("Receipt not found.")
+
+        snapshot = _receipt_row_snapshot(row)
+        delivery = _receipt_delivery_from_row(row, snapshot)
+        if delivery.get("state") != "pending":
+            raise ValueError("Receipt is not queued for email.")
+
+        receipt = _receipt_from_queue_row(row)
+        attempt_at = datetime.now(timezone.utc).isoformat()
+
+        try:
+            recipients = _send_receipt_email(receipt)
+        except Exception as exc:
+            with conn:
+                _update_receipt_delivery_state(
+                    conn,
+                    receipt_id=int(row["id"]),
+                    snapshot=snapshot,
+                    state="failed",
+                    last_attempt_at=attempt_at,
+                    sent_at=None,
+                    last_error=str(exc),
+                )
+            raise
+
+        with conn:
+            _update_receipt_delivery_state(
+                conn,
+                receipt_id=int(row["id"]),
+                snapshot=snapshot,
+                state="sent",
+                last_attempt_at=attempt_at,
+                sent_at=attempt_at,
+                last_error=None,
+            )
+
+        return {
+            "receipt_id": int(row["id"]),
+            "recipients": recipients,
+            "sent_at": attempt_at,
+        }
+    finally:
+        conn.close()
+
+
 @app.get("/receipts")
 @require_login
 def receipts_list():
@@ -4763,6 +4963,41 @@ def receipts_list():
             "building_room": building_room,
         },
     )
+
+
+@app.post("/receipts/<int:receipt_id>/send")
+@require_login
+def receipt_send(receipt_id: int):
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        if wants_json():
+            return {"ok": False, "error": "Locked"}, 401
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    try:
+        result = _send_queued_receipt(receipt_id)
+    except ValueError as exc:
+        if wants_json():
+            return {"ok": False, "error": str(exc)}, 400
+        flash(str(exc), "error")
+        return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+    except Exception as exc:
+        if wants_json():
+            return {"ok": False, "error": str(exc)}, 500
+        flash(f"Receipt email failed: {exc}", "error")
+        return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+
+    if wants_json():
+        return {
+            "ok": True,
+            "receipt_id": result["receipt_id"],
+            "recipients": result["recipients"],
+            "sent_at": result["sent_at"],
+        }
+
+    flash(f"Receipt email sent to {', '.join(result['recipients'])}.", "success")
+    return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
 
 @app.get("/receipts/<int:receipt_id>/pdf")

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -89,6 +89,11 @@
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="chip" href="{{ url_for('human_report') }}">Open Current Status Report</a>
     <a class="chip" href="{{ url_for('receipt_pdf', receipt_id=receipt.id) }}">Download Receipt PDF</a>
+    {% if receipt.delivery.state == "pending" %}
+      <form method="post" action="{{ url_for('receipt_send', receipt_id=receipt.id) }}">
+        <button type="submit">Send Receipt Email</button>
+      </form>
+    {% endif %}
   </nav>
 
   <section class="card">

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -27,6 +27,7 @@ def _insert_holder(
     identifier: str,
     organization: str = "",
     organization_id: int | None = None,
+    contact_info: str = "",
 ) -> None:
     conn = db.get_connection()
     try:
@@ -43,9 +44,9 @@ def _insert_holder(
             INSERT INTO holders (
                 id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
             )
-            VALUES (?, 'PERSON', ?, ?, ?, ?, '', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            VALUES (?, 'PERSON', ?, ?, ?, ?, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
             """,
-            (holder_id, name, organization, organization_id, identifier),
+            (holder_id, name, organization, organization_id, identifier, contact_info),
         )
         conn.commit()
     finally:
@@ -594,6 +595,187 @@ def test_return_receipt_pdf_download_uses_human_readable_filename(client_with_te
     disposition = response.headers.get("Content-Disposition") or ""
     assert "attachment;" in disposition
     assert "Return Receipt - Return Holder One - Mar 29, 2026.pdf" in disposition
+
+
+def test_receipt_send_success_updates_delivery_state(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_holder(
+        1,
+        name="Issue Holder",
+        identifier="IH-1",
+        organization="Operations",
+        organization_id=9,
+        contact_info="issue@example.org",
+    )
+    _insert_slot(10, "CASE-10", 1)
+    _insert_asset(100, "ISSUE-100", location_type="STORAGE", home_slot_id=10, building_room="Storage/A1")
+    _occupy_slot(10, 100)
+    _login_issue_operator(client_with_temp_db)
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="ISSUE-100", equipment_type="laptop"))
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+    assert commit.status_code == 302
+    receipt_id = _latest_receipt_id()
+
+    sent_receipts: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        sent_receipts.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 200
+    assert response.json["ok"] is True
+    assert int(response.json["receipt_id"]) == receipt_id
+    assert response.json["recipients"] == ["issue@example.org"]
+    assert sent_receipts == [receipt_id]
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT sent_at, last_attempt_at, last_error FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["sent_at"] is not None
+    assert row["last_attempt_at"] is not None
+    assert row["last_error"] is None
+
+
+def test_receipt_send_failure_updates_delivery_state(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_holder(
+        1,
+        name="Issue Holder",
+        identifier="IH-1",
+        organization="Operations",
+        organization_id=9,
+        contact_info="issue@example.org",
+    )
+    _insert_slot(10, "CASE-10", 1)
+    _insert_asset(100, "ISSUE-100", location_type="STORAGE", home_slot_id=10, building_room="Storage/A1")
+    _occupy_slot(10, 100)
+    _login_issue_operator(client_with_temp_db)
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="ISSUE-100", equipment_type="laptop"))
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+    assert commit.status_code == 302
+    receipt_id = _latest_receipt_id()
+
+    def _fake_send(_receipt: dict[str, object]) -> list[str]:
+        raise RuntimeError("smtp offline")
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 500
+    assert response.json == {"ok": False, "error": "smtp offline"}
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT sent_at, last_attempt_at, last_error FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    assert row["sent_at"] is None
+    assert row["last_attempt_at"] is not None
+    assert row["last_error"] == "smtp offline"
+
+
+def test_receipt_send_rejects_historical_nonqueued_receipt(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot.pop("delivery", None)
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = NULL, last_attempt_at = NULL, last_error = NULL
+            WHERE id = ?;
+            """,
+            (json.dumps(snapshot, sort_keys=True), receipt_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 400
+    assert response.json == {"ok": False, "error": "Receipt is not queued for email."}
+    assert send_calls == []
+
+
+def test_receipt_send_does_not_resend_after_success(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_holder(
+        1,
+        name="Issue Holder",
+        identifier="IH-1",
+        organization="Operations",
+        organization_id=9,
+        contact_info="issue@example.org",
+    )
+    _insert_slot(10, "CASE-10", 1)
+    _insert_asset(100, "ISSUE-100", location_type="STORAGE", home_slot_id=10, building_room="Storage/A1")
+    _occupy_slot(10, 100)
+    _login_issue_operator(client_with_temp_db)
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="ISSUE-100", equipment_type="laptop"))
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+    assert commit.status_code == 302
+    receipt_id = _latest_receipt_id()
+
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    first = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+    second = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert first.status_code == 200
+    assert second.status_code == 400
+    assert second.json == {"ok": False, "error": "Receipt is not queued for email."}
+    assert send_calls == [receipt_id]
 
 
 def test_receipt_pdf_is_deterministic_for_same_snapshot(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Add an exact-row queued receipt send path from receipt detail and update delivery state deterministically to sent or failed.

## Related Issue
Closes #354 

## Changes
- add receipt-detail send action for eligible queued receipts
- send using stored receipt snapshot data only
- reuse generated receipt PDF as attachment
- update delivery state to sent on success
- update delivery state to failed with error details on failure
- reject historical non-queued receipts and prevent resend of sent receipts

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed for queued receipt eligibility
- [x] Failed send updates state to failed
- [x] Failure reason is shown clearly
- [x] Historical non-queued receipts are rejected
- [x] Sent receipts are not resent
- [x] No schema or migration changes
- [x] No workflow seam changes

## Notes
- This issue implements the send path and deterministic delivery-state transitions
- Normal successful sending depends on stored recipient data being available in the receipt snapshot
- Follow-on work is tracked separately in Issue 26-56