### PR TITLE
Issue 26-125: remove asset delete and standardize retire

### DIFF
--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -126,32 +126,18 @@
     </div>
 
     <div class="card">
-      <h2>Orphan / Junk Asset Cleanup</h2>
+      <h2>Asset Removal</h2>
       <p class="muted">
-        Use cleanup delete only for orphan/junk records with no event history and no live inventory links.
-        If this record represents a real asset that left service, use
+        Asset records are not removed from the admin UI. If this asset left service, use
         <a class="nav-link" href="{{ url_for('admin_retire_asset') }}">Retire Asset</a>
-        instead so audit history stays intact.
+        so the inventory record and audit history stay aligned.
       </p>
       {% if asset.cleanup.allowed %}
-        <p>This asset has no event history, no slot assignment, and no active custody state. Cleanup delete is allowed.</p>
+        <p>This record has no event history or live inventory links, but removal is not exposed here. Use the retire flow for asset removal handling.</p>
       {% else %}
-        <p>This asset cannot be cleanup-deleted. Use Retire Asset instead if this is a real asset record.</p>
-        <ul>
-          {% for reason in asset.cleanup.reasons %}
-            <li>{{ reason }}</li>
-          {% endfor %}
-        </ul>
+        <p>This asset must use the retire flow rather than removal from edit.</p>
       {% endif %}
-      <form method="post" action="{{ url_for('admin_edit_asset') }}">
-        <input type="hidden" name="action" value="cleanup" />
-        <input type="hidden" name="lookup_asset_tag" value="{{ form.lookup_asset_tag or asset.asset_tag }}" />
-        <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
-        <button
-          type="submit"
-          {% if not asset.cleanup.allowed %}disabled{% else %}onclick="return confirm('Delete this orphan/junk asset record permanently? Only assets with no event history or live dependencies may be removed this way.');"{% endif %}
-        >Delete Orphan / Junk Asset</button>
-      </form>
+      <p><a class="nav-link" href="{{ url_for('admin_retire_asset') }}">Open Retire Asset</a></p>
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -285,7 +285,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         deleted = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
         self.assertIsNone(deleted)
 
-    def test_cleanup_ui_describes_orphan_only_delete_path(self) -> None:
+    def test_edit_asset_ui_directs_admins_to_retire_flow_instead_of_delete(self) -> None:
         self._insert_asset(
             "AT-JUNK-UI-1",
             serial_number="SER-JUNK-UI-1",
@@ -297,12 +297,12 @@ class AdminEditAssetUiTests(unittest.TestCase):
         response = self.client.get("/admin/assets/edit?asset_tag=AT-JUNK-UI-1")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Orphan / Junk Asset Cleanup", response.data)
-        self.assertIn(b"Use cleanup delete only for orphan/junk records", response.data)
-        self.assertIn(b"Cleanup delete is allowed.", response.data)
-        self.assertIn(b"Delete Orphan / Junk Asset", response.data)
-        self.assertIn(b"Delete this orphan/junk asset record permanently?", response.data)
+        self.assertIn(b"Asset Removal", response.data)
+        self.assertIn(b"Asset records are not removed from the admin UI.", response.data)
+        self.assertIn(b"Use the retire flow for asset removal handling.", response.data)
+        self.assertIn(b"Open Retire Asset", response.data)
         self.assertIn(b'href="/admin/assets/retire"', response.data)
+        self.assertNotIn(b"Delete Orphan / Junk Asset", response.data)
 
     def test_cleanup_blocks_asset_with_event_history(self) -> None:
         asset_id = self._insert_asset(
@@ -325,9 +325,8 @@ class AdminEditAssetUiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Asset has event history and cannot be removed.", response.data)
-        self.assertIn(b"This asset cannot be cleanup-deleted.", response.data)
-        self.assertIn(b"Use Retire Asset instead", response.data)
-        self.assertIn(b'Delete Orphan / Junk Asset</button>', response.data)
+        self.assertIn(b"This asset must use the retire flow rather than removal from edit.", response.data)
+        self.assertIn(b"Open Retire Asset", response.data)
         self.assertIn(b'href="/admin/assets/retire"', response.data)
         still_present = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
         self.assertIsNotNone(still_present)


### PR DESCRIPTION
## Summary
Remove asset delete from the admin UI and standardize admins on the retire flow instead.

## Related Issue
Closes #546 

## Changes
- removed the exposed delete/cleanup section from the admin edit asset page
- removed delete-oriented wording from the visible admin surface
- directed admins to use Retire Asset instead
- updated focused UI tests to match the retire-only model

## Verification checklist
- [x] admin edit asset page no longer shows delete button
- [x] admin edit asset page no longer shows cleanup/delete section
- [x] page directs admins to use Retire Asset
- [x] retire flow still loads and works
- [x] operator/admin route boundaries remain intact
- [x] targeted tests pass

## Notes
UI/behavior clarification only. No schema, auth, event, or retire-logic changes.