### PR TITLE
Issue 26-82: remove unused holders list columns

### DIFF
--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -79,9 +79,7 @@
             <th style="width: 120px;">Type</th>
             <th style="width: 220px;">Name</th>
             <th style="width: 200px;">Organization</th>
-            <th style="width: 180px;">Identifier</th>
             <th style="width: 220px;">Email</th>
-            <th>Contact</th>
             <th style="width: 100px;">Assets</th>
             <th style="width: 120px;">Edit</th>
             <th style="width: 120px;">Select</th>
@@ -99,9 +97,7 @@
                 {% endif %}
               </td>
               <td>{{ h["organization"] or "" }}</td>
-              <td><code>{{ h["identifier"] or "" }}</code></td>
               <td>{{ h["email"] or "" }}</td>
-              <td>{{ h["contact_info"] or "" }}</td>
               <td>{{ h.get("asset_count", "") }}</td>
               <td>
                 {% if return_to %}


### PR DESCRIPTION
## Summary
Removed the unused Identifier and Contact columns from the holders list view to simplify the table and reduce visual clutter.

## Related Issue
Closes #453 

## Changes
- removed Identifier column from `/holders`
- removed Contact column from `/holders`
- left holder data, links, actions, and behavior unchanged

## Verification checklist
- [x] targeted tests passing
- [x] manual visual check completed
- [x] Identifier column removed
- [x] Contact column removed
- [x] remaining table layout and behavior unchanged

## Notes
Kept this limited to the holders list template only. No holder data or search behavior was changed.