### PR TITLE
Issue 26-62: bootstrap Docker data directory before first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Current architecture includes:
 * SQLite storage
 * Deterministic event logging
 * Dockerized runtime
-* Named-volume persistence
+* Bind-mounted host-directory persistence
 * Clean container security baseline (Trivy: 0 vulnerabilities)
 
 Root (`/`) routes to login.
@@ -49,7 +49,7 @@ AssetTrack currently provides:
 * Atomic SQLite commits
 * Deterministic clearing of the preview queue on success
 * Persistent event logging
-* Docker-based deployment with named volume durability
+* Docker-based deployment with bind-mounted host-directory durability
 
 Not included:
 
@@ -82,8 +82,10 @@ Clone the repository and start the system:
 ```bash
 git clone https://github.com/gacurl/AssetTrack.git
 cd AssetTrack
-docker compose up -d --build
+./scripts/bootstrap_docker.sh
 ```
+
+The bootstrap script creates the host `./data` directory if it is missing, applies first-run write permissions for the non-root container user, and then runs `docker compose up -d --build`.
 
 On a first run with no database file, AssetTrack initializes the approved SQLite schema automatically in the mounted `/app/data/assettrack.db` path before the web app starts.
 
@@ -100,7 +102,7 @@ If this is a fresh database with no users yet, bootstrap the first admin at:
 Run inventory import inside the running Docker container so it uses the image's installed dependencies and the mounted persistent SQLite database:
 
 ```bash
-docker compose up -d --build
+./scripts/bootstrap_docker.sh
 ./scripts/import_inventory_docker.sh
 ```
 
@@ -127,29 +129,17 @@ AssetTrack includes a full release documentation package.
 
 ## Persistence Model (Important)
 
-AssetTrack uses a named Docker volume mounted to:
+AssetTrack uses a host bind mount for persistent Docker data:
 
 ```
-/app/data
+./data:/app/data
 ```
 
 This means:
 
 * Database survives container restarts
 * Database survives `docker compose down`
-* Data resets only if the Docker volume is explicitly removed
-
-To inspect volumes:
-
-```
-docker volume ls
-```
-
-To remove the AssetTrack volume (destructive):
-
-```
-docker volume rm assettrack_data
-```
+* Data remains in the repo-local `./data` directory unless you remove it yourself
 
 The database path inside the container is controlled by:
 
@@ -172,7 +162,7 @@ Use this manual check to prove holder data survives container restarts.
 1. Start the app:
 
 ```
-docker compose up -d --build
+./scripts/bootstrap_docker.sh
 ```
 
 2. In the UI (`http://localhost:8000`), create a holder from:
@@ -217,7 +207,7 @@ PY
 
 Expected: the holder row is present both before and after `down/up`.
 `docker compose down` preserves data in the mounted `/app/data/assettrack.db`.
-Data is wiped only if you explicitly remove volumes (for example `docker compose down -v`).
+Data is wiped only if you explicitly remove the repo-local `./data` contents.
 
 ---
 
@@ -249,7 +239,7 @@ Keep the repository inside the Linux filesystem (`~`).
 ### Start the Application
 
 ```
-docker compose up -d --build
+./scripts/bootstrap_docker.sh
 ```
 
 Then open:

--- a/docs/docker-data-persistence.md
+++ b/docs/docker-data-persistence.md
@@ -51,6 +51,14 @@ AssetTrack must always be run with the host data directory mounted into the cont
 
 This ensures the application and the host are reading and writing the same database file.
 
+Use the repo-managed bootstrap from the repository root:
+
+```bash
+./scripts/bootstrap_docker.sh
+```
+
+That script creates `./data` if it is missing, applies first-run write permissions, and then starts Docker Compose with the existing `./data:/app/data` bind mount.
+
 ## How to verify it’s working
 
 After starting the container with the volume mount:

--- a/docs/release/deployment.md
+++ b/docs/release/deployment.md
@@ -28,15 +28,17 @@ cd AssetTrack
 From the repository root, run:
 
 ```bash
-docker compose up -d --build
+./scripts/bootstrap_docker.sh
 ```
 
 What this does:
 
 1. Builds the AssetTrack Docker image.
-2. Starts the AssetTrack container in the background.
-3. Exposes the application on port `8000`.
-4. On first run, initializes the approved SQLite schema in `/app/data/assettrack.db` if the database file is missing or empty.
+2. Ensures the host `./data` bind-mount directory exists.
+3. Applies first-run write permissions so the non-root container can create SQLite files.
+4. Starts the AssetTrack container in the background.
+5. Exposes the application on port `8000`.
+6. On first run, initializes the approved SQLite schema in `/app/data/assettrack.db` if the database file is missing or empty.
 
 After startup, open:
 
@@ -80,7 +82,7 @@ AssetTrack persists SQLite data across restarts by keeping the database in the m
 This means:
 
 - `docker compose down` does not erase the database
-- `docker compose up -d --build` starts the app again using the same database file
+- `./scripts/bootstrap_docker.sh` starts the app again using the same database file
 - SQLite persistence survives normal container restarts
 
 ## Standard inventory import path
