### PR TITLE
Issue 26-100: implement server-side session timeout and expiration

### DIFF
--- a/assettrack/auth.py
+++ b/assettrack/auth.py
@@ -2,10 +2,46 @@
 from __future__ import annotations
 
 from functools import wraps
+import time
 
 from flask import g, render_template, request, session
 
 from assettrack.users import ALLOWED_ROLES, get_user_by_id
+
+SESSION_IDLE_TIMEOUT_SECONDS = 20 * 60
+SESSION_ABSOLUTE_TIMEOUT_SECONDS = 60 * 60
+AUTH_SESSION_KEYS = ("user_id", "last_seen", "session_started_at")
+
+
+def now_seconds() -> int:
+    return int(time.time())
+
+
+def begin_auth_session(user_id: int) -> None:
+    started_at = now_seconds()
+    session["user_id"] = int(user_id)
+    session["last_seen"] = started_at
+    session["session_started_at"] = started_at
+
+
+def clear_auth_session() -> None:
+    for key in AUTH_SESSION_KEYS:
+        session.pop(key, None)
+
+
+def _session_timing_valid() -> bool:
+    try:
+        last_seen = int(session["last_seen"])
+        session_started_at = int(session["session_started_at"])
+    except (KeyError, TypeError, ValueError):
+        return False
+
+    current = now_seconds()
+    if current - last_seen > SESSION_IDLE_TIMEOUT_SECONDS:
+        return False
+    if current - session_started_at > SESSION_ABSOLUTE_TIMEOUT_SECONDS:
+        return False
+    return True
 
 
 def _prefers_json_response() -> bool:
@@ -29,16 +65,21 @@ def current_user() -> dict | None:
         return g.current_user
 
     user_id = session.get("user_id")
+    if user_id is not None and not _session_timing_valid():
+        clear_auth_session()
+        g.current_user = None
+        return None
+
     user = get_user_by_id(user_id)
     if user is None:
-        session.pop("user_id", None)
+        clear_auth_session()
         g.current_user = None
         return None
 
     role = str(user.get("role") or "").strip().lower()
     active = int(user.get("active") or 0) == 1
     if role not in ALLOWED_ROLES or not active:
-        session.pop("user_id", None)
+        clear_auth_session()
         g.current_user = None
         return None
 

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -47,7 +47,14 @@ from assettrack.ingest.validator import validate_rows
 from assettrack.ingest.committer import BatchCommitError, commit_batch
 from assettrack.intake.scan import Scan
 from assettrack.intake.to_ingest import scan_to_ingest_row
