### PR TITLE
Issue 26-117: simplify holder detail for operator decision-making

### DIFF
--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -35,6 +35,78 @@
     .page-header-actions form {
       margin: 0;
     }
+    .holder-identity {
+      display: grid;
+      gap: 0.35rem;
+      margin-bottom: 1rem;
+    }
+    .holder-kicker {
+      color: var(--color-text-muted);
+      font-size: 0.95rem;
+    }
+    .holder-context {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem 1rem;
+      color: var(--color-text-muted);
+    }
+    .holder-context-item strong {
+      color: var(--color-text);
+    }
+    .holder-summary {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+    .summary-card {
+      padding: 0.9rem 1rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 10px;
+      background: var(--color-surface-bg);
+    }
+    .summary-label {
+      display: block;
+      color: var(--color-text-muted);
+      font-size: 0.9rem;
+      margin-bottom: 0.3rem;
+    }
+    .summary-value {
+      font-size: 1.45rem;
+      font-weight: 700;
+      line-height: 1.1;
+    }
+    .summary-note {
+      margin-top: 0.35rem;
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
+    }
+    .holder-assets-card h2,
+    .holder-details-card h2 {
+      margin-top: 0;
+    }
+    .holder-assets-card {
+      margin-top: 0;
+    }
+    .holder-assets-intro {
+      margin: 0 0 0.9rem;
+      color: var(--color-text-muted);
+    }
+    .holder-details-card {
+      margin-top: 1rem;
+    }
+    .holder-details-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem 1rem;
+    }
+    .holder-detail-item strong {
+      display: block;
+      margin-bottom: 0.2rem;
+    }
+    .holder-detail-item {
+      color: var(--color-text-muted);
+    }
   </style>
 {% endblock %}
 
@@ -65,19 +137,50 @@
     </div>
   </div>
 
-  <section class="card">
-    <p>
-      <strong>Type:</strong> {{ holder_display_type(holder) }}<br />
-      <strong>Person or group:</strong> {{ holder_display_name(holder) }}<br />
-      <strong>Organization:</strong> {{ holder.organization or "" }}<br />
-      <strong>Identifier:</strong> {{ holder.identifier or "" }}<br />
-      <strong>Email:</strong> {{ holder.email or "" }}<br />
-      <strong>Contact information:</strong> {{ holder.contact_info or "" }}
-    </p>
+  <section class="holder-identity" aria-label="Holder identity">
+    <div class="holder-kicker">{{ holder_display_type(holder) }}</div>
+    <div class="holder-context">
+      {% if holder.organization %}
+        <div class="holder-context-item"><strong>Organization:</strong> {{ holder.organization }}</div>
+      {% endif %}
+      {% if holder.identifier %}
+        <div class="holder-context-item"><strong>Identifier:</strong> {{ holder.identifier }}</div>
+      {% endif %}
+    </div>
   </section>
 
-  <section class="card">
-    <h2>Assigned Assets ({{ asset_count }})</h2>
+  <section class="holder-summary" aria-label="Holder summary">
+    <div class="summary-card">
+      <span class="summary-label">Assets currently assigned</span>
+      <div class="summary-value">{{ asset_count }}</div>
+      <div class="summary-note">
+        {% if asset_count == 0 %}
+          No assets need action from this holder right now.
+        {% elif asset_count == 1 %}
+          Review the assigned asset below.
+        {% else %}
+          Review the assigned assets below.
+        {% endif %}
+      </div>
+    </div>
+    <div class="summary-card">
+      <span class="summary-label">Holder record</span>
+      <div class="summary-value">{{ holder_display_name(holder) }}</div>
+      <div class="summary-note">
+        {% if holder.organization %}
+          {{ holder.organization }}
+        {% else %}
+          {{ holder_display_type(holder) }}
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  <section class="card holder-assets-card">
+    <h2>Assets In Custody ({{ asset_count }})</h2>
+    <p class="holder-assets-intro">
+      Use this list to review what the holder has before selecting the next workflow action.
+    </p>
     <table>
       <thead>
         <tr>
@@ -107,4 +210,30 @@
       </tbody>
     </table>
   </section>
+
+  {% if holder.email or holder.contact_info or holder.identifier %}
+    <section class="card holder-details-card">
+      <h2>Holder Details</h2>
+      <div class="holder-details-grid">
+        {% if holder.email %}
+          <div class="holder-detail-item">
+            <strong>Email:</strong>
+            <div>{{ holder.email }}</div>
+          </div>
+        {% endif %}
+        {% if holder.contact_info %}
+          <div class="holder-detail-item">
+            <strong>Contact information:</strong>
+            <div>{{ holder.contact_info }}</div>
+          </div>
+        {% endif %}
+        {% if holder.identifier %}
+          <div class="holder-detail-item">
+            <strong>Identifier:</strong>
+            <div>{{ holder.identifier }}</div>
+          </div>
+        {% endif %}
+      </div>
+    </section>
+  {% endif %}
 {% endblock %}

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -390,7 +390,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Holder: Detail Holder", response.data)
         self.assertIn(b"Organization:</strong> Org Detail", response.data)
         self.assertIn(b"Email:</strong>", response.data)
-        self.assertIn(b"Assigned Assets (1)", response.data)
+        self.assertIn(b"Assets In Custody (1)", response.data)
         self.assertIn(b"DETAIL-ASSET-1", response.data)
         self.assertIn(f'href="/holders/edit/{holder_id}"'.encode("utf-8"), response.data)
 
@@ -613,7 +613,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
         response = self.client.get(f"/holders/{int(holder_row['id'])}")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Assigned Assets (0)", response.data)
+        self.assertIn(b"Assets In Custody (0)", response.data)
         self.assertIn(b"No assigned assets.", response.data)
 
     def test_holder_detail_displays_group_holder_cleanly(self) -> None:
@@ -631,8 +631,8 @@ class HolderCreationViabilityTests(unittest.TestCase):
         response = self.client.get(f"/holders/{int(holder_row['id'])}")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Type:</strong> Group / organization", response.data)
-        self.assertIn(b"Person or group:</strong> Ops Section", response.data)
+        self.assertIn(b"Group / organization", response.data)
+        self.assertIn(b"Ops Section", response.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Simplifies holder detail page to support faster operator decision-making by reducing noise and improving hierarchy.

## Related Issue
Closes #525 

## Changes
- reorganized page into decision-first layout
- added clear identity and at-a-glance summary
- made Assets In Custody the dominant section
- moved low-value metadata into a quieter secondary section
- preserved all existing behavior and navigation
- updated holder detail tests to match layout changes

## Verification checklist
- [x] holder identity is immediately clear
- [x] assets in custody are easy to scan
- [x] page feels calmer and less dense
- [x] navigation and actions unchanged
- [x] tests pass (27/27)

## Notes
Presentation-only change. No impact to events, audit history, schema, or workflow behavior.