### PR TITLE
Issue 26-80: polish demo page layout and copy

### DIFF
--- a/assettrack/intake/templates/demo.html
+++ b/assettrack/intake/templates/demo.html
@@ -2,64 +2,200 @@
 
 {% block title %}AssetTrack Demo{% endblock %}
 {% block page_heading %}AssetTrack Demo{% endblock %}
+{% block page_class %} demo-page{% endblock %}
 
 {% block extra_head %}
   <style>
+    .page.demo-page {
+      max-width: 1380px;
+      padding: 1.5rem 1.75rem 2.5rem;
+    }
+    .demo-page .page-header {
+      margin-bottom: 1rem;
+    }
+    .demo-page .page-header h1 {
+      font-size: clamp(2rem, 2.6vw, 2.65rem);
+      letter-spacing: -0.02em;
+    }
     .demo-hero {
       display: grid;
-      gap: 1rem;
-      padding: 1.25rem;
+      gap: 1.15rem;
+      padding: 1.6rem 1.7rem;
       border: 1px solid var(--color-surface);
       border-radius: 16px;
       background:
         linear-gradient(135deg, color-mix(in srgb, var(--color-primary) 14%, transparent), transparent 55%),
         linear-gradient(180deg, var(--color-surface-bg), color-mix(in srgb, var(--color-primary-soft) 30%, var(--color-surface-bg)));
     }
+    .demo-hero-copy {
+      display: grid;
+      gap: 0.75rem;
+      max-width: min(90ch, 100%);
+    }
+    .demo-hero-copy h2,
+    .demo-grid .card h2 {
+      margin: 0;
+    }
+    .demo-hero-copy h2 {
+      font-size: clamp(1.8rem, 2.4vw, 2.4rem);
+      line-height: 1.08;
+      letter-spacing: -0.025em;
+    }
+    .demo-hero-copy p,
+    .demo-grid .card p {
+      margin: 0;
+    }
+    .demo-hero-copy p {
+      font-size: 1.02rem;
+      line-height: 1.55;
+    }
     .demo-hero-actions {
       display: flex;
+      justify-content: flex-start;
+      align-items: flex-start;
       gap: 0.75rem;
-      flex-wrap: wrap;
+      flex-wrap: nowrap;
+    }
+    .demo-hero-actions .chip:first-child {
+      background: var(--color-primary);
+      border-color: var(--color-primary);
+      color: #fff;
+    }
+    .demo-hero-actions .chip:not(:first-child) {
+      background: var(--color-surface-bg);
+    }
+    .demo-summary {
+      margin-top: 1.25rem;
+      display: grid;
+      gap: 0.55rem;
+    }
+    .demo-summary h2 {
+      margin: 0;
+      font-size: 1rem;
     }
     .demo-grid {
       display: grid;
-      grid-template-columns: repeat(2, minmax(260px, 1fr));
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      align-items: start;
+      gap: 1.25rem;
+      margin-top: 1.5rem;
+    }
+    .demo-grid > .card {
+      margin-top: 0;
+      display: grid;
       gap: 1rem;
-      margin-top: 1rem;
+      min-width: 0;
+      padding: 1.2rem 1.25rem 1.25rem;
     }
     .demo-metrics {
       display: grid;
-      grid-template-columns: repeat(4, minmax(140px, 1fr));
-      gap: 0.75rem;
-      margin-top: 1rem;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 1rem;
+      margin-top: 1.25rem;
     }
     .demo-metric {
-      padding: 1rem;
+      padding: 1rem 1.1rem;
       border: 1px solid var(--color-surface);
       border-radius: 12px;
       background: var(--color-surface-bg);
     }
