### PR TITLE
Issue 26-106: standardize navigation chip icon usage

### DIFF
--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -49,7 +49,7 @@
 
 {% block content %}
   <div class="report-actions">
-    <a class="chip" href="{{ url_for('admin_system') }}">&larr; Back to Admin Tools</a>
+    <a class="chip" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
     <a class="chip" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
     <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
   </div>

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -53,7 +53,7 @@
 
 {% block content %}
   <div class="report-actions">
-    <a class="chip" href="{{ url_for('dashboard') }}">&larr; Back to Dashboard</a>
+    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </div>
 
   {% if report_error %}


### PR DESCRIPTION
## Summary
Standardize navigation chip appearance by removing arrow icons for consistent, text-only labels.

## Related Issue
Closes #494 

## Changes
- removed arrow icons from remaining chip-based navigation links
- ensured all navigation chips use plain text labels
- verified no remaining chip icon inconsistencies in templates

## Verification checklist
- [x] Manual smoke test completed
- [x] Chips render with plain text only
- [x] Navigation still functions normally
- [x] Visual consistency improved across pages
- [x] No changes to routes, auth, schema, or persistence

## Notes
Follow-on issue created for full navigation pattern standardization:
- 26-107 — standardize chips vs link-based navigation