### PR TITLE
Issue 26-112: Add actionable report navigation using existing routes

### DIFF
--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Current Status Report{% endblock %}
-{% block page_heading %}Current Status Report{% endblock %}
+{% block title %}Current System State{% endblock %}
+{% block page_heading %}Current System State{% endblock %}
 {% block page_class %} report-page{% endblock %}
 
 {% block extra_head %}
@@ -30,10 +30,26 @@
       gap: 0.75rem;
     }
     .report-stat {
+      display: block;
       padding: 0.85rem;
       border: 1px solid var(--color-surface);
       border-radius: 10px;
       background: var(--color-surface-soft);
+    }
+    .report-stat-link {
+      color: inherit;
+      text-decoration: none;
+      transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+    }
+    .report-stat-link:hover {
+      text-decoration: none;
+      border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-surface));
+      background: color-mix(in srgb, var(--color-primary-soft) 35%, var(--color-surface-bg));
+      transform: translateY(-1px);
+    }
+    .report-stat-link:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
     }
     .report-stat strong {
       display: block;
@@ -127,9 +143,9 @@
 
   <div class="card report-priority">
     <div>
-      <h2>What Matters Now</h2>
+      <h2>Use Current State to Decide the Next Step</h2>
       <p class="report-priority-copy">
-        Start with assets in custody and open case space. Use the links below to move directly from this report into follow-up work.
+        This page shows the current custody and storage picture. Use the links below to move from status into the next existing view without re-searching.
       </p>
     </div>
     <div class="report-actions nav-row report-priority-links">
@@ -139,26 +155,26 @@
       <a class="nav-link" href="{{ url_for('receipts_list') }}">Open receipts</a>
     </div>
     <div class="report-grid">
-      <div class="report-stat">
+      <a class="report-stat report-stat-link" href="{{ url_for('asset_search') }}">
         Total assets
         <strong>{{ asset_summary.total_assets }}</strong>
-        <a class="nav-link report-stat-action" href="{{ url_for('asset_search') }}">Search asset records</a>
-      </div>
-      <div class="report-stat">
+        <span class="nav-link report-stat-action">Search asset records</span>
+      </a>
+      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_cases') }}">
         In storage
         <strong>{{ asset_summary.storage_assets }}</strong>
-        <a class="nav-link report-stat-action" href="{{ url_for('dashboard_cases') }}">Review case space</a>
-      </div>
-      <div class="report-stat">
+        <span class="nav-link report-stat-action">Review case space</span>
+      </a>
+      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_holders') }}">
         In custody
         <strong>{{ asset_summary.in_custody_assets }}</strong>
-        <a class="nav-link report-stat-action" href="{{ url_for('dashboard_holders') }}">Open holder follow-up</a>
-      </div>
-      <div class="report-stat">
+        <span class="nav-link report-stat-action">Open holder follow-up</span>
+      </a>
+      <a class="report-stat report-stat-link" href="{{ url_for('receipts_list') }}">
         Disposed
         <strong>{{ asset_summary.disposed_assets }}</strong>
-        <a class="nav-link report-stat-action" href="{{ url_for('receipts_list') }}">Review receipts</a>
-      </div>
+        <span class="nav-link report-stat-action">Review receipts</span>
+      </a>
     </div>
   </div>
 

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -453,12 +453,17 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     response = client_with_temp_db.get("/report")
 
     assert response.status_code == 200
-    assert b"What Matters Now" in response.data
+    assert b"Use Current State to Decide the Next Step" in response.data
+    assert b"This page shows the current custody and storage picture." in response.data
     assert b"Report Scope" not in response.data
     assert b"Review holders with assets out" in response.data
     assert b"Check case space" in response.data
     assert b"Look up an asset" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
+    assert response.data.count(b'href="/assets/search"') >= 2
+    assert b'href="/dashboard/cases"' in response.data
+    assert b'href="/dashboard/holders"' in response.data
+    assert b'href="/receipts"' in response.data
     assert b' href="/assets/search?asset_tag=AT-100"' in response.data
     assert b' href="/holders/1"' in response.data
     assert b' href="/dashboard/cases/CASE-1"' in response.data


### PR DESCRIPTION
## Summary
Make `/report` actionable by adding direct navigation paths from report elements to relevant existing views.

## Related Issue
Closes #519 

## Changes
- made summary cards clickable using existing routes
- added drill-in links for asset tags and holders
- tightened report header and purpose copy
- intentionally left location unlinked (no safe destination exists)

## Verification checklist
- [x] summary cards navigate correctly
- [x] asset drill-in links work
- [x] holder drill-in links work
- [x] no dead links
- [x] layout remains readable desktop and narrow
- [x] no regression outside `/report`

## Notes
Follow-on UX improvements identified during smoke test:
- priority link spacing
- return-to-report navigation
- link affordance clarity
- receipts table spacing
- holder detail page simplification