### PR TITLE
Issue 26-130: add safe partial lookup for admin retire

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1243,6 +1243,15 @@ def _build_admin_retire_asset_view(conn, scan_tag: str) -> tuple[Optional[dict],
     return view, errors
 
 
+def _lookup_retire_asset_matches(conn: sqlite3.Connection, asset_tag: str) -> tuple[list[dict], Optional[str]]:
+    matches, error_message, _ = _lookup_asset_for_verification(
+        conn,
+        asset_tag=asset_tag,
+        serial_number="",
+    )
+    return matches, error_message
+
+
 def _resolve_replacement_target_slot(
     conn: sqlite3.Connection,
     *,
@@ -6685,6 +6694,7 @@ def admin_retire_asset():
         "confirm_in_field": False,
     }
     asset_view: Optional[dict] = None
+    asset_matches: list[dict] = []
     error_message: Optional[str] = None
 
     if request.method == "POST":
@@ -6699,13 +6709,24 @@ def admin_retire_asset():
 
         conn = get_connection()
         try:
-            asset_view, blocking_errors = _build_admin_retire_asset_view(conn, form_state["asset_tag"])
             if action == "lookup":
                 if not form_state["asset_tag"]:
                     error_message = "asset_tag is required."
-                elif blocking_errors:
-                    error_message = "; ".join(blocking_errors)
+                else:
+                    try:
+                        exact_asset = _find_asset_for_scan_tag(conn, form_state["asset_tag"])
+                    except ValueError as exc:
+                        exact_asset = None
+                        error_message = str(exc)
+
+                    if exact_asset is not None:
+                        asset_view, blocking_errors = _build_admin_retire_asset_view(conn, form_state["asset_tag"])
+                        if blocking_errors:
+                            error_message = "; ".join(blocking_errors)
+                    elif error_message is None:
+                        asset_matches, error_message = _lookup_retire_asset_matches(conn, form_state["asset_tag"])
             elif action == "retire":
+                asset_view, blocking_errors = _build_admin_retire_asset_view(conn, form_state["asset_tag"])
                 errors: list[str] = []
                 if not form_state["asset_tag"]:
                     errors.append("asset_tag is required.")
@@ -6782,6 +6803,7 @@ def admin_retire_asset():
         "admin_retire_asset.html",
         form=form_state,
         asset=asset_view,
+        asset_matches=asset_matches,
         error_message=error_message,
         failure_type_options=sorted(RETIRE_FAILURE_TYPES),
     )

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -7,6 +7,20 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
+    .search-actions {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      align-items: center;
+      margin-top: 0.25rem;
+    }
+    .search-clear {
+      display: inline-flex;
+      align-items: center;
+      color: var(--color-text-muted);
+      font-weight: 600;
+    }
+    .results-table code { white-space: nowrap; }
     input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 120px; }
     .warn { color: #8a1f11; font-weight: 700; }
@@ -46,20 +60,73 @@
   {% endif %}
 
   <div class="card">
-    <h2>1) Lookup Asset</h2>
+    <h2>Find Asset</h2>
+    <p class="muted">Enter a full or partial asset tag. Exact matches load directly. Partial matches require you to select one asset before retiring.</p>
     <form method="post" action="{{ url_for('admin_retire_asset') }}">
       <input type="hidden" name="action" value="lookup" />
       <div class="row">
         <label for="asset_tag"><strong>asset_tag</strong> (required)</label><br />
         <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" required autofocus />
       </div>
-      <button type="submit">Lookup Asset</button>
+      <div class="search-actions">
+        <button type="submit">Search</button>
+        {% if form.asset_tag %}
+          <a class="search-clear" href="{{ url_for('admin_retire_asset') }}">Clear</a>
+        {% endif %}
+      </div>
     </form>
   </div>
 
