### PR TITLE
Issue 26-120: improve holder detail back-link spacing

### DIFF
--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -21,6 +21,17 @@
       gap: 0.5rem;
       flex-wrap: wrap;
     }
+    .page-header-nav {
+      align-items: flex-start;
+      column-gap: 0.9rem;
+      row-gap: 0.35rem;
+    }
+    .page-header-nav .nav-link {
+      display: inline-flex;
+      align-items: center;
+      min-height: 2rem;
+      white-space: nowrap;
+    }
     .page-header-actions form {
       margin: 0;
     }


### PR DESCRIPTION
## Summary
Improve spacing and wrap behavior for holder detail back links so Back to Report and Back to Holders read as distinct navigation choices.

## Related Issue
Closes #532 

## Changes
- added spacing between back links
- improved wrap behavior for narrow widths
- preserved header structure and destinations

## Verification checklist
- [x] links are visually distinct
- [x] no misclick risk
- [x] wrap behavior is clean
- [x] navigation unchanged
- [x] no regression to header layout

## Notes
Completes polish for header navigation introduced in 26-119.