### PR TITLE
Issue 26-127: standardize admin retire lookup with asset search pattern

### DIFF
--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -7,6 +7,35 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    .asset-retire-lookup {
+      width: 100%;
+    }
+    .asset-retire-lookup .search-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 0.75rem 1rem;
+      width: 100%;
+    }
+    .asset-retire-lookup .search-field {
+      min-width: 0;
+    }
+    .asset-retire-lookup .search-field .form-input {
+      display: block;
+      max-width: none;
+    }
+    .search-actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-top: 0.25rem;
+    }
+    .search-clear {
+      display: inline-flex;
+      align-items: center;
+      color: var(--color-text-muted);
+      font-weight: 600;
+    }
     input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 120px; }
     .warn { color: #8a1f11; font-weight: 700; }
@@ -46,20 +75,28 @@
   {% endif %}
 
   <div class="card">
-    <h2>1) Lookup Asset</h2>
-    <form method="post" action="{{ url_for('admin_retire_asset') }}">
+    <h2>Find Asset</h2>
+    <p class="muted">Search by asset tag to load the asset before reviewing its current state and retiring it.</p>
+    <form class="asset-retire-lookup" method="post" action="{{ url_for('admin_retire_asset') }}">
       <input type="hidden" name="action" value="lookup" />
-      <div class="row">
-        <label for="asset_tag"><strong>asset_tag</strong> (required)</label><br />
-        <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" required autofocus />
+      <div class="search-grid">
+        <div class="row form-group search-field">
+          <label class="form-label" for="asset_tag"><strong>Asset tag</strong></label>
+          <input class="form-input" type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" required autofocus />
+        </div>
       </div>
-      <button type="submit">Lookup Asset</button>
+      <div class="search-actions">
+        <button type="submit">Search</button>
+        {% if form.asset_tag %}
+          <a class="search-clear" href="{{ url_for('admin_retire_asset') }}">Clear</a>
+        {% endif %}
+      </div>
     </form>
   </div>
 
   {% if asset %}
     <div class="card">
-      <h2>2) Current Asset State</h2>
+      <h2>Current Asset State</h2>
       <div class="grid">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
         <div><strong>location_type:</strong> <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span></div>
@@ -80,7 +117,7 @@
     </div>
 
     <div class="card">
-      <h2>3) Retire Asset</h2>
+      <h2>Retire Asset</h2>
       <p class="warn">Retirement is terminal. This action marks the asset as DISPOSED.</p>
       <form method="post" action="{{ url_for('admin_retire_asset') }}">
         <input type="hidden" name="action" value="retire" />

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -84,6 +84,9 @@ class AdminRetireAssetTests(unittest.TestCase):
         response = self.client.get("/admin/assets/retire")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Retire Asset", response.data)
+        self.assertIn(b"Find Asset", response.data)
+        self.assertIn(b"Search by asset tag", response.data)
+        self.assertIn(b">Search<", response.data)
 
     def test_retire_from_storage_is_atomic_and_logs_event(self) -> None:
         self._insert_slot(10, "CASE-A", 1, current_asset_tag="RET-100")


### PR DESCRIPTION
## Summary
Align admin retire asset lookup with the standard asset search pattern for consistent, predictable operator interaction.

## Related Issue
Closes #550 

## Changes
- standardized lookup block to match asset search pattern
- aligned heading, helper copy, and field layout
- added clear/reset affordance for entered asset tag
- removed numeric prefixes from section headers for cleaner UI

## Verification checklist
- [x] Tests pass
- [x] Manual verification completed
- [x] Lookup block matches asset search pattern
- [x] Search loads asset correctly
- [x] Clear resets to empty lookup state
- [x] Retire flow behavior unchanged

## Notes
- Template/UI-only changes
- No schema, persistence, auth, or retire logic changes