### PR TITLE
Issue 26-123: add admin navigation to asset maintenance

### DIFF
--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -113,7 +113,13 @@
         <tbody>
           {% for asset in assets %}
             <tr>
-              <td><code>{{ asset.asset_tag or "" }}</code></td>
+              <td>
+                {% if authenticated_role == 'admin' and asset.asset_tag %}
+                  <a class="nav-link" href="{{ url_for('admin_edit_asset', asset_tag=asset.asset_tag) }}"><code>{{ asset.asset_tag }}</code></a>
+                {% else %}
+                  <code>{{ asset.asset_tag or "" }}</code>
+                {% endif %}
+              </td>
               <td>{{ asset.serial_number or "Not recorded" }}</td>
               <td>{{ asset.state_label }}</td>
               <td>{{ asset.holder_label or "Not assigned" }}</td>

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -99,6 +99,18 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Alex Holder (Field Ops)", response.data)
         self.assertIn(b"CASE-A", response.data)
         self.assertIn(b"Slot 4", response.data)
+        self.assertNotIn(b'href="/admin/assets/edit?asset_tag=AT-100"', response.data)
+
+    def test_admin_search_links_asset_tag_to_admin_edit_asset(self) -> None:
+        admin_user_id = create_test_user(username="admin-search", password="admin-pass", role="admin")
+        login_session(self.client, admin_user_id)
+        self._insert_asset("AT-ADMIN-1", serial_number="SER-ADMIN-1", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=AT-ADMIN-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b' href="/admin/assets/edit?asset_tag=AT-ADMIN-1"', response.data)
+        self.assertIn(b"AT-ADMIN-1", response.data)
 
     def test_search_finds_asset_by_serial_number(self) -> None:
         self._insert_asset("AT-200", serial_number="SER-200", location_type="IN_CUSTODY", home_slot_id=None)


### PR DESCRIPTION
## Summary
Add an admin-only navigation path from asset search results to the asset maintenance/edit surface.

## Related Issue
Closes #542 

## Changes
- made asset tag clickable for admins in asset search results
- linked to existing admin edit asset route
- preserved plain text display for operators
- added focused test coverage for admin vs operator behavior

## Verification checklist
- [x] admin can click asset tag from search results
- [x] navigation leads to admin edit asset page
- [x] operator does not see admin navigation
- [x] search behavior remains unchanged
- [x] targeted tests pass

## Notes
Navigation-only change. No impact to schema, persistence, auth boundaries, or event logic.