+  {% if asset_matches and not asset %}
+    <div class="card">
+      <h2>Select Asset</h2>
+      <p class="muted">{{ asset_matches|length }} matches found. Select one asset to load its current state before retiring.</p>
+      <table class="results-table">
+        <thead>
+          <tr>
+            <th>Asset tag</th>
+            <th>Serial number</th>
+            <th>Current state</th>
+            <th>Current holder</th>
+            <th>Home case</th>
+            <th>Home slot</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for match in asset_matches %}
+            <tr>
+              <td><code>{{ match.asset_tag }}</code></td>
+              <td>{{ match.serial_number or "Not recorded" }}</td>
+              <td>
+                <span class="state-badge{% if asset_is_terminal(match.location_type) %} terminal{% endif %}">{{ asset_state_label(match.location_type) }}</span>
+              </td>
+              <td>{{ match.holder_label or "Not assigned" }}</td>
+              <td>{{ match.home_case_name or "Not assigned" }}</td>
+              <td>
+                {% if match.home_slot_position is not none %}
+                  Slot {{ match.home_slot_position }}
+                {% else %}
+                  Not assigned
+                {% endif %}
+              </td>
+              <td>
+                <form method="post" action="{{ url_for('admin_retire_asset') }}">
+                  <input type="hidden" name="action" value="lookup" />
+                  <input type="hidden" name="asset_tag" value="{{ match.asset_tag }}" />
+                  <button type="submit">Select</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+
   {% if asset %}
     <div class="card">
-      <h2>2) Current Asset State</h2>
+      <h2>Current Asset State</h2>
       <div class="grid">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
         <div><strong>location_type:</strong> <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span></div>
@@ -80,7 +147,7 @@
     </div>
 
     <div class="card">
-      <h2>3) Retire Asset</h2>
+      <h2>Retire Asset</h2>
       <p class="warn">Retirement is terminal. This action marks the asset as DISPOSED.</p>
       <form method="post" action="{{ url_for('admin_retire_asset') }}">
         <input type="hidden" name="action" value="retire" />

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -84,6 +84,7 @@ class AdminRetireAssetTests(unittest.TestCase):
         response = self.client.get("/admin/assets/retire")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Retire Asset", response.data)
+        self.assertIn(b"Find Asset", response.data)
 
     def test_retire_from_storage_is_atomic_and_logs_event(self) -> None:
         self._insert_slot(10, "CASE-A", 1, current_asset_tag="RET-100")
@@ -194,6 +195,39 @@ class AdminRetireAssetTests(unittest.TestCase):
         self.assertEqual(event["holder_id"], 51)
         payload = json.loads(event["payload"])
         self.assertEqual(payload["failure_type"], "LOST")
+
+    def test_partial_lookup_requires_explicit_selection_before_retire(self) -> None:
+        self._insert_asset("RET-210", location_type="STORAGE")
+        self._insert_asset("RET-211", location_type="STORAGE")
+
+        response = self.client.post(
+            "/admin/assets/retire",
+            data={
+                "action": "lookup",
+                "asset_tag": "RET-21",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Select Asset", response.data)
+        self.assertIn(b"RET-210", response.data)
+        self.assertIn(b"RET-211", response.data)
+        self.assertNotIn(b"Current Asset State", response.data)
+        self.assertNotIn(b'Retirement is terminal. This action marks the asset as DISPOSED.', response.data)
+        self.assertIn(b">Select<", response.data)
+
+        selected = self.client.post(
+            "/admin/assets/retire",
+            data={
+                "action": "lookup",
+                "asset_tag": "RET-210",
+            },
+        )
+        self.assertEqual(selected.status_code, 200)
+        self.assertIn(b"Current Asset State", selected.data)
+        self.assertIn(b"Retire Asset", selected.data)
+        self.assertIn(b"RET-210", selected.data)
+        self.assertNotIn(b"RET-211", selected.data)
 
     def test_retired_assets_are_blocked_from_issue_and_return(self) -> None:
         self._insert_slot(20, "CASE-B", 2, current_asset_tag=None)


### PR DESCRIPTION
## Summary
Add safe partial asset lookup to the admin retire flow while preserving explicit selection before any terminal action.

## Related Issue
Closes #26-130

## Changes
- added partial asset-tag lookup to admin retire
- preserved exact-match direct-load fast path
- show selectable match list for non-exact input
- require explicit Select before current state or retire form appears
- kept retire logic unchanged

## Verification checklist
- [x] Tests pass
- [x] Manual verification completed
- [x] Partial input shows a match list
- [x] No retire form appears before explicit selection
- [x] Selecting an asset loads Current Asset State correctly
- [x] Exact-match input still loads directly
- [x] No ambiguous retire path exists

## Notes
- No schema, persistence, auth, or lifecycle changes
- Safety improvement through explicit selection gating