-from assettrack.auth import current_user, require_login, require_role
+from assettrack.auth import (
+    SESSION_IDLE_TIMEOUT_SECONDS,
+    begin_auth_session,
+    clear_auth_session,
+    current_user,
+    require_login,
+    require_role,
+)
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, update_holder
 from assettrack.reference_data import (
     create_building,
@@ -81,7 +88,7 @@ bootstrap_db(db_module.DB_PATH)
 # In-memory only: wiped on restart
 SCAN_QUEUE: list[Scan] = []
 
-INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", "300"))  # default 5 min
+INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", str(SESSION_IDLE_TIMEOUT_SECONDS)))
 TERMINAL_LOCATION_TYPE = "DISPOSED"
 TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
@@ -445,8 +452,7 @@ def is_authed() -> bool:
 def set_authed(value: bool) -> None:
     if value:
         return
-    session.pop("user_id", None)
-    session.pop("last_seen", None)
+    clear_auth_session()
 
 
 def auth_ok(submitted: str | None) -> bool:
@@ -3547,8 +3553,7 @@ def intake():
         session.pop("user_id", None)
         return render_template("splash.html", error="Access denied"), 403
 
-    session["user_id"] = int(user["id"])
-    touch_session()
+    begin_auth_session(int(user["id"]))
     return redirect("/dashboard")
 
 
@@ -3663,14 +3668,13 @@ def bootstrap_admin():
     except sqlite3.IntegrityError:
         return render_template("bootstrap_admin.html", error="Username already exists."), 400
 
-    session["user_id"] = int(user["id"])
-    touch_session()
+    begin_auth_session(int(user["id"]))
     return redirect("/dashboard")
 
 
 @app.get("/logout")
 def logout():
-    session.pop("user_id", None)
+    clear_auth_session()
     return redirect("/")
 
 

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -32,6 +32,11 @@ def test_active_user_login_succeeds(client_with_temp_db) -> None:
     response = _login(client_with_temp_db, "operator", "op-pass")
     assert response.status_code == 302
     assert (response.headers.get("Location") or "").endswith("/dashboard")
+    with client_with_temp_db.session_transaction() as sess:
+        assert "user_id" in sess
+        assert "last_seen" in sess
+        assert "session_started_at" in sess
+        assert sess["session_started_at"] == sess["last_seen"]
 
 
 def test_wrong_password_login_fails(client_with_temp_db) -> None:
@@ -357,6 +362,29 @@ def test_inactive_user_login_fails(client_with_temp_db) -> None:
     response = _login(client_with_temp_db, "inactive", "op-pass")
     assert response.status_code == 403
     assert b"Access denied" in response.data
+
+
+def test_logout_clears_auth_keys_and_preserves_workflow_state(client_with_temp_db) -> None:
+    create_user("operator", "op-pass", "operator", True)
+    _login(client_with_temp_db, "operator", "op-pass")
+    with client_with_temp_db.session_transaction() as sess:
+        sess["holder_id"] = 41
+        sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
+
+    response = client_with_temp_db.get("/logout")
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/")
+    with client_with_temp_db.session_transaction() as sess:
+        assert "user_id" not in sess
+        assert "last_seen" not in sess
+        assert "session_started_at" not in sess
+        assert sess["holder_id"] == 41
+        assert sess["issue_mode"] is True
+        assert sess["issue_building"] == "HQ North"
+        assert sess["issue_room"] == "210"
 
 
 def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -49,9 +49,11 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 def _login_with_timeout(client, *, role: str = "admin") -> int:
     user_id = create_test_user(username=f"{role}-timeout-user", password="op-pass", role=role)
+    now = intake_app.now_seconds()
     with client.session_transaction() as sess:
         sess["user_id"] = user_id
-        sess["last_seen"] = intake_app.now_seconds()
+        sess["last_seen"] = now
+        sess["session_started_at"] = now
     return user_id
 
 

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import assettrack.auth as auth
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from assettrack.intake.scan import Scan
@@ -29,7 +30,13 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return intake_app.app.test_client()
 
 
-def _login(client, monkeypatch: pytest.MonkeyPatch, *, last_seen: int = 100) -> int:
+def _login(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    last_seen: int = 100,
+    session_started_at: int = 100,
+) -> int:
     user_id = create_test_user(username=f"user-{last_seen}", password="op-pass", role="operator")
     with client.session_transaction() as sess:
         sess["user_id"] = user_id
@@ -38,34 +45,42 @@ def _login(client, monkeypatch: pytest.MonkeyPatch, *, last_seen: int = 100) -> 
         sess["issue_building"] = "HQ North"
         sess["issue_room"] = "210"
         sess["last_seen"] = last_seen
+        sess["session_started_at"] = session_started_at
     return user_id
 
 
+def _set_now(monkeypatch: pytest.MonkeyPatch, value: int) -> None:
+    monkeypatch.setattr(auth, "now_seconds", lambda: value)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: value)
+
+
 def test_authenticated_navigation_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
-    _login(client_with_temp_db, monkeypatch, last_seen=100)
-    monkeypatch.setattr(intake_app, "now_seconds", lambda: 200)
+    _login(client_with_temp_db, monkeypatch, last_seen=100, session_started_at=50)
+    _set_now(monkeypatch, 200)
 
     response = client_with_temp_db.get("/dashboard")
 
     assert response.status_code == 200
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 200
+        assert sess["session_started_at"] == 50
 
 
 def test_preview_load_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
-    _login(client_with_temp_db, monkeypatch, last_seen=110)
+    _login(client_with_temp_db, monkeypatch, last_seen=110, session_started_at=80)
     intake_app.SCAN_QUEUE.append(Scan.now("PREVIEW-TAG"))
