### PR TITLE
Issue 26-58: import holders from CSV by email

### DIFF
--- a/assettrack/holder_import.py
+++ b/assettrack/holder_import.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assettrack.db import bootstrap_db
+from assettrack.holders import _normalize_email
+
+REQUIRED_COLUMNS = ("organization", "name", "email")
+
+
+@dataclass(frozen=True)
+class HolderImportRow:
+    row_number: int
+    organization: str
+    name: str
+    email: str
+
+
+@dataclass(frozen=True)
+class HolderImportReport:
+    processed: int
+    created: int
+    updated: int
+    errors: tuple[str, ...]
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "processed": self.processed,
+            "created": self.created,
+            "updated": self.updated,
+            "errors": len(self.errors),
+        }
+
+
+def _normalize_header(name: str | None) -> str:
+    return str(name or "").strip().lower()
+
+
+def _normalize_required_text(value: str | None, *, field_name: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    return normalized
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_csv_rows(csv_path: str | Path) -> HolderImportReport | list[HolderImportRow]:
+    path = Path(csv_path)
+    if not path.exists():
+        return HolderImportReport(processed=0, created=0, updated=0, errors=(f"CSV not found: {path}",))
+
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return HolderImportReport(
+                processed=0,
+                created=0,
+                updated=0,
+                errors=("CSV header row is required.",),
+            )
+
+        normalized_headers = [_normalize_header(field_name) for field_name in reader.fieldnames]
+        if any(not header for header in normalized_headers):
+            return HolderImportReport(
+                processed=0,
+                created=0,
+                updated=0,
+                errors=("CSV headers must not be blank.",),
+            )
+        if len(set(normalized_headers)) != len(normalized_headers):
+            return HolderImportReport(
+                processed=0,
+                created=0,
+                updated=0,
+                errors=("CSV headers must be unique.",),
+            )
+
+        missing_columns = [column for column in REQUIRED_COLUMNS if column not in normalized_headers]
+        if missing_columns:
+            return HolderImportReport(
+                processed=0,
+                created=0,
+                updated=0,
+                errors=(f"Missing required CSV columns: {', '.join(missing_columns)}",),
+            )
+
+        rows: list[HolderImportRow] = []
+        errors: list[str] = []
+        seen_emails: dict[str, int] = {}
+        processed = 0
+
+        for line_number, raw_row in enumerate(reader, start=2):
+            normalized_row = {_normalize_header(key): value for key, value in raw_row.items() if key is not None}
+            if None in raw_row:
+                errors.append(f"Row {line_number}: malformed CSV row has extra columns.")
+                continue
+            if any(value is None for value in normalized_row.values()):
+                errors.append(f"Row {line_number}: malformed CSV row has missing columns.")
+                continue
+
+            if all(not str(value or "").strip() for value in normalized_row.values()):
+                continue
+
+            processed += 1
+
+            try:
+                organization = _normalize_required_text(normalized_row.get("organization"), field_name="organization")
+                name = _normalize_required_text(normalized_row.get("name"), field_name="name")
+                email = _normalize_required_text(normalized_row.get("email"), field_name="email")
+                normalized_email = _normalize_email(email)
+                assert normalized_email is not None
+            except ValueError as exc:
+                errors.append(f"Row {line_number}: {exc}")
+                continue
+
+            previous_row = seen_emails.get(normalized_email)
+            if previous_row is not None:
+                errors.append(
+                    f"Row {line_number}: duplicate email in CSV matches row {previous_row}: {normalized_email}"
+                )
+                continue
+
+            seen_emails[normalized_email] = line_number
+            rows.append(
+                HolderImportRow(
+                    row_number=line_number,
+                    organization=organization,
+                    name=name,
+                    email=normalized_email,
+                )
+            )
+
+        if errors:
+            return HolderImportReport(processed=processed, created=0, updated=0, errors=tuple(errors))
+
+        return rows
+
+
+def _organizations_by_name(conn: sqlite3.Connection) -> dict[str, sqlite3.Row]:
+    rows = conn.execute(
+        """
+        SELECT id, name
+        FROM organizations;
+        """
+    ).fetchall()
+    return {str(row["name"] or "").strip().lower(): row for row in rows if str(row["name"] or "").strip()}
+
+
+def _holder_rows_by_email(conn: sqlite3.Connection, emails: set[str]) -> dict[str, list[sqlite3.Row]]:
+    holders_by_email: dict[str, list[sqlite3.Row]] = {}
+    for email in emails:
+        rows = conn.execute(
+            """
+            SELECT id, holder_type, name, organization, organization_id, email
+            FROM holders
+            WHERE LOWER(TRIM(COALESCE(email, ''))) = ?;
+            """,
+            (email,),
+        ).fetchall()
+        holders_by_email[email] = list(rows)
+    return holders_by_email
+
+
+def _ensure_organization(conn: sqlite3.Connection, organization_name: str, organizations: dict[str, sqlite3.Row]) -> int:
+    existing = organizations.get(organization_name.lower())
+    if existing is not None:
+        return int(existing["id"])
+
+    now_iso = _utc_now_iso()
+    cursor = conn.execute(
+        """
+        INSERT INTO organizations (name, created_at, updated_at)
+        VALUES (?, ?, ?);
+        """,
+        (organization_name, now_iso, now_iso),
+    )
+    row = conn.execute(
+        """
+        SELECT id, name
+        FROM organizations
+        WHERE id = ?;
+        """,
+        (int(cursor.lastrowid),),
+    ).fetchone()
+    assert row is not None
+    organizations[organization_name.lower()] = row
+    return int(row["id"])
+
+
+def import_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderImportReport:
+    parsed = _load_csv_rows(csv_path)
+    if isinstance(parsed, HolderImportReport):
+        return parsed
+
+    bootstrap_db(Path(db_path))
+    conn = sqlite3.connect(Path(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        organizations = _organizations_by_name(conn)
+        rows_by_email = _holder_rows_by_email(conn, {row.email for row in parsed})
+
+        duplicate_email_errors: list[str] = []
+        for row in parsed:
+            matches = rows_by_email.get(row.email, [])
+            if len(matches) > 1:
+                duplicate_email_errors.append(
+                    f"Row {row.row_number}: multiple holders already use email {row.email}; import cannot choose a match."
+                )
+
+        if duplicate_email_errors:
+            return HolderImportReport(
+                processed=len(parsed),
+                created=0,
+                updated=0,
+                errors=tuple(duplicate_email_errors),
+            )
+
+        created = 0
+        updated = 0
+
+        with conn:
+            for row in parsed:
+                organization_id = _ensure_organization(conn, row.organization, organizations)
+                matches = rows_by_email.get(row.email, [])
+                now_iso = _utc_now_iso()
+
+                if not matches:
+                    conn.execute(
+                        """
+                        INSERT INTO holders (
+                            holder_type, name, organization, organization_id, email, identifier, contact_info, created_at, updated_at
+                        )
+                        VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?);
+                        """,
+                        ("PERSON", row.name, row.organization, organization_id, row.email, now_iso, now_iso),
+                    )
+                    created += 1
+                    continue
+
+                holder_id = int(matches[0]["id"])
+                conn.execute(
+                    """
+                    UPDATE holders
+                    SET name = ?, organization = ?, organization_id = ?, email = ?, updated_at = ?
+                    WHERE id = ?;
+                    """,
+                    (row.name, row.organization, organization_id, row.email, now_iso, holder_id),
+                )
+                updated += 1
+
+        return HolderImportReport(processed=len(parsed), created=created, updated=updated, errors=())
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="assettrack.holder_import")
+    parser.add_argument("csv_path", help="Path to holder CSV file")
+    parser.add_argument(
+        "--db",
+        required=True,
+        help="Path to SQLite DB",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        report = import_holders_csv(args.csv_path, db_path=args.db)
+    except Exception as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(report.summary(), sort_keys=True))
+    if report.errors:
+        for error in report.errors:
+            print(error, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/import_holders_csv.py
+++ b/scripts/import_holders_csv.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from assettrack.holder_import import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_holder_import.py
+++ b/tests/test_holder_import.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assettrack import holder_import
+from assettrack.db import bootstrap_db
+
+
+class HolderImportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "assettrack.db"
+        bootstrap_db(self.db_path)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write_csv(self, name: str, content: str) -> Path:
+        path = Path(self.temp_dir.name) / name
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def _connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _insert_organization(self, name: str) -> int:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        conn = self._connection()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO organizations (name, created_at, updated_at)
+                VALUES (?, ?, ?);
+                """,
+                (name, now_iso, now_iso),
+            )
+            conn.commit()
+            return int(cursor.lastrowid)
+        finally:
+            conn.close()
+
+    def _insert_holder(self, *, name: str, organization: str, organization_id: int, email: str) -> int:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        conn = self._connection()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO holders (
+                    holder_type, name, organization, organization_id, email, identifier, contact_info, created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, NULL, NULL, ?, ?);
+                """,
+                ("PERSON", name, organization, organization_id, email, now_iso, now_iso),
+            )
+            conn.commit()
+            return int(cursor.lastrowid)
+        finally:
+            conn.close()
+
+    def test_import_creates_new_holder_for_new_email(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,Jane Doe,jane@example.org\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 1, "created": 1, "updated": 0, "errors": 0})
+        conn = self._connection()
+        try:
+            holder = conn.execute(
+                "SELECT name, organization, email FROM holders WHERE email = ?;",
+                ("jane@example.org",),
+            ).fetchone()
+            self.assertIsNotNone(holder)
+            self.assertEqual(dict(holder), {"name": "Jane Doe", "organization": "Ops Alpha", "email": "jane@example.org"})
+        finally:
+            conn.close()
+
+    def test_import_updates_existing_holder_for_matching_email(self) -> None:
+        original_org_id = self._insert_organization("Ops Alpha")
+        self._insert_holder(
+            name="Old Name",
+            organization="Ops Alpha",
+            organization_id=original_org_id,
+            email="jane@example.org",
+        )
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Bravo,New Name,jane@example.org\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 1, "created": 0, "updated": 1, "errors": 0})
+        conn = self._connection()
+        try:
+            holder = conn.execute(
+                "SELECT name, organization, email FROM holders WHERE email = ?;",
+                ("jane@example.org",),
+            ).fetchone()
+            self.assertIsNotNone(holder)
+            self.assertEqual(dict(holder), {"name": "New Name", "organization": "Ops Bravo", "email": "jane@example.org"})
+
+            org = conn.execute("SELECT name FROM organizations WHERE name = ?;", ("Ops Bravo",)).fetchone()
+            self.assertIsNotNone(org)
+        finally:
+            conn.close()
+
+    def test_import_rejects_blank_organization(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\n,Jane Doe,jane@example.org\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 1, "created": 0, "updated": 0, "errors": 1})
+        self.assertEqual(report.errors, ("Row 2: organization is required",))
+
+    def test_import_rejects_blank_name(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,,jane@example.org\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 1, "created": 0, "updated": 0, "errors": 1})
+        self.assertEqual(report.errors, ("Row 2: name is required",))
+
+    def test_import_rejects_blank_email(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,Jane Doe,\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 1, "created": 0, "updated": 0, "errors": 1})
+        self.assertEqual(report.errors, ("Row 2: email is required",))
+
+    def test_import_rejects_malformed_csv_rows(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,Jane Doe,jane@example.org,unexpected\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 0, "created": 0, "updated": 0, "errors": 1})
+        self.assertEqual(report.errors, ("Row 2: malformed CSV row has extra columns.",))
+
+    def test_cli_returns_summary_and_nonzero_exit_on_invalid_csv(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,,jane@example.org\n",
+        )
+
+        exit_code = holder_import.main([str(csv_path), "--db", str(self.db_path)])
+
+        self.assertEqual(exit_code, 2)
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+        self.assertEqual(json.dumps(report.summary(), sort_keys=True), "{\"created\": 0, \"errors\": 1, \"processed\": 1, \"updated\": 0}")
+
+    def test_script_entrypoint_runs_end_to_end(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,Jane Doe,jane@example.org\n",
+        )
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "import_holders_csv.py"
+
+        result = subprocess.run(
+            [sys.executable, str(script_path), str(csv_path), "--db", str(self.db_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(
+            json.loads(result.stdout.strip()),
+            {"processed": 1, "created": 1, "updated": 0, "errors": 0},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add a CLI-only holder CSV importer that creates or updates holders by exact email match.

## Related Issue
Closes #401 

## Changes
- added holder CSV import logic
- added a script entrypoint for running the import
- required organization, name, and email
- update existing holders by exact normalized email
- create new holders when email is new
- fail safely on invalid rows, duplicate CSV emails, or ambiguous DB email matches
- added focused importer tests

## Verification checklist
- [x] Import creates new holders from valid CSV
- [x] Re-import updates existing holders by email
- [x] Blank required fields fail clearly
- [x] Duplicate email rows in CSV fail safely
- [x] Ambiguous duplicate emails in DB fail safely
- [x] Focused tests pass
- [x] Existing holder tests still pass
- [x] Manual CLI verification performed

## Notes
Separate holder form email requirement and wording updates should stay in a follow-on issue.