### PR TITLE
Issue 26-126: standardize retired asset display state

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -134,6 +134,8 @@ def inject_auth_user():
         "authenticated_user": user,
         "authenticated_role": None if user is None else user.get("role"),
         "case_status_summary": _case_status_summary,
+        "asset_state_label": _asset_state_label,
+        "asset_is_terminal": _is_terminal_location_type,
         "holder_display_name": _holder_display_name,
         "holder_display_type": _holder_display_type,
     }
@@ -785,7 +787,7 @@ def _asset_state_label(location_type: object) -> str:
     if normalized == "IN_CUSTODY":
         return "In custody"
     if normalized in TERMINAL_LOCATION_TYPES:
-        return "Retired / disposed"
+        return "RETIRED — Not in service"
     if not normalized:
         return "Unknown"
     return normalized.replace("_", " ").title()
@@ -1083,7 +1085,7 @@ def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], l
 
     location_type = _normalize_location_type(asset.get("location_type"))
     if _is_terminal_location_type(location_type):
-        return None, ["Asset is retired/disposed and cannot be edited."]
+        return None, [f"Asset is {_asset_state_label(location_type)} and cannot be edited."]
 
     current_slot = _asset_current_slot(conn, int(asset["id"]), str(asset["asset_tag"]))
     home_slot = _asset_home_slot(conn, asset.get("home_slot_id"))

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -7,6 +7,22 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    .state-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.24rem 0.58rem;
+      border-radius: 999px;
+      font-weight: 700;
+      line-height: 1.2;
+      background: var(--color-surface-soft);
+      color: var(--color-text);
+    }
+    .state-badge.terminal {
+      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
+      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
+      color: var(--color-danger);
+      letter-spacing: 0.01em;
+    }
   </style>
 {% endblock %}
 
@@ -62,7 +78,9 @@
           </div>
           <div class="row form-group">
             <label class="form-label"><strong>location_type</strong></label>
-            <input class="form-input" type="text" value="{{ asset.location_type }}" readonly />
+            <div class="form-input" aria-readonly="true">
+              <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span>
+            </div>
           </div>
           <div class="row form-group">
             <label class="form-label" for="serial_number"><strong>serial_number</strong> (required)</label>

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -34,6 +34,22 @@
     .table-wrap {
       overflow-x: auto;
     }
+    .state-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.24rem 0.58rem;
+      border-radius: 999px;
+      font-weight: 700;
+      line-height: 1.2;
+      background: var(--color-surface-soft);
+      color: var(--color-text);
+    }
+    .state-badge.terminal {
+      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
+      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
+      color: var(--color-danger);
+      letter-spacing: 0.01em;
+    }
     @media print {
       .page-tools,
       .top-nav,
@@ -92,7 +108,9 @@
               <td><code>{{ row.asset_tag }}</code></td>
               <td>{{ row.equipment_type or "" }}</td>
               <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
-              <td>{{ row.location_type or "" }}</td>
+              <td>
+                <span class="state-badge{% if asset_is_terminal(row.location_type) %} terminal{% endif %}">{{ asset_state_label(row.location_type) }}</span>
+              </td>
               <td>
                 {% if row.holder_name %}
                   {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -11,6 +11,22 @@
     textarea { min-height: 120px; }
     .warn { color: #8a1f11; font-weight: 700; }
     .check { display: flex; align-items: center; gap: 0.5rem; }
+    .state-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.24rem 0.58rem;
+      border-radius: 999px;
+      font-weight: 700;
+      line-height: 1.2;
+      background: var(--color-surface-soft);
+      color: var(--color-text);
+    }
+    .state-badge.terminal {
+      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
+      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
+      color: var(--color-danger);
+      letter-spacing: 0.01em;
+    }
   </style>
 {% endblock %}
 
@@ -46,7 +62,7 @@
       <h2>2) Current Asset State</h2>
       <div class="grid">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
-        <div><strong>location_type:</strong> <code>{{ asset.location_type }}</code></div>
+        <div><strong>location_type:</strong> <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span></div>
         <div><strong>manufacturer:</strong> {{ asset.manufacturer or "" }}</div>
         <div><strong>model:</strong> {{ asset.model or "" }}</div>
         <div><strong>serial_number:</strong> {{ asset.serial_number or "" }}</div>

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -37,6 +37,22 @@
     }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .results-table code { white-space: nowrap; }
