### PR TITLE
Issue 26-103: clarify nav vs dashboard workflow duplication

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -78,6 +78,10 @@
 
     .actions { margin: 0.75rem 0 1rem 0; }
     .chip.secondary { background: var(--color-panel-bg); }
+    .actions-note {
+      margin: 0;
+      color: var(--color-text-muted);
+    }
 
     .grid { display: grid; grid-template-columns: repeat(2, minmax(280px, 1fr)); gap: 1rem; }
     .grid > .card {
@@ -191,11 +195,10 @@
   </section>
 
   <section class="card" aria-label="Quick actions panel">
-    <h2>Workflow Shortcuts</h2>
+    <h2>Dashboard References</h2>
     <div class="accent"></div>
+    <p class="actions-note">Use the top navigation to start Issue or Return. Dashboard links below are for follow-up review.</p>
     <div class="actions">
-      <a class="chip" href="{{ url_for('issue_preview') }}">Issue</a>
-      <a class="chip" href="{{ url_for('return_queue') }}">Return</a>
       <a class="chip" href="{{ url_for('dashboard_holders') }}">Outstanding Holders</a>
       <a class="chip" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
       <a class="chip" href="{{ url_for('human_report') }}">View Current Status Report</a>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -189,7 +189,9 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Assets in custody", response.data)
         self.assertIn(b"Open storage slots", response.data)
         self.assertIn(b"Holders with assets out", response.data)
-        self.assertLess(response.data.index(b"At a Glance"), response.data.index(b"Workflow Shortcuts"))
+        self.assertIn(b"Dashboard References", response.data)
+        self.assertIn(b"Use the top navigation to start Issue or Return.", response.data)
+        self.assertLess(response.data.index(b"At a Glance"), response.data.index(b"Dashboard References"))
         self.assertIn(b"Inventory Summary", response.data)
         self.assertIn(b"Slot Summary", response.data)
         self.assertIn(b"Custody Summary", response.data)
@@ -208,6 +210,8 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Issued to", response.data)
         self.assertIn(b"AT-CUST", response.data)
         self.assertIn(b'href="/holders/1"', response.data)
+        self.assertNotIn(b"Workflow Shortcuts", response.data)
+        self.assertNotIn(b'href="/issue/preview">Issue</a>', response.data)
 
     def test_dashboard_empty_states_are_operator_facing(self) -> None:
         response = self.client.get("/dashboard")


### PR DESCRIPTION
## Summary
Clarify where operators take action by making the top navigation the primary workflow surface and removing duplicated actions from the dashboard.

## Related Issue
Closes #491 

## Changes
- made top nav the clear primary action surface for Issue and Return
- removed duplicate Issue and Return buttons from the dashboard panel
- renamed “Workflow Shortcuts” to “Dashboard References”
- kept dashboard links focused on follow-up and review actions
- added guidance to use top navigation for primary workflows
- updated dashboard tests for wording and placement

## Verification checklist
- [x] Targeted tests passed (`tests/test_dashboard.py`)
- [x] Incognito smoke test completed
- [x] No duplicate Issue/Return actions on dashboard
- [x] Top navigation clearly indicates primary actions
- [x] All workflows still accessible
- [x] No changes to routes, auth, schema, or persistence

## Notes
Follow-on issues identified:
- standardize navigation chip icon usage (26-106)
- standardize page container widths (26-104)
- collapsible dashboard summary (26-105)