### PR TITLE
Issue 26-143: reconcile exact report style duplicates

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -118,6 +118,72 @@
   height: auto;
 }
 
+.report-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+
+.report-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.report-stat {
+  display: block;
+  padding: 0.85rem;
+  border: 1px solid var(--color-surface);
+  border-radius: 10px;
+  background: var(--color-surface-soft);
+}
+
+.report-stat strong {
+  display: block;
+  font-size: 1.35rem;
+  margin-top: 0.25rem;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+.state-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.24rem 0.58rem;
+  border-radius: 999px;
+  font-weight: 700;
+  line-height: 1.2;
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+}
+
+.state-badge.terminal {
+  background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
+  border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
+  color: var(--color-danger);
+  letter-spacing: 0.01em;
+}
+
+.page.report-page .card h2 {
+  margin-top: 0;
+}
+
+@media print {
+  .page.report-page .page-tools,
+  .page.report-page .top-nav,
+  .page.report-page .report-actions {
+    display: none !important;
+  }
+
+  .page.report-page .card {
+    break-inside: avoid;
+    box-shadow: none;
+  }
+}
+
 @media (max-width: 900px) {
   .hero-support-image-wrap {
     justify-content: center;

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -6,61 +6,6 @@
 
 {% block extra_head %}
   <style>
-    .report-actions {
-      display: flex;
-      gap: 0.5rem;
-      flex-wrap: wrap;
-      margin-bottom: 1rem;
-    }
-    .report-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 0.75rem;
-    }
-    .report-stat {
-      padding: 0.85rem;
-      border: 1px solid var(--color-surface);
-      border-radius: 10px;
-      background: var(--color-surface-soft);
-    }
-    .report-stat strong {
-      display: block;
-      font-size: 1.35rem;
-      margin-top: 0.25rem;
-    }
-    .card h2 {
-      margin-top: 0;
-    }
-    .table-wrap {
-      overflow-x: auto;
-    }
-    .state-badge {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.24rem 0.58rem;
-      border-radius: 999px;
-      font-weight: 700;
-      line-height: 1.2;
-      background: var(--color-surface-soft);
-      color: var(--color-text);
-    }
-    .state-badge.terminal {
-      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
-      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
-      color: var(--color-danger);
-      letter-spacing: 0.01em;
-    }
-    @media print {
-      .page-tools,
-      .top-nav,
-      .report-actions {
-        display: none !important;
-      }
-      .card {
-        break-inside: avoid;
-        box-shadow: none;
-      }
-    }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -7,7 +7,6 @@
 
 {% block extra_head %}
   <style>
-    .actions { display: flex; gap: 0.5rem; margin-bottom: 0.75rem; flex-wrap: wrap; }
     .drill-link {
       display: inline-flex;
       align-items: center;

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -148,7 +148,6 @@
       font-size: 0.95rem;
       font-variant-numeric: tabular-nums;
     }
-    .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
     .muted-cell { color: var(--color-text-muted); }
     @media (max-width: 1180px) {
       .receipts-table {

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -6,12 +6,6 @@
 
 {% block extra_head %}
   <style>
-    .report-actions {
-      display: flex;
-      gap: 0.5rem;
-      flex-wrap: wrap;
-      margin-bottom: 1rem;
-    }
     .report-priority {
       display: grid;
       gap: 0.9rem;
@@ -45,18 +39,6 @@
     .report-priority-links .nav-link:focus-visible {
       outline-offset: 1px;
     }
-    .report-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-      gap: 0.75rem;
-    }
-    .report-stat {
-      display: block;
-      padding: 0.85rem;
-      border: 1px solid var(--color-surface);
-      border-radius: 10px;
-      background: var(--color-surface-soft);
-    }
     .report-stat-link {
       color: inherit;
       text-decoration: none;
@@ -72,37 +54,10 @@
       outline: 2px solid var(--color-primary);
       outline-offset: 2px;
     }
-    .report-stat strong {
-      display: block;
-      font-size: 1.35rem;
-      margin-top: 0.25rem;
-    }
     .report-stat-action {
       display: block;
       margin-top: 0.65rem;
       width: fit-content;
-    }
-    .card h2 {
-      margin-top: 0;
-    }
-    .table-wrap {
-      overflow-x: auto;
-    }
-    .state-badge {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.24rem 0.58rem;
-      border-radius: 999px;
-      font-weight: 700;
-      line-height: 1.2;
-      background: var(--color-surface-soft);
-      color: var(--color-text);
-    }
-    .state-badge.terminal {
-      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
-      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
-      color: var(--color-danger);
-      letter-spacing: 0.01em;
     }
     details.report-section {
       margin-top: 1rem;
@@ -166,15 +121,8 @@
       text-underline-offset: 0.16em;
     }
     @media print {
-      .page-tools,
-      .top-nav,
-      .report-actions,
       details.report-section summary {
         display: none !important;
-      }
-      .card {
-        break-inside: avoid;
-        box-shadow: none;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
Reconcile exact duplicate report-related CSS definitions to reduce drift and establish a single source of truth.

## Related Issue
Closes #576 

## Changes
- centralized shared report primitives into `base.css`
- removed duplicate styles from:
  - `report_readonly.html`
  - `admin_human_report.html`
- removed redundant local styles:
  - `.actions` in `dashboard_holders.html`
  - `.mono` in `receipts_list.html`
- preserved behavior for `.report-stat` using the more complete shared definition
- reconciled shared print rules while keeping report-specific rules local

## Verification checklist
- [x] Confirmed duplicates were exact or functionally identical
- [x] Rebuilt with `docker compose up -d --build`
- [x] Verified `/report`
- [x] Verified `/admin/report`
- [x] Verified `/dashboard/holders`
- [x] Verified `/receipts`
- [x] Verified print preview behavior for report pages
- [x] Confirmed no visual or spacing regressions

## Notes
Duplicate-removal only. No redesign, layout changes, or broader CSS refactor.