-    monkeypatch.setattr(intake_app, "now_seconds", lambda: 210)
+    _set_now(monkeypatch, 210)
 
     response = client_with_temp_db.get("/issue/preview")
 
     assert response.status_code == 200
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 210
+        assert sess["session_started_at"] == 80
 
 
 def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
-    _login(client_with_temp_db, monkeypatch, last_seen=120)
+    _login(client_with_temp_db, monkeypatch, last_seen=120, session_started_at=90)
     conn = db.get_connection()
     conn.execute(
         """
@@ -75,7 +90,7 @@ def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: p
     )
     conn.commit()
     conn.close()
-    monkeypatch.setattr(intake_app, "now_seconds", lambda: 220)
+    _set_now(monkeypatch, 220)
 
     response = client_with_temp_db.post(
         "/",
@@ -87,12 +102,13 @@ def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: p
     assert len(intake_app.SCAN_QUEUE) == 1
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 220
+        assert sess["session_started_at"] == 90
 
 
 def test_queue_action_refreshes_last_seen(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
-    _login(client_with_temp_db, monkeypatch, last_seen=130)
+    _login(client_with_temp_db, monkeypatch, last_seen=130, session_started_at=100)
     intake_app.SCAN_QUEUE.append(Scan.now("CLEAR-ME"))
-    monkeypatch.setattr(intake_app, "now_seconds", lambda: 230)
+    _set_now(monkeypatch, 230)
 
     response = client_with_temp_db.post(
         "/",
@@ -104,6 +120,50 @@ def test_queue_action_refreshes_last_seen(client_with_temp_db, monkeypatch: pyte
     assert len(intake_app.SCAN_QUEUE) == 0
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 230
+        assert sess["session_started_at"] == 100
+
+
+def test_idle_expired_session_is_rejected_and_preserves_workflow_state(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=100, session_started_at=100)
+    _set_now(monkeypatch, 100 + auth.SESSION_IDLE_TIMEOUT_SECONDS + 1)
+
+    response = client_with_temp_db.get("/dashboard")
+
+    assert response.status_code == 403
+    with client_with_temp_db.session_transaction() as sess:
+        assert "user_id" not in sess
+        assert "last_seen" not in sess
+        assert "session_started_at" not in sess
+        assert sess["holder_id"] == 1
+        assert sess["issue_mode"] is True
+        assert sess["issue_building"] == "HQ North"
+        assert sess["issue_room"] == "210"
+
+
+def test_absolute_expired_session_is_rejected_and_preserves_workflow_state(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(
+        client_with_temp_db,
+        monkeypatch,
+        last_seen=200,
+        session_started_at=100,
+    )
+    _set_now(monkeypatch, 100 + auth.SESSION_ABSOLUTE_TIMEOUT_SECONDS + 1)
+
+    response = client_with_temp_db.get("/dashboard")
+
+    assert response.status_code == 403
+    with client_with_temp_db.session_transaction() as sess:
+        assert "user_id" not in sess
+        assert "last_seen" not in sess
+        assert "session_started_at" not in sess
+        assert sess["holder_id"] == 1
+        assert sess["issue_mode"] is True
+        assert sess["issue_building"] == "HQ North"
+        assert sess["issue_room"] == "210"
 
 
 def test_public_unauthenticated_request_does_not_refresh_last_seen(


### PR DESCRIPTION
## Summary
Adds server-side session expiration with idle timeout and absolute lifetime enforcement to strengthen authentication security without affecting workflow continuity.

## Related Issue
Closes #487 

## Changes
- added session timing metadata (`last_seen`, `session_started_at`)
- enforced idle timeout (20 min) and absolute lifetime (60 min) in `current_user()`
- ensured idle refresh only applies to valid sessions
- updated logout to clear all auth-related session keys
- preserved workflow session state across timeout/logout
- aligned workflow timeout UI with server idle window
- added focused tests for session expiration and refresh behavior

## Verification checklist
- [x] login and protected routes work normally
- [x] idle timeout invalidates session
- [x] absolute timeout invalidates session even with activity
- [x] logout clears authentication
- [x] workflow seam (entry → queue → preview → commit) remains intact
- [x] tests pass

## Notes
- protected HTML routes continue using existing 403 behavior on auth failure
- existing sessions without `session_started_at` require re-login