+    .demo-metric span {
+      display: block;
+      font-size: 0.95rem;
+      color: var(--color-text-muted);
+    }
+    .demo-metric small {
+      display: block;
+      margin-top: 0.45rem;
+      color: var(--color-text-muted);
+      line-height: 1.35;
+    }
     .demo-metric strong {
       display: block;
-      font-size: 1.55rem;
-      margin-top: 0.25rem;
+      font-size: 1.8rem;
+      margin-top: 0.35rem;
+      letter-spacing: -0.03em;
     }
     .demo-list {
       margin: 0;
-      padding-left: 1.15rem;
+      padding-left: 1.25rem;
       display: grid;
-      gap: 0.5rem;
+      gap: 0.65rem;
+    }
+    .demo-table-wrap {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+      border: 1px solid var(--color-surface);
+      border-radius: 10px;
+      background: var(--color-surface-bg);
+    }
+    .demo-table-wrap table {
+      min-width: 100%;
+      border: 0;
+      margin: 0;
+    }
+    .demo-table-wide {
+      min-width: 680px;
+    }
+    .demo-wrap {
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+    .demo-table-wrap th:first-child,
+    .demo-table-wrap td:first-child {
+      padding-left: 0.75rem;
+    }
+    .demo-table-wrap th:last-child,
+    .demo-table-wrap td:last-child {
+      padding-right: 0.75rem;
     }
     .demo-note {
-      margin-top: 1rem;
-      padding: 0.9rem 1rem;
+      margin-top: 1.5rem;
+      padding: 1rem 1.15rem;
       border-radius: 12px;
       border: 1px solid rgba(244, 162, 97, 0.34);
       background: var(--color-warning-soft);
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr);
+      gap: 0.7rem;
+      align-items: start;
+    }
+    .demo-note strong {
+      white-space: nowrap;
+    }
+    .demo-note p {
+      margin: 0;
+      max-width: none;
+      line-height: 1.5;
+    }
+    @media (max-width: 1180px) {
+      .page.demo-page {
+        max-width: 1220px;
+        padding-left: 1.4rem;
+        padding-right: 1.4rem;
+      }
+      .demo-hero-actions {
+        flex-wrap: wrap;
+      }
+      .demo-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .demo-grid {
+        grid-template-columns: 1fr;
+      }
     }
     @media (max-width: 820px) {
-      .demo-grid,
+      .page.demo-page {
+        padding: 1.15rem 1rem 2rem;
+      }
       .demo-metrics {
         grid-template-columns: 1fr;
+      }
+      .demo-hero {
+        padding: 1.2rem;
+      }
+      .demo-table-wide {
+        min-width: 540px;
       }
     }
   </style>
@@ -67,51 +203,73 @@
 
 {% block content %}
   <div class="demo-hero">
-    <div>
+    <div class="demo-hero-copy">
       <p class="chip">Read-Only Demo</p>
-      <h2>Offline asset custody with a clear operator workflow</h2>
+      <h2>Asset custody, without the guesswork</h2>
       <p>
-        This demo uses curated sample data only. It is separate from operational use and does not read or write the live system of record.
+        This page uses sample data. It does not touch live records or the system of record.
       </p>
     </div>
     <div class="demo-hero-actions">
-      <a class="chip" href="{{ url_for('intake') }}">Operator Login</a>
-      <a class="chip" href="#workflow">See Workflow</a>
-      <a class="chip" href="#audit">See Audit Concept</a>
+      <a class="chip" href="{{ url_for('intake') }}">Go to Operator Login</a>
+      <a class="chip" href="#workflow">See the workflow</a>
+      <a class="chip" href="#audit">View audit trail</a>
     </div>
   </div>
 
+  <div class="demo-summary">
+    <h2>Demo at a glance</h2>
+  </div>
+
   <div class="demo-metrics" aria-label="Demo summary">
-    <div class="demo-metric"><span>Assets in custody</span><strong>{{ summary.assets_in_custody }}</strong></div>
-    <div class="demo-metric"><span>Active holders</span><strong>{{ summary.holders }}</strong></div>
-    <div class="demo-metric"><span>Pending receipts</span><strong>{{ summary.pending_receipts }}</strong></div>
-    <div class="demo-metric"><span>Tracked cases</span><strong>{{ summary.cases }}</strong></div>
+    <div class="demo-metric">
+      <span>Assets in custody</span>
+      <strong>{{ summary.assets_in_custody }}</strong>
+      <small>Currently checked out in the demo</small>
+    </div>
+    <div class="demo-metric">
+      <span>Active holders</span>
+      <strong>{{ summary.holders }}</strong>
+      <small>People or teams holding assets</small>
+    </div>
+    <div class="demo-metric">
+      <span>Pending receipts</span>
+      <strong>{{ summary.pending_receipts }}</strong>
+      <small>Follow-up messages not yet sent</small>
+    </div>
+    <div class="demo-metric">
+      <span>Tracked cases</span>
+      <strong>{{ summary.cases }}</strong>
+      <small>Storage cases represented in demo data</small>
+    </div>
   </div>
 
   <div class="demo-grid">
     <div class="card">
