### PR TITLE
Issue 26-70: add public recruiter demo page

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -86,6 +86,36 @@ TERMINAL_LOCATION_TYPE = "DISPOSED"
 TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
 ASSET_EQUIPMENT_TYPE_OPTIONS = ("laptop", "tablet")
+DEMO_SUMMARY = {
+    "assets_in_custody": 18,
+    "pending_receipts": 2,
+    "holders": 7,
+    "cases": 4,
+}
+DEMO_HOLDERS = [
+    {"name": "Signal Platoon", "organization": "Operations", "email": "signal.platoon@example.demo", "asset_count": 6},
+    {"name": "Maintenance Shop", "organization": "Support", "email": "maintenance.shop@example.demo", "asset_count": 4},
+    {"name": "Forward Team Alpha", "organization": "Field Team", "email": "fta@example.demo", "asset_count": 3},
+]
+DEMO_RECEIPTS = [
+    {
+        "title": "Issue Receipt - Signal Platoon - Apr 3, 2026",
+        "status": "Queued",
+        "recipient_email": "signal.platoon@example.demo",
+        "receipt_key": "ISSUE-2026-0042",
+    },
+    {
+        "title": "Return Receipt - Maintenance Shop - Apr 2, 2026",
+        "status": "Sent",
+        "recipient_email": "maintenance.shop@example.demo",
+        "receipt_key": "RETURN-2026-0017",
+    },
+]
+DEMO_AUDIT = [
+    {"event_date": "2026-04-03T09:14:00Z", "event_type": "ISSUE", "asset_tag": "LT-4421", "actor": "operator-demo"},
+    {"event_date": "2026-04-03T09:18:00Z", "event_type": "ISSUE", "asset_tag": "TB-1188", "actor": "operator-demo"},
+    {"event_date": "2026-04-02T16:42:00Z", "event_type": "RETURN", "asset_tag": "LT-3010", "actor": "operator-demo"},
+]
 
 
 @app.after_request
@@ -131,6 +161,21 @@ def _should_refresh_session_activity() -> bool:
 def sanitize_scan(raw: str) -> str:
     """Keep only letters and numbers; drop tabs/newlines/suffix junk."""
     return "".join(ch for ch in raw if ch.isalnum()).upper()
+
+
+def _demo_page_context() -> dict[str, object]:
+    return {
+        "summary": DEMO_SUMMARY,
+        "holders": DEMO_HOLDERS,
+        "receipts": DEMO_RECEIPTS,
+        "audit_rows": DEMO_AUDIT,
+        "workflow_steps": [
+            "Select the holder and confirm prerequisites.",
+            "Scan assets into the queue without committing immediately.",
+            "Preview the batch before commit so operators can catch mistakes.",
+            "Commit once and let receipts track follow-up notification state.",
+        ],
+    }
 
 
 def _queue_contains_asset_tag(asset_tag: str) -> bool:
@@ -3283,6 +3328,11 @@ def add_assets():
         slot_options=slot_options,
         case_options=case_options,
     )
+
+
+@app.get("/demo")
+def demo():
+    return render_template("demo.html", **_demo_page_context())
 
 
 @app.post("/add-assets/review")

