### PR TITLE
Issue 26-81: widen dashboard, holders, and return page width

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -1,3 +1,7 @@
+.page.page-wide {
+  max-width: 1320px;
+}
+
 .actions {
   display: flex;
   gap: 0.5rem;

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -3,6 +3,7 @@
 
 {% block title %}AssetTrack Dashboard{% endblock %}
 {% block page_heading %}Dashboard Summary Metrics{% endblock %}
+{% block page_class %} page-wide{% endblock %}
 
 {% block extra_head %}
   <style>

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -3,6 +3,7 @@
 
 {% block title %}AssetTrack Holders{% endblock %}
 {% block page_heading %}Holders{% endblock %}
+{% block page_class %} page-wide{% endblock %}
 
 {% block extra_head %}
   <style>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -3,6 +3,7 @@
 
 {% block title %}{{ page_title or "Return Assets" }}{% endblock %}
 {% block page_heading %}{{ page_heading or "Return Assets" }}{% endblock %}
+{% block page_class %} page-wide{% endblock %}
 
 {% block extra_head %}
   <style>


### PR DESCRIPTION
## Summary
Widened desktop content width for dashboard, holders, and return pages using a scoped page modifier class without changing global layout behavior.

## Related Issue
Closes #451 

## Changes
- added `.page.page-wide` modifier in shared CSS
- applied `page-wide` via existing page_class hook to:
  - dashboard
  - holders
  - return
- left global `.page` width unchanged
- did not modify workflow pages like issue/preview

## Verification checklist
- [x] targeted tests passing
- [x] manual visual smoke check completed
- [x] dashboard, holders, return render wider on desktop
- [x] unrelated pages remain unchanged
- [x] no workflow or behavior changes

## Notes
Implemented as a narrow opt-in modifier to avoid global layout impact.