### PR TITLE
Issue 26-114: Preserve safe return-to-report navigation context

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -3650,6 +3650,7 @@ def dashboard():
 @app.get("/dashboard/holders")
 @require_login
 def dashboard_holders():
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     conn = get_connection()
     try:
         holders = list_holders_in_custody(conn)
@@ -3659,12 +3660,14 @@ def dashboard_holders():
     return render_template(
         "dashboard_holders.html",
         holders=holders,
+        return_to=return_to,
     )
 
 
 @app.get("/dashboard/holders/<int:holder_id>")
 @require_login
 def dashboard_holder_detail(holder_id: int):
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     conn = get_connection()
     try:
         detail = get_holder_custody_detail(conn, holder_id)
@@ -3677,12 +3680,14 @@ def dashboard_holder_detail(holder_id: int):
     return render_template(
         "dashboard_holder_detail.html",
         holder=detail,
+        return_to=return_to,
     )
 
 
 @app.get("/dashboard/cases")
 @require_login
 def dashboard_cases():
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     conn = get_connection()
     try:
         cases = list_case_summaries(conn)
@@ -3692,12 +3697,14 @@ def dashboard_cases():
     return render_template(
         "dashboard_cases.html",
         cases=cases,
+        return_to=return_to,
     )
 
 
 @app.get("/dashboard/cases/<case_name>")
 @require_login
 def dashboard_case_detail(case_name: str):
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     conn = get_connection()
     try:
         detail = get_case_slot_detail(conn, case_name)
@@ -3710,6 +3717,7 @@ def dashboard_case_detail(case_name: str):
     return render_template(
         "dashboard_case_detail.html",
         case_detail=detail,
+        return_to=return_to,
     )
 
 
@@ -3721,6 +3729,7 @@ def asset_search():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     form_state = {
         "asset_tag": (request.args.get("asset_tag") or "").strip().upper(),
         "serial_number": (request.args.get("serial_number") or "").strip(),
@@ -3746,6 +3755,7 @@ def asset_search():
         assets=assets,
         error_message=error_message,
         lookup_mode=lookup_mode,
+        return_to=return_to,
     )
 
 
@@ -4396,7 +4406,7 @@ def holders_search():
         return redirect(url_for("intake"))
 
     query = (request.args.get("q") or "").strip()
-    return_to = (request.args.get("return_to") or "").strip()
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     results = search_holders(query) if query else list_holders()
 
     return render_template(
@@ -4422,7 +4432,7 @@ def holder_detail(holder_id: int):
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
-    return_to = (request.args.get("return_to") or "").strip()
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     holder = get_holder(holder_id)
     if holder is None:
         abort(404)
@@ -5253,6 +5263,7 @@ def receipts_list():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
     asset_tag = (request.args.get("asset_tag") or "").strip()
     holder_name = (request.args.get("holder_name") or "").strip()
     building_room = (request.args.get("building_room") or "").strip()
@@ -5350,6 +5361,7 @@ def receipts_list():
             "holder_name": holder_name,
             "building_room": building_room,
         },
+        return_to=return_to,
     )
 
 

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -46,6 +46,12 @@
 {% endblock %}
 
 {% block content %}
+  {% if return_to == url_for('human_report') %}
+    <nav class="actions nav-row" aria-label="Asset search navigation">
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    </nav>
+  {% endif %}
+
   {% if error_message %}
     <div class="flash error">{{ error_message }}</div>
   {% endif %}
@@ -54,6 +60,9 @@
     <h2>Find Asset</h2>
     <p class="muted">Search by asset tag or serial number. If both are entered, asset tag is used first.</p>
     <form class="asset-search-form" method="get" action="{{ url_for('asset_search') }}">
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
       <div class="search-grid">
         <div class="row form-group search-field">
           <label class="form-label" for="asset_tag"><strong>Asset tag</strong></label>
@@ -67,7 +76,11 @@
       <div class="search-actions">
         <button type="submit">Search</button>
         {% if form.asset_tag or form.serial_number %}
-          <a class="search-clear" href="{{ url_for('asset_search') }}">Clear</a>
+          {% if return_to %}
+            <a class="search-clear" href="{{ url_for('asset_search', return_to=return_to) }}">Clear</a>
+          {% else %}
+            <a class="search-clear" href="{{ url_for('asset_search') }}">Clear</a>
+          {% endif %}
         {% endif %}
       </div>
     </form>

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -19,8 +19,11 @@
   {% set empty_slots = total_slots - occupied_slots %}
   {% set status = case_status_summary(total_slots, occupied_slots) %}
   <nav class="actions" aria-label="Contextual navigation">
