### PR TITLE
Issue 26-109: improve inline navigation link spacing

### DIFF
--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -2,6 +2,7 @@
 
 {% block title %}Admin Current Status Report{% endblock %}
 {% block page_heading %}Admin: Current Status Report{% endblock %}
+{% block page_class %} report-page{% endblock %}
 
 {% block extra_head %}
   <style>
@@ -48,7 +49,7 @@
 {% endblock %}
 
 {% block content %}
-  <div class="report-actions">
+  <div class="report-actions nav-row mixed-nav-row">
     <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
     <a class="chip" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
     <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -198,7 +198,7 @@
     <h2>Dashboard References</h2>
     <div class="accent"></div>
     <p class="actions-note">Use the top navigation to start Issue or Return. Dashboard links below are for follow-up review.</p>
-    <div class="actions">
+    <div class="actions nav-row">
       <a class="nav-link" href="{{ url_for('dashboard_holders') }}">Outstanding Holders</a>
       <a class="nav-link" href="{{ url_for('dashboard_cases') }}">Case Drilldown</a>
       <a class="nav-link" href="{{ url_for('human_report') }}">View Current Status Report</a>


### PR DESCRIPTION
## Summary
Improve readability and alignment of inline navigation links, especially in mixed rows with action chips.

## Related Issue
Closes #500 

## Changes
- replaced per-link spacing with container-level layout using `.nav-row`
- introduced `.mixed-nav-row` for rows that combine navigation links with chip/button actions
- aligned links and chips on a consistent baseline
- preserved link-only group readability without adding separators
- kept action vs navigation distinction intact

## Verification checklist
- [x] Manual browser review completed across dashboard, receipts, report, and admin pages
- [x] Mixed rows (link + chips) align cleanly
- [x] Link-only groups remain readable and properly spaced
- [x] No layout regression across pages or themes
- [x] No changes to routes, auth, schema, persistence, or workflow behavior

## Notes
Spacing and alignment improved across the system. Minor visual tradeoffs remain in some edge cases (e.g., `/add-assets`), which were deferred to avoid overfitting layout rules.