### PR TITLE
Issue 26-128: make report active-first and order retired assets last

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -5689,7 +5689,7 @@ def admin_system():
     )
 
 
-def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
+def _load_admin_human_report_data(resolved_db_path: Path, *, include_retired_assets: bool = True) -> dict:
     recent_events_limit = 10
     conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
@@ -5699,17 +5699,29 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
             """
             SELECT
                 COUNT(*) AS total_assets,
+                SUM(CASE WHEN COALESCE(location_type, '') NOT IN ('DISPOSED', 'RETIRED') THEN 1 ELSE 0 END) AS active_assets,
                 SUM(CASE WHEN location_type = 'STORAGE' THEN 1 ELSE 0 END) AS storage_assets,
                 SUM(CASE WHEN location_type = 'IN_CUSTODY' THEN 1 ELSE 0 END) AS in_custody_assets,
-                SUM(CASE WHEN location_type = 'DISPOSED' THEN 1 ELSE 0 END) AS disposed_assets
+                SUM(CASE WHEN location_type IN ('DISPOSED', 'RETIRED') THEN 1 ELSE 0 END) AS disposed_assets
             FROM assets;
             """
         ).fetchone()
 
+        asset_where = ""
+        if not include_retired_assets:
+            asset_where = "WHERE COALESCE(a.location_type, '') NOT IN ('DISPOSED', 'RETIRED')"
+
+        asset_order_by = "a.asset_tag COLLATE NOCASE ASC, a.id ASC"
+        if include_retired_assets:
+            asset_order_by = (
+                "CASE WHEN COALESCE(a.location_type, '') IN ('DISPOSED', 'RETIRED') THEN 1 ELSE 0 END ASC, "
+                "a.asset_tag COLLATE NOCASE ASC, a.id ASC"
+            )
+
         assets = [
             dict(row)
             for row in conn.execute(
-                """
+                f"""
                 SELECT
                     a.asset_tag,
                     COALESCE(a.equipment_type, '') AS equipment_type,
@@ -5727,7 +5739,8 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
                   ON h.id = a.current_holder_id
                 LEFT JOIN slots s
                   ON s.id = a.home_slot_id
-                ORDER BY a.asset_tag COLLATE NOCASE ASC, a.id ASC;
+                {asset_where}
+                ORDER BY {asset_order_by};
                 """
             ).fetchall()
         ]
@@ -5853,7 +5866,10 @@ def _load_admin_human_report_data(resolved_db_path: Path) -> dict:
 
         return {
             "asset_summary": {
-                "total_assets": int(asset_summary_row["total_assets"] or 0),
+                "total_assets": int(
+                    asset_summary_row["total_assets" if include_retired_assets else "active_assets"] or 0
+                ),
+                "active_assets": int(asset_summary_row["active_assets"] or 0),
                 "storage_assets": int(asset_summary_row["storage_assets"] or 0),
                 "in_custody_assets": int(asset_summary_row["in_custody_assets"] or 0),
                 "disposed_assets": int(asset_summary_row["disposed_assets"] or 0),
@@ -6107,9 +6123,11 @@ def admin_db_export():
 def human_report():
     resolved_db_path = _resolved_runtime_db_path()
     report_error: str | None = None
+    include_retired_assets = request.args.get("include_retired") == "1"
     report_data = {
         "asset_summary": {
             "total_assets": 0,
+            "active_assets": 0,
             "storage_assets": 0,
             "in_custody_assets": 0,
             "disposed_assets": 0,
@@ -6124,13 +6142,17 @@ def human_report():
     }
 
     try:
-        report_data = _load_admin_human_report_data(resolved_db_path)
+        report_data = _load_admin_human_report_data(
+            resolved_db_path,
+            include_retired_assets=include_retired_assets,
+        )
     except sqlite3.Error as exc:
         report_error = f"Could not read report data: {exc}"
 
     return render_template(
         "report_readonly.html",
         report_error=report_error,
+        include_retired_assets=include_retired_assets,
         **report_data,
     )
 
@@ -6144,6 +6166,7 @@ def admin_human_report():
     report_data = {
         "asset_summary": {
             "total_assets": 0,
+            "active_assets": 0,
             "storage_assets": 0,
             "in_custody_assets": 0,
             "disposed_assets": 0,

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -181,7 +181,7 @@
 {% endblock %}
 
 {% block content %}
-  {% set report_return_to = url_for('human_report') %}
+  {% set report_return_to = url_for('human_report', include_retired='1') if include_retired_assets else url_for('human_report') %}
   <div class="report-actions nav-row">
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
   </div>
@@ -194,7 +194,11 @@
     <div>
       <h2>Use Current State to Decide the Next Step</h2>
       <p class="report-priority-copy">
-        This page shows the current custody and storage picture. Use the links below to move from status into the next existing view without re-searching.
+        {% if include_retired_assets %}
+          This page shows the full inventory picture, including retired assets. Use the links below to move from status into the next existing view without re-searching.
+        {% else %}
+          This page shows the active custody and storage picture first. Use the links below to move from status into the next existing view without re-searching.
+        {% endif %}
       </p>
     </div>
     <div class="report-actions nav-row report-priority-links">
@@ -202,12 +206,17 @@
       <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=report_return_to) }}">Check case space</a>
       <a class="nav-link" href="{{ url_for('asset_search', return_to=report_return_to) }}">Look up an asset</a>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Open receipts</a>
+      {% if include_retired_assets %}
+        <a class="nav-link" href="{{ url_for('human_report') }}">View active inventory only</a>
+      {% else %}
+        <a class="nav-link" href="{{ url_for('human_report', include_retired='1') }}">Include retired assets</a>
+      {% endif %}
     </div>
     <div class="report-grid">
       <a class="report-stat report-stat-link" href="{{ url_for('asset_search', return_to=report_return_to) }}">
-        Total assets
+        {% if include_retired_assets %}Total assets{% else %}Active assets{% endif %}
         <strong>{{ asset_summary.total_assets }}</strong>
-        <span class="nav-link report-stat-action">Search asset records</span>
+        <span class="nav-link report-stat-action">{% if include_retired_assets %}Search all asset records{% else %}Search active asset records{% endif %}</span>
       </a>
       <a class="report-stat report-stat-link" href="{{ url_for('dashboard_cases', return_to=report_return_to) }}">
         In storage
@@ -219,18 +228,24 @@
         <strong>{{ asset_summary.in_custody_assets }}</strong>
         <span class="nav-link report-stat-action">Open holder follow-up</span>
       </a>
-      <a class="report-stat report-stat-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">
-        Disposed
+      <a class="report-stat report-stat-link" href="{% if include_retired_assets %}{{ url_for('human_report') }}{% else %}{{ url_for('human_report', include_retired='1') }}{% endif %}">
+        {% if include_retired_assets %}Retired shown{% else %}Retired hidden{% endif %}
         <strong>{{ asset_summary.disposed_assets }}</strong>
-        <span class="nav-link report-stat-action">Review receipts</span>
+        <span class="nav-link report-stat-action">{% if include_retired_assets %}Return to active-first view{% else %}Include retired assets{% endif %}</span>
       </a>
     </div>
   </div>
 
-  <details class="report-section" open>
+  <details class="report-section">
     <summary>
       <span class="report-section-title">Assets</span>
-      <span class="report-section-hint">{{ asset_summary.total_assets }} total records</span>
+      <span class="report-section-hint">
+        {% if include_retired_assets %}
+          {{ asset_summary.total_assets }} total records
+        {% else %}
+          {{ asset_summary.total_assets }} active records
+        {% endif %}
+      </span>
     </summary>
     <div class="report-section-body">
     <div class="table-wrap">

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -429,6 +429,50 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     )
     conn.execute(
         """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            manufacturer,
+            equipment_type,
+            building,
+            room,
+            model,
+            model_code,
+            notes,
+            building_room,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            current_holder_id,
+            home_slot_id
+        )
+        VALUES (
+            'AT-OLD-1',
+            'SN-OLD-1',
+            'Dell',
+            'laptop',
+            'Report HQ',
+            '099',
+            'Latitude',
+            'LAT',
+            NULL,
+            'Report HQ/099',
+            'retired',
+            'accountable',
+            'unserviceable',
+            '2025-12-01',
+            '2026-01-01T00:00:00Z',
+            'DISPOSED',
+            NULL,
+            NULL
+        );
+        """
+    )
+    conn.execute(
+        """
         INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
         SELECT 10, id, '2026-01-01T00:00:00Z'
         FROM assets
@@ -456,11 +500,12 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
 
     assert response.status_code == 200
     assert b"Use Current State to Decide the Next Step" in response.data
-    assert b"This page shows the current custody and storage picture." in response.data
+    assert b"This page shows the active custody and storage picture first." in response.data
     assert b"Report Scope" not in response.data
     assert b"Review holders with assets out" in response.data
     assert b"Check case space" in response.data
     assert b"Look up an asset" in response.data
+    assert b"Include retired assets" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
     assert response.data.count(b'href="/assets/search?return_to=/report"') >= 2
     assert b'href="/dashboard/cases?return_to=/report"' in response.data
@@ -470,6 +515,11 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b' href="/holders/1?return_to=/report"' in response.data
     assert b' href="/dashboard/cases/CASE-1?return_to=/report"' in response.data
     assert b"Last 10 Events" in response.data
+    assert b"Active assets" in response.data
+    assert b"1 active records" in response.data
+    assert b"Retired hidden" in response.data
+    assert b"AT-OLD-1" not in response.data
+    assert b'<details class="report-section" open>' not in response.data
     assert b"Jan 2, 2026 12:00 AM" in response.data
     assert b"2026-01-02T00:00:00Z" not in response.data
 
@@ -713,11 +763,20 @@ def test_reports_mark_retired_assets_as_not_in_service(client_with_temp_db) -> N
     response = client_with_temp_db.get("/report")
 
     assert response.status_code == 200
-    assert b"AT-RET-1" in response.data
-    assert b"RETIRED \xe2\x80\x94 Not in service" in response.data
-    assert b"state-badge terminal" in response.data
+    assert b"AT-RET-1" not in response.data
+    assert b"RETIRED \xe2\x80\x94 Not in service" not in response.data
+    assert b"Include retired assets" in response.data
     assert b"In storage" in response.data
     assert b"Retired / disposed" not in response.data
+
+    full_response = client_with_temp_db.get("/report?include_retired=1")
+    assert full_response.status_code == 200
+    assert b"AT-RET-1" in full_response.data
+    assert b"RETIRED \xe2\x80\x94 Not in service" in full_response.data
+    assert b"state-badge terminal" in full_response.data
+    assert b"View active inventory only" in full_response.data
+    assert b"2 total records" in full_response.data
+    assert full_response.data.find(b"AT-LIVE-1") < full_response.data.find(b"AT-RET-1")
 
     admin_id = create_test_user(username="admin-report-retired", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)


### PR DESCRIPTION
## Summary
Make operator report active-inventory first by default and ensure retired assets appear only when explicitly included, with active assets listed first.

## Related Issue
Closes #552 

## Changes
- default /report to active-inventory-first view
- exclude retired assets by default
- add explicit include-retired toggle
- update summary counts to reflect active assets
- default Assets section to collapsed for lower noise
- ensure active assets render first and retired assets render last in full view
- preserve admin report as full historical view

## Verification checklist
- [x] Tests pass
- [x] Manual verification completed
- [x] Default report excludes retired assets
- [x] Summary reflects active assets by default
- [x] Assets section defaults collapsed
- [x] Include-retired view shows full inventory
- [x] Active assets render first in full view
- [x] Retired assets render last in full view
- [x] Drill-in returns to correct report mode

## Notes
- Read-only report behavior only
- No schema, persistence, auth, or lifecycle changes
- Operator and admin report scopes intentionally differ