+    {% if return_to == url_for('human_report') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    {% endif %}
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="nav-link" href="{{ url_for('dashboard_cases') }}">Back to Cases</a>
+    <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=return_to) }}">Back to Cases</a>
   </nav>
 
   <section class="card status-card">

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -15,6 +15,9 @@
 
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
+    {% if return_to == url_for('human_report') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    {% endif %}
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </nav>
 
@@ -35,7 +38,7 @@
         {% for row in cases %}
           {% set status = case_status_summary(row.total_slots, row.occupied_slots) %}
           <tr>
-            <td><a href="{{ url_for('dashboard_case_detail', case_name=row.case_name) }}">{{ row.case_name }}</a></td>
+            <td><a href="{{ url_for('dashboard_case_detail', case_name=row.case_name, return_to=return_to) }}">{{ row.case_name }}</a></td>
             <td class="status-cell">
               <span class="status-badge">
                 <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -6,8 +6,11 @@
 
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
+    {% if return_to == url_for('human_report') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    {% endif %}
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="nav-link" href="{{ url_for('dashboard_holders') }}">Back to Holders</a>
+    <a class="nav-link" href="{{ url_for('dashboard_holders', return_to=return_to) }}">Back to Holders</a>
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -13,6 +13,9 @@
 
 {% block content %}
   <nav class="actions" aria-label="Contextual navigation">
+    {% if return_to == url_for('human_report') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    {% endif %}
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </nav>
 
@@ -29,7 +32,7 @@
       <tbody>
         {% for row in holders %}
           <tr>
-            <td><a href="{{ url_for('dashboard_holder_detail', holder_id=row.holder_id) }}">{{ row.holder_name }}</a></td>
+            <td><a href="{{ url_for('dashboard_holder_detail', holder_id=row.holder_id, return_to=return_to) }}">{{ row.holder_name }}</a></td>
             <td>{{ row.organization or "" }}</td>
             <td>{{ row.asset_count }}</td>
           </tr>

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -6,6 +6,9 @@
 
 {% block content %}
   <nav class="actions" aria-label="Holder navigation">
+    {% if return_to == url_for('human_report') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    {% endif %}
     <a class="nav-link" href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>
     {% if return_to %}
       <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=return_to) }}">Edit Holder</a>

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -180,13 +180,21 @@
 
 {% block content %}
   <nav class="actions nav-row" aria-label="Receipt navigation">
+    {% if return_to == url_for('human_report') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+    {% endif %}
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="nav-link" href="{{ url_for('human_report') }}">Open Current Status Report</a>
+    {% if return_to != url_for('human_report') %}
+      <a class="nav-link" href="{{ url_for('human_report') }}">Open Current Status Report</a>
+    {% endif %}
   </nav>
 
   <section class="card">
     <h2>Search Receipts</h2>
     <form method="get" action="{{ url_for('receipts_list') }}">
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
       <div class="filters">
         <div class="row">
           <label for="asset_tag">Asset Tag</label>
@@ -204,7 +212,11 @@
           <div class="filter-actions">
             <button type="submit">Search</button>
             {% if filters.asset_tag or filters.holder_name or filters.building_room %}
-              <a class="nav-link" href="{{ url_for('receipts_list') }}">Clear search</a>
+              {% if return_to %}
+                <a class="nav-link" href="{{ url_for('receipts_list', return_to=return_to) }}">Clear search</a>
+              {% else %}
+                <a class="nav-link" href="{{ url_for('receipts_list') }}">Clear search</a>
+              {% endif %}
             {% endif %}
           </div>
         </div>

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -158,6 +158,7 @@
 {% endblock %}
 
 {% block content %}
+  {% set report_return_to = url_for('human_report') %}
   <div class="report-actions nav-row">
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </div>
@@ -174,28 +175,28 @@
       </p>
     </div>
     <div class="report-actions nav-row report-priority-links">
-      <a class="nav-link" href="{{ url_for('dashboard_holders') }}">Review holders with assets out</a>
-      <a class="nav-link" href="{{ url_for('dashboard_cases') }}">Check case space</a>
-      <a class="nav-link" href="{{ url_for('asset_search') }}">Look up an asset</a>
-      <a class="nav-link" href="{{ url_for('receipts_list') }}">Open receipts</a>
+      <a class="nav-link" href="{{ url_for('dashboard_holders', return_to=report_return_to) }}">Review holders with assets out</a>
+      <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=report_return_to) }}">Check case space</a>
+      <a class="nav-link" href="{{ url_for('asset_search', return_to=report_return_to) }}">Look up an asset</a>
+      <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Open receipts</a>
     </div>
     <div class="report-grid">
