### PR TITLE
Issue 26-56: add holder email and snapshot receipt recipient email

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -405,6 +405,7 @@ def _create_schema(conn: sqlite3.Connection):
             organization TEXT NULL,
             organization_id INTEGER NULL REFERENCES organizations(id),
             identifier TEXT NULL,
+            email TEXT NULL,
             contact_info TEXT NULL,
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
@@ -494,6 +495,13 @@ def _create_schema(conn: sqlite3.Connection):
             """
             ALTER TABLE holders
             ADD COLUMN organization_id INTEGER NULL REFERENCES organizations(id);
+            """
+        )
+    if _table_exists(conn, "holders") and not _column_exists(conn, "holders", "email"):
+        cursor.execute(
+            """
+            ALTER TABLE holders
+            ADD COLUMN email TEXT NULL;
             """
         )
 

--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -1,10 +1,22 @@
 # file: assettrack/holders.py
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 
 from assettrack.db import DEFAULT_AD_HOC_ORGANIZATION, get_connection
 from assettrack.reference_data import get_organization
+
+EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _normalize_email(email: str | None) -> str | None:
+    normalized = str(email or "").strip().lower()
+    if not normalized:
+        return None
+    if len(normalized) > 254 or not EMAIL_PATTERN.match(normalized):
+        raise ValueError("email is invalid")
+    return normalized
 
 
 def search_holders(query: str, limit: int = 20) -> list[dict]:
@@ -45,12 +57,13 @@ def list_holders() -> list[dict]:
                 h.name,
                 h.organization,
                 h.identifier,
+                h.email,
                 h.contact_info,
                 COUNT(a.id) AS asset_count
             FROM holders h
             LEFT JOIN assets a
               ON a.current_holder_id = h.id
-            GROUP BY h.id, h.holder_type, h.name, h.organization, h.identifier, h.contact_info
+            GROUP BY h.id, h.holder_type, h.name, h.organization, h.identifier, h.email, h.contact_info
             ORDER BY h.name COLLATE NOCASE ASC, h.id ASC;
             """
         ).fetchall()
@@ -88,6 +101,7 @@ def create_holder(
     *,
     holder_type: str = "PERSON",
     organization_id: int,
+    email: str | None = None,
     identifier: str | None = None,
     contact_info: str | None = None,
 ) -> dict:
@@ -105,14 +119,17 @@ def create_holder(
         raise ValueError("name is required")
     normalized_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else holder_type
     persisted_name = normalized_name or normalized_organization
+    normalized_email = _normalize_email(email)
 
     now_iso = datetime.now(timezone.utc).isoformat()
     conn = get_connection()
     try:
         cursor = conn.execute(
             """
