### PR TITLE
Issue 26-57: wire SMTP environment variables into docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,13 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - ASSETTRACK_DB_PATH=${ASSETTRACK_DB_PATH:-/app/data/assettrack.db}
+      ASSETTRACK_DB_PATH: ${ASSETTRACK_DB_PATH:-/app/data/assettrack.db}
+      ASSETTRACK_SMTP_HOST: ${ASSETTRACK_SMTP_HOST}
+      ASSETTRACK_SMTP_PORT: ${ASSETTRACK_SMTP_PORT}
+      ASSETTRACK_SMTP_USERNAME: ${ASSETTRACK_SMTP_USERNAME}
+      ASSETTRACK_SMTP_PASSWORD: ${ASSETTRACK_SMTP_PASSWORD}
+      ASSETTRACK_SMTP_STARTTLS: ${ASSETTRACK_SMTP_STARTTLS}
+      ASSETTRACK_SMTP_USE_SSL: ${ASSETTRACK_SMTP_USE_SSL}
     volumes:
       - ./data:/app/data
     restart: unless-stopped


### PR DESCRIPTION
## Summary
Wire SMTP environment variables into docker compose so the container can access mail configuration and enable receipt email delivery.

## Related Issue
Closes #403 

## Changes
- add SMTP environment variable passthrough in docker-compose.yml
- align variable names with application expectations (ASSETTRACK_SMTP_*)
- preserve existing DB path configuration behavior

## Verification checklist
- [x] docker compose exec assettrack env | grep ASSETTRACK_SMTP returns all variables
- [x] receipt send no longer reports "not configured"
- [x] Gmail SMTP authentication succeeds using app password
- [x] receipt email successfully delivered end-to-end
- [x] delivery status updates to "Sent" in UI
- [x] no regression to DB path or persistence behavior

## Notes
- Gmail requires STARTTLS on port 587 with app password authentication
- Variable name alignment between .env and docker-compose.yml was required for container injection
- This change enables SMTP without modifying application logic