-      <a class="report-stat report-stat-link" href="{{ url_for('asset_search') }}">
+      <a class="report-stat report-stat-link" href="{{ url_for('asset_search', return_to=report_return_to) }}">
         Total assets
         <strong>{{ asset_summary.total_assets }}</strong>
         <span class="nav-link report-stat-action">Search asset records</span>
       </a>
-      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_cases') }}">
+      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_cases', return_to=report_return_to) }}">
         In storage
         <strong>{{ asset_summary.storage_assets }}</strong>
         <span class="nav-link report-stat-action">Review case space</span>
       </a>
-      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_holders') }}">
+      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_holders', return_to=report_return_to) }}">
         In custody
         <strong>{{ asset_summary.in_custody_assets }}</strong>
         <span class="nav-link report-stat-action">Open holder follow-up</span>
       </a>
-      <a class="report-stat report-stat-link" href="{{ url_for('receipts_list') }}">
+      <a class="report-stat report-stat-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">
         Disposed
         <strong>{{ asset_summary.disposed_assets }}</strong>
         <span class="nav-link report-stat-action">Review receipts</span>
@@ -224,14 +225,14 @@
         <tbody>
           {% for row in assets %}
             <tr>
-              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag) }}"><code>{{ row.asset_tag }}</code></a></td>
+              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.equipment_type or "" }}</td>
               <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
               <td>{{ row.location_type or "" }}</td>
               <td>
                 {% if row.holder_name %}
                   {% if row.holder_detail_id %}
-                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
                   {% else %}
                     {{ row.holder_name }}
                   {% endif %}
@@ -240,7 +241,7 @@
               </td>
               <td>
                 {% if row.home_case_name %}
-                  <a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.home_case_name) }}">{{ row.home_slot }}</a>
+                  <a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.home_case_name, return_to=report_return_to) }}">{{ row.home_slot }}</a>
                 {% else %}
                   {{ row.home_slot or "" }}
                 {% endif %}
@@ -278,7 +279,7 @@
             <tr>
               <td><code>{{ row.id }}</code></td>
               <td>{{ row.holder_type }}</td>
-              <td><a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.id) }}">{{ row.name }}</a></td>
+              <td><a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.id, return_to=report_return_to) }}">{{ row.name }}</a></td>
               <td>{{ row.organization }}</td>
               <td>{{ row.identifier }}</td>
               <td>{{ row.assets_in_custody }}</td>
@@ -363,13 +364,13 @@
             <tr>
               <td>
                 {% if row.holder_detail_id %}
-                  <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                  <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
                 {% else %}
                   {{ row.holder_name }}
                 {% endif %}
               </td>
               <td>{{ row.organization }}</td>
-              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag) }}"><code>{{ row.asset_tag }}</code></a></td>
+              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.equipment_type }}</td>
               <td>{{ row.current_location }}</td>
             </tr>
@@ -404,12 +405,12 @@
             <tr>
               <td><code>{{ row.id }}</code></td>
               <td>{{ row.event_date }}</td>
-              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag) }}"><code>{{ row.asset_tag }}</code></a></td>
+              <td><a class="nav-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.event_type }}</td>
               <td>
                 {% if row.holder_name %}
                   {% if row.holder_detail_id %}
-                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id) }}">{{ row.holder_name }}</a>
+                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
                   {% else %}
                     {{ row.holder_name }}
                   {% endif %}
@@ -444,7 +445,7 @@
         <tbody>
           {% for row in cases %}
             <tr>
-              <td><a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.case_name) }}">{{ row.case_name }}</a></td>
+              <td><a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.case_name, return_to=report_return_to) }}">{{ row.case_name }}</a></td>
               <td>{{ row.total_slots }}</td>
               <td>{{ row.occupied_slots }}</td>
             </tr>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -460,13 +460,119 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b"Check case space" in response.data
     assert b"Look up an asset" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
