### PR TITLE
Issue 26-142: remove duplicate page-wide shell rule

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -1,7 +1,3 @@
-.page.page-wide {
-  max-width: 1320px;
-}
-
 .actions {
   display: flex;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
Remove the duplicate `.page.page-wide` rule so the shell width modifier has one clear owner.

## Related Issue
Closes #574 

## Changes
- removed the duplicate `.page.page-wide` rule from `assettrack/intake/static/css/base.css`
- kept the authoritative `.page.page-wide` rule in `assettrack/intake/templates/base.html`
- made no other CSS changes

## Verification checklist
- [x] Confirmed the duplicate rules were identical
- [x] Rebuilt with `docker compose up -d --build`
- [x] Verified `/dashboard`
- [x] Verified `/issue`
- [x] Verified `/return`
- [x] Verified `/receipts`
- [x] Verified a receipt detail page
- [x] Verified `/report`
- [x] Verified `/demo`
- [x] Confirmed no layout or width regressions

## Notes
Small deduplication only. No layout redesign, behavior changes, or broader CSS refactor.