### PR TITLE
Issue 26-77: refresh container base image and libpng package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.12-alpine
+FROM python:3.12.13-alpine3.23
 
 RUN python -m pip install --upgrade "pip==26.0"
 
@@ -14,7 +14,8 @@ RUN apk update && apk upgrade --no-cache
 RUN addgroup -S assettrack && adduser -S -G assettrack -h /app assettrack
 
 # System deps for common scientific + imaging stacks
-RUN apk add --no-cache \
+RUN apk add --no-cache --upgrade \
+        libpng \
         libjpeg-turbo \
         freetype \
         lcms2 \


### PR DESCRIPTION
## Summary
Refresh the container base image and explicitly upgrade `libpng` so the built AssetTrack image clears the remaining Trivy HIGH findings.

## Related Issue
Closes #438 

## Changes
- pinned the base image to `python:3.12.13-alpine3.23`
- made `libpng` an explicit upgraded runtime package in `Dockerfile`
- kept application code unchanged

## Verification checklist
- [x] `docker compose up -d --build`
- [x] `docker compose exec assettrack sh -lc 'apk list --installed | grep "^libpng-"'`
- [x] `trivy image --severity HIGH,CRITICAL assettrack-assettrack`
- [x] `curl -i http://localhost:8000`
- [ ] Full operator smoke test run

## Notes
Trivy is clean at HIGH/CRITICAL after rebuild. Codex noted newer transitive runtime packages were picked up at build time, so a quick browser smoke test is recommended before merge.