### PR TITLE
Issue 26-119: Standardize detail page header navigation and actions

### DIFF
--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -6,6 +6,20 @@
 
 {% block extra_head %}
   <style>
+    .page-header-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 0.75rem 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .page-header-nav {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
     .status-card { margin-bottom: 1rem; }
     .status-dot.full { background: #12b76a; }
     .status-dot.low { background: #f79009; }
@@ -18,13 +32,14 @@
   {% set total_slots = case_detail.slots | length %}
   {% set empty_slots = total_slots - occupied_slots %}
   {% set status = case_status_summary(total_slots, occupied_slots) %}
-  <nav class="actions" aria-label="Contextual navigation">
-    {% if return_to == url_for('human_report') %}
-      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
-    {% endif %}
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=return_to) }}">Back to Cases</a>
-  </nav>
+  <div class="page-header-bar">
+    <nav class="page-header-nav" aria-label="Contextual navigation">
+      {% if return_to == url_for('human_report') %}
+        <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+      {% endif %}
+      <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=return_to) }}">Back to Cases</a>
+    </nav>
+  </div>
 
   <section class="card status-card">
     <h2>Case Status</h2>

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -4,14 +4,34 @@
 {% block title %}Holder Detail{% endblock %}
 {% block page_heading %}Outstanding Assets: {{ holder.holder_name }}{% endblock %}
 
+{% block extra_head %}
+  <style>
+    .page-header-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 0.75rem 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .page-header-nav {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
-  <nav class="actions" aria-label="Contextual navigation">
-    {% if return_to == url_for('human_report') %}
-      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
-    {% endif %}
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="nav-link" href="{{ url_for('dashboard_holders', return_to=return_to) }}">Back to Holders</a>
-  </nav>
+  <div class="page-header-bar">
+    <nav class="page-header-nav" aria-label="Contextual navigation">
+      {% if return_to == url_for('human_report') %}
+        <a class="nav-link" href="{{ return_to }}">Back to Report</a>
+      {% endif %}
+      <a class="nav-link" href="{{ url_for('dashboard_holders', return_to=return_to) }}">Back to Holders</a>
+    </nav>
+  </div>
 
   <section class="card">
     <p>

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -4,25 +4,55 @@
 {% block title %}Holder Detail{% endblock %}
 {% block page_heading %}Holder: {{ holder_display_name(holder) }}{% endblock %}
 
+{% block extra_head %}
+  <style>
+    .page-header-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 0.75rem 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .page-header-nav,
+    .page-header-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .page-header-actions form {
+      margin: 0;
+    }
+  </style>
+{% endblock %}
+
 {% block content %}
-  <nav class="actions" aria-label="Holder navigation">
-    {% if return_to == url_for('human_report') %}
-      <a class="nav-link" href="{{ return_to }}">Back to Report</a>
-    {% endif %}
-    <a class="nav-link" href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>
-    {% if return_to %}
-      <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=return_to) }}">Edit Holder</a>
-    {% else %}
-      <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id) }}">Edit Holder</a>
-    {% endif %}
-    <form method="post" action="{{ url_for('holders_select') }}">
-      <input type="hidden" name="holder_id" value="{{ holder.id }}" />
-      {% if return_to %}
-        <input type="hidden" name="return_to" value="{{ return_to }}" />
+  <div class="page-header-bar">
+    <nav class="page-header-nav" aria-label="Holder navigation">
+      {% if return_to == url_for('human_report') %}
+        <a class="nav-link" href="{{ return_to }}">Back to Report</a>
       {% endif %}
-      <button type="submit">Select Holder</button>
-    </form>
-  </nav>
+      <a class="nav-link" href="{{ url_for('holders_search', return_to=return_to) }}">Back to Holders</a>
+    </nav>
+    <div class="page-header-actions" aria-label="Holder actions">
+      {% set passive_return_target = url_for('holder_detail', holder_id=holder.id, return_to=return_to) %}
+      <form method="post" action="{{ url_for('holders_select') }}">
+        <input type="hidden" name="holder_id" value="{{ holder.id }}" />
+        {% if return_to and return_to != url_for('human_report') %}
+          <input type="hidden" name="return_to" value="{{ return_to }}" />
+        {% endif %}
+        <button type="submit">Select Holder</button>
+      </form>
+      {% if return_to == url_for('human_report') %}
+        <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=passive_return_target) }}">Edit Holder</a>
+      {% elif return_to %}
+        <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=return_to) }}">Edit Holder</a>
+      {% else %}
+        <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id) }}">Edit Holder</a>
+      {% endif %}
+    </div>
+  </div>
 
   <section class="card">
     <p>

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -286,6 +286,37 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertTrue((response.headers["Location"]).endswith("/issue"))
 