-    assert response.data.count(b'href="/assets/search"') >= 2
-    assert b'href="/dashboard/cases"' in response.data
-    assert b'href="/dashboard/holders"' in response.data
-    assert b'href="/receipts"' in response.data
-    assert b' href="/assets/search?asset_tag=AT-100"' in response.data
-    assert b' href="/holders/1"' in response.data
-    assert b' href="/dashboard/cases/CASE-1"' in response.data
+    assert response.data.count(b'href="/assets/search?return_to=/report"') >= 2
+    assert b'href="/dashboard/cases?return_to=/report"' in response.data
+    assert b'href="/dashboard/holders?return_to=/report"' in response.data
+    assert b'href="/receipts?return_to=/report"' in response.data
+    assert b' href="/assets/search?asset_tag=AT-100&amp;return_to=/report"' in response.data
+    assert b' href="/holders/1?return_to=/report"' in response.data
+    assert b' href="/dashboard/cases/CASE-1?return_to=/report"' in response.data
+
+
+def test_report_drill_ins_show_back_to_report_only_for_safe_report_context(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-report-return", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    conn = db.get_connection()
+    _create_assets_table(conn)
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Return Holder', 'RET-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (10, 'CASE-RETURN', 1, 'RET-100');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (
+            'RET-100',
+            'SN-RET-100',
+            'Dell',
+            'laptop',
+            'HQ',
+            '100',
+            'Latitude',
+            'LAT',
+            NULL,
+            'HQ/100',
+            'issued_to',
+            'accountable',
+            'serviceable',
+            '2026-01-01',
+            '2026-01-01T00:00:00Z',
+            'IN_CUSTODY',
+            1,
+            10
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        SELECT 10, id, '2026-01-01T00:00:00Z'
+        FROM assets
+        WHERE asset_tag = 'RET-100';
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    asset_response = client_with_temp_db.get("/assets/search?asset_tag=RET-100&return_to=/report")
+    assert asset_response.status_code == 200
+    assert b'href="/report"' in asset_response.data
+    assert b"Back to Report" in asset_response.data
+
+    holder_response = client_with_temp_db.get("/holders/1?return_to=/report")
+    assert holder_response.status_code == 200
+    assert b"Back to Report" in holder_response.data
+
+    receipts_response = client_with_temp_db.get("/receipts?return_to=/report")
+    assert receipts_response.status_code == 200
+    assert b"Back to Report" in receipts_response.data
+    assert b"Open Current Status Report" not in receipts_response.data
+
+    cases_response = client_with_temp_db.get("/dashboard/cases?return_to=/report")
+    assert cases_response.status_code == 200
+    assert b"Back to Report" in cases_response.data
+    assert b'href="/dashboard/cases/CASE-RETURN?return_to=/report"' in cases_response.data
+
+    case_detail_response = client_with_temp_db.get("/dashboard/cases/CASE-RETURN?return_to=/report")
+    assert case_detail_response.status_code == 200
+    assert b"Back to Report" in case_detail_response.data
+    assert b'href="/dashboard/cases?return_to=/report"' in case_detail_response.data
+
+    direct_asset_response = client_with_temp_db.get("/assets/search?asset_tag=RET-100")
+    assert direct_asset_response.status_code == 200
+    assert b"Back to Report" not in direct_asset_response.data
+
+    unsafe_asset_response = client_with_temp_db.get("/assets/search?asset_tag=RET-100&return_to=//evil.example")
+    assert unsafe_asset_response.status_code == 200
+    assert b"Back to Report" not in unsafe_asset_response.data
 
 
 def test_admin_can_download_human_readable_report_pdf(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Preserve return-to-report navigation context so operators can move from `/report` into drill-in pages and return in one step.

## Related Issue
Closes #522 

## Changes
- added return_to=/report to report drill-in links
- validated return paths using existing safe-local rules
- surfaced Back to Report on destination pages when context exists
- preserved return context through local navigation chains

## Verification checklist
- [x] asset drill-ins show Back to Report
- [x] holder drill-ins show Back to Report
- [x] receipts drill-ins show Back to Report
- [x] Back to Report returns correctly
- [x] no return_to → no extra link shown
- [x] no unsafe redirects
- [x] no regression to existing navigation

## Notes
Follow-on UX improvements identified:
- header action clutter on detail pages
- standardization of top-of-page navigation patterns