--- a/assettrack/intake/templates/demo.html
+++ b/assettrack/intake/templates/demo.html
@@ -1,0 +1,166 @@
+{% extends "base.html" %}
+
+{% block title %}AssetTrack Demo{% endblock %}
+{% block page_heading %}AssetTrack Demo{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .demo-hero {
+      display: grid;
+      gap: 1rem;
+      padding: 1.25rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 16px;
+      background:
+        linear-gradient(135deg, color-mix(in srgb, var(--color-primary) 14%, transparent), transparent 55%),
+        linear-gradient(180deg, var(--color-surface-bg), color-mix(in srgb, var(--color-primary-soft) 30%, var(--color-surface-bg)));
+    }
+    .demo-hero-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(260px, 1fr));
+      gap: 1rem;
+      margin-top: 1rem;
+    }
+    .demo-metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(140px, 1fr));
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+    .demo-metric {
+      padding: 1rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 12px;
+      background: var(--color-surface-bg);
+    }
+    .demo-metric strong {
+      display: block;
+      font-size: 1.55rem;
+      margin-top: 0.25rem;
+    }
+    .demo-list {
+      margin: 0;
+      padding-left: 1.15rem;
+      display: grid;
+      gap: 0.5rem;
+    }
+    .demo-note {
+      margin-top: 1rem;
+      padding: 0.9rem 1rem;
+      border-radius: 12px;
+      border: 1px solid rgba(244, 162, 97, 0.34);
+      background: var(--color-warning-soft);
+    }
+    @media (max-width: 820px) {
+      .demo-grid,
+      .demo-metrics {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="demo-hero">
+    <div>
+      <p class="chip">Read-Only Demo</p>
+      <h2>Offline asset custody with a clear operator workflow</h2>
+      <p>
+        This demo uses curated sample data only. It is separate from operational use and does not read or write the live system of record.
+      </p>
+    </div>
+    <div class="demo-hero-actions">
+      <a class="chip" href="{{ url_for('intake') }}">Operator Login</a>
+      <a class="chip" href="#workflow">See Workflow</a>
+      <a class="chip" href="#audit">See Audit Concept</a>
+    </div>
+  </div>
+
+  <div class="demo-metrics" aria-label="Demo summary">
+    <div class="demo-metric"><span>Assets in custody</span><strong>{{ summary.assets_in_custody }}</strong></div>
+    <div class="demo-metric"><span>Active holders</span><strong>{{ summary.holders }}</strong></div>
+    <div class="demo-metric"><span>Pending receipts</span><strong>{{ summary.pending_receipts }}</strong></div>
+    <div class="demo-metric"><span>Tracked cases</span><strong>{{ summary.cases }}</strong></div>
+  </div>
+
+  <div class="demo-grid">
+    <div class="card">
+      <h2>Dashboard Value</h2>
+      <p>Supervisors can see who currently has assets, what still needs receipt follow-up, and where bottlenecks are forming.</p>
+      <table>
+        <thead>
+          <tr><th>Holder</th><th>Organization</th><th>Email</th><th>Assets</th></tr>
+        </thead>
+        <tbody>
+          {% for holder in holders %}
+            <tr>
+              <td>{{ holder.name }}</td>
+              <td>{{ holder.organization }}</td>
+              <td>{{ holder.email }}</td>
+              <td>{{ holder.asset_count }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card" id="workflow">
+      <h2>Issue / Return Workflow</h2>
+      <p>AssetTrack keeps the operator seam explicit so review happens before any write is committed.</p>
+      <ol class="demo-list">
+        {% for step in workflow_steps %}
+          <li>{{ step }}</li>
+        {% endfor %}
+      </ol>
+    </div>
+
+    <div class="card">
+      <h2>Receipts Concept</h2>
+      <p>Receipts capture the handoff snapshot and track whether the follow-up message is queued or sent.</p>
+      <table>
+        <thead>
+          <tr><th>Receipt</th><th>Status</th><th>Recipient</th><th>Key</th></tr>
+        </thead>
+        <tbody>
+          {% for receipt in receipts %}
+            <tr>
+              <td>{{ receipt.title }}</td>
+              <td>{{ receipt.status }}</td>
+              <td>{{ receipt.recipient_email }}</td>
+              <td><code>{{ receipt.receipt_key }}</code></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card" id="audit">
+      <h2>Audit Concept</h2>
+      <p>The event log remains the source of truth. State and receipts are downstream views of that history.</p>
+      <table>
+        <thead>
+          <tr><th>When</th><th>Event</th><th>Asset</th><th>Actor</th></tr>
+        </thead>
+        <tbody>
+          {% for row in audit_rows %}
+            <tr>
+              <td>{{ row.event_date }}</td>
+              <td>{{ row.event_type }}</td>
+              <td>{{ row.asset_tag }}</td>
+              <td>{{ row.actor }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="demo-note">
+    <strong>Safety note:</strong> this demo does not expose operational holder, receipt, or event records and does not submit changes into the custody system.
+  </div>
+{% endblock %}

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -57,6 +57,55 @@ def test_login_screen_renders_theme_toggle_without_persistence_storage(client_wi
     assert b"sessionStorage" not in response.data
 
 
+def test_demo_route_is_public_and_uses_demo_only_copy(client_with_temp_db) -> None:
+    conn = db.get_connection()
+    try:
+        before = {
+            "holders": int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0]),
+            "receipts": int(conn.execute("SELECT COUNT(*) FROM receipt_queue;").fetchone()[0]),
+            "events": int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0]),
+        }
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/demo")
+
+    assert response.status_code == 200
+    assert b"AssetTrack Demo" in response.data
+    assert b"Read-Only Demo" in response.data
+    assert b"curated sample data only" in response.data
+    assert b"does not read or write the live system of record" in response.data
+    assert b"Dashboard Value" in response.data
+    assert b"Issue / Return Workflow" in response.data
+    assert b"Receipts Concept" in response.data
+    assert b"Audit Concept" in response.data
+
+    conn = db.get_connection()
+    try:
+        after = {
+            "holders": int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0]),
+            "receipts": int(conn.execute("SELECT COUNT(*) FROM receipt_queue;").fetchone()[0]),
+            "events": int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0]),
+        }
+    finally:
+        conn.close()
+
+    assert after == before
+
+
+def test_demo_route_does_not_unlock_protected_operational_pages(client_with_temp_db) -> None:
+    demo_response = client_with_temp_db.get("/demo")
+    assert demo_response.status_code == 200
+
+    dashboard_response = client_with_temp_db.get("/dashboard")
+    holders_response = client_with_temp_db.get("/holders")
+    receipts_response = client_with_temp_db.get("/receipts")
+
+    assert dashboard_response.status_code == 403
+    assert holders_response.status_code == 403
+    assert receipts_response.status_code == 403
+
+
 def test_dark_theme_cookie_persists_across_authenticated_navigation(client_with_temp_db) -> None:
     create_user("operator", "op-pass", "operator", True)
     _login(client_with_temp_db, "operator", "op-pass")


### PR DESCRIPTION
## Summary
Add a public read-only demo page so recruiters can understand AssetTrack without using live operational data.

## Related Issue
Closes #426 

## Changes
- added public `/demo` route
- rendered demo from static sample data only
- added standalone demo template
- added auth-safety coverage to confirm protected routes stay protected

## Verification checklist
- [x] `/demo` loads without login
- [x] `/dashboard` blocked without login
- [x] `/holders` blocked without login
- [x] `/receipts` blocked without login
- [x] demo has no write path into live system
- [x] tests pass
- [x] manual smoke test completed

## Notes
Demo is isolated from the operational database and does not weaken normal auth boundaries.