### PR TITLE
Issue 26-96: simplify receipt document and email-safe PDF

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4668,7 +4668,7 @@ def _send_receipt_email(receipt: dict[str, object]) -> list[str]:
         message["Cc"] = ", ".join(cc_recipients)
     message.set_content(_build_receipt_email_body(receipt))
     message.add_attachment(
-        _build_receipt_pdf(receipt),
+        _build_receipt_pdf(receipt, for_email=True),
         maintype="application",
         subtype="pdf",
         filename=_receipt_pdf_download_name(receipt),
@@ -4754,11 +4754,31 @@ def _receipt_pdf_location_type_label(value: object) -> str:
     return str(value or "").strip().replace("_", " ")
 
 
-def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
+def _build_receipt_pdf(receipt: dict[str, object], *, for_email: bool = False) -> bytes:
     styles = getSampleStyleSheet()
     body = styles["BodyText"]
     heading = styles["Heading2"]
     title = styles["Title"]
+    hero = ParagraphStyle(
+        "ReceiptPdfHero",
+        parent=styles["Heading1"],
+        fontSize=16,
+        leading=19,
+        spaceAfter=4,
+    )
+    status = ParagraphStyle(
+        "ReceiptPdfStatus",
+        parent=body,
+        fontName="Helvetica-Bold",
+        textColor=colors.HexColor("#335c81"),
+        spaceAfter=4,
+    )
+    supporting = ParagraphStyle(
+        "ReceiptPdfSupporting",
+        parent=body,
+        textColor=colors.HexColor("#4f5d6b"),
+        spaceAfter=4,
+    )
     table_body = ParagraphStyle(
         "ReceiptPdfTableBody",
         parent=body,
@@ -4815,6 +4835,53 @@ def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
 
     typed_name = _receipt_pdf_ack_name(receipt)
     location_summary = _receipt_pdf_location_summary(receipt)
+    receipt_type_label = _receipt_type_label(receipt_type)
+    asset_count = sum(1 for asset in receipt.get("assets", []) if isinstance(asset, dict))
+    asset_count_label = f"{asset_count} asset" if asset_count == 1 else f"{asset_count} assets"
+    action_phrase = "issued to"
+    if receipt_type == "RETURN":
+        action_phrase = "returned from"
+    elif receipt_type not in {"ISSUE", "RETURN"}:
+        action_phrase = "recorded for"
+
+    delivery = receipt.get("delivery")
+    delivery_state = ""
+    delivery_error = ""
+    if isinstance(delivery, dict):
+        delivery_state = str(delivery.get("state") or "").strip().lower()
+        delivery_error = str(delivery.get("last_error") or "").strip()
+
+    if for_email:
+        status_text = "Receipt attached for your records."
+    elif delivery_state == "failed":
+        status_text = "Receipt email failed. Resend recommended."
+    elif delivery_state == "pending":
+        status_text = "Receipt email queued. No action needed unless delivery stalls."
+    else:
+        status_text = "No action needed."
+
+    recorded_at = _receipt_display_timestamp(ack_timestamp or receipt.get("commit_at"))
+    summary_rows = [
+        ["Action", receipt_type_label],
+        ["Assets in this receipt", str(asset_count)],
+        ["Recorded at", recorded_at or "Unknown"],
+        ["Holder", typed_name],
+        ["Organization", organization_name],
+        ["Location", location_summary],
+    ]
+    audit_rows = [
+        ["Receipt ID", str(receipt.get("id") or "Unknown")],
+        ["Receipt key", str(receipt.get("receipt_key") or "Unknown")],
+        ["Acknowledgment", _receipt_acknowledgment_statement(receipt_type)],
+        ["Typed name", typed_name],
+        ["Initials", _receipt_pdf_initials(typed_name)],
+    ]
+    recipient_email = str(receipt.get("recipient_email") or "").strip().lower()
+    if recipient_email:
+        audit_rows.append(["Recipient email", recipient_email])
+    if delivery_error:
+        audit_rows.append(["Delivery issue", delivery_error])
+
     asset_rows: list[list[object]] = []
 
     for asset in receipt.get("assets", []):
@@ -4851,27 +4918,46 @@ def _build_receipt_pdf(receipt: dict[str, object]) -> bytes:
     )
 
     story: list[object] = [
-        Paragraph("Custody Acknowledgment Receipt", title),
+        Paragraph(receipt_type_label, title),
         Spacer(1, 0.1 * inch),
-        Paragraph(f"Receipt ID: {_text(receipt.get('id'))}", body),
-        Paragraph(f"Receipt key: {_text(receipt.get('receipt_key'))}", body),
-        Paragraph(f"Receipt type: {_text(receipt_type)}", body),
-        Paragraph(f"Holder: {_text(typed_name)}", body),
-        Paragraph(f"Organization: {_text(organization_name)}", body),
-        Paragraph(f"Location: {_text(location_summary)}", body),
-        Paragraph(f"Acknowledgment: {_text(_receipt_acknowledgment_statement(receipt_type))}", body),
-        Paragraph(f"Typed name: {_text(typed_name)}", body),
-        Paragraph(f"Initials: {_text(_receipt_pdf_initials(typed_name))}", body),
-        Paragraph(f"Timestamp: {_text(ack_timestamp or 'Unknown')}", body),
+        Paragraph(f"{_text(asset_count_label)} {action_phrase} {_text(typed_name)}", hero),
+        Paragraph(_text(status_text), status),
+        Paragraph(
+            _text(" · ".join(part for part in [recorded_at or "Unknown", organization_name, location_summary] if part)),
+            supporting,
+        ),
+        Spacer(1, 0.08 * inch),
+        Paragraph("What Happened", heading),
+        Spacer(1, 0.05 * inch),
+        _render_table(
+            ["Question", "Answer"],
+            summary_rows,
+            [1.8 * inch, 5.2 * inch],
+        ),
+        Spacer(1, 0.16 * inch),
         Spacer(1, 0.18 * inch),
         Paragraph("Assets", heading),
         Spacer(1, 0.08 * inch),
         _render_table(
-            ["Asset Tag", "Equipment", "Serial", "Make / Model", "From", "To"],
+            ["Tag", "Type", "Serial", "Item", "From", "To"],
             asset_rows or [["No assets captured.", "", "", "", "", ""]],
             [1.15 * inch, 1.0 * inch, 1.25 * inch, 1.95 * inch, 0.95 * inch, 1.0 * inch],
         ),
     ]
+
+    if not for_email:
+        story.extend(
+            [
+                Spacer(1, 0.16 * inch),
+                Paragraph("Audit Details", heading),
+                Spacer(1, 0.05 * inch),
+                _render_table(
+                    ["Detail", "Recorded value"],
+                    audit_rows,
+                    [1.8 * inch, 5.2 * inch],
+                ),
+            ]
+        )
 
     def _invariant_canvas(*args, **kwargs):
         kwargs.setdefault("invariant", 1)

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -12,7 +12,7 @@
     }
     .receipt-hero {
       display: grid;
-      gap: 0.65rem;
+      gap: 0.8rem;
       padding: 1.15rem 1.2rem;
       border: 1px solid var(--color-surface);
       border-radius: 14px;
@@ -38,15 +38,22 @@
     }
     .receipt-hero-title {
       margin: 0;
-      font-size: 1.45rem;
-      line-height: 1.2;
+      font-size: 1.7rem;
+      line-height: 1.15;
     }