-            INSERT INTO holders (holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+            INSERT INTO holders (
+                holder_type, name, organization, organization_id, identifier, email, contact_info, created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
             (
                 normalized_holder_type,
@@ -120,6 +137,7 @@ def create_holder(
                 normalized_organization,
                 normalized_organization_id,
                 identifier,
+                normalized_email,
                 contact_info,
                 now_iso,
                 now_iso,
@@ -144,6 +162,7 @@ def update_holder(
     *,
     name: str,
     organization_id: int,
+    email: str | None = None,
 ) -> dict:
     try:
         normalized_id = int(holder_id)
@@ -164,6 +183,7 @@ def update_holder(
         raise ValueError("name is required")
     persisted_name = normalized_name or normalized_organization
     persisted_holder_type = "ORGANIZATION" if not normalized_name and normalized_organization else "PERSON"
+    normalized_email = _normalize_email(email)
     now_iso = datetime.now(timezone.utc).isoformat()
 
     conn = get_connection()
@@ -171,7 +191,7 @@ def update_holder(
         cursor = conn.execute(
             """
             UPDATE holders
-            SET holder_type = ?, name = ?, organization = ?, organization_id = ?, updated_at = ?
+            SET holder_type = ?, name = ?, organization = ?, organization_id = ?, email = ?, updated_at = ?
             WHERE id = ?;
             """,
             (
@@ -179,6 +199,7 @@ def update_holder(
                 persisted_name,
                 normalized_organization,
                 normalized_organization_id,
+                normalized_email,
                 now_iso,
                 normalized_id,
             ),

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -638,6 +638,8 @@ def _holder_form_error_message(exc: ValueError) -> str:
         return "Choose an organization for this holder."
     if message == "name is required":
         return "Enter a person or group name when using Ad Hoc."
+    if message == "email is invalid":
+        return "Enter a valid email address or leave it blank."
     return message
 
 
@@ -2231,7 +2233,7 @@ def _receipt_holder_snapshot(conn, holder_id: Optional[int]) -> Optional[dict]:
 
     row = conn.execute(
         """
-        SELECT id, holder_type, name, organization, organization_id, identifier, contact_info
+        SELECT id, holder_type, name, organization, organization_id, identifier, email, contact_info
         FROM holders
         WHERE id = ?
         LIMIT 1;
@@ -2248,8 +2250,15 @@ def _receipt_holder_snapshot(conn, holder_id: Optional[int]) -> Optional[dict]:
         "organization": str(row["organization"] or ""),
         "organization_id": None if row["organization_id"] is None else int(row["organization_id"]),
         "identifier": str(row["identifier"] or ""),
+        "email": str(row["email"] or ""),
         "contact_info": str(row["contact_info"] or ""),
     }
+
+
+def _receipt_recipient_email(holder_snapshot: object) -> str:
+    if not isinstance(holder_snapshot, dict):
+        return ""
+    return str(holder_snapshot.get("email") or "").strip().lower()
 
 
 def _receipt_operator_snapshot(conn, user_id: int) -> Optional[dict]:
@@ -2486,6 +2495,7 @@ def _build_receipt_snapshot_from_stored_facts(
             "commit_operator": commit_operator_snapshot,
             "holder_id": batch_holder_id,
             "holder_snapshot": batch_holder_snapshot,
+            "recipient_email": _receipt_recipient_email(batch_holder_snapshot),
             "organization_snapshot": None if batch_holder_snapshot is None else {
                 "organization": str(batch_holder_snapshot.get("organization") or ""),
                 "organization_id": batch_holder_snapshot.get("organization_id"),
@@ -2562,6 +2572,7 @@ def _build_receipt_snapshot_from_stored_facts(
         "commit_operator": commit_operator_snapshot,
         "holder_id": batch_holder_id,
         "holder_snapshot": batch_holder_snapshot,
+        "recipient_email": _receipt_recipient_email(batch_holder_snapshot),
         "organization_snapshot": None if batch_holder_snapshot is None else {
             "organization": str(batch_holder_snapshot.get("organization") or ""),
             "organization_id": batch_holder_snapshot.get("organization_id"),
@@ -4258,6 +4269,7 @@ def _receipt_from_queue_row(row: sqlite3.Row) -> dict[str, object]:
         "commit_operator": snapshot.get("commit_operator") if isinstance(snapshot.get("commit_operator"), dict) else None,
         "holder_id": snapshot.get("holder_id") if snapshot.get("holder_id") is not None else row["holder_id"],
         "holder_snapshot": holder_snapshot,
+        "recipient_email": str(snapshot.get("recipient_email") or "").strip().lower(),
         "organization_snapshot": (
             snapshot.get("organization_snapshot") if isinstance(snapshot.get("organization_snapshot"), dict) else None
         ),
@@ -4480,26 +4492,14 @@ def _receipt_display_title(receipt_type: str, holder_name: str, display_date: st
 
 
 def _receipt_email_recipients(receipt: dict[str, object]) -> list[str]:
-    contact_values: list[str] = []
-
-    def _append_contact(snapshot: object) -> None:
-        if not isinstance(snapshot, dict):
-            return
-        contact_info = str(snapshot.get("contact_info") or "").strip()
-        if contact_info:
-            contact_values.append(contact_info)
-
-    _append_contact(receipt.get("holder_snapshot"))
-    for asset in receipt.get("assets", []):
-        if not isinstance(asset, dict):
-            continue
-        _append_contact(asset.get("holder_snapshot"))
-        _append_contact(asset.get("from_holder_snapshot"))
+    recipient_email = str(receipt.get("recipient_email") or "").strip().lower()
+    if not recipient_email:
+        return []
 
     recipients: list[str] = []
-    for _, email_address in getaddresses(contact_values):
-        normalized = str(email_address or "").strip()
-        if normalized and "@" in normalized and normalized not in recipients:
+    for _, email_address in getaddresses([recipient_email]):
+        normalized = str(email_address or "").strip().lower()
+        if normalized and normalized not in recipients:
             recipients.append(normalized)
 
     return recipients
@@ -5059,7 +5059,7 @@ def holders_new():
     return_to = _safe_local_return_to(request.args.get("return_to") or "")
     form = session.pop("holder_new_form", None)
     if not isinstance(form, dict):
-        form = {"name": "", "organization_id": ""}
+        form = {"name": "", "organization_id": "", "email": ""}
 
     return render_template(
         "holder_new.html",
@@ -5080,12 +5080,14 @@ def holders_create():
     return_to = _safe_local_return_to(request.form.get("return_to") or "")
     name = (request.form.get("name") or "").strip()
     organization_id_raw = (request.form.get("organization_id") or "").strip()
-    form = {"name": name, "organization_id": organization_id_raw}
+    email = (request.form.get("email") or "").strip()
+    form = {"name": name, "organization_id": organization_id_raw, "email": email}
 
     try:
         created = create_holder(
             name,
             organization_id=None if not organization_id_raw else int(organization_id_raw),
+            email=email,
         )
     except ValueError as e:
         session["holder_new_form"] = form
@@ -5118,6 +5120,7 @@ def holders_edit(holder_id: int):
         form = {
             "name": str(holder.get("name") or ""),
             "organization_id": "" if holder.get("organization_id") is None else str(holder.get("organization_id")),
+            "email": str(holder.get("email") or ""),
         }
 
     return render_template(
@@ -5141,6 +5144,7 @@ def holders_edit_submit(holder_id: int):
     form = {
         "name": (request.form.get("name") or "").strip(),
         "organization_id": (request.form.get("organization_id") or "").strip(),
+        "email": (request.form.get("email") or "").strip(),
     }
 
     holder = get_holder(holder_id)
@@ -5152,6 +5156,7 @@ def holders_edit_submit(holder_id: int):
             holder_id,
             name=form["name"],
             organization_id=None if not form["organization_id"] else int(form["organization_id"]),
+            email=form["email"],
         )
     except ValueError as e:
         session[f"holder_edit_form:{holder_id}"] = form

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -35,6 +35,7 @@
       <strong>Person or group:</strong> {{ holder_display_name(holder) }}<br />
       <strong>Organization:</strong> {{ holder.organization or "" }}<br />
       <strong>Identifier:</strong> {{ holder.identifier or "" }}<br />
+      <strong>Email:</strong> {{ holder.email or "" }}<br />
       <strong>Contact information:</strong> {{ holder.contact_info or "" }}
     </p>
   </section>

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -41,6 +41,10 @@
           {% endfor %}
         </select>
       </div>
+      <div class="row">
+        <label for="email"><strong>Email</strong> (optional)</label><br />
+        <input type="text" id="email" name="email" value="{{ form.email or '' }}" inputmode="email" autocomplete="email" />
+      </div>
       <button type="submit">Save Holder</button>
     </form>
   </div>

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -41,6 +41,10 @@
           {% endfor %}
         </select>
       </div>
+      <div class="row">
+        <label for="email"><strong>Email</strong> (optional)</label><br />
+        <input type="text" id="email" name="email" value="{{ form.email or '' }}" inputmode="email" autocomplete="email" />
+      </div>
       <button type="submit">Create Holder</button>
     </form>
   </div>

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -60,7 +60,8 @@
         <strong>Type:</strong> {{ holder_display_type(selected_holder) }}<br />
         <strong>Person or group:</strong> {{ holder_display_name(selected_holder) }}<br />
         <strong>Organization:</strong> {{ selected_holder["organization"] or "" }}<br />
-        <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}
+        <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}<br />
+        <strong>Email:</strong> {{ selected_holder["email"] or "" }}
       </p>
       <form method="post" action="{{ url_for('holders_clear') }}">
         <button type="submit">Clear selection</button>
@@ -80,6 +81,7 @@
             <th style="width: 220px;">Name</th>
             <th style="width: 200px;">Organization</th>
             <th style="width: 180px;">Identifier</th>
+            <th style="width: 220px;">Email</th>
             <th>Contact</th>
             <th style="width: 100px;">Assets</th>
             <th style="width: 120px;">Edit</th>
@@ -99,6 +101,7 @@
               </td>
               <td>{{ h["organization"] or "" }}</td>
               <td><code>{{ h["identifier"] or "" }}</code></td>
+              <td>{{ h["email"] or "" }}</td>
               <td>{{ h["contact_info"] or "" }}</td>
               <td>{{ h.get("asset_count", "") }}</td>
               <td>

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -125,6 +125,10 @@
             </div>
           </div>
         {% endif %}
+        <div class="summary-value">
+          <div class="summary-label">Recipient email</div>
+          <div class="summary-copy">{{ receipt.recipient_email or "Not captured" }}</div>
+        </div>
         {% if receipt.delivery.last_attempt_at %}
           <div class="summary-value">
             <div class="summary-label">Last delivery attempt</div>

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -58,6 +58,7 @@ def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> N
 
     assert "organization" in columns
     assert "organization_id" in columns
+    assert "email" in columns
     assert "organizations" in tables
     assert "buildings" in tables
     assert "organization_buildings" in tables
@@ -212,6 +213,61 @@ def test_initialize_schema_creates_ad_hoc_and_backfills_null_holder_organization
     assert holder is not None
     assert holder[0] == "Ad Hoc"
     assert holder[1] == ad_hoc[0]
+
+
+def test_initialize_schema_adds_holder_email_column_to_existing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                organization_id INTEGER NULL,
+                identifier TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(holders);").fetchall()}
+    finally:
+        conn.close()
+
+    assert "email" in columns
 
 
 def test_initialize_if_missing_or_empty_does_not_mask_invalid_nonempty_db(tmp_path: Path) -> None:

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -57,18 +57,19 @@ class HolderCreationViabilityTests(unittest.TestCase):
         org_id = self._create_org("Alpha Org")
         response = self.client.post(
             "/holders/new",
-            data={"name": holder_name, "organization_id": str(org_id)},
+            data={"name": holder_name, "organization_id": str(org_id), "email": "holder@example.org"},
         )
         self.assertEqual(response.status_code, 302)
         self.assertTrue(response.headers["Location"].endswith("/holders"))
 
         row = self.conn.execute(
-            "SELECT id, name, organization, organization_id FROM holders WHERE name = ?;",
+            "SELECT id, name, organization, organization_id, email FROM holders WHERE name = ?;",
             (holder_name,),
         ).fetchone()
         self.assertIsNotNone(row)
         self.assertEqual(row["organization"], "Alpha Org")
         self.assertEqual(int(row["organization_id"]), org_id)
+        self.assertEqual(row["email"], "holder@example.org")
 
     def test_post_holders_new_rejects_missing_organization(self) -> None:
         response = self.client.post(
@@ -176,18 +177,19 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
         edit_post = self.client.post(
             f"/holders/edit/{int(holder_row['id'])}",
-            data={"name": "Editable Holder", "organization_id": str(org_two_id)},
+            data={"name": "Editable Holder", "organization_id": str(org_two_id), "email": "updated@example.org"},
             follow_redirects=True,
         )
         self.assertEqual(edit_post.status_code, 200)
         self.assertIn(b"Updated holder: Editable Holder", edit_post.data)
 
         updated = self.conn.execute(
-            "SELECT organization, organization_id FROM holders WHERE id = ?;",
+            "SELECT organization, organization_id, email FROM holders WHERE id = ?;",
             (int(holder_row["id"]),),
         ).fetchone()
         self.assertEqual(updated["organization"], "Org Two")
         self.assertEqual(int(updated["organization_id"]), org_two_id)
+        self.assertEqual(updated["email"], "updated@example.org")
 
     def test_edit_holder_rejects_missing_organization(self) -> None:
         org_id = self._create_org("Org One")
@@ -317,9 +319,50 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Holder: Detail Holder", response.data)
         self.assertIn(b"Organization:</strong> Org Detail", response.data)
+        self.assertIn(b"Email:</strong>", response.data)
         self.assertIn(b"Assigned Assets (1)", response.data)
         self.assertIn(b"DETAIL-ASSET-1", response.data)
         self.assertIn(f'href="/holders/edit/{holder_id}"'.encode("utf-8"), response.data)
+
+    def test_post_holders_new_rejects_invalid_email_with_clear_feedback(self) -> None:
+        org_id = self._create_org("Alpha Org")
+
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "Invalid Email Holder", "organization_id": str(org_id), "email": "bad-email"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/holders/new"))
+
+        follow_up = self.client.get("/holders/new")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"Enter a valid email address or leave it blank.", follow_up.data)
+        self.assertIn(b'value="bad-email"', follow_up.data)
+
+    def test_edit_holder_rejects_invalid_email_with_clear_feedback(self) -> None:
+        org_id = self._create_org("Alpha Org")
+        self.client.post("/holders/new", data={"name": "Editable Holder", "organization_id": str(org_id)})
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Editable Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        response = self.client.post(
+            f"/holders/edit/{int(holder_row['id'])}",
+            data={"name": "Editable Holder", "organization_id": str(org_id), "email": "bad-email"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith(f"/holders/edit/{int(holder_row['id'])}"))
+
+        follow_up = self.client.get(f"/holders/edit/{int(holder_row['id'])}")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"Enter a valid email address or leave it blank.", follow_up.data)
+        self.assertIn(b'value="bad-email"', follow_up.data)
 
     def test_holder_detail_shows_zero_assets_state(self) -> None:
         organization_id = self._create_org("Ad Hoc")

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -73,6 +73,7 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual(holder["name"], "Jane Doe")
         self.assertEqual(holder["identifier"], "ID-123")
         self.assertEqual(holder["organization"], "Ad Hoc")
+        self.assertIsNone(holder["email"])
 
     def test_search_holders_by_name_and_identifier(self) -> None:
         ad_hoc_id = self._insert_organization("Ad Hoc")
@@ -115,15 +116,23 @@ class HoldersTests(unittest.TestCase):
     def test_create_and_update_holder_organization(self) -> None:
         alpha_org_id = self._insert_organization("Alpha Org")
         bravo_org_id = self._insert_organization("Bravo Org")
-        created = create_holder("Org Holder", organization_id=alpha_org_id)
+        created = create_holder("Org Holder", organization_id=alpha_org_id, email="first@example.org")
         self.assertEqual(created["organization"], "Alpha Org")
+        self.assertEqual(created["email"], "first@example.org")
 
-        updated = update_holder(int(created["id"]), name="Org Holder", organization_id=bravo_org_id)
+        updated = update_holder(
+            int(created["id"]),
+            name="Org Holder",
+            organization_id=bravo_org_id,
+            email="second@example.org",
+        )
         self.assertEqual(updated["organization"], "Bravo Org")
+        self.assertEqual(updated["email"], "second@example.org")
 
         fetched = get_holder(int(created["id"]))
         self.assertIsNotNone(fetched)
         self.assertEqual(fetched["organization"], "Bravo Org")
+        self.assertEqual(fetched["email"], "second@example.org")
 
     def test_create_holder_with_organization_id_sets_denormalized_text(self) -> None:
         organization_id = self._insert_organization("Support Org")
@@ -149,3 +158,17 @@ class HoldersTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "name is required"):
             create_holder("", organization_id=ad_hoc_id)
+
+    def test_create_holder_rejects_invalid_email(self) -> None:
+        organization_id = self._insert_organization("Support Org")
+
+        with self.assertRaisesRegex(ValueError, "email is invalid"):
+            create_holder("Bad Email", organization_id=organization_id, email="not-an-email")
+
+    def test_update_holder_allows_clearing_email(self) -> None:
+        organization_id = self._insert_organization("Support Org")
+        created = create_holder("Email Holder", organization_id=organization_id, email="holder@example.org")
+
+        updated = update_holder(int(created["id"]), name="Email Holder", organization_id=organization_id, email="")
+
+        self.assertIsNone(updated["email"])

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -17,8 +17,8 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     conn = db.get_connection()
     conn.execute(
         """
-        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
-        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        INSERT INTO holders (id, holder_type, name, identifier, email, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Issue Holder', 'IH-1', 'issue@example.org', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
         """
     )
     conn.commit()
@@ -230,7 +230,10 @@ def test_issue_commit_after_case_scan_writes_one_event_per_asset(client_with_tem
     receipt_snapshot = json.loads(str(receipt_row["snapshot_json"]))
     assert receipt_snapshot["source_event_ids"] == source_event_ids
     assert receipt_snapshot["delivery"]["state"] == "pending"
+    assert receipt_snapshot["recipient_email"] == "issue@example.org"
+    assert receipt_snapshot["holder_snapshot"]["email"] == "issue@example.org"
     assert len(receipt_snapshot["assets"]) == 2
+    assert receipt_snapshot["assets"][0]["holder_snapshot"]["email"] == "issue@example.org"
     assert receipt_row["sent_at"] is None
     assert receipt_row["last_attempt_at"] is None
     assert receipt_row["last_error"] is None

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -27,6 +27,7 @@ def _insert_holder(
     identifier: str,
     organization: str = "",
     organization_id: int | None = None,
+    email: str = "",
     contact_info: str = "",
 ) -> None:
     conn = db.get_connection()
@@ -42,11 +43,11 @@ def _insert_holder(
         conn.execute(
             """
             INSERT INTO holders (
-                id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+                id, holder_type, name, organization, organization_id, identifier, email, contact_info, created_at, updated_at
             )
-            VALUES (?, 'PERSON', ?, ?, ?, ?, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            VALUES (?, 'PERSON', ?, ?, ?, ?, ?, ?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
             """,
-            (holder_id, name, organization, organization_id, identifier, contact_info),
+            (holder_id, name, organization, organization_id, identifier, email, contact_info),
         )
         conn.commit()
     finally:
@@ -169,7 +170,14 @@ def _extract_pdf_text(pdf_bytes: bytes) -> str:
 
 
 def _create_issue_receipt(client) -> int:
-    _insert_holder(1, name="Issue Holder", identifier="IH-1", organization="Operations", organization_id=9)
+    _insert_holder(
+        1,
+        name="Issue Holder",
+        identifier="IH-1",
+        organization="Operations",
+        organization_id=9,
+        email="issue@example.org",
+    )
     _insert_slot(10, "CASE-10", 1)
     _insert_asset(
         100,
@@ -200,8 +208,8 @@ def _create_issue_receipt(client) -> int:
 
 
 def _create_return_receipt(client, *, mixed_holders: bool = False) -> int:
-    _insert_holder(7, name="Return Holder One", identifier="RH-7")
-    _insert_holder(8, name="Return Holder Two", identifier="RH-8")
+    _insert_holder(7, name="Return Holder One", identifier="RH-7", email="return.one@example.org")
+    _insert_holder(8, name="Return Holder Two", identifier="RH-8", email="return.two@example.org")
     _insert_slot(20, "CASE-20", 1)
     _insert_slot(21, "CASE-20", 2)
     _insert_asset(
@@ -265,6 +273,7 @@ def test_issue_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None
     assert b"issue-operator" in response.data
     assert b"Receipt holder" in response.data
     assert b"Issue Holder" in response.data
+    assert b"issue@example.org" in response.data
     assert b"Issue Location" in response.data
     assert b"HQ North" in response.data
     assert b"210" in response.data
@@ -286,6 +295,7 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     assert b"Return Receipt \xe2\x80\x94 Return Holder One \xe2\x80\x94 Mar 29, 2026" in response.data
     assert b"RETURN:" in response.data
     assert b"Return Holder One" in response.data
+    assert b"return.one@example.org" in response.data
     assert b"RETURN-200" in response.data
     assert b"Apple" in response.data
     assert b"iPad" in response.data
@@ -560,6 +570,53 @@ def test_receipt_detail_uses_stable_holder_fallback_when_snapshot_name_is_missin
     assert b"Issue Receipt \xe2\x80\x94 Holder 1 \xe2\x80\x94 Mar 29, 2026" in response.data
 
 
+def test_issue_receipt_snapshot_stores_holder_email(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    snapshot = json.loads(str(row["snapshot_json"]))
+    assert snapshot["recipient_email"] == "issue@example.org"
+    assert snapshot["holder_snapshot"]["email"] == "issue@example.org"
+    assert snapshot["assets"][0]["holder_snapshot"]["email"] == "issue@example.org"
+
+
+def test_return_receipt_snapshot_stores_unique_holder_email(client_with_temp_db) -> None:
+    receipt_id = _create_return_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    snapshot = json.loads(str(row["snapshot_json"]))
+    assert snapshot["recipient_email"] == "return.one@example.org"
+    assert snapshot["holder_snapshot"]["email"] == "return.one@example.org"
+    assert snapshot["assets"][0]["from_holder_snapshot"]["email"] == "return.one@example.org"
+
+
+def test_mixed_holder_return_snapshot_keeps_recipient_email_blank(client_with_temp_db) -> None:
+    receipt_id = _create_return_receipt(client_with_temp_db, mixed_holders=True)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+    finally:
+        conn.close()
+
+    assert row is not None
+    snapshot = json.loads(str(row["snapshot_json"]))
+    assert snapshot["holder_id"] is None
+    assert snapshot["recipient_email"] == ""
+
+
 def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_db) -> None:
     receipt_id = _create_issue_receipt(client_with_temp_db)
 
@@ -604,7 +661,7 @@ def test_receipt_send_success_updates_delivery_state(client_with_temp_db, monkey
         identifier="IH-1",
         organization="Operations",
         organization_id=9,
-        contact_info="issue@example.org",
+        email="issue@example.org",
     )
     _insert_slot(10, "CASE-10", 1)
     _insert_asset(100, "ISSUE-100", location_type="STORAGE", home_slot_id=10, building_room="Storage/A1")
@@ -658,7 +715,7 @@ def test_receipt_send_failure_updates_delivery_state(client_with_temp_db, monkey
         identifier="IH-1",
         organization="Operations",
         organization_id=9,
-        contact_info="issue@example.org",
+        email="issue@example.org",
     )
     _insert_slot(10, "CASE-10", 1)
     _insert_asset(100, "ISSUE-100", location_type="STORAGE", home_slot_id=10, building_room="Storage/A1")
@@ -745,7 +802,7 @@ def test_receipt_send_does_not_resend_after_success(client_with_temp_db, monkeyp
         identifier="IH-1",
         organization="Operations",
         organization_id=9,
-        contact_info="issue@example.org",
+        email="issue@example.org",
     )
     _insert_slot(10, "CASE-10", 1)
     _insert_asset(100, "ISSUE-100", location_type="STORAGE", home_slot_id=10, building_room="Storage/A1")
@@ -776,6 +833,15 @@ def test_receipt_send_does_not_resend_after_success(client_with_temp_db, monkeyp
     assert second.status_code == 400
     assert second.json == {"ok": False, "error": "Receipt is not queued for email."}
     assert send_calls == [receipt_id]
+
+
+def test_receipt_send_fails_clearly_when_snapshot_email_is_missing(client_with_temp_db) -> None:
+    receipt_id = _create_return_receipt(client_with_temp_db, mixed_holders=True)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 400
+    assert response.json == {"ok": False, "error": "Receipt has no stored email recipient."}
 
 
 def test_receipt_pdf_is_deterministic_for_same_snapshot(client_with_temp_db) -> None:

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -59,7 +59,21 @@ class ReturnBatchTests(unittest.TestCase):
         )
         self.conn.commit()
 
+    def _insert_holder(self, holder_id: int, name: str, email: str = "") -> None:
+        self.conn.execute(
+            """
+            INSERT INTO holders (
+                id, holder_type, name, identifier, email, contact_info, created_at, updated_at
+            )
+            VALUES (?, 'PERSON', ?, ?, ?, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (holder_id, name, f"H-{holder_id}", email),
+        )
+        self.conn.commit()
+
     def test_return_preview_and_commit_gating(self) -> None:
+        self._insert_holder(5, "Return Holder Five")
+        self._insert_holder(9, "Return Holder Nine", email="return@example.org")
         self._insert_slot(10, "A", 1, None)
         self._insert_slot(20, "B", 2, None)
         self._insert_asset("TAG-VALID", location_type="IN_CUSTODY", holder_id=5, home_slot_id=10)
@@ -87,7 +101,7 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"Current State", preview_render.data)
         self.assertIn(b"After Return", preview_render.data)
         self.assertIn(b"Location: IN_CUSTODY", preview_render.data)
-        self.assertIn(b"Issued to: holder_id 5", preview_render.data)
+        self.assertIn(b"Issued to: Return Holder Five", preview_render.data)
         self.assertIn(b"Home location: A / 1", preview_render.data)
         self.assertIn(b'name="confirm_responsibility_ack"', preview_render.data)
         self.assertIn(b"responsibility for this return batch was acknowledged before commit", preview_render.data)
@@ -203,13 +217,48 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(receipt_snapshot["holder_id"], 9)
         self.assertEqual(receipt_snapshot["source_event_ids"], [int(event_row["id"])])
         self.assertEqual(receipt_snapshot["delivery"]["state"], "pending")
+        self.assertEqual(receipt_snapshot["recipient_email"], "return@example.org")
+        self.assertEqual(receipt_snapshot["holder_snapshot"]["email"], "return@example.org")
         self.assertEqual(len(receipt_snapshot["assets"]), 1)
         self.assertEqual(receipt_snapshot["assets"][0]["asset_tag"], "TAG-OK")
+        self.assertEqual(receipt_snapshot["assets"][0]["from_holder_snapshot"]["email"], "return@example.org")
         self.assertEqual(receipt_snapshot["assets"][0]["from_location_type"], "IN_CUSTODY")
         self.assertEqual(receipt_snapshot["assets"][0]["to_location_type"], "STORAGE")
         self.assertIsNone(receipt_row["sent_at"])
         self.assertIsNone(receipt_row["last_attempt_at"])
         self.assertIsNone(receipt_row["last_error"])
+
+    def test_return_commit_with_mixed_holders_keeps_snapshot_email_blank(self) -> None:
+        self._insert_holder(5, "Return Holder Five", email="five@example.org")
+        self._insert_holder(9, "Return Holder Nine", email="nine@example.org")
+        self._insert_slot(10, "A", 1, None)
+        self._insert_slot(20, "B", 2, None)
+        self._insert_asset("TAG-ONE", location_type="IN_CUSTODY", holder_id=5, home_slot_id=10)
+        self._insert_asset("TAG-TWO", location_type="IN_CUSTODY", holder_id=9, home_slot_id=20)
+
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-ONE", equipment_type="laptop"))
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-TWO", equipment_type="laptop"))
+
+        success = self.client.post(
+            "/return/commit?json=1",
+            data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        )
+
+        self.assertEqual(success.status_code, 200)
+
+        receipt_row = self.conn.execute(
+            """
+            SELECT holder_id, snapshot_json
+            FROM receipt_queue
+            ORDER BY id DESC
+            LIMIT 1;
+            """
+        ).fetchone()
+        self.assertIsNotNone(receipt_row)
+        self.assertIsNone(receipt_row["holder_id"])
+        receipt_snapshot = json.loads(str(receipt_row["snapshot_json"]))
+        self.assertIsNone(receipt_snapshot["holder_id"])
+        self.assertEqual(receipt_snapshot["recipient_email"], "")
 
     def test_return_commit_missing_ack_redirects_back_to_preview_with_message(self) -> None:
         self._insert_slot(21, "C", 3, None)


### PR DESCRIPTION
## Summary
Add holder email support and snapshot a deterministic receipt recipient email at commit time so receipt sending no longer depends on live holder lookup.

## Related Issue
Closes #399 

## Changes
- add optional holder email field with startup migration support
- support email entry and edit in holder create/edit flows
- validate entered holder email with basic sanity checks
- display holder email on holder surfaces where useful
- snapshot recipient_email into receipt data at commit time
- update receipt send path to use stored snapshot email only
- keep mixed-holder returns deterministic by not guessing a recipient

## Verification checklist
- [x] Targeted pytest passed
- [x] Manual browser verification passed for holder email create/edit
- [x] Issue flow snapshots recipient email into receipt
- [x] Receipt detail shows captured recipient email
- [x] Send path uses snapped email
- [x] Missing or unconfigured delivery still fails clearly
- [x] No event or audit semantics changed
- [x] No workflow seam changes

## Notes
- Holder selection is the source of truth for recipient identity
- Typed acknowledgment name remains separate from recipient selection
- Mixed-holder returns intentionally leave recipient_email uncaptured rather than guess