### PR TITLE
Issue 26-107: standardize navigation patterns (actions vs navigation)

### DIFF
--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="actions">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to dashboard</a>
+    <a href="{{ url_for('dashboard') }}">Back to dashboard</a>
     <a class="chip" href="{{ url_for('admin_new_asset') }}">Create asset</a>
   </div>
 

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -49,7 +49,7 @@
 
 {% block content %}
   <div class="report-actions">
-    <a class="chip" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+    <a href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
     <a class="chip" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
     <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
   </div>

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -12,8 +12,8 @@
 
   <div class="card">
     <h2>Admin Tools</h2>
-    <p><a class="chip" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
-    <p><a class="chip" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
+    <p><a href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
+    <p><a href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
     <p><a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a></p>
     <table>
       <tbody>

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -199,9 +199,9 @@
     <div class="accent"></div>
     <p class="actions-note">Use the top navigation to start Issue or Return. Dashboard links below are for follow-up review.</p>
     <div class="actions">
-      <a class="chip" href="{{ url_for('dashboard_holders') }}">Outstanding Holders</a>
-      <a class="chip" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
-      <a class="chip" href="{{ url_for('human_report') }}">View Current Status Report</a>
+      <a href="{{ url_for('dashboard_holders') }}">Outstanding Holders</a>
+      <a href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
+      <a href="{{ url_for('human_report') }}">View Current Status Report</a>
     </div>
   </section>
 

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -19,8 +19,8 @@
   {% set empty_slots = total_slots - occupied_slots %}
   {% set status = case_status_summary(total_slots, occupied_slots) %}
   <nav class="actions" aria-label="Contextual navigation">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="chip" href="{{ url_for('dashboard_cases') }}">Back to Cases</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('dashboard_cases') }}">Back to Cases</a>
   </nav>
 
   <section class="card status-card">

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -14,7 +14,7 @@
 
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -6,8 +6,8 @@
 
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="chip" href="{{ url_for('dashboard_holders') }}">Back to Holders</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('dashboard_holders') }}">Back to Holders</a>
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/demo.html
+++ b/assettrack/intake/templates/demo.html
@@ -212,8 +212,8 @@
     </div>
     <div class="demo-hero-actions">
       <a class="chip" href="{{ url_for('intake') }}">Go to Operator Login</a>
-      <a class="chip" href="#workflow">See the workflow</a>
-      <a class="chip" href="#audit">View audit trail</a>
+      <a href="#workflow">See the workflow</a>
+      <a href="#audit">View audit trail</a>
     </div>
   </div>
 

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <nav class="actions" aria-label="Holder navigation">
-    <a class="chip" href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>
+    <a href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>
     {% if return_to %}
       <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=return_to) }}">Edit Holder</a>
     {% else %}

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -14,7 +14,7 @@
 
 {% block content %}
   <nav class="actions" aria-label="Issue preview navigation">
-    <a class="chip" href="{{ url_for('preview') }}">Back to batch preview</a>
+    <a href="{{ url_for('preview') }}">Back to batch preview</a>
   </nav>
 
   {% include "_timeout_status.html" %}

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -168,8 +168,8 @@
   {% set email_timing_label = "Delivered" if receipt.delivery.sent_at else "Last attempted" if receipt.delivery.last_attempt_at else "" %}
   {% set email_timing_value = receipt.delivery_display.sent_at or receipt.delivery_display.last_attempt_at %}
   <nav class="actions" aria-label="Receipt navigation">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="chip" href="{{ url_for('human_report') }}">Open Current Status Report</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('human_report') }}">Open Current Status Report</a>
     <a class="chip" href="{{ url_for('receipt_pdf', receipt_id=receipt.id) }}">Download Receipt PDF</a>
     {% if receipt.delivery.state in ["pending", "failed"] %}
       <form method="post" action="{{ url_for('receipt_send', receipt_id=receipt.id) }}">

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -183,8 +183,8 @@
 
 {% block content %}
   <nav class="actions" aria-label="Receipt navigation">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="chip" href="{{ url_for('human_report') }}">Open Current Status Report</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('human_report') }}">Open Current Status Report</a>
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -53,7 +53,7 @@
 
 {% block content %}
   <div class="report-actions">
-    <a class="chip" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+    <a href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </div>
 
   {% if report_error %}

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -14,7 +14,7 @@
 {% block content %}
   {% set blocked_count = queued_count - ready_count %}
   <nav class="actions" aria-label="Return preview navigation">
-    <a class="chip" href="{{ url_for('return_queue') }}">Back to Return Queue</a>
+    <a href="{{ url_for('return_queue') }}">Back to Return Queue</a>
   </nav>
 
   {% include "_timeout_status.html" %}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -111,7 +111,7 @@
   {% endif %}
 
   {% if issue_location_form is defined %}
-    <p><a class="chip" href="{{ jump_to_scan_href }}">Jump to scan</a></p>
+    <p><a href="{{ jump_to_scan_href }}">Jump to scan</a></p>
   {% endif %}
 
   {% if issue_location_form is defined %}
@@ -176,7 +176,7 @@
       {% endfor %}
     {% endif %}
     {% if queue_len > 0 %}
-      <p><a class="chip" href="{{ jump_to_queue_href }}">Jump to queue</a></p>
+      <p><a href="{{ jump_to_queue_href }}">Jump to queue</a></p>
     {% endif %}
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">


### PR DESCRIPTION
## Summary
Standardize navigation patterns so operators can clearly distinguish between actions and navigation.

## Related Issue
Closes #496 

## Changes
- applied rule: actions use chip/button styling, navigation uses plain links
- converted contextual navigation (back links, dashboard references, drilldowns) to plain links
- preserved chip/button styling for primary actions (Issue, Return, workflow actions)
- removed mixed patterns (link + arrow, chip-like navigation)
- kept top navigation as primary action surface

## Verification checklist
- [x] Targeted tests passed (`tests/test_dashboard.py`)
- [x] Incognito smoke test completed
- [x] Actions and navigation visually distinct on dashboard
- [x] No duplicate or conflicting navigation patterns
- [x] All links and workflows still function correctly
- [x] No changes to routes, auth, schema, or persistence

## Notes
Follow-on issue:
- 26-108 — improve navigation link affordance (links currently lack clear clickability in light mode)