### PR TITLE
Issue 26-118: Left-align report section titles and keep counts right-…

### DIFF
--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -125,11 +125,15 @@
       content: "▾";
     }
     .report-section-title {
+      flex: 1 1 auto;
       margin: 0;
       font-size: 1.02rem;
       line-height: 1.3;
+      text-align: left;
     }
     .report-section-hint {
+      margin-left: auto;
+      flex: 0 0 auto;
       color: var(--color-text-muted);
       font-size: 0.92rem;
       font-weight: 500;


### PR DESCRIPTION
## Summary
Left-align expandable section titles on `/report` while keeping counts right-aligned for improved readability.

## Related Issue
Closes #527 

## Changes
- left-aligned section titles
- kept counts pinned to the right
- preserved existing flex layout and behavior

## Verification checklist
- [x] titles left-aligned consistently
- [x] counts right-aligned consistently
- [x] expand/collapse behavior unchanged
- [x] layout stable across sections
- [x] no regression to report page

## Notes
Improves scanability and consistency with overall page layout.