### PR TITLE
Issue 26-69: consolidate shared template styles

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -1,0 +1,87 @@
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.actions form {
+  margin: 0;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.pill {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.pill.bad {
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent);
+}
+
+.workflow-card h2 {
+  margin: 0 0 0.55rem 0;
+}
+
+.workflow-summary {
+  margin: 0;
+  line-height: 1.55;
+}
+
+.workflow-table td strong {
+  color: var(--color-primary);
+}
+
+.workflow-table code {
+  font-size: 0.94rem;
+  font-weight: 600;
+}
+
+.state-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.15rem 0;
+}
+
+.state-block + .state-block {
+  margin-top: 0.55rem;
+  padding-top: 0.55rem;
+  border-top: 1px solid var(--color-surface);
+}
+
+.review-signal {
+  border-left: 4px solid var(--color-primary);
+  background: var(--color-primary-soft);
+}
+
+.review-signal.blocked {
+  border-left-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.status-cell {
+  white-space: nowrap;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 700;
+}
+
+.status-dot {
+  width: 0.7rem;
+  height: 0.7rem;
+  border-radius: 999px;
+  display: inline-block;
+  border: 1px solid rgba(18, 32, 47, 0.18);
+  flex: 0 0 auto;
+}

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -8,7 +8,6 @@
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
-    .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 0.75rem; }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -6,6 +6,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{% block title %}AssetTrack{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/base.css') }}" />
     <style>
       :root {
         --palette-bg: #F7F7F7;

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -11,18 +11,11 @@
       font-size: 1.08rem;
       line-height: 1.3;
     }
-    .muted { color: var(--color-text-muted); }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
 
     .topbar { display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 0.75rem; }
     .subtitle { margin: 0; }
 
-    .actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
-      margin: 0.75rem 0 1rem 0;
-    }
+    .actions { margin: 0.75rem 0 1rem 0; }
     .chip.secondary { background: var(--color-panel-bg); }
 
     .grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: 1rem; }
@@ -69,21 +62,6 @@
     .summary-hint { font-weight: 500; font-size: 0.9rem; color: var(--color-text-muted); }
     .collapsible-body { padding: 0.9rem 1rem 1rem 1rem; }
     .collapsible-body .table-wrap { margin-top: 0.25rem; }
-    .status-cell { white-space: nowrap; }
-    .status-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-weight: 700;
-    }
-    .status-dot {
-      width: 0.7rem;
-      height: 0.7rem;
-      border-radius: 999px;
-      display: inline-block;
-      border: 1px solid rgba(18, 32, 47, 0.18);
-      flex: 0 0 auto;
-    }
     .status-dot.full { background: var(--color-primary); }
     .status-dot.low { background: var(--color-surface); }
     .status-dot.open { background: var(--color-accent); }

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -6,23 +6,7 @@
 
 {% block extra_head %}
   <style>
