### PR TITLE
Issue 26-124: add admin route auth regression coverage

### DIFF
--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -331,6 +331,9 @@ def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:
     response = client_with_temp_db.get("/admin/assets/new")
     assert response.status_code == 403
 
+    retire_response = client_with_temp_db.get("/admin/assets/retire")
+    assert retire_response.status_code == 403
+
     post_response = client_with_temp_db.post(
         "/admin/assets/new",
         data={
@@ -363,6 +366,8 @@ def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     assert response.status_code == 200
     edit_response = client_with_temp_db.get("/admin/assets/edit")
     assert edit_response.status_code == 200
+    retire_response = client_with_temp_db.get("/admin/assets/retire")
+    assert retire_response.status_code == 200
     reference_data_response = client_with_temp_db.get("/admin/reference-data")
     assert reference_data_response.status_code == 200
 


### PR DESCRIPTION
## Summary
Add regression coverage to lock in consistent admin authorization across the asset edit and retire routes.

## Related Issue
Closes #544 

## Changes
- added explicit auth regression coverage for `/admin/assets/retire`
- verified admin access remains allowed for both admin edit and admin retire routes
- verified operator access remains blocked for both routes

## Verification checklist
- [x] admin can access admin edit asset route
- [x] admin can access admin retire asset route
- [x] operator is blocked from admin edit asset route
- [x] operator is blocked from admin retire asset route
- [x] targeted tests pass
- [x] manual admin/operator verification passed in clean session

## Notes
No app behavior changed. This issue adds regression coverage to enforce the existing correct auth boundary.