### PR TITLE
Issue 26-94: remove developer-facing sections from receipt detail

### DIFF
--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -150,9 +150,6 @@
     .receipt-extra-card p {
       margin: 0;
     }
-    .source-events-list {
-      line-height: 1.5;
-    }
     @media (max-width: 960px) {
       .receipt-extra-grid,
       .receipt-summary {
@@ -304,7 +301,7 @@
       <summary>More Receipt Detail</summary>
       <div class="receipt-extra-grid">
         <section class="receipt-extra-card">
-          <h2 class="summary-group-title">Internal Metadata</h2>
+          <h2 class="summary-group-title">Additional Receipt Info</h2>
           <p><span class="summary-label">Internal receipt ID</span><br /><span class="mono">{{ receipt.id }}</span></p>
           <p><span class="summary-label">Receipt key</span><br /><span class="mono">{{ receipt.receipt_key }}</span></p>
           {% if receipt.delivery.last_attempt_at %}
@@ -342,19 +339,6 @@
             <p><strong>Combined location:</strong> {{ receipt.location_context.get("building_room") or "Unknown" }}</p>
           </section>
         {% endif %}
-
-        <section class="receipt-extra-card">
-          <h2 class="summary-group-title">Source Events</h2>
-          <p class="source-events-list">
-            {% if receipt.source_event_ids %}
-              {% for event_id in receipt.source_event_ids %}
-                <span class="mono">{{ event_id }}</span>{% if not loop.last %}, {% endif %}
-              {% endfor %}
-            {% else %}
-              None recorded.
-            {% endif %}
-          </p>
-        </section>
       </div>
     </details>
   </section>

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -326,10 +326,11 @@ def test_issue_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None
     assert response.status_code == 200
     assert b"Issue Receipt" in response.data
     assert expected_title.encode("utf-8") in response.data
-    assert f"Internal receipt ID {receipt_id}".encode("utf-8") in response.data
+    assert b"Internal receipt ID" in response.data
+    assert f">{receipt_id}<".encode("utf-8") in response.data
     assert b"Receipt key" in response.data
     assert b"ISSUE:" in response.data
-    assert b"Receipt title" in response.data
+    assert b"What Happened" in response.data
     assert b"Committed by" in response.data
     assert b"issue-operator" in response.data
     assert b"Receipt holder" in response.data
@@ -343,7 +344,6 @@ def test_issue_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None
     assert b"Dell" in response.data
     assert b"Latitude" in response.data
     assert b"CASE-10 / 1" in response.data
-    assert b"Source Events" in response.data
 
 
 def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> None:
@@ -362,7 +362,6 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     assert b"Apple" in response.data
     assert b"iPad" in response.data
     assert b"CASE-20 / 1" in response.data
-    assert b"Source Events" in response.data
 
 
 def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(client_with_temp_db) -> None:
@@ -411,7 +410,7 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
     assert b"Send Receipt Email" not in failed_response.data
     assert b"Last delivery attempt" in failed_response.data
     assert b"2026-03-29T12:00:00+00:00" in failed_response.data
-    assert b"Last delivery error" in failed_response.data
+    assert b"Current issue" in failed_response.data
     assert b"smtp offline" in failed_response.data
 
     conn = db.get_connection()
@@ -488,7 +487,7 @@ def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Receipt title" in response.data
+    assert b"What Happened" in response.data
     assert expected_title.encode("utf-8") in response.data
     assert b"Receipt holder" not in response.data
     assert b"Return Holder One" in response.data


### PR DESCRIPTION
## Summary
Removes developer-facing data from the receipt detail view to improve operator clarity and reduce noise.

## Related Issue
Closes #474 

## Changes
- removed Source Events section from receipt detail page
- reframed secondary detail section as “Additional Receipt Info”
- preserved all operator-facing information and actions

## Verification checklist
- [x] Targeted tests pass
- [x] Manual browser verification passed
- [x] Receipt detail is cleaner and easier to scan
- [x] No impact to receipt actions or workflow
- [x] No schema, auth, or persistence changes

## Notes
This change removes developer-facing noise while preserving all underlying data and operator functionality.