### PR TITLE
Issue 26-91: Simplify selected holder presentation

### DIFF
--- a/assettrack/intake/templates/_workflow_context_banner.html
+++ b/assettrack/intake/templates/_workflow_context_banner.html
@@ -1,13 +1,17 @@
 <!-- file: assettrack/intake/templates/_workflow_context_banner.html -->
 <div class="card workflow-banner">
   <h2>{{ workflow_banner_title }}</h2>
-  <p>
-    {% if selected_holder %}
-      <strong>Issued to:</strong>
-      {{ holder_display_name(selected_holder) }}{% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %} ({{ selected_holder["organization"] }}){% endif %}<br />
+  {% if selected_holder %}
+    <p class="muted" style="margin: 0 0 0.2rem 0; font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase;">Selected holder</p>
+    <p style="margin: 0; font-size: 1.15rem; font-weight: 700;">{{ holder_display_name(selected_holder) }}</p>
+    {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+      <p class="muted" style="margin: 0.2rem 0 0 0;">{{ selected_holder["organization"] }}</p>
     {% endif %}
+  {% endif %}
+  <p class="workflow-summary" style="margin: {% if selected_holder %}0.75rem{% else %}0{% endif %} 0 0 0;">
     {% if workflow_banner_destination %}
-      <strong>Home location:</strong> {{ workflow_banner_destination }}<br />
+      <strong>Home location:</strong> {{ workflow_banner_destination }}
+      {% if workflow_banner_outcome or not workflow_banner_outcome and workflow_banner_queued_count is not none %}<br />{% endif %}
     {% endif %}
     {% if workflow_banner_outcome %}
       <strong>Status:</strong> {{ workflow_banner_outcome }}

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -10,6 +10,23 @@
     input[type="text"] { width: 100%; max-width: 520px; box-sizing: border-box; padding: 0.6rem; font-size: 1rem; }
     button { margin-left: 0.25rem; }
     th, td { border-bottom: 1px solid #eee; }
+    .selected-holder-name {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .selected-holder-subtle {
+      margin: 0.22rem 0 0 0;
+      color: var(--color-text-muted);
+    }
+    .selected-holder-meta {
+      display: flex;
+      gap: 0.45rem 0.8rem;
+      flex-wrap: wrap;
+      margin-top: 0.65rem;
+      color: var(--color-text-muted);
+      font-size: 0.94rem;
+    }
   </style>
 {% endblock %}
 
@@ -55,16 +72,25 @@
   <div class="card">
     <h2>Selected Holder</h2>
     {% if selected_holder %}
-      <p>
-        <strong>Type:</strong> {{ holder_display_type(selected_holder) }}<br />
-        <strong>Person or group:</strong> {{ holder_display_name(selected_holder) }}<br />
-        <strong>Organization:</strong> {{ selected_holder["organization"] or "" }}<br />
-        <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}<br />
-        <strong>Email:</strong> {{ selected_holder["email"] or "" }}
-      </p>
-      <form method="post" action="{{ url_for('holders_clear') }}">
-        <button type="submit">Clear selection</button>
-      </form>
+      <p class="muted" style="margin: 0 0 0.2rem 0; font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase;">Current selection</p>
+      <p class="selected-holder-name">{{ holder_display_name(selected_holder) }}</p>
+      {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+        <p class="selected-holder-subtle">{{ selected_holder["organization"] }}</p>
+      {% endif %}
+      <div class="selected-holder-meta" aria-label="Selected holder details">
+        <span>{{ holder_display_type(selected_holder) }}</span>
+        {% if selected_holder["identifier"] %}
+          <span>ID {{ selected_holder["identifier"] }}</span>
+        {% endif %}
+        {% if selected_holder["email"] %}
+          <span>{{ selected_holder["email"] }}</span>
+        {% endif %}
+      </div>
+      <div class="actions" style="margin-top: 0.75rem;">
+        <form method="post" action="{{ url_for('holders_clear') }}">
+          <button type="submit">Clear selection</button>
+        </form>
+      </div>
     {% else %}
       <p>No holder selected.</p>
     {% endif %}

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -9,6 +9,23 @@
     .pill.good { background: var(--color-primary-soft); border: 1px solid var(--color-primary); }
     ul { margin: 0.5rem 0 0 1.25rem; }
     .holder-summary { margin: 0; line-height: 1.55; }
+    .holder-name {
+      margin: 0;
+      font-size: 1.2rem;
+      font-weight: 700;
+    }
+    .holder-subtle {
+      margin: 0.22rem 0 0 0;
+      color: var(--color-text-muted);
+    }
+    .holder-meta {
+      display: flex;
+      gap: 0.45rem 0.8rem;
+      flex-wrap: wrap;
+      margin-top: 0.65rem;
+      color: var(--color-text-muted);
+      font-size: 0.94rem;
+    }
   </style>
 {% endblock %}
 
@@ -45,14 +62,19 @@
   <div class="card workflow-card">
     <h2>Selected Holder</h2>
     {% if selected_holder %}
-      <p class="holder-summary">
-        <strong>Type:</strong> {{ holder_display_type(selected_holder) }}<br />
-        <strong>Person or group:</strong> {{ holder_display_name(selected_holder) }}<br />
-        <strong>Organization:</strong> {{ selected_holder["organization"] or "" }}<br />
-        <strong>Identifier:</strong> {{ selected_holder["identifier"] or "" }}
-      </p>
+      <p class="muted" style="margin: 0 0 0.2rem 0; font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase;">Ready to issue to</p>
+      <p class="holder-name">{{ holder_display_name(selected_holder) }}</p>
+      {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+        <p class="holder-subtle">{{ selected_holder["organization"] }}</p>
+      {% endif %}
+      <div class="holder-meta" aria-label="Selected holder details">
+        <span>{{ holder_display_type(selected_holder) }}</span>
+        {% if selected_holder["identifier"] %}
+          <span>ID {{ selected_holder["identifier"] }}</span>
+        {% endif %}
+      </div>
       <div class="actions" style="margin-top: 0.75rem;">
-        <a class="chip" href="{{ url_for('holders_search') }}">Change holder selection</a>
+        <a class="chip" href="{{ url_for('holders_search') }}">Change holder</a>
       </div>
     {% else %}
       <p>No holder selected.</p>

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -85,7 +85,9 @@ def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_hol
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
     assert b"Issuing Assets" in issue_page.data
-    assert b"Issue Holder (Issue Org)" in issue_page.data
+    assert b"Selected holder" in issue_page.data
+    assert b"Issue Holder" in issue_page.data
+    assert b"Issue Org" in issue_page.data
     assert b"Enable issue mode before using Issue Assets." not in issue_page.data
 
 
@@ -128,8 +130,9 @@ def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> Non
 
     assert response.status_code == 200
     assert b"Issuing Assets" in response.data
-    assert b"Issued to:</strong>" in response.data
-    assert b"Issue Holder (Issue Org)" in response.data
+    assert b"Selected holder" in response.data
+    assert b"Issue Holder" in response.data
+    assert b"Issue Org" in response.data
     assert b"Queued:</strong> 0 assets" in response.data
 
 
@@ -154,6 +157,6 @@ def test_issue_page_displays_selected_group_holder_context(client_with_temp_db) 
 
     assert response.status_code == 200
     assert b"Issuing Assets" in response.data
-    assert b"Issued to:</strong>" in response.data
+    assert b"Selected holder" in response.data
     assert b"Maintenance Team" in response.data
     assert b"Maintenance Team (Maintenance Team)" not in response.data


### PR DESCRIPTION
## Summary
Simplify selected holder presentation so the holder name is clearer, organization is secondary, and actions are easier to scan.

## Related Issue
Closes #470 

## Changes
- simplify the selected holder presentation in the shared workflow banner
- simplify the Selected Holder card in issue preview
- de-emphasize low-value metadata
- group holder actions more cleanly using existing action/chip patterns
- update targeted prerequisite test assertions for the new presentation

## Verification checklist
- [x] Targeted tests pass
- [ ] Manual check: selected holder is easy to scan on `/issue`
- [ ] Manual check: issue preview shows holder name first and actions clearly
- [ ] Manual check: scan → preview → commit behavior remains unchanged

## Notes
Template-only UI change. No holder selection logic, auth, route, workflow, or persistence changes.