@@ -88,7 +90,7 @@ This means:
 If you need to load the approved `.xlsx` inventory workbook, run the import inside the existing `assettrack` container:
 
 ```bash
-docker compose up -d --build
+./scripts/bootstrap_docker.sh
 ./scripts/import_inventory_docker.sh
 ```
 
@@ -113,7 +115,7 @@ After startup:
 
 For normal field use:
 
-1. Start the app with `docker compose up -d --build`.
+1. Start the app with `./scripts/bootstrap_docker.sh`.
 2. Perform the required operator workflows.
 3. Stop the app with `docker compose down` when finished.
 

--- a/docs/release/troubleshooting.md
+++ b/docs/release/troubleshooting.md
@@ -8,7 +8,7 @@ This guide covers common issues operators and administrators may see during star
 
 Symptom:
 
-- `docker compose up -d --build` fails to start correctly
+- `./scripts/bootstrap_docker.sh` fails to start correctly
 - Port `8000` is already in use
 
 What to do:
@@ -16,7 +16,7 @@ What to do:
 1. Close any other local process already using port `8000`.
 2. Stop any old AssetTrack container that may still be running.
 3. Run `docker compose down`.
-4. Run `docker compose up -d --build` again.
+4. Run `./scripts/bootstrap_docker.sh` again.
 
 ## Docker not running
 
@@ -29,7 +29,7 @@ What to do:
 
 1. Start Docker Desktop or the local Docker service.
 2. Wait until Docker reports that it is ready.
-3. Re-run `docker compose up -d --build`.
+3. Re-run `./scripts/bootstrap_docker.sh`.
 
 ## Login failure
 
@@ -71,10 +71,10 @@ Symptom:
 
 What to check:
 
-1. Start the app with `docker compose up -d --build`.
+1. Start the app with `./scripts/bootstrap_docker.sh`.
 2. Log in and create a simple record such as a test holder.
 3. Stop the app with `docker compose down`.
-4. Start it again with `docker compose up -d --build`.
+4. Start it again with `./scripts/bootstrap_docker.sh`.
 5. Confirm the record still exists.
 
 Why this works:

--- a/scripts/bootstrap_docker.sh
+++ b/scripts/bootstrap_docker.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+cd "$(dirname "$0")/.."
+
+DATA_DIR="data"
+
+echo "Ensuring ${DATA_DIR}/ exists for Docker bind mount..."
+mkdir -p "$DATA_DIR"
+
+echo "Setting ${DATA_DIR}/ permissions for first-run SQLite creation..."
+chmod 0777 "$DATA_DIR"
+
+if [ ! -w "$DATA_DIR" ]; then
+    echo "AssetTrack bootstrap failed: ${DATA_DIR}/ is not writable." >&2
+    exit 1
+fi
+
+echo "Starting AssetTrack with Docker Compose..."
+exec docker compose up -d --build

--- a/tests/test_bootstrap_docker_script.py
+++ b/tests/test_bootstrap_docker_script.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+def test_bootstrap_docker_script_prepares_data_dir_and_starts_compose(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+
+    source_script = Path(__file__).resolve().parents[1] / "scripts" / "bootstrap_docker.sh"
+    target_script = scripts_dir / "bootstrap_docker.sh"
+    shutil.copy2(source_script, target_script)
+
+    docker_bin_dir = tmp_path / "bin"
+    docker_bin_dir.mkdir()
+    docker_args_path = tmp_path / "docker-args.txt"
+    docker_stub = docker_bin_dir / "docker"
+    docker_stub.write_text(
+        "#!/bin/sh\n"
+        f"printf '%s\\n' \"$@\" > \"{docker_args_path}\"\n",
+        encoding="utf-8",
+    )
+    docker_stub.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{docker_bin_dir}:{env['PATH']}"
+
+    subprocess.run(
+        [str(target_script)],
+        cwd=repo_root,
+        env=env,
+        check=True,
+    )
+
+    data_dir = repo_root / "data"
+    assert data_dir.is_dir()
+    assert stat.S_IMODE(data_dir.stat().st_mode) == 0o777
+    assert docker_args_path.read_text(encoding="utf-8").splitlines() == ["compose", "up", "-d", "--build"]


### PR DESCRIPTION
## Summary
Add a repo-managed Docker bootstrap script that prepares the bind-mounted data directory before first run so fresh clones start cleanly without manual mkdir/chmod repair.

## Related Issue
Closes #410 

## Changes
- Add bootstrap_docker.sh to create and prepare ./data before Compose startup
- Verify the directory is writable before launching Docker
- Update README and deployment/troubleshooting docs to use the bootstrap path
- Add focused test coverage for the bootstrap script behavior

## Verification checklist
- [x] Fresh clone path works without manual data directory repair
- [x] Bootstrap script creates ./data with writable permissions
- [x] Docker container reaches healthy state
- [x] /app/data/assettrack.db is created successfully
- [x] App responds on port 8000
- [x] Persistence remains intact across restart
- [x] No schema changes
- [x] No auth or role changes
- [x] No workflow seam changes

## Notes
This fixes the host-side bind mount setup gap discovered during clean cloud deployment validation.