-      <h2>Dashboard Value</h2>
-      <p>Supervisors can see who currently has assets, what still needs receipt follow-up, and where bottlenecks are forming.</p>
-      <table>
-        <thead>
-          <tr><th>Holder</th><th>Organization</th><th>Email</th><th>Assets</th></tr>
-        </thead>
-        <tbody>
-          {% for holder in holders %}
-            <tr>
-              <td>{{ holder.name }}</td>
-              <td>{{ holder.organization }}</td>
-              <td>{{ holder.email }}</td>
-              <td>{{ holder.asset_count }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      <h2>Who Has What</h2>
+      <p>Supervisors can see who is holding assets, who still needs follow-up, and where work is starting to stack up.</p>
+      <div class="demo-table-wrap">
+        <table class="demo-table-wide">
+          <thead>
+            <tr><th>Holder</th><th>Organization</th><th>Email</th><th>Assets</th></tr>
+          </thead>
+          <tbody>
+            {% for holder in holders %}
+              <tr>
+                <td>{{ holder.name }}</td>
+                <td>{{ holder.organization }}</td>
+                <td class="demo-wrap">{{ holder.email }}</td>
+                <td>{{ holder.asset_count }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <div class="card" id="workflow">
-      <h2>Issue / Return Workflow</h2>
-      <p>AssetTrack keeps the operator seam explicit so review happens before any write is committed.</p>
+      <h2>How the Workflow Stays Safe</h2>
+      <p>The operator path stays explicit, so review happens before anything is written to the record.</p>
       <ol class="demo-list">
         {% for step in workflow_steps %}
           <li>{{ step }}</li>
@@ -120,47 +278,52 @@
     </div>
 
     <div class="card">
-      <h2>Receipts Concept</h2>
-      <p>Receipts capture the handoff snapshot and track whether the follow-up message is queued or sent.</p>
-      <table>
-        <thead>
-          <tr><th>Receipt</th><th>Status</th><th>Recipient</th><th>Key</th></tr>
-        </thead>
-        <tbody>
-          {% for receipt in receipts %}
-            <tr>
-              <td>{{ receipt.title }}</td>
-              <td>{{ receipt.status }}</td>
-              <td>{{ receipt.recipient_email }}</td>
-              <td><code>{{ receipt.receipt_key }}</code></td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      <h2>Receipts, At a Glance</h2>
+      <p>Each receipt captures the handoff snapshot and shows whether follow-up is still queued or already sent.</p>
+      <div class="demo-table-wrap">
+        <table class="demo-table-wide">
+          <thead>
+            <tr><th>Receipt</th><th>Status</th><th>Recipient</th><th>Key</th></tr>
+          </thead>
+          <tbody>
+            {% for receipt in receipts %}
+              <tr>
+                <td>{{ receipt.title }}</td>
+                <td>{{ receipt.status }}</td>
+                <td class="demo-wrap">{{ receipt.recipient_email }}</td>
+                <td><code class="demo-wrap">{{ receipt.receipt_key }}</code></td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
 
     <div class="card" id="audit">
-      <h2>Audit Concept</h2>
-      <p>The event log remains the source of truth. State and receipts are downstream views of that history.</p>
-      <table>
-        <thead>
-          <tr><th>When</th><th>Event</th><th>Asset</th><th>Actor</th></tr>
-        </thead>
-        <tbody>
-          {% for row in audit_rows %}
-            <tr>
-              <td>{{ row.event_date }}</td>
-              <td>{{ row.event_type }}</td>
-              <td>{{ row.asset_tag }}</td>
-              <td>{{ row.actor }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      <h2>Why the Audit Trail Matters</h2>
+      <p>The event log stays the source of truth. Current state and receipts are views built from that history.</p>
+      <div class="demo-table-wrap">
+        <table class="demo-table-wide">
+          <thead>
+            <tr><th>When</th><th>Event</th><th>Asset</th><th>Actor</th></tr>
+          </thead>
+          <tbody>
+            {% for row in audit_rows %}
+              <tr>
+                <td>{{ row.event_date }}</td>
+                <td>{{ row.event_type }}</td>
+                <td>{{ row.asset_tag }}</td>
+                <td class="demo-wrap">{{ row.actor }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
   </div>
 
   <div class="demo-note">
-    <strong>Safety note:</strong> this demo does not expose operational holder, receipt, or event records and does not submit changes into the custody system.
+    <strong>Safety note:</strong>
+    <p>This page shows sample holder, receipt, and event data only. It does not expose operational records, and it cannot submit changes into the custody system.</p>
   </div>
 {% endblock %}

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -73,12 +73,12 @@ def test_demo_route_is_public_and_uses_demo_only_copy(client_with_temp_db) -> No
     assert response.status_code == 200
     assert b"AssetTrack Demo" in response.data
     assert b"Read-Only Demo" in response.data
-    assert b"curated sample data only" in response.data
-    assert b"does not read or write the live system of record" in response.data
-    assert b"Dashboard Value" in response.data
-    assert b"Issue / Return Workflow" in response.data
-    assert b"Receipts Concept" in response.data
-    assert b"Audit Concept" in response.data
+    assert b"This page uses sample data." in response.data
+    assert b"It does not touch live records or the system of record." in response.data
+    assert b"Who Has What" in response.data
+    assert b"How the Workflow Stays Safe" in response.data
+    assert b"Receipts, At a Glance" in response.data
+    assert b"Why the Audit Trail Matters" in response.data
 
     conn = db.get_connection()
     try:


### PR DESCRIPTION
## Summary
Polishes the public demo page so it reads more clearly, uses space better, and feels more intentional without changing behavior.

## Related Issue
Closes #447 

## Changes
- refined demo page hero layout and copy
- improved action-row clarity
- balanced metric cards with helper text
- tightened framing and safety-note copy
- kept all changes scoped to demo presentation

## Verification checklist
- [x] /demo still loads publicly
- [x] protected routes remain protected
- [x] demo copy and layout read more clearly
- [x] metric cards feel balanced
- [x] tests pass

## Notes
Presentation-only change. No impact to routes, auth, persistence, or event model.