+    .state-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.24rem 0.58rem;
+      border-radius: 999px;
+      font-weight: 700;
+      line-height: 1.2;
+      background: var(--color-surface-soft);
+      color: var(--color-text);
+    }
+    .state-badge.terminal {
+      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
+      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
+      color: var(--color-danger);
+      letter-spacing: 0.01em;
+    }
     @media (max-width: 720px) {
       .search-grid {
         grid-template-columns: 1fr;
@@ -121,7 +137,9 @@
                 {% endif %}
               </td>
               <td>{{ asset.serial_number or "Not recorded" }}</td>
-              <td>{{ asset.state_label }}</td>
+              <td>
+                <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span>
+              </td>
               <td>{{ asset.holder_label or "Not assigned" }}</td>
               <td>{{ asset.home_case_name or "Not assigned" }}</td>
               <td>

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -88,6 +88,22 @@
     .table-wrap {
       overflow-x: auto;
     }
+    .state-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.24rem 0.58rem;
+      border-radius: 999px;
+      font-weight: 700;
+      line-height: 1.2;
+      background: var(--color-surface-soft);
+      color: var(--color-text);
+    }
+    .state-badge.terminal {
+      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
+      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
+      color: var(--color-danger);
+      letter-spacing: 0.01em;
+    }
     details.report-section {
       margin-top: 1rem;
       border: 1px solid var(--color-surface);
@@ -235,7 +251,9 @@
               <td><a class="nav-link report-drill-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
               <td>{{ row.equipment_type or "" }}</td>
               <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
-              <td>{{ row.location_type or "" }}</td>
+              <td>
+                <span class="state-badge{% if asset_is_terminal(row.location_type) %} terminal{% endif %}">{{ asset_state_label(row.location_type) }}</span>
+              </td>
               <td>
                 {% if row.holder_name %}
                   {% if row.holder_detail_id %}

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -102,6 +102,21 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Edit Asset", response.data)
 
+    def test_edit_asset_ui_marks_retired_assets_as_not_in_service(self) -> None:
+        self._insert_asset(
+            "AT-RET-EDIT-1",
+            serial_number="SER-RET-EDIT-1",
+            location_type="DISPOSED",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.get("/admin/assets/edit?asset_tag=AT-RET-EDIT-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"RETIRED \xe2\x80\x94 Not in service", response.data)
+        self.assertNotIn(b"Retired / disposed", response.data)
+
     def test_edit_storage_asset_moves_slot_and_persists_fields(self) -> None:
         self._insert_slot(201, "CASE-A", 1)
         self._insert_slot(202, "CASE-B", 2)

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -636,6 +636,101 @@ def test_report_recent_active_events_is_limited_to_latest_ten_and_newest_first(c
     assert b"2026-01-12T00:00:00Z" not in admin_response.data
 
 
+def test_reports_mark_retired_assets_as_not_in_service(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-report-retired", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    conn = db.get_connection()
+    _create_assets_table(conn)
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES
+            (
+                'AT-LIVE-1',
+                'SN-LIVE',
+                'Dell',
+                'laptop',
+                'HQ',
+                '100',
+                'Latitude',
+                'LAT',
+                NULL,
+                'HQ/100',
+                'in_stock',
+                'accountable',
+                'serviceable',
+                '2026-01-01',
+                '2026-01-01T00:00:00Z',
+                'STORAGE',
+                NULL,
+                NULL
+            ),
+            (
+                'AT-RET-1',
+                'SN-RET',
+                'Dell',
+                'laptop',
+                'HQ',
+                '200',
+                'Latitude',
+                'LAT',
+                NULL,
+                'HQ/200',
+                'retired',
+                'accountable',
+                'unserviceable',
+                '2026-01-01',
+                '2026-01-02T00:00:00Z',
+                'DISPOSED',
+                NULL,
+                NULL
+            );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.get("/report")
+
+    assert response.status_code == 200
+    assert b"AT-RET-1" in response.data
+    assert b"RETIRED \xe2\x80\x94 Not in service" in response.data
+    assert b"state-badge terminal" in response.data
+    assert b"In storage" in response.data
+    assert b"Retired / disposed" not in response.data
+
+    admin_id = create_test_user(username="admin-report-retired", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    admin_response = client_with_temp_db.get("/admin/report")
+
+    assert admin_response.status_code == 200
+    assert b"AT-RET-1" in admin_response.data
+    assert b"RETIRED \xe2\x80\x94 Not in service" in admin_response.data
+    assert b"state-badge terminal" in admin_response.data
+    assert b"In storage" in admin_response.data
+    assert b"Retired / disposed" not in admin_response.data
+
+
 def test_admin_can_download_human_readable_report_pdf(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-report-pdf", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -126,6 +126,16 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Not assigned", response.data)
         self.assertIn(b"Not assigned", response.data)
 
+    def test_search_marks_retired_assets_with_clear_terminal_label(self) -> None:
+        self._insert_asset("AT-RET-1", serial_number="SER-RET-1", location_type="DISPOSED", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=AT-RET-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"RETIRED \xe2\x80\x94 Not in service", response.data)
+        self.assertIn(b"state-badge terminal", response.data)
+        self.assertNotIn(b"Retired / disposed", response.data)
+
     def test_partial_asset_tag_search_returns_matching_assets(self) -> None:
         self._insert_holder(1, "Alex Holder", "Field Ops")
         self._insert_asset("AT-100", serial_number="SER-100", location_type="IN_CUSTODY", home_slot_id=None, current_holder_id=1)


### PR DESCRIPTION
## Summary
Make retired assets visually unmistakable across the main inventory surfaces.

## Related Issue
Closes #547 

## Changes
- standardized terminal asset display to `RETIRED — Not in service`
- applied a consistent retired-state visual treatment across search, admin asset surfaces, and report views
- aligned retired messaging on admin surfaces with the same wording
- added focused regression coverage for retired-state rendering

## Verification checklist
- [x] retired asset shows `RETIRED — Not in service` in asset search
- [x] retired state is visually distinct from active states
- [x] admin asset surfaces use the same retired wording
- [x] `/report` and `/admin/report` use the same retired wording
- [x] active assets still show normal active-state labels
- [x] targeted tests pass

## Notes
Display-only change. No retire logic, schema, auth, or event behavior changed.