### PR TITLE
Issue 26-72: add friendly 403 and 404 pages

### DIFF
--- a/assettrack/auth.py
+++ b/assettrack/auth.py
@@ -3,15 +3,25 @@ from __future__ import annotations
 
 from functools import wraps
 
-from flask import g, jsonify, request, session
+from flask import g, render_template, request, session
 
 from assettrack.users import ALLOWED_ROLES, get_user_by_id
 
 
+def _prefers_json_response() -> bool:
+    if request.is_json:
+        return True
+
+    best = request.accept_mimetypes.best_match(["application/json", "text/html"])
+    return best == "application/json" and (
+        request.accept_mimetypes["application/json"] >= request.accept_mimetypes["text/html"]
+    )
+
+
 def _forbidden_response():
-    if request.path.startswith("/admin/") or request.is_json:
+    if _prefers_json_response():
         return {"ok": False, "error": "Forbidden"}, 403
-    return jsonify({"ok": False, "error": "Forbidden"}), 403
+    return render_template("403.html"), 403
 
 
 def current_user() -> dict | None:

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -158,6 +158,23 @@ def _should_refresh_session_activity() -> bool:
     return True
 
 
+def _prefers_json_error_response() -> bool:
+    if request.is_json:
+        return True
+
+    best = request.accept_mimetypes.best_match(["application/json", "text/html"])
+    return best == "application/json" and (
+        request.accept_mimetypes["application/json"] >= request.accept_mimetypes["text/html"]
+    )
+
+
+@app.errorhandler(404)
+def not_found_page(_error):
+    if _prefers_json_error_response():
+        return {"ok": False, "error": "Not Found"}, 404
+    return render_template("404.html"), 404
+
+
 def sanitize_scan(raw: str) -> str:
     """Keep only letters and numbers; drop tabs/newlines/suffix junk."""
     return "".join(ch for ch in raw if ch.isalnum()).upper()

--- a/assettrack/intake/templates/403.html
+++ b/assettrack/intake/templates/403.html
@@ -1,0 +1,13 @@
+<!-- file: assettrack/intake/templates/403.html -->
+{% extends "base.html" %}
+
+{% block title %}AssetTrack Access Not Allowed{% endblock %}
+{% block page_heading %}Access Not Allowed{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <p>This page is not available with your current access.</p>
+    <p class="muted">Safe next steps: go back to the dashboard, sign in with the correct account, or contact an admin if you expected access.</p>
+    <p><a href="{{ url_for('dashboard') if authenticated_user else url_for('add_assets') }}">Return to a safe page</a></p>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/404.html
+++ b/assettrack/intake/templates/404.html
@@ -1,0 +1,13 @@
+<!-- file: assettrack/intake/templates/404.html -->
+{% extends "base.html" %}
+
+{% block title %}AssetTrack Page Not Found{% endblock %}
+{% block page_heading %}Page Not Found{% endblock %}
+
+{% block content %}
+  <div class="card">
+    <p>The page you requested does not exist in this AssetTrack session.</p>
+    <p class="muted">Safe next steps: check the address, return to the dashboard, or use the main navigation to continue.</p>
+    <p><a href="{{ url_for('dashboard') if authenticated_user else url_for('add_assets') }}">Return to a safe page</a></p>
+  </div>
+{% endblock %}

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -125,11 +125,34 @@ def test_demo_route_and_unauthed_protected_routes_do_not_require_db_access(
     assert b"Safety note:" in demo_response.data
 
     assert dashboard_response.status_code == 403
-    assert dashboard_response.json == {"ok": False, "error": "Forbidden"}
+    assert b"Access Not Allowed" in dashboard_response.data
+    assert b"This page is not available with your current access." in dashboard_response.data
     assert holders_response.status_code == 403
-    assert holders_response.json == {"ok": False, "error": "Forbidden"}
+    assert b"Access Not Allowed" in holders_response.data
     assert receipts_response.status_code == 403
-    assert receipts_response.json == {"ok": False, "error": "Forbidden"}
+    assert b"Access Not Allowed" in receipts_response.data
+
+
+def test_protected_route_can_still_return_json_forbidden_when_json_is_requested(client_with_temp_db) -> None:
+    response = client_with_temp_db.get("/dashboard", headers={"Accept": "application/json"})
+
+    assert response.status_code == 403
+    assert response.json == {"ok": False, "error": "Forbidden"}
+
+
+def test_unknown_route_renders_friendly_404_page(client_with_temp_db) -> None:
+    response = client_with_temp_db.get("/missing-page")
+
+    assert response.status_code == 404
+    assert b"Page Not Found" in response.data
+    assert b"The page you requested does not exist in this AssetTrack session." in response.data
+
+
+def test_unknown_route_can_still_return_json_not_found_when_json_is_requested(client_with_temp_db) -> None:
+    response = client_with_temp_db.get("/missing-page", headers={"Accept": "application/json"})
+
+    assert response.status_code == 404
+    assert response.json == {"ok": False, "error": "Not Found"}
 
 
 def test_dark_theme_cookie_persists_across_authenticated_navigation(client_with_temp_db) -> None:

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -519,7 +519,7 @@ def test_receipt_detail_requires_login(client_with_temp_db) -> None:
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 403
-    assert response.json == {"ok": False, "error": "Forbidden"}
+    assert b"Access Not Allowed" in response.data
 
 
 def test_receipt_detail_timeout_matches_existing_readonly_pattern(

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -187,7 +187,7 @@ def test_receipts_list_requires_login(client_with_temp_db) -> None:
     response = client_with_temp_db.get("/receipts")
 
     assert response.status_code == 403
-    assert response.json == {"ok": False, "error": "Forbidden"}
+    assert b"Access Not Allowed" in response.data
 
 
 def test_receipts_list_timeout_matches_existing_readonly_pattern(


### PR DESCRIPTION
## Summary
Adds friendly 403 and 404 pages for browser users while preserving correct status codes and existing auth behavior.

## Related Issue
Closes #429 

## Changes
- Added custom 403 and 404 templates
- Updated auth guard to return HTML or JSON based on request
- Added 404 error handler
- Extended tests for error handling behavior

## Verification checklist
- [x] Operator hitting protected route receives friendly 403 page
- [x] Unknown route returns friendly 404 page
- [x] Status codes remain correct (403/404)
- [x] Auth boundaries unchanged
- [x] Tests pass

## Notes
Presentation-only change. No impact to schema, persistence, or event model.