### PR TITLE
Issue 26-66: enforce holder email uniqueness

### DIFF
--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -19,6 +19,34 @@ def _normalize_email(email: str | None) -> str | None:
     return normalized
 
 
+def _ensure_unique_holder_email(
+    conn,
+    normalized_email: str | None,
+    *,
+    current_holder_id: int | None = None,
+) -> None:
+    if not normalized_email:
+        return
+
+    row = conn.execute(
+        """
+        SELECT id
+        FROM holders
+        WHERE LOWER(TRIM(COALESCE(email, ''))) = ?
+        LIMIT 1;
+        """,
+        (normalized_email,),
+    ).fetchone()
+    if row is None:
+        return
+
+    existing_holder_id = int(row["id"])
+    if current_holder_id is not None and existing_holder_id == int(current_holder_id):
+        return
+
+    raise ValueError("email already exists")
+
+
 def search_holders(query: str, limit: int = 20) -> list[dict]:
     q = (query or "").strip()
     if not q:
@@ -124,6 +152,7 @@ def create_holder(
     now_iso = datetime.now(timezone.utc).isoformat()
     conn = get_connection()
     try:
+        _ensure_unique_holder_email(conn, normalized_email)
         cursor = conn.execute(
             """
             INSERT INTO holders (
@@ -188,6 +217,7 @@ def update_holder(
 
     conn = get_connection()
     try:
+        _ensure_unique_holder_email(conn, normalized_email, current_holder_id=normalized_id)
         cursor = conn.execute(
             """
             UPDATE holders

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -639,6 +639,8 @@ def _holder_form_error_message(exc: ValueError) -> str:
         return "Enter a person or group name when using Ad Hoc."
     if message == "email is required":
         return "Enter an email address so this holder can receive receipts."
+    if message == "email already exists":
+        return "A holder with that email already exists."
     if message == "email is invalid":
         return "Enter a valid email address so this holder can receive receipts."
     return message

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -395,6 +395,28 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Enter an email address so this holder can receive receipts.", follow_up.data)
         self.assertIn(b'value="Missing Email Holder"', follow_up.data)
 
+    def test_post_holders_new_rejects_duplicate_email_with_clear_feedback(self) -> None:
+        org_id = self._create_org("Alpha Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "First Holder", "organization_id": str(org_id), "email": "shared@example.org"},
+        )
+
+        response = self.client.post(
+            "/holders/new",
+            data={"name": "Second Holder", "organization_id": str(org_id), "email": "shared@example.org"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/holders/new"))
+
+        follow_up = self.client.get("/holders/new")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"A holder with that email already exists.", follow_up.data)
+        self.assertIn(b'value="Second Holder"', follow_up.data)
+        self.assertIn(b'value="shared@example.org"', follow_up.data)
+
     def test_edit_holder_rejects_invalid_email_with_clear_feedback(self) -> None:
         org_id = self._create_org("Alpha Org")
         self.client.post(
@@ -446,6 +468,59 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(follow_up.status_code, 200)
         self.assertIn(b"Enter an email address so this holder can receive receipts.", follow_up.data)
         self.assertIn(b'value="Editable Holder"', follow_up.data)
+
+    def test_edit_holder_rejects_duplicate_email_with_clear_feedback(self) -> None:
+        org_id = self._create_org("Alpha Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "First Holder", "organization_id": str(org_id), "email": "first@example.org"},
+        )
+        self.client.post(
+            "/holders/new",
+            data={"name": "Second Holder", "organization_id": str(org_id), "email": "second@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Second Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        response = self.client.post(
+            f"/holders/edit/{int(holder_row['id'])}",
+            data={"name": "Second Holder", "organization_id": str(org_id), "email": "first@example.org"},
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith(f"/holders/edit/{int(holder_row['id'])}"))
+
+        follow_up = self.client.get(f"/holders/edit/{int(holder_row['id'])}")
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"A holder with that email already exists.", follow_up.data)
+        self.assertIn(b'value="Second Holder"', follow_up.data)
+        self.assertIn(b'value="first@example.org"', follow_up.data)
+
+    def test_edit_holder_allows_unchanged_same_holder_email(self) -> None:
+        org_id = self._create_org("Alpha Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Editable Holder", "organization_id": str(org_id), "email": "editable@example.org"},
+            follow_redirects=False,
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Editable Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        response = self.client.post(
+            f"/holders/edit/{int(holder_row['id'])}",
+            data={"name": "Editable Holder Renamed", "organization_id": str(org_id), "email": "editable@example.org"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Updated holder: Editable Holder Renamed", response.data)
 
     def test_holder_detail_shows_zero_assets_state(self) -> None:
         organization_id = self._create_org("Ad Hoc")

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -172,3 +172,40 @@ class HoldersTests(unittest.TestCase):
         updated = update_holder(int(created["id"]), name="Email Holder", organization_id=organization_id, email="")
 
         self.assertIsNone(updated["email"])
+
+    def test_create_holder_rejects_duplicate_email(self) -> None:
+        organization_id = self._insert_organization("Support Org")
+        create_holder("First Holder", organization_id=organization_id, email="holder@example.org")
+
+        with self.assertRaisesRegex(ValueError, "email already exists"):
+            create_holder("Second Holder", organization_id=organization_id, email="holder@example.org")
+
+    def test_update_holder_rejects_duplicate_email_on_different_holder(self) -> None:
+        organization_id = self._insert_organization("Support Org")
+        first = create_holder("First Holder", organization_id=organization_id, email="first@example.org")
+        second = create_holder("Second Holder", organization_id=organization_id, email="second@example.org")
+
+        with self.assertRaisesRegex(ValueError, "email already exists"):
+            update_holder(
+                int(second["id"]),
+                name="Second Holder",
+                organization_id=organization_id,
+                email="first@example.org",
+            )
+
+        fetched = get_holder(int(second["id"]))
+        self.assertIsNotNone(fetched)
+        self.assertEqual(fetched["email"], "second@example.org")
+
+    def test_update_holder_allows_unchanged_email_on_same_holder(self) -> None:
+        organization_id = self._insert_organization("Support Org")
+        created = create_holder("Stable Holder", organization_id=organization_id, email="stable@example.org")
+
+        updated = update_holder(
+            int(created["id"]),
+            name="Stable Holder",
+            organization_id=organization_id,
+            email="stable@example.org",
+        )
+
+        self.assertEqual(updated["email"], "stable@example.org")


### PR DESCRIPTION
## Summary
Enforce unique email per holder so one email maps to one holder.

## Related Issue
Closes #421 

## Changes
- added app-level email uniqueness validation in holder helpers
- reject duplicate email on create and edit
- allow unchanged email on same holder
- wired validation into existing PRG + flash flow
- updated tests for duplicate handling

## Verification checklist
- [x] Create rejects duplicate email
- [x] Edit rejects duplicate email
- [x] Same-holder email edit allowed
- [x] Existing valid flows still work
- [x] Tests pass
- [x] Manual smoke test completed

## Notes
App-level enforcement only. No schema change or migration.