### PR TITLE
Issue 26-83: consolidate shared form control styles

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -13,6 +13,25 @@
   margin: 0;
 }
 
+.form-group {
+  margin: 0.75rem 0;
+}
+
+.form-label {
+  display: block;
+  margin-bottom: 0.35rem;
+}
+
+.form-input,
+.form-select {
+  width: 100%;
+  max-width: 520px;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 0.6rem;
+  font-size: 1rem;
+}
+
 .mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -7,7 +7,6 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    input[type="text"], select { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
   </style>
 {% endblock %}
 
@@ -33,9 +32,10 @@
     <h2>Lookup Asset</h2>
     <form method="post" action="{{ url_for('admin_edit_asset') }}">
       <input type="hidden" name="action" value="lookup" />
-      <div class="row">
-        <label for="lookup_asset_tag"><strong>asset_tag</strong></label><br />
+      <div class="row form-group">
+        <label class="form-label" for="lookup_asset_tag"><strong>asset_tag</strong></label>
         <input
+          class="form-input"
           type="text"
           id="lookup_asset_tag"
           name="lookup_asset_tag"
@@ -56,58 +56,58 @@
         <input type="hidden" name="action" value="update" />
         <input type="hidden" name="lookup_asset_tag" value="{{ form.lookup_asset_tag or asset.asset_tag }}" />
         <div class="grid">
-          <div class="row">
-            <label for="asset_tag"><strong>asset_tag</strong></label><br />
-            <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" readonly />
+          <div class="row form-group">
+            <label class="form-label" for="asset_tag"><strong>asset_tag</strong></label>
+            <input class="form-input" type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" readonly />
           </div>
-          <div class="row">
-            <label><strong>location_type</strong></label><br />
-            <input type="text" value="{{ asset.location_type }}" readonly />
+          <div class="row form-group">
+            <label class="form-label"><strong>location_type</strong></label>
+            <input class="form-input" type="text" value="{{ asset.location_type }}" readonly />
           </div>
-          <div class="row">
-            <label for="serial_number"><strong>serial_number</strong> (required)</label><br />
-            <input type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" required />
+          <div class="row form-group">
+            <label class="form-label" for="serial_number"><strong>serial_number</strong> (required)</label>
+            <input class="form-input" type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" required />
           </div>
-          <div class="row">
-            <label for="manufacturer"><strong>manufacturer</strong> (required)</label><br />
-            <input type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" required />
+          <div class="row form-group">
+            <label class="form-label" for="manufacturer"><strong>manufacturer</strong> (required)</label>
+            <input class="form-input" type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" required />
           </div>
-          <div class="row">
-            <label for="equipment_type"><strong>equipment_type</strong> (required)</label><br />
-            <input type="text" id="equipment_type" name="equipment_type" value="{{ form.equipment_type or '' }}" required />
+          <div class="row form-group">
+            <label class="form-label" for="equipment_type"><strong>equipment_type</strong> (required)</label>
+            <input class="form-input" type="text" id="equipment_type" name="equipment_type" value="{{ form.equipment_type or '' }}" required />
           </div>
-          <div class="row">
-            <label for="building"><strong>building</strong> (required)</label><br />
-            <input type="text" id="building" name="building" value="{{ form.building or '' }}" required />
+          <div class="row form-group">
+            <label class="form-label" for="building"><strong>building</strong> (required)</label>
+            <input class="form-input" type="text" id="building" name="building" value="{{ form.building or '' }}" required />
           </div>
-          <div class="row">
-            <label for="room"><strong>room</strong> (required)</label><br />
-            <input type="text" id="room" name="room" value="{{ form.room or '' }}" required />
+          <div class="row form-group">
+            <label class="form-label" for="room"><strong>room</strong> (required)</label>
+            <input class="form-input" type="text" id="room" name="room" value="{{ form.room or '' }}" required />
           </div>
-          <div class="row">
-            <label for="model"><strong>model</strong> (optional)</label><br />
-            <input type="text" id="model" name="model" value="{{ form.model or '' }}" />
+          <div class="row form-group">
+            <label class="form-label" for="model"><strong>model</strong> (optional)</label>
+            <input class="form-input" type="text" id="model" name="model" value="{{ form.model or '' }}" />
           </div>
-          <div class="row">
-            <label for="model_code"><strong>model_code</strong> (optional)</label><br />
-            <input type="text" id="model_code" name="model_code" value="{{ form.model_code or '' }}" />
+          <div class="row form-group">
+            <label class="form-label" for="model_code"><strong>model_code</strong> (optional)</label>
+            <input class="form-input" type="text" id="model_code" name="model_code" value="{{ form.model_code or '' }}" />
           </div>
-          <div class="row">
-            <label for="notes"><strong>notes</strong> (optional)</label><br />
-            <input type="text" id="notes" name="notes" value="{{ form.notes or '' }}" />
+          <div class="row form-group">
+            <label class="form-label" for="notes"><strong>notes</strong> (optional)</label>
+            <input class="form-input" type="text" id="notes" name="notes" value="{{ form.notes or '' }}" />
           </div>
-          <div class="row">
-            <label for="case_name"><strong>case</strong></label><br />
-            <select id="case_name" name="case_name">
+          <div class="row form-group">
+            <label class="form-label" for="case_name"><strong>case</strong></label>
+            <select class="form-select" id="case_name" name="case_name">
               <option value="">Unassigned</option>
               {% for case_name in case_options %}
                 <option value="{{ case_name }}" {% if form.case_name == case_name %}selected{% endif %}>{{ case_name }}</option>
               {% endfor %}
             </select>
           </div>
-          <div class="row">
-            <label for="slot_id"><strong>slot</strong></label><br />
-            <select id="slot_id" name="slot_id">
+          <div class="row form-group">
+            <label class="form-label" for="slot_id"><strong>slot</strong></label>
+            <select class="form-select" id="slot_id" name="slot_id">
               <option value="">Unassigned</option>
               {% for slot in slot_options %}
                 <option

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -18,14 +18,9 @@
     .asset-search-page .search-field {
       min-width: 0;
     }
-    .asset-search-page .search-field input[type="text"] {
+    .asset-search-page .search-field .form-input {
       display: block;
-      width: 100%;
       max-width: none;
-      min-width: 0;
-      box-sizing: border-box;
-      padding: 0.6rem;
-      font-size: 1rem;
     }
     .search-actions {
       display: flex;
@@ -60,13 +55,13 @@
     <p class="muted">Search by asset tag or serial number. If both are entered, asset tag is used first.</p>
     <form class="asset-search-form" method="get" action="{{ url_for('asset_search') }}">
       <div class="search-grid">
-        <div class="row search-field">
-          <label for="asset_tag"><strong>Asset tag</strong></label><br />
-          <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" autofocus />
+        <div class="row form-group search-field">
+          <label class="form-label" for="asset_tag"><strong>Asset tag</strong></label>
+          <input class="form-input" type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" autofocus />
         </div>
-        <div class="row search-field">
-          <label for="serial_number"><strong>Serial number</strong></label><br />
-          <input type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" />
+        <div class="row form-group search-field">
+          <label class="form-label" for="serial_number"><strong>Serial number</strong></label>
+          <input class="form-input" type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" />
         </div>
       </div>
       <div class="search-actions">

--- a/assettrack/intake/templates/holder_edit.html
+++ b/assettrack/intake/templates/holder_edit.html
@@ -4,12 +4,6 @@
 {% block title %}Edit Holder{% endblock %}
 {% block page_heading %}Edit Holder{% endblock %}
 
-{% block extra_head %}
-  <style>
-    input[type="text"], select { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
-  </style>
-{% endblock %}
-
 {% block content %}
   <p><a href="{{ return_to or url_for('holders_search') }}">&larr; Back to holders</a></p>
 
@@ -28,22 +22,22 @@
       {% if return_to %}
         <input type="hidden" name="return_to" value="{{ return_to }}" />
       {% endif %}
-      <div class="row">
-        <label for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label><br />
-        <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
+      <div class="row form-group">
+        <label class="form-label" for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label>
+        <input class="form-input" type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
-      <div class="row">
-        <label for="organization_id"><strong>Group / organization</strong></label><br />
-        <select id="organization_id" name="organization_id">
+      <div class="row form-group">
+        <label class="form-label" for="organization_id"><strong>Group / organization</strong></label>
+        <select class="form-select" id="organization_id" name="organization_id">
           <option value="">Select organization</option>
           {% for organization in organization_options %}
             <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>
           {% endfor %}
         </select>
       </div>
-      <div class="row">
-        <label for="email"><strong>Email</strong> (required for receipts)</label><br />
-        <input type="text" id="email" name="email" value="{{ form.email or '' }}" inputmode="email" autocomplete="email" />
+      <div class="row form-group">
+        <label class="form-label" for="email"><strong>Email</strong> (required for receipts)</label>
+        <input class="form-input" type="text" id="email" name="email" value="{{ form.email or '' }}" inputmode="email" autocomplete="email" />
       </div>
       <button type="submit">Save Holder</button>
     </form>

--- a/assettrack/intake/templates/holder_new.html
+++ b/assettrack/intake/templates/holder_new.html
@@ -4,12 +4,6 @@
 {% block title %}AssetTrack New Holder{% endblock %}
 {% block page_heading %}Create Holder{% endblock %}
 
-{% block extra_head %}
-  <style>
-    input[type="text"], select { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
-  </style>
-{% endblock %}
-
 {% block content %}
   <p><a href="{{ return_to or url_for('holders_search') }}">&larr; Back to holders</a></p>
 
@@ -28,22 +22,22 @@
       {% if return_to %}
         <input type="hidden" name="return_to" value="{{ return_to }}" />
       {% endif %}
-      <div class="row">
-        <label for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label><br />
-        <input type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
+      <div class="row form-group">
+        <label class="form-label" for="name"><strong>Person or group name</strong> (required when using Ad Hoc)</label>
+        <input class="form-input" type="text" id="name" name="name" value="{{ form.name or '' }}" autofocus />
       </div>
-      <div class="row">
-        <label for="organization_id"><strong>Group / organization</strong></label><br />
-        <select id="organization_id" name="organization_id">
+      <div class="row form-group">
+        <label class="form-label" for="organization_id"><strong>Group / organization</strong></label>
+        <select class="form-select" id="organization_id" name="organization_id">
           <option value="">Select organization</option>
           {% for organization in organization_options %}
             <option value="{{ organization.id }}" {% if form.organization_id == (organization.id|string) %}selected{% endif %}>{{ organization.name }}</option>
           {% endfor %}
         </select>
       </div>
-      <div class="row">
-        <label for="email"><strong>Email</strong> (required for receipts)</label><br />
-        <input type="text" id="email" name="email" value="{{ form.email or '' }}" inputmode="email" autocomplete="email" />
+      <div class="row form-group">
+        <label class="form-label" for="email"><strong>Email</strong> (required for receipts)</label>
+        <input class="form-input" type="text" id="email" name="email" value="{{ form.email or '' }}" inputmode="email" autocomplete="email" />
       </div>
       <button type="submit">Create Holder</button>
     </form>

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -44,7 +44,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Create Holder", response.data)
         self.assertIn(b"required for receipts", response.data)
-        self.assertIn(b"box-sizing: border-box;", response.data)
+        self.assertIn(b'class="form-input"', response.data)
+        self.assertIn(b'class="form-select"', response.data)
         self.assertIn(b"novalidate", response.data)
         self.assertNotIn(b'name="organization_id" required', response.data)
 
@@ -175,7 +176,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         edit_get = self.client.get(f"/holders/edit/{int(holder_row['id'])}")
         self.assertEqual(edit_get.status_code, 200)
         self.assertIn(b"Edit Holder", edit_get.data)
-        self.assertIn(b"box-sizing: border-box;", edit_get.data)
+        self.assertIn(b'class="form-input"', edit_get.data)
+        self.assertIn(b'class="form-select"', edit_get.data)
         self.assertIn(b"novalidate", edit_get.data)
         self.assertNotIn(b'name="organization_id" required', edit_get.data)
 


### PR DESCRIPTION
## Summary
Moved shared form control styling into static CSS so common inputs and labels render consistently without changing behavior.

## Related Issue
Closes #456 

## Changes
- added shared `.form-group`, `.form-label`, `.form-input`, and `.form-select` classes to `base.css`
- updated holder create/edit templates to use shared form classes
- updated asset search to reuse the shared input class while preserving its page-specific width override
- updated admin asset edit template to use shared form classes
- adjusted holder UI tests to assert shared classes instead of removed inline CSS

## Verification checklist
- [x] targeted tests passing
- [x] manual browser verification completed
- [x] shared form controls render correctly
- [x] spacing and alignment remain stable
- [x] no overflow or clipping introduced
- [x] no behavior changes

## Notes
Kept this opt-in and narrow to avoid broad styling impact on unrelated templates.