### PR TITLE
Issue 26-60: restore slot occupancy on asset return

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2107,7 +2107,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
 
         rows = conn.execute(
             """
-            SELECT asset_tag, location_type, current_holder_id, home_slot_id
+            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id
             FROM assets
             WHERE UPPER(asset_tag) = UPPER(?)
                OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
@@ -2851,7 +2851,7 @@ def _return_batch(
 
         rows = conn.execute(
             """
-            SELECT asset_tag, location_type, current_holder_id, home_slot_id
+            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id
             FROM assets
             WHERE UPPER(asset_tag) = UPPER(?)
                OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
@@ -2920,6 +2920,7 @@ def _return_batch(
 
                 validated_rows.append(
                     {
+                        "asset_id": int(asset_row["id"]),
                         "asset_tag": canon_tag,
                         "home_slot_id": int(slot["id"]),
                         "current_holder_id": None if asset_row["current_holder_id"] is None else int(asset_row["current_holder_id"]),
@@ -2944,6 +2945,7 @@ def _return_batch(
             event_ids: list[int] = []
 
             for row in validated_rows:
+                asset_id = row["asset_id"]
                 canon_tag = row["asset_tag"]
                 home_slot_id = row["home_slot_id"]
                 current_holder_id = row["current_holder_id"]
@@ -2956,6 +2958,14 @@ def _return_batch(
                        OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?);
                     """,
                     ("STORAGE", canon_tag, canon_tag),
+                )
+
+                conn.execute(
+                    """
+                    INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                    VALUES (?, ?, ?);
+                    """,
+                    (home_slot_id, asset_id, now_iso),
                 )
 
                 cursor = conn.execute(

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -173,6 +173,18 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(asset_after["location_type"], "STORAGE")
         self.assertIsNone(asset_after["current_holder_id"])
 
+        occupancy_after = self.conn.execute(
+            """
+            SELECT slot_id
+            FROM slot_occupancy
+            WHERE asset_id = (SELECT id FROM assets WHERE asset_tag = ?)
+            LIMIT 1;
+            """,
+            ("TAG-OK",),
+        ).fetchone()
+        self.assertIsNotNone(occupancy_after)
+        self.assertEqual(int(occupancy_after["slot_id"]), 20)
+
         slot_after = self.conn.execute(
             "SELECT current_asset_tag FROM slots WHERE id = ?;",
             (20,),
@@ -227,6 +239,49 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIsNone(receipt_row["sent_at"])
         self.assertIsNone(receipt_row["last_attempt_at"])
         self.assertIsNone(receipt_row["last_error"])
+
+    def test_return_commit_restores_slot_occupancy_after_issue_path_removal(self) -> None:
+        self._insert_holder(5, "Return Holder Five")
+        self._insert_slot(55, "CASE-55", 5, None)
+        self._insert_asset("TAG-RESTORE", location_type="IN_CUSTODY", holder_id=5, home_slot_id=55)
+
+        asset_id = int(
+            self.conn.execute(
+                "SELECT id FROM assets WHERE asset_tag = ? LIMIT 1;",
+                ("TAG-RESTORE",),
+            ).fetchone()[0]
+        )
+
+        self.assertIsNone(
+            self.conn.execute(
+                "SELECT 1 FROM slot_occupancy WHERE asset_id = ? LIMIT 1;",
+                (asset_id,),
+            ).fetchone()
+        )
+
+        intake_app.SCAN_QUEUE.clear()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="TAG-RESTORE", equipment_type="laptop"))
+
+        success = self.client.post(
+            "/return/commit?json=1",
+            data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        )
+
+        self.assertEqual(success.status_code, 200)
+        self.assertTrue(success.json["ok"])
+
+        occupancy_after = self.conn.execute(
+            "SELECT slot_id FROM slot_occupancy WHERE asset_id = ? LIMIT 1;",
+            (asset_id,),
+        ).fetchone()
+        self.assertIsNotNone(occupancy_after)
+        self.assertEqual(int(occupancy_after["slot_id"]), 55)
+
+        slot_after = self.conn.execute(
+            "SELECT current_asset_tag FROM slots WHERE id = 55 LIMIT 1;"
+        ).fetchone()
+        self.assertIsNotNone(slot_after)
+        self.assertEqual(str(slot_after["current_asset_tag"]), "TAG-RESTORE")
 
     def test_return_commit_with_mixed_holders_keeps_snapshot_email_blank(self) -> None:
         self._insert_holder(5, "Return Holder Five", email="five@example.org")


### PR DESCRIPTION
## Summary
Fix return flow so assets are reinserted into slot_occupancy on return, restoring correct slotted state.

## Related Issue
Closes #406 

## Changes
- Carry asset_id through return validation
- Insert slot_occupancy row during return commit
- Add regression test to verify occupancy is restored

## Verification checklist
- [x] Issue → Return restores slot occupancy
- [x] Dashboard unslotted count remains correct
- [x] Case view shows asset back in home slot
- [x] tests/test_return_batch.py passes

## Notes
Fix ensures slot_occupancy remains the source of truth for slotted state and keeps system state aligned with expected return behavior.