+    def test_edit_holder_can_return_to_holder_detail_with_report_context(self) -> None:
+        organization_id = self._create_org("Report Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Report Workflow Holder", "organization_id": str(organization_id), "email": "report-workflow@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Report Workflow Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        response = self.client.post(
+            f"/holders/edit/{holder_id}",
+            data={
+                "name": "Report Workflow Holder",
+                "organization_id": str(organization_id),
+                "email": "report-workflow@example.org",
+                "return_to": f"/holders/{holder_id}?return_to=/report",
+            },
+            follow_redirects=False,
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith(f"/holders/{holder_id}?return_to=/report"))
+
+        follow_up = self.client.get(response.headers["Location"])
+        self.assertEqual(follow_up.status_code, 200)
+        self.assertIn(b"Back to Report", follow_up.data)
+
     def test_holders_list_shows_holders_and_asset_count(self) -> None:
         holder_name = "Holder List Person"
         organization_id = self._create_org("Ad Hoc")
@@ -362,6 +393,49 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Assigned Assets (1)", response.data)
         self.assertIn(b"DETAIL-ASSET-1", response.data)
         self.assertIn(f'href="/holders/edit/{holder_id}"'.encode("utf-8"), response.data)
+
+    def test_holder_detail_from_report_keeps_back_link_but_not_report_action_return_to(self) -> None:
+        organization_id = self._create_org("Report Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Report Holder", "organization_id": str(organization_id), "email": "report@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Report Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        response = self.client.get(f"/holders/{holder_id}?return_to=/report")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'href="/report"', response.data)
+        self.assertIn(b"Back to Report", response.data)
+        self.assertIn(b'action="/holders/select"', response.data)
+        self.assertIn(b'name="holder_id"', response.data)
+        self.assertNotIn(b'name="return_to" value="/report"', response.data)
+        self.assertIn(f'href="/holders/edit/{holder_id}?return_to=/holders/{holder_id}?return_to%3D/report"'.encode("utf-8"), response.data)
+        self.assertNotIn(f'href="/holders/edit/{holder_id}?return_to=/report"'.encode("utf-8"), response.data)
+
+    def test_holder_detail_preserves_non_report_action_return_to(self) -> None:
+        organization_id = self._create_org("Issue Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Issue Holder", "organization_id": str(organization_id), "email": "issue@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Issue Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        response = self.client.get(f"/holders/{holder_id}?return_to=/issue")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'name="return_to" value="/issue"', response.data)
+        self.assertIn(f'href="/holders/edit/{holder_id}?return_to=/issue"'.encode("utf-8"), response.data)
 
     def test_post_holders_new_rejects_invalid_email_with_clear_feedback(self) -> None:
         org_id = self._create_org("Alpha Org")


### PR DESCRIPTION
## Summary
Standardize detail page header actions so navigation and actions are separated more clearly, with a follow-up fix to keep report-origin context passive and preserve it across the holder edit flow.

## Related Issue
Closes #530 

## Changes
- split holder detail header into left-side navigation and right-side actions
- reduced redundant back links on dashboard holder detail and dashboard case detail
- prevented report-origin `return_to` from leaking into holder action destinations
- preserved Back to Report across the holder edit round-trip

## Verification checklist
- [x] holder detail header reads cleanly with navigation left and actions right
- [x] dashboard holder detail header is reduced to meaningful back path(s)
- [x] dashboard case detail header is reduced to meaningful back path(s)
- [x] Select Holder does not redirect to `/report`
- [x] Edit Holder does not redirect to `/report`
- [x] report-origin holder detail still shows Back to Report after edit flow
- [x] no regression to non-report holder flows

## Notes
Follow-on UI issue noted during smoke test: Back to Report / Back to Holders spacing on holder detail is cramped and should be polished separately.