### PR TITLE
Issue 26-98: improve report actionability and scanability

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -5407,8 +5407,11 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
                     COALESCE(a.manufacturer, '') AS manufacturer,
                     COALESCE(a.model, '') AS model,
                     COALESCE(a.location_type, '') AS location_type,
+                    h.id AS holder_detail_id,
                     COALESCE(h.name, '') AS holder_name,
                     COALESCE(h.organization, '') AS holder_organization,
+                    COALESCE(s.case_name, '') AS home_case_name,
+                    s.slot_position AS home_slot_position,
                     COALESCE(s.case_name || ' / ' || s.slot_position, '') AS home_slot
                 FROM assets a
                 LEFT JOIN holders h
@@ -5480,6 +5483,7 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
             for row in conn.execute(
                 """
                 SELECT
+                    h.id AS holder_detail_id,
                     h.name AS holder_name,
                     COALESCE(h.organization, '') AS organization,
                     a.asset_tag,
@@ -5503,6 +5507,7 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
                     e.event_date,
                     e.asset_tag,
                     e.event_type,
+                    h.id AS holder_detail_id,
                     COALESCE(h.name, '') AS holder_name,
                     COALESCE(h.organization, '') AS holder_organization
                 FROM asset_events e

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -12,6 +12,18 @@
       flex-wrap: wrap;
       margin-bottom: 1rem;
     }
+    .report-priority {
+      display: grid;
+      gap: 0.9rem;
+    }
+    .report-priority-copy {
+      margin: 0;
+      color: var(--color-text-muted);
+      max-width: 60rem;
+    }
+    .report-priority-links {
+      margin-top: 0.1rem;
+    }
     .report-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -28,16 +40,72 @@
       font-size: 1.35rem;
       margin-top: 0.25rem;
     }
+    .report-stat-action {
+      display: block;
+      margin-top: 0.65rem;
+      width: fit-content;
+    }
     .card h2 {
       margin-top: 0;
     }
     .table-wrap {
       overflow-x: auto;
     }
+    details.report-section {
+      margin-top: 1rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 10px;
+      background: var(--color-surface-bg);
+      overflow: hidden;
+    }
+    details.report-section summary {
+      cursor: pointer;
+      list-style: none;
+      padding: 1rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      background: var(--color-surface-soft);
+      font-weight: 700;
+      transition: background 120ms ease, color 120ms ease;
+    }
+    details.report-section summary::-webkit-details-marker {
+      display: none;
+    }
+    details.report-section summary:hover {
+      background: color-mix(in srgb, var(--color-primary-soft) 45%, var(--color-surface-bg));
+    }
+    details.report-section summary::before {
+      content: "▸";
+      flex: 0 0 auto;
+      color: var(--color-primary);
+      font-size: 1rem;
+      line-height: 1;
+      transform: translateY(0.02rem);
+    }
+    details.report-section[open] summary::before {
+      content: "▾";
+    }
+    .report-section-title {
+      margin: 0;
+      font-size: 1.02rem;
+      line-height: 1.3;
+    }
+    .report-section-hint {
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
+      font-weight: 500;
+      text-align: right;
+    }
+    .report-section-body {
+      padding: 1rem;
+    }
     @media print {
       .page-tools,
       .top-nav,
-      .report-actions {
+      .report-actions,
+      details.report-section summary {
         display: none !important;
       }
       .card {
@@ -57,21 +125,50 @@
     <div class="flash error">{{ report_error }}</div>
   {% endif %}
 
-  <div class="card">
-    <h2>Report Scope</h2>
-    <p>This page is a read-only human-readable report for custody review and verification.</p>
-    <p><strong>Recent events section:</strong> showing recent active events only.</p>
+  <div class="card report-priority">
+    <div>
+      <h2>What Matters Now</h2>
+      <p class="report-priority-copy">
+        Start with assets in custody and open case space. Use the links below to move directly from this report into follow-up work.
+      </p>
+    </div>
+    <div class="report-actions nav-row report-priority-links">
+      <a class="nav-link" href="{{ url_for('dashboard_holders') }}">Review holders with assets out</a>
+      <a class="nav-link" href="{{ url_for('dashboard_cases') }}">Check case space</a>
+      <a class="nav-link" href="{{ url_for('asset_search') }}">Look up an asset</a>
+      <a class="nav-link" href="{{ url_for('receipts_list') }}">Open receipts</a>
+    </div>
+    <div class="report-grid">
+      <div class="report-stat">
+        Total assets
+        <strong>{{ asset_summary.total_assets }}</strong>
+        <a class="nav-link report-stat-action" href="{{ url_for('asset_search') }}">Search asset records</a>
+      </div>
+      <div class="report-stat">
+        In storage
+        <strong>{{ asset_summary.storage_assets }}</strong>
+        <a class="nav-link report-stat-action" href="{{ url_for('dashboard_cases') }}">Review case space</a>
+      </div>
+      <div class="report-stat">
+        In custody
+        <strong>{{ asset_summary.in_custody_assets }}</strong>
+        <a class="nav-link report-stat-action" href="{{ url_for('dashboard_holders') }}">Open holder follow-up</a>
+      </div>
+      <div class="report-stat">
+        Disposed
+        <strong>{{ asset_summary.disposed_assets }}</strong>
+        <a class="nav-link report-stat-action" href="{{ url_for('receipts_list') }}">Review receipts</a>
+      </div>
+    </div>
   </div>
 
-  <div class="card">
-    <h2>Assets</h2>
-    <div class="report-grid">
-      <div class="report-stat">Total assets<strong>{{ asset_summary.total_assets }}</strong></div>
-      <div class="report-stat">In storage<strong>{{ asset_summary.storage_assets }}</strong></div>
-      <div class="report-stat">In custody<strong>{{ asset_summary.in_custody_assets }}</strong></div>
-      <div class="report-stat">Disposed<strong>{{ asset_summary.disposed_assets }}</strong></div>
-    </div>
-    <div class="table-wrap" style="margin-top: 1rem;">
+  <details class="report-section" open>
+    <summary>
+      <span class="report-section-title">Assets</span>
+      <span class="report-section-hint">{{ asset_summary.total_assets }} total records</span>
+    </summary>
+    <div class="report-section-body">
+    <div class="table-wrap">
       <table>
         <thead>
           <tr>
@@ -86,16 +183,27 @@
         <tbody>
           {% for row in assets %}
             <tr>
-              <td><code>{{ row.asset_tag }}</code></td>
+              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.equipment_type or "" }}</td>
               <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
               <td>{{ row.location_type or "" }}</td>
               <td>
                 {% if row.holder_name %}
-                  {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                  {% if row.holder_detail_id %}
+                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                  {% else %}
+                    {{ row.holder_name }}
+                  {% endif %}
+                  {% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
                 {% endif %}
               </td>
-              <td>{{ row.home_slot or "" }}</td>
+              <td>
+                {% if row.home_case_name %}
+                  <a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.home_case_name) }}">{{ row.home_slot }}</a>
+                {% else %}
+                  {{ row.home_slot or "" }}
+                {% endif %}
+              </td>
             </tr>
           {% else %}
             <tr><td colspan="6">No assets found.</td></tr>
@@ -103,10 +211,15 @@
         </tbody>
       </table>
     </div>
-  </div>
+    </div>
+  </details>
 
-  <div class="card">
-    <h2>Holders</h2>
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Holders</span>
+      <span class="report-section-hint">{{ holders|length }} records</span>
+    </summary>
+    <div class="report-section-body">
     <div class="table-wrap">
       <table>
         <thead>
@@ -124,7 +237,7 @@
             <tr>
               <td><code>{{ row.id }}</code></td>
               <td>{{ row.holder_type }}</td>
-              <td>{{ row.name }}</td>
+              <td><a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.id) }}">{{ row.name }}</a></td>
               <td>{{ row.organization }}</td>
               <td>{{ row.identifier }}</td>
               <td>{{ row.assets_in_custody }}</td>
@@ -135,10 +248,15 @@
         </tbody>
       </table>
     </div>
-  </div>
+    </div>
+  </details>
 
-  <div class="card">
-    <h2>Organizations and Building Access</h2>
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Organizations and Building Access</span>
+      <span class="report-section-hint">{{ organizations|length }} organizations</span>
+    </summary>
+    <div class="report-section-body">
     <div class="table-wrap">
       <table>
         <thead>
@@ -179,10 +297,15 @@
         </tbody>
       </table>
     </div>
-  </div>
+    </div>
+  </details>
 
-  <div class="card">
-    <h2>Current Custody</h2>
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Current Custody</span>
+      <span class="report-section-hint">{{ current_custody|length }} assets out</span>
+    </summary>
+    <div class="report-section-body">
     <div class="table-wrap">
       <table>
         <thead>
@@ -197,9 +320,15 @@
         <tbody>
           {% for row in current_custody %}
             <tr>
-              <td>{{ row.holder_name }}</td>
+              <td>
+                {% if row.holder_detail_id %}
+                  <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                {% else %}
+                  {{ row.holder_name }}
+                {% endif %}
+              </td>
               <td>{{ row.organization }}</td>
-              <td><code>{{ row.asset_tag }}</code></td>
+              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.equipment_type }}</td>
               <td>{{ row.current_location }}</td>
             </tr>
@@ -209,10 +338,15 @@
         </tbody>
       </table>
     </div>
-  </div>
+    </div>
+  </details>
 
-  <div class="card">
-    <h2>Recent Active Events</h2>
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Recent Active Events</span>
+      <span class="report-section-hint">{{ recent_active_events|length }} latest active events</span>
+    </summary>
+    <div class="report-section-body">
     <div class="table-wrap">
       <table>
         <thead>
@@ -229,11 +363,16 @@
             <tr>
               <td><code>{{ row.id }}</code></td>
               <td>{{ row.event_date }}</td>
-              <td><code>{{ row.asset_tag }}</code></td>
+              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.event_type }}</td>
               <td>
                 {% if row.holder_name %}
-                  {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                  {% if row.holder_detail_id %}
+                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                  {% else %}
+                    {{ row.holder_name }}
+                  {% endif %}
+                  {% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
                 {% endif %}
               </td>
             </tr>
@@ -243,10 +382,15 @@
         </tbody>
       </table>
     </div>
-  </div>
+    </div>
+  </details>
 
-  <div class="card">
-    <h2>Location and Case Data</h2>
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Location and Case Data</span>
+      <span class="report-section-hint">{{ cases|length }} cases</span>
+    </summary>
+    <div class="report-section-body">
     <div class="table-wrap">
       <table>
         <thead>
@@ -259,7 +403,7 @@
         <tbody>
           {% for row in cases %}
             <tr>
-              <td>{{ row.case_name }}</td>
+              <td><a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.case_name) }}">{{ row.case_name }}</a></td>
               <td>{{ row.total_slots }}</td>
               <td>{{ row.occupied_slots }}</td>
             </tr>
@@ -269,5 +413,6 @@
         </tbody>
       </table>
     </div>
-  </div>
+    </div>
+  </details>
 {% endblock %}

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -318,7 +318,6 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
 
     assert response.status_code == 200
     assert b"Admin: Human-Readable Report" in response.data
-    assert b"This page is a read-only human-readable report" in response.data
     assert b"Download PDF" in response.data
     assert b"Download Database Backup" in response.data
     assert b"showing recent active events only" in response.data
@@ -332,6 +331,137 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     assert b"Jane Operator" in response.data
     assert b"Report Ops" in response.data
     assert b"CASE-1" in response.data
+
+
+def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-view-report", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    conn = db.get_connection()
+    _create_assets_table(conn)
+    conn.execute(
+        """
+        INSERT INTO organizations (name, created_at, updated_at)
+        VALUES ('Report Ops', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO buildings (name, created_at, updated_at)
+        VALUES ('Report HQ', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    organization_id = int(
+        conn.execute("SELECT id FROM organizations WHERE name = 'Report Ops' LIMIT 1;").fetchone()[0]
+    )
+    building_id = int(
+        conn.execute("SELECT id FROM buildings WHERE name = 'Report HQ' LIMIT 1;").fetchone()[0]
+    )
+    conn.execute(
+        """
+        INSERT INTO organization_buildings (organization_id, building_id, created_at)
+        VALUES (?, ?, '2026-01-01T00:00:00Z');
+        """,
+        (organization_id, building_id),
+    )
+    conn.execute(
+        """
+        INSERT INTO holders (
+            id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+        )
+        VALUES (
+            1, 'PERSON', 'Jane Operator', 'Report Ops', ?, 'H-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+        );
+        """,
+        (organization_id,),
+    )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (10, 'CASE-1', 1, 'AT-100');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (
+            'AT-100',
+            'SN-100',
+            'Dell',
+            'laptop',
+            'Report HQ',
+            '100',
+            'Latitude',
+            'LAT',
+            NULL,
+            'Report HQ/100',
+            'issued_to',
+            'accountable',
+            'serviceable',
+            '2026-01-01',
+            '2026-01-01T00:00:00Z',
+            'IN_CUSTODY',
+            1,
+            10
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        SELECT 10, id, '2026-01-01T00:00:00Z'
+        FROM assets
+        WHERE asset_tag = 'AT-100';
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (
+            'AT-100',
+            'ISSUE',
+            '2026-01-02T00:00:00Z',
+            'system',
+            NULL,
+            '{"to_location_type":"IN_CUSTODY"}',
+            1
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.get("/report")
+
+    assert response.status_code == 200
+    assert b"What Matters Now" in response.data
+    assert b"Report Scope" not in response.data
+    assert b"Review holders with assets out" in response.data
+    assert b"Check case space" in response.data
+    assert b"Look up an asset" in response.data
+    assert response.data.count(b"<details class=\"report-section\"") >= 5
+    assert b' href="/assets/search?asset_tag=AT-100"' in response.data
+    assert b' href="/holders/1"' in response.data
+    assert b' href="/dashboard/cases/CASE-1"' in response.data
 
 
 def test_admin_can_download_human_readable_report_pdf(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Improve /report so operators can quickly understand what matters and take action.

## Related Issue
Closes #480 

## Changes
- added “What Matters Now” section with direct follow-up links
- introduced safe drill-in links (asset, holder, case)
- exposed existing IDs in report context to support navigation
- removed low-value Report Scope block
- converted long sections into collapsible groups using native details/summary
- added visual affordance (chevrons and hover states) so sections are clearly expandable
- preserved report meaning, data, and workflow behavior

## Verification checklist
- [x] Targeted tests passed (`tests/test_admin_system_health.py`)
- [x] Manual browser review completed
- [x] Top-level actionability is clear
- [x] Drill-in links land on valid existing pages
- [x] Collapsible sections are obvious and usable
- [x] No dead ends or broken navigation
- [x] No changes to routes, auth, schema, persistence, or workflow behavior

## Notes
Focus remained on UI clarity and actionability only. No data model or workflow changes were introduced.