### PR TITLE
Issue 26-59: make DB bootstrap deterministic on first run

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -166,6 +166,16 @@ def initialize_if_missing_or_empty(db_path: Path) -> bool:
     return True
 
 
+def bootstrap_db(db_path: Path) -> bool:
+    """
+    Ensure the approved schema is present before any query path runs.
+    Returns True when first-run bootstrap was performed.
+    """
+    initialized = initialize_if_missing_or_empty(db_path)
+    assert_schema_present(db_path)
+    return initialized
+
+
 def assert_schema_present(db_path: Path) -> None:
     """
     Validate that a DB file contains the required AssetTrack tables.
@@ -203,7 +213,7 @@ def get_connection():
     Returns a SQLite connection to the AssetTrack database.
     Ensures the database and schema exist.
     """
-    initialize_schema(DB_PATH)
+    bootstrap_db(DB_PATH)
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
 

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -36,7 +36,7 @@ from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, Tabl
 import assettrack.db as db_module
 from assettrack.assets import get_asset_table_columns
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
-from assettrack.db import assert_schema_present, get_connection, initialize_schema
+from assettrack.db import bootstrap_db, get_connection
 from assettrack.drilldowns import (
     get_case_slot_detail,
     get_holder_custody_detail,
@@ -76,8 +76,7 @@ from assettrack.users import (
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
 
-initialize_schema(db_module.DB_PATH)
-assert_schema_present(db_module.DB_PATH)
+bootstrap_db(db_module.DB_PATH)
 
 # In-memory only: wiped on restart
 SCAN_QUEUE: list[Scan] = []

--- a/scripts/import_inventory.py
+++ b/scripts/import_inventory.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
+from assettrack.db import assert_schema_present
 
 DB_PATH = Path("data/assettrack.db")
 EXCEL_PATH = Path("data/import/BQ26 ETP.xlsx")
@@ -156,6 +157,8 @@ def run_import(rows: list[ImportRow]) -> tuple[int, int, int]:
     inserted_slots = 0
     inserted_assets = 0
     inserted_occupancy = 0
+
+    assert_schema_present(DB_PATH)
 
     connection = sqlite3.connect(DB_PATH)
     connection.row_factory = sqlite3.Row

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -45,6 +45,30 @@ def test_initialize_if_missing_or_empty_preserves_existing_db(tmp_path: Path) ->
     db.assert_schema_present(db_path)
 
 
+def test_bootstrap_db_bootstraps_missing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+
+    initialized = db.bootstrap_db(db_path)
+
+    assert initialized is True
+    db.assert_schema_present(db_path)
+
+
+def test_get_connection_bootstraps_missing_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+
+    conn = db.get_connection()
+    try:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table';").fetchall()}
+    finally:
+        conn.close()
+
+    assert "assets" in tables
+    assert "asset_events" in tables
+    assert "receipt_queue" in tables
+
+
 def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> None:
     db_path = tmp_path / "assettrack.db"
     db.initialize_schema(db_path)


### PR DESCRIPTION
## Summary
Make SQLite bootstrap deterministic on first run so a fresh clone plus Docker startup creates a valid database with schema before any queries execute.

## Related Issue
Closes #405 

## Changes
- Add shared bootstrap guard for SQLite startup
- Initialize schema when DB is missing or empty
- Align startup and runtime DB paths
- Assert schema before importer access
- Add startup DB test coverage

## Verification checklist
- [x] Fresh clone boot works
- [x] DB file created correctly
- [x] No table errors on startup
- [x] Import works via project venv
- [x] Issue flow passes
- [x] Return flow passes
- [x] Slot occupancy restored correctly
- [x] Persistence verified after restart

## Notes
Issue 26-60 discovered during validation and fixed separately.