### PR TITLE
Issue 26-121: make report timestamps human readable

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4768,6 +4768,24 @@ def _receipt_display_timestamp(value: object) -> str:
     return f"{month} {day}, {year} at {parsed.strftime('%H:%M')} UTC"
 
 
+def _report_event_display_timestamp(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+
+    parsed = _parse_display_timestamp(text)
+    if parsed is None:
+        return text
+
+    month = parsed.strftime("%b")
+    day = parsed.day
+    year = parsed.year
+    hour = parsed.strftime("%I").lstrip("0") or "0"
+    minute = parsed.strftime("%M")
+    meridiem = parsed.strftime("%p")
+    return f"{month} {day}, {year} {hour}:{minute} {meridiem}"
+
+
 def _receipt_display_holder_name(
     holder_snapshot: Optional[dict[str, object]],
     *,
@@ -5788,7 +5806,10 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
         ]
 
         recent_active_events = [
-            dict(row)
+            {
+                **dict(row),
+                "event_date_display": _report_event_display_timestamp(row["event_date"]),
+            }
             for row in conn.execute(
                 f"""
                 SELECT

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -215,7 +215,7 @@
   </div>
 
   <div class="card">
-    <h2>Recent Active Events</h2>
+    <h2>Last 10 Events</h2>
     <div class="table-wrap">
       <table>
         <thead>
@@ -231,7 +231,7 @@
           {% for row in recent_active_events %}
             <tr>
               <td><code>{{ row.id }}</code></td>
-              <td>{{ row.event_date }}</td>
+              <td>{{ row.event_date_display }}</td>
               <td><code>{{ row.asset_tag }}</code></td>
               <td>{{ row.event_type }}</td>
               <td>

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -392,8 +392,7 @@
 
   <details class="report-section">
     <summary>
-      <span class="report-section-title">Recent Active Events</span>
-      <span class="report-section-hint">{{ recent_active_events|length }} latest active events</span>
+      <span class="report-section-title">Last 10 Events</span>
     </summary>
     <div class="report-section-body">
     <div class="table-wrap">
@@ -411,7 +410,7 @@
           {% for row in recent_active_events %}
             <tr>
               <td><code>{{ row.id }}</code></td>
-              <td>{{ row.event_date }}</td>
+              <td>{{ row.event_date_display }}</td>
               <td><a class="nav-link report-drill-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.event_type }}</td>
               <td>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -317,7 +317,7 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     response = client_with_temp_db.get("/admin/report")
 
     assert response.status_code == 200
-    assert b"Admin: Human-Readable Report" in response.data
+    assert b"Admin: Current Status Report" in response.data
     assert b"Download PDF" in response.data
     assert b"Download Database Backup" in response.data
     assert b"showing recent active events only" in response.data
@@ -325,12 +325,14 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     assert b"Holders" in response.data
     assert b"Organizations and Building Access" in response.data
     assert b"Current Custody" in response.data
-    assert b"Recent Active Events" in response.data
+    assert b"Last 10 Events" in response.data
     assert b"Location and Case Data" in response.data
     assert b"AT-100" in response.data
     assert b"Jane Operator" in response.data
     assert b"Report Ops" in response.data
     assert b"CASE-1" in response.data
+    assert b"Jan 2, 2026 12:00 AM" in response.data
+    assert b"2026-01-02T00:00:00Z" not in response.data
 
 
 def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp_db) -> None:
@@ -467,6 +469,9 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b' href="/assets/search?asset_tag=AT-100&amp;return_to=/report"' in response.data
     assert b' href="/holders/1?return_to=/report"' in response.data
     assert b' href="/dashboard/cases/CASE-1?return_to=/report"' in response.data
+    assert b"Last 10 Events" in response.data
+    assert b"Jan 2, 2026 12:00 AM" in response.data
+    assert b"2026-01-02T00:00:00Z" not in response.data
 
 
 def test_report_drill_ins_show_back_to_report_only_for_safe_report_context(client_with_temp_db) -> None:
@@ -607,23 +612,28 @@ def test_report_recent_active_events_is_limited_to_latest_ten_and_newest_first(c
     response = client_with_temp_db.get("/report")
 
     assert response.status_code == 200
-    assert b"10 latest active events" in response.data
+    assert b"Last 10 Events" in response.data
     assert response.data.find(b"TAIL-12") < response.data.find(b"TAIL-11")
     assert response.data.find(b"TAIL-11") < response.data.find(b"TAIL-10")
     assert b"TAIL-12" in response.data
     assert b"TAIL-03" in response.data
     assert b"TAIL-02" not in response.data
     assert b"TAIL-01" not in response.data
+    assert b"Jan 12, 2026 12:00 AM" in response.data
+    assert b"2026-01-12T00:00:00Z" not in response.data
 
     admin_id = create_test_user(username="admin-report-tail", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
     admin_response = client_with_temp_db.get("/admin/report")
 
     assert admin_response.status_code == 200
+    assert b"Last 10 Events" in admin_response.data
     assert b"TAIL-12" in admin_response.data
     assert b"TAIL-03" in admin_response.data
     assert b"TAIL-02" not in admin_response.data
     assert b"TAIL-01" not in admin_response.data
+    assert b"Jan 12, 2026 12:00 AM" in admin_response.data
+    assert b"2026-01-12T00:00:00Z" not in admin_response.data
 
 
 def test_admin_can_download_human_readable_report_pdf(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Make report recent-event timestamps easier to read and simplify the section wording.

## Related Issue
Closes #536 

## Changes
- added display-only human-readable timestamp formatting for recent events
- updated `/report` recent-events wording to `Last 10 Events`
- updated `/admin/report` recent-events wording to match
- added focused test coverage for readable report output

## Verification checklist
- [x] `/report` shows `Last 10 Events`
- [x] `/report` shows human-readable timestamps
- [x] `/admin/report` shows matching wording and timestamp formatting
- [x] raw ISO timestamps no longer appear in that recent-events table
- [x] ordering still reads newest-first
- [x] targeted tests pass

## Notes
Display-only change. No impact to event storage, schema, auth, or workflow behavior.