### PR TITLE
Issue 26-92: Show human-readable UTC timestamps on users page

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4527,9 +4527,8 @@ def _receipt_display_date(commit_at: str) -> str:
     if not value:
         return "Unknown Date"
 
-    try:
-        parsed = datetime.fromisoformat(value)
-    except ValueError:
+    parsed = _parse_display_timestamp(value)
+    if parsed is None:
         return value
 
     month = parsed.strftime("%b")
@@ -4538,14 +4537,25 @@ def _receipt_display_date(commit_at: str) -> str:
     return f"{month} {day}, {year}"
 
 
+def _parse_display_timestamp(value: object) -> Optional[datetime]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
 def _receipt_display_timestamp(value: object) -> str:
     text = str(value or "").strip()
     if not text:
         return ""
 
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
+    parsed = _parse_display_timestamp(text)
+    if parsed is None:
         return text
 
     month = parsed.strftime("%b")
@@ -5436,6 +5446,9 @@ def holders_clear():
 @require_role("admin")
 def admin_users():
     users = list_users()
+    for user in users:
+        user["created_at_display"] = _receipt_display_timestamp(user.get("created_at"))
+        user["updated_at_display"] = _receipt_display_timestamp(user.get("updated_at"))
     return render_template("admin_users.html", users=users)
 
 

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -22,7 +22,20 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 def test_admin_can_view_user_table(client_with_temp_db) -> None:
     admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
-    create_test_user(username="operator-a", password="op-pass", role="operator")
+    operator_id = create_test_user(username="operator-a", password="op-pass", role="operator")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            UPDATE users
+            SET created_at = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            ("2026-04-05T13:15:00+00:00", "2026-04-06T09:45:00+00:00", operator_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
     login_session(client_with_temp_db, admin_user_id)
 
     response = client_with_temp_db.get("/admin/users")
@@ -30,6 +43,30 @@ def test_admin_can_view_user_table(client_with_temp_db) -> None:
     assert response.status_code == 200
     assert b"Admin: Users" in response.data
     assert b"operator-a" in response.data
+    assert b"Apr 5, 2026 at 13:15 UTC" in response.data
+    assert b"Apr 6, 2026 at 09:45 UTC" in response.data
+    assert b"2026-04-05T13:15:00+00:00" not in response.data
+    assert b"2026-04-06T09:45:00+00:00" not in response.data
+
+
+def test_admin_users_page_formats_microsecond_timestamps(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    target_user_id = create_test_user(username="operator-b", password="op-pass", role="operator")
+    stored_user = get_user_by_id(target_user_id)
+    assert stored_user is not None
+    raw_created_at = str(stored_user["created_at"])
+    raw_updated_at = str(stored_user["updated_at"])
+    assert "." in raw_created_at
+    assert "." in raw_updated_at
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.get("/admin/users")
+
+    assert response.status_code == 200
+    assert raw_created_at.encode("utf-8") not in response.data
+    assert raw_updated_at.encode("utf-8") not in response.data
+    assert intake_app._receipt_display_timestamp(raw_created_at).encode("utf-8") in response.data
+    assert intake_app._receipt_display_timestamp(raw_updated_at).encode("utf-8") in response.data
 
 
 def test_admin_can_create_operator_user(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Show human-readable UTC timestamps on the Admin Users page and support ISO timestamps with microseconds in the shared display formatter.

## Related Issue
Closes #471 

## Changes
- harden the shared display timestamp parser to handle ISO timestamps with or without microseconds
- reuse existing human-readable UTC format used by receipts/email
- ensure newly created users render correctly on /admin/users
- update targeted admin user management tests

## Verification checklist
- [x] Targeted tests pass
- [x] Manual check: `/admin/users` shows readable UTC timestamps
- [x] Manual check: no raw ISO timestamps remain for valid records
- [x] Manual check: table order and actions behave the same
- [x] Manual check: receipt/email timestamps unchanged

## Notes
Display-only change. No schema, auth, route, sorting, or persistence changes.