-    .receipt-hero-copy {
+    .receipt-status-line {
       margin: 0;
-      color: var(--color-text-muted);
-      line-height: 1.5;
+      font-size: 1.02rem;
+      font-weight: 600;
+      line-height: 1.4;
     }
-    .receipt-meta-line {
+    .receipt-status-line[data-tone="calm"] {
+      color: var(--color-text-muted);
+    }
+    .receipt-status-line[data-tone="action"] {
+      color: var(--color-accent);
+    }
+    .receipt-context-line {
       margin: 0;
       color: var(--color-text-muted);
       font-size: 0.92rem;
@@ -54,7 +61,7 @@
     }
     .receipt-summary {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: repeat(3, minmax(0, 1fr));
       gap: 1rem;
     }
     .summary-group {
@@ -93,6 +100,13 @@
     }
     .summary-status {
       align-content: start;
+    }
+    .summary-group.emphasis {
+      background: linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--color-primary-soft) 36%, var(--color-surface-bg)),
+        var(--color-surface-bg)
+      );
     }
     .status-chip {
       display: inline-flex;
@@ -147,6 +161,31 @@
     .receipt-extra-card p {
       margin: 0;
     }
+    .receipt-assets-lead {
+      margin: 0 0 0.85rem 0;
+      color: var(--color-text-muted);
+    }
+    .asset-tag {
+      font-weight: 700;
+    }
+    .asset-detail-stack,
+    .asset-move-stack,
+    .asset-holder-stack {
+      display: grid;
+      gap: 0.22rem;
+    }
+    .asset-subtle {
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
+      line-height: 1.35;
+    }
+    .asset-move-label {
+      color: var(--color-text-muted);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
     @media (max-width: 960px) {
       .receipt-extra-grid,
       .receipt-summary {
@@ -164,6 +203,36 @@
   {% set receipt_action_label = "Retry Send" if receipt.delivery.state == "failed" else "Send Receipt Email" %}
   {% set email_timing_label = "Delivered" if receipt.delivery.sent_at else "Last attempted" if receipt.delivery.last_attempt_at else "" %}
   {% set email_timing_value = receipt.delivery_display.sent_at or receipt.delivery_display.last_attempt_at %}
+  {% set holder_display_name = holder.name if holder and holder.name else receipt.holder_display_name %}
+  {% set receipt_action_word = "issued" if receipt.receipt_type == "ISSUE" else "returned" %}
+  {% set receipt_direction = "to" if receipt.receipt_type == "ISSUE" else "from" %}
+  {% set headline_subject = holder_display_name if holder_display_name else "recorded holder" %}
+  {% set context_parts = [] %}
+  {% if holder_display_name %}
+    {% set context_parts = context_parts + [holder_display_name] %}
+  {% endif %}
+  {% if receipt.location_context and receipt.location_context.get("building_room") %}
+    {% set context_parts = context_parts + [receipt.location_context.get("building_room")] %}
+  {% endif %}
+  {% if receipt.commit_at_display %}
+    {% set context_parts = context_parts + [receipt.commit_at_display] %}
+  {% endif %}
+  {% if operator and operator.username %}
+    {% set context_parts = context_parts + ["Recorded by " ~ operator.username] %}
+  {% endif %}
+  {% if receipt.delivery.state == "failed" %}
+    {% set receipt_status_text = "Email failed — resend recommended" %}
+    {% set receipt_status_tone = "action" %}
+  {% elif receipt.delivery.state == "pending" %}
+    {% set receipt_status_text = "Email queued — no action needed unless delivery stalls" %}
+    {% set receipt_status_tone = "calm" %}
+  {% elif receipt.delivery.state == "sent" %}
+    {% set receipt_status_text = "No action needed" %}
+    {% set receipt_status_tone = "calm" %}
+  {% else %}
+    {% set receipt_status_text = "No action needed" %}
+    {% set receipt_status_tone = "calm" %}
+  {% endif %}
   <nav class="actions nav-row mixed-nav-row" aria-label="Receipt navigation">
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="nav-link" href="{{ url_for('human_report') }}">Open Current Status Report</a>
@@ -184,39 +253,36 @@
             <span class="status-chip" data-state="{{ receipt.delivery.state }}">{{ email_status_label }}</span>
           {% endif %}
         </div>
-        <h2 class="receipt-hero-title">{{ receipt.display_title }}</h2>
-        <p class="receipt-hero-copy">
-          {{ receipt.assets|length }} asset{% if receipt.assets|length != 1 %}s{% endif %}
-          {% if holder and holder.name %}
-            for <strong>{{ holder.name }}</strong>
-          {% elif receipt.holder_display_name %}
-            for <strong>{{ receipt.holder_display_name }}</strong>
-          {% endif %}
-          committed on <strong>{{ receipt.commit_at_display or "Unknown" }}</strong>.
+        <h2 class="receipt-hero-title">
+          {{ receipt.assets|length }} asset{% if receipt.assets|length != 1 %}s{% endif %} {{ receipt_action_word }} {{ receipt_direction }} {{ headline_subject }}
+        </h2>
+        <p class="receipt-status-line" data-tone="{{ receipt_status_tone }}">
+          {{ receipt_status_text }}
         </p>
-        <p class="receipt-meta-line">
-          Recipient: <strong>{{ receipt.recipient_email or "Not captured" }}</strong>
+        <p class="receipt-context-line">
+          {{ context_parts|join(" · ") if context_parts else "Context not captured" }}
+          {% if receipt.recipient_email %}
+            · Receipt email {{ receipt.recipient_email }}
+          {% endif %}
           {% if email_timing_value %}
-            • {{ email_timing_label }} <strong>{{ email_timing_value }}</strong>
-          {% endif %}
-          {% if receipt.delivery.last_error %}
-            • Last error: <strong>{{ receipt.delivery.last_error }}</strong>
-          {% endif %}
-          {% if receipt.delivery.state in ["pending", "failed"] %}
-            • Action available: <strong>{{ receipt_action_label }}</strong>
+            · {{ email_timing_label }} {{ email_timing_value }}
           {% endif %}
         </p>
       </section>
 
       <div class="receipt-summary">
-        <section class="summary-group">
+        <section class="summary-group emphasis">
           <h2 class="summary-group-title">What Happened</h2>
           <div class="summary-value">
-            <div class="summary-label">Receipt type</div>
+            <div class="summary-label">Action</div>
             <div class="summary-copy">{{ receipt.receipt_type_label }}</div>
           </div>
           <div class="summary-value">
-            <div class="summary-label">Committed at</div>
+            <div class="summary-label">Assets in this receipt</div>
+            <div class="summary-copy">{{ receipt.assets|length }}</div>
+          </div>
+          <div class="summary-value">
+            <div class="summary-label">Recorded at</div>
             <div class="summary-copy">{{ receipt.commit_at_display or "Unknown" }}</div>
           </div>
         </section>
@@ -256,17 +322,7 @@
         </section>
 
         <section class="summary-group">
-          <h2 class="summary-group-title">Who Was Involved</h2>
-          <div class="summary-value">
-            <div class="summary-label">Committed by</div>
-            <div class="summary-copy">
-              {% if operator and operator.username %}
-                {{ operator.username }}{% if operator.role %} ({{ operator.role }}){% endif %}
-              {% else %}
-                Unknown
-              {% endif %}
-            </div>
-          </div>
+          <h2 class="summary-group-title">Who and Where</h2>
           {% if holder or receipt.holder_id is not none %}
             <div class="summary-value">
               <div class="summary-label">Receipt holder</div>
@@ -280,10 +336,6 @@
               </div>
             </div>
           {% endif %}
-        </section>
-
-        <section class="summary-group">
-          <h2 class="summary-group-title">Context</h2>
           {% if organization %}
             <div class="summary-value">
               <div class="summary-label">Organization</div>
@@ -296,17 +348,30 @@
               <div class="summary-copy">{{ receipt.location_context.get("building_room") or "Unknown" }}</div>
             </div>
           {% endif %}
+          <div class="summary-value">
+            <div class="summary-label">Committed by</div>
+            <div class="summary-copy">
+              {% if operator and operator.username %}
+                {{ operator.username }}
+              {% else %}
+                Unknown
+              {% endif %}
+            </div>
+          </div>
         </section>
       </div>
     </div>
 
     <details class="receipt-extra">
-      <summary>More Receipt Detail</summary>
+      <summary>Technical Details</summary>
       <div class="receipt-extra-grid">
         <section class="receipt-extra-card">
-          <h2 class="summary-group-title">Additional Receipt Info</h2>
+          <h2 class="summary-group-title">Receipt Record</h2>
           <p><span class="summary-label">Internal receipt ID</span><br /><span class="mono">{{ receipt.id }}</span></p>
           <p><span class="summary-label">Receipt key</span><br /><span class="mono">{{ receipt.receipt_key }}</span></p>
+          {% if operator and operator.role %}
+            <p><span class="summary-label">Committed by role</span><br />{{ operator.role }}</p>
+          {% endif %}
           {% if receipt.delivery.last_attempt_at %}
             <p><span class="summary-label">Last delivery attempt</span><br />{{ receipt.delivery_display.last_attempt_at }}</p>
           {% endif %}
@@ -348,15 +413,13 @@
 
   <section class="card">
     <h2>Assets ({{ receipt.assets|length }})</h2>
+    <p class="receipt-assets-lead">Review this only if something looks wrong. Each row shows the asset, movement, holder context, and home slot.</p>
     <table>
       <thead>
         <tr>
           <th>Asset Tag</th>
-          <th>Equipment</th>
-          <th>Serial</th>
-          <th>Make / Model</th>
-          <th>From</th>
-          <th>To</th>
+          <th>Details</th>
+          <th>Movement</th>
           <th>Holder</th>
           <th>Home Slot</th>
         </tr>
@@ -367,36 +430,52 @@
           {% set return_holder = asset.get("from_holder_snapshot") if asset.get("from_holder_snapshot") is mapping else None %}
           {% set home_slot = asset.get("home_slot") if asset.get("home_slot") is mapping else None %}
           <tr>
-            <td class="mono">{{ asset.get("asset_tag") or "" }}</td>
-            <td>{{ asset.get("equipment_type") or "" }}</td>
-            <td class="mono">{{ asset.get("serial_number") or "" }}</td>
+            <td class="mono asset-tag">{{ asset.get("asset_tag") or "" }}</td>
             <td>
-              {{ asset.get("manufacturer") or "" }}
-              {% if asset.get("model") %} / {{ asset.get("model") }}{% endif %}
-              {% if asset.get("model_code") %} ({{ asset.get("model_code") }}){% endif %}
+              <div class="asset-detail-stack">
+                <div>{{ asset.get("equipment_type") or "Unknown type" }}</div>
+                <div class="asset-subtle">Serial: <span class="mono">{{ asset.get("serial_number") or "Not captured" }}</span></div>
+                <div class="asset-subtle">
+                  {{ asset.get("manufacturer") or "Unknown make" }}
+                  {% if asset.get("model") %} / {{ asset.get("model") }}{% endif %}
+                  {% if asset.get("model_code") %} ({{ asset.get("model_code") }}){% endif %}
+                </div>
+              </div>
             </td>
-            <td>{{ asset.get("from_location_type") or "" }}{% if asset.get("from_building_room") %}<br />{{ asset.get("from_building_room") }}{% endif %}</td>
-            <td>{{ asset.get("to_location_type") or "" }}{% if asset.get("to_building_room") %}<br />{{ asset.get("to_building_room") }}{% endif %}</td>
             <td>
-              {% if receipt.receipt_type == "ISSUE" %}
-                {% if issue_holder and issue_holder.get("name") %}
-                  {{ issue_holder.get("name") }}
-                  {% if issue_holder.get("identifier") %}<br />ID {{ issue_holder.get("identifier") }}{% endif %}
-                {% elif asset.get("holder_id") is not none %}
-                  holder_id {{ asset.get("holder_id") }}
+              <div class="asset-move-stack">
+                <div>
+                  <span class="asset-move-label">From</span><br />
+                  {{ asset.get("from_location_type") or "Unknown" }}{% if asset.get("from_building_room") %}<br /><span class="asset-subtle">{{ asset.get("from_building_room") }}</span>{% endif %}
+                </div>
+                <div>
+                  <span class="asset-move-label">To</span><br />
+                  {{ asset.get("to_location_type") or "Unknown" }}{% if asset.get("to_building_room") %}<br /><span class="asset-subtle">{{ asset.get("to_building_room") }}</span>{% endif %}
+                </div>
+              </div>
+            </td>
+            <td>
+              <div class="asset-holder-stack">
+                {% if receipt.receipt_type == "ISSUE" %}
+                  {% if issue_holder and issue_holder.get("name") %}
+                    <div>{{ issue_holder.get("name") }}</div>
+                    {% if issue_holder.get("identifier") %}<div class="asset-subtle">ID {{ issue_holder.get("identifier") }}</div>{% endif %}
+                  {% elif asset.get("holder_id") is not none %}
+                    <div>holder_id {{ asset.get("holder_id") }}</div>
+                  {% else %}
+                    <div>Unknown</div>
+                  {% endif %}
                 {% else %}
-                  Unknown
+                  {% if return_holder and return_holder.get("name") %}
+                    <div>{{ return_holder.get("name") }}</div>
+                    {% if return_holder.get("identifier") %}<div class="asset-subtle">ID {{ return_holder.get("identifier") }}</div>{% endif %}
+                  {% elif asset.get("from_holder_id") is not none %}
+                    <div>holder_id {{ asset.get("from_holder_id") }}</div>
+                  {% else %}
+                    <div>None</div>
+                  {% endif %}
                 {% endif %}
-              {% else %}
-                {% if return_holder and return_holder.get("name") %}
-                  {{ return_holder.get("name") }}
-                  {% if return_holder.get("identifier") %}<br />ID {{ return_holder.get("identifier") }}{% endif %}
-                {% elif asset.get("from_holder_id") is not none %}
-                  holder_id {{ asset.get("from_holder_id") }}
-                {% else %}
-                  None
-                {% endif %}
-              {% endif %}
+              </div>
             </td>
             <td>
               {% if home_slot %}
@@ -408,7 +487,7 @@
           </tr>
         {% else %}
           <tr>
-            <td colspan="8">No assets were captured in this receipt snapshot.</td>
+            <td colspan="5">No assets were captured in this receipt snapshot.</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -699,14 +699,21 @@ def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_d
     assert expected_download_name in disposition
 
     pdf_text = _extract_pdf_text(response.data)
-    assert "Custody Acknowledgment Receipt" in pdf_text
-    assert f"Receipt ID: {receipt_id}" in pdf_text
-    assert "Receipt type: ISSUE" in pdf_text
-    assert "Holder: Issue Holder" in pdf_text
-    assert "Organization: Operations" in pdf_text
-    assert "Location: HQ North/210" in pdf_text
-    assert "Typed name: Issue Holder" in pdf_text
-    assert "Initials: IH" in pdf_text
+    assert "Issue Receipt" in pdf_text
+    assert "1 asset issued to Issue Holder" in pdf_text
+    assert "Receipt email queued. No action needed unless delivery stalls." in pdf_text
+    assert "What Happened" in pdf_text
+    assert "Action" in pdf_text
+    assert "Assets in this receipt" in pdf_text
+    assert "Organization" in pdf_text
+    assert "Operations" in pdf_text
+    assert "Location" in pdf_text
+    assert "HQ North/210" in pdf_text
+    assert "Audit Details" in pdf_text
+    assert "Receipt ID" in pdf_text
+    assert str(receipt_id) in pdf_text
+    assert "Typed name" in pdf_text
+    assert "Initials" in pdf_text
     assert "ISSUE-100" in pdf_text
     assert "Dell / Latitude (LAT-14)" in pdf_text
     assert "IN CUSTODY" in pdf_text
@@ -1041,10 +1048,26 @@ def test_send_receipt_email_adds_configured_cc_recipient(monkeypatch: pytest.Mon
         "id": 7,
         "receipt_key": "R-7",
         "display_title": "Issue Receipt",
+        "receipt_type": "ISSUE",
         "commit_at": "2026-01-01T00:00:00Z",
         "holder_display_name": "Issue Holder",
+        "holder_snapshot": {"name": "Issue Holder"},
+        "organization_snapshot": {"organization": "Operations"},
+        "location_context": {"building_room": "HQ North/210"},
         "recipient_email": "issue@example.org",
-        "assets": [{"asset_tag": "ISSUE-100"}],
+        "delivery": {"state": "pending", "last_error": "SMTP timeout"},
+        "assets": [
+            {
+                "asset_tag": "ISSUE-100",
+                "equipment_type": "Laptop",
+                "serial_number": "SN-ISSUE-100",
+                "manufacturer": "Dell",
+                "model": "Latitude",
+                "model_code": "LAT-14",
+                "from_location_type": "IN_CUSTODY",
+                "to_location_type": "IN_CUSTODY",
+            }
+        ],
     }
 
     captured: dict[str, object] = {}
@@ -1076,6 +1099,18 @@ def test_send_receipt_email_adds_configured_cc_recipient(monkeypatch: pytest.Mon
     assert isinstance(message, EmailMessage)
     assert message["To"] == "issue@example.org"
     assert message["Cc"] == "oversight@example.org"
+    attachments = list(message.iter_attachments())
+    assert len(attachments) == 1
+    pdf_text = _extract_pdf_text(attachments[0].get_payload(decode=True))
+    assert "Issue Receipt" in pdf_text
+    assert "Receipt attached for your records." in pdf_text
+    assert "ISSUE-100" in pdf_text
+    assert "Audit Details" not in pdf_text
+    assert "Receipt ID" not in pdf_text
+    assert "Receipt key" not in pdf_text
+    assert "Recipient email" not in pdf_text
+    assert "Delivery issue" not in pdf_text
+    assert "Receipt email queued. No action needed unless delivery stalls." not in pdf_text
 
 
 def test_send_receipt_email_omits_cc_when_config_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1083,8 +1118,10 @@ def test_send_receipt_email_omits_cc_when_config_is_blank(monkeypatch: pytest.Mo
         "id": 8,
         "receipt_key": "R-8",
         "display_title": "Issue Receipt",
+        "receipt_type": "ISSUE",
         "commit_at": "2026-01-01T00:00:00Z",
         "holder_display_name": "Issue Holder",
+        "holder_snapshot": {"name": "Issue Holder"},
         "recipient_email": "issue@example.org",
         "assets": [{"asset_tag": "ISSUE-101"}],
     }
@@ -1173,8 +1210,9 @@ def test_return_receipt_pdf_lists_multiple_holders_when_batch_is_mixed(client_wi
 
     assert response.status_code == 200
     pdf_text = _extract_pdf_text(response.data)
-    assert "Receipt type: RETURN" in pdf_text
-    assert "Holder: Return Holder One, Return Holder Two" in pdf_text
-    assert "Location: HQ North/210, HQ North/211" in pdf_text
+    assert "Return Receipt" in pdf_text
+    assert "2 assets returned from Return Holder One, Return Holder Two" in pdf_text
+    assert "Location" in pdf_text
+    assert "HQ North/210, HQ North/211" in pdf_text
     assert "RETURN-200" in pdf_text
     assert "RETURN-201" in pdf_text


### PR DESCRIPTION
## Summary
Simplify receipt presentation across UI and PDF so operators and recipients can quickly understand what happened and whether action is needed.

## Related Issue
Closes #476 

## Changes
- refactored receipt detail page to use headline + status + context pattern
- improved visual hierarchy to lead with the answer
- reduced prominence of low-value technical metadata
- simplified asset table for better scanability
- updated PDF generation to match simplified structure
- added email-safe PDF mode that omits internal audit details from emailed receipts
- preserved full audit detail in internal/downloaded PDF

## Verification checklist
- [x] Receipt detail page clearly answers what happened on first glance
- [x] Status line is calm and actionable
- [x] Context line is readable and not overloaded
- [x] Downloaded PDF reflects simplified structure
- [x] Emailed PDF omits audit details while preserving core information
- [x] Internal PDF retains full audit visibility
- [x] Targeted tests passed (`tests/test_receipt_detail.py`)
- [x] Manual verification completed for Issue and Return workflows
- [x] No changes to routes, auth, schema, persistence, or workflow behavior

## Notes
Introduced a clean separation between internal system receipts (full audit detail) and external communication receipts (simplified), improving clarity without weakening audit integrity.