-    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     .status-card { margin-bottom: 1rem; }
-    .status-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-weight: 700;
-    }
-    .status-dot {
-      width: 0.7rem;
-      height: 0.7rem;
-      border-radius: 999px;
-      display: inline-block;
-      border: 1px solid rgba(18, 32, 47, 0.18);
-      flex: 0 0 auto;
-    }
     .status-dot.full { background: #12b76a; }
     .status-dot.low { background: #f79009; }
     .status-dot.open { background: #b42318; }

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -6,22 +6,6 @@
 
 {% block extra_head %}
   <style>
-    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
-    .status-cell { white-space: nowrap; }
-    .status-badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-weight: 700;
-    }
-    .status-dot {
-      width: 0.7rem;
-      height: 0.7rem;
-      border-radius: 999px;
-      display: inline-block;
-      border: 1px solid rgba(18, 32, 47, 0.18);
-      flex: 0 0 auto;
-    }
     .status-dot.full { background: #12b76a; }
     .status-dot.low { background: #f79009; }
     .status-dot.open { background: #b42318; }

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -4,13 +4,6 @@
 {% block title %}Holder Detail{% endblock %}
 {% block page_heading %}Outstanding Assets: {{ holder.holder_name }}{% endblock %}
 
-{% block extra_head %}
-  <style>
-    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-  </style>
-{% endblock %}
-
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
     <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -4,14 +4,6 @@
 {% block title %}Holder Detail{% endblock %}
 {% block page_heading %}Holder: {{ holder_display_name(holder) }}{% endblock %}
 
-{% block extra_head %}
-  <style>
-    .actions { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem; }
-    .actions form { margin: 0; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-  </style>
-{% endblock %}
-
 {% block content %}
   <nav class="actions" aria-label="Holder navigation">
     <a class="chip" href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -9,8 +9,6 @@
     input[type="text"] { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
     button { margin-left: 0.25rem; }
     th, td { border-bottom: 1px solid #eee; }
-    .actions { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.75rem; }
-    .actions form { margin: 0; }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -6,38 +6,9 @@
 
 {% block extra_head %}
   <style>
-    .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
     .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
-    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
     ul { margin: 0.5rem 0 0 1.25rem; }
-    .workflow-card h2 { margin: 0 0 0.55rem 0; }
-    .workflow-summary { margin: 0; line-height: 1.55; }
     .holder-summary { margin: 0; line-height: 1.55; }
-    .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-    .workflow-table td strong { color: var(--color-primary); }
-    .workflow-table code {
-      font-size: 0.94rem;
-      font-weight: 600;
-    }
-    .state-block {
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-      padding: 0.15rem 0;
-    }
-    .state-block + .state-block {
-      margin-top: 0.55rem;
-      padding-top: 0.55rem;
-      border-top: 1px solid var(--color-surface);
-    }
-    .review-signal {
-      border-left: 4px solid var(--color-primary);
-      background: var(--color-primary-soft);
-    }
-    .review-signal.blocked {
-      border-left-color: var(--color-accent);
-      background: var(--color-accent-soft);
-    }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -7,9 +7,7 @@
 {% block extra_head %}
   <style>
     pre { white-space: pre-wrap; word-break: break-word; }
-    .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
     .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
-    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -9,8 +9,6 @@
     .page.receipt-detail-page {
       max-width: 1320px;
     }
-    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     .receipt-summary {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -9,7 +9,6 @@
     .page.receipts-page {
       max-width: 1440px;
     }
-    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
     .filters {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -6,37 +6,8 @@
 
 {% block extra_head %}
   <style>
-    .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
     .pill.good { background: var(--color-success-soft); border: 1px solid var(--color-success); color: var(--color-text); font-weight: 700; }
-    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
     ul { margin: 0.5rem 0 0 1.25rem; }
-    .workflow-card h2 { margin: 0 0 0.55rem 0; }
-    .workflow-summary { margin: 0; line-height: 1.55; }
-    .actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
-    .workflow-table td strong { color: var(--color-primary); }
-    .workflow-table code {
-      font-size: 0.94rem;
-      font-weight: 600;
-    }
-    .state-block {
-      display: flex;
-      flex-direction: column;
-      gap: 0.25rem;
-      padding: 0.15rem 0;
-    }
-    .state-block + .state-block {
-      margin-top: 0.55rem;
-      padding-top: 0.55rem;
-      border-top: 1px solid var(--color-surface);
-    }
-    .review-signal {
-      border-left: 4px solid var(--color-primary);
-      background: var(--color-primary-soft);
-    }
-    .review-signal.blocked {
-      border-left-color: var(--color-accent);
-      background: var(--color-accent-soft);
-    }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -6,14 +6,12 @@
 
 {% block extra_head %}
   <style>
-    .pill { display: inline-block; padding: 0.25rem 0.5rem; border-radius: 999px; font-size: 0.9rem; }
     .pill.good {
       background: var(--color-success-soft);
       border: 1px solid var(--color-success);
       color: var(--color-text);
       font-weight: 700;
     }
-    .pill.bad { background: var(--color-accent-soft); border: 1px solid var(--color-accent); }
     input[type="text"] { padding: 0.6rem; font-size: 1rem; width: 420px; }
     #issue-building,
     #issue-room {
@@ -35,8 +33,6 @@
       border: 1px solid var(--color-surface);
       white-space: nowrap;
     }
-    .workflow-card h2 { margin: 0 0 0.55rem 0; }
-    .workflow-summary { margin: 0; line-height: 1.55; }
     .workflow-action { margin: 0; }
     .queue-list {
       list-style: none;


### PR DESCRIPTION
## Summary
Moved shared duplicated template styles into a static base stylesheet to reduce CSS duplication and keep styling more consistent without changing behavior.

## Related Issue
Closes #424 

## Changes
- added shared stylesheet at `assettrack/intake/static/css/base.css`
- linked shared stylesheet from `base.html`
- moved clearly shared class-based selectors out of inline template `<style>` blocks
- left page-specific styles in place to keep blast radius low

## Verification checklist
- [x] targeted tests passing
- [x] manual visual smoke check completed
- [x] no workflow or behavior changes
- [x] auth and protected-route behavior preserved

## Notes
Kept this intentionally narrow. Broader form-control selector consolidation was deferred to avoid unnecessary risk.