### PR TITLE
Issue 26-145B: add login rate limiting in unauthenticated branch

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -125,6 +125,9 @@ DEMO_AUDIT = [
 ]
 DEMO_RECEIPT_SEND_LIMIT = 2
 DEMO_RECEIPT_COOLDOWN_SECONDS = 30
+LOGIN_RATE_LIMIT_WINDOW_SECONDS = 5 * 60
+LOGIN_RATE_LIMIT_MAX_FAILURES = 5
+LOGIN_FAILURE_ATTEMPTS: dict[str, list[int]] = {}
 
 
 @app.after_request
@@ -472,6 +475,41 @@ def seconds_since_last_seen() -> Optional[int]:
     if last_seen is None:
         return None
     return max(0, now_seconds() - int(last_seen))
+
+
+def _login_rate_limit_key() -> str:
+    remote_addr = str(request.remote_addr or "unknown").strip() or "unknown"
+    username = (request.form.get("username") or "").strip().lower()
+    if username:
+        return f"{remote_addr}|{username}"
+    return remote_addr
+
+
+def _prune_login_failures(rate_limit_key: str, *, current_time: Optional[int] = None) -> list[int]:
+    now = now_seconds() if current_time is None else int(current_time)
+    attempts = LOGIN_FAILURE_ATTEMPTS.get(rate_limit_key, [])
+    window_start = now - LOGIN_RATE_LIMIT_WINDOW_SECONDS
+    pruned = [attempt for attempt in attempts if attempt > window_start]
+    if pruned:
+        LOGIN_FAILURE_ATTEMPTS[rate_limit_key] = pruned
+    else:
+        LOGIN_FAILURE_ATTEMPTS.pop(rate_limit_key, None)
+    return pruned
+
+
+def _login_is_rate_limited(rate_limit_key: str) -> bool:
+    attempts = _prune_login_failures(rate_limit_key)
+    return len(attempts) >= LOGIN_RATE_LIMIT_MAX_FAILURES
+
+
+def _record_login_failure(rate_limit_key: str) -> None:
+    attempts = _prune_login_failures(rate_limit_key)
+    attempts.append(now_seconds())
+    LOGIN_FAILURE_ATTEMPTS[rate_limit_key] = attempts
+
+
+def _clear_login_failures(rate_limit_key: str) -> None:
+    LOGIN_FAILURE_ATTEMPTS.pop(rate_limit_key, None)
 
 
 def build_parsed_rows_from_queue() -> list[dict]:
@@ -3547,16 +3585,23 @@ def intake():
 
     username = (request.form.get("username") or "").strip()
     password = request.form.get("password") or ""
+    login_rate_limit_key = _login_rate_limit_key()
+    if _login_is_rate_limited(login_rate_limit_key):
+        return render_template("splash.html", error="Too many login attempts. Wait and try again."), 403
+
     user = get_user_by_username(username)
     if user is None or not verify_password(user, password):
+        _record_login_failure(login_rate_limit_key)
         return render_template("splash.html", error="Invalid login"), 403
 
     role = str(user.get("role") or "").strip().lower()
     active = int(user.get("active") or 0) == 1
     if role not in {"admin", "operator"} or not active:
         session.pop("user_id", None)
+        _record_login_failure(login_rate_limit_key)
         return render_template("splash.html", error="Access denied"), 403
 
+    _clear_login_failures(login_rate_limit_key)
     begin_auth_session(int(user["id"]))
     return redirect("/dashboard")
 

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -18,6 +18,7 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
     conn = db.get_connection()
     conn.close()
+    intake_app.LOGIN_FAILURE_ATTEMPTS.clear()
     intake_app.app.testing = True
     client = intake_app.app.test_client()
     return client
@@ -50,6 +51,67 @@ def test_nonexistent_user_login_fails(client_with_temp_db) -> None:
     response = _login(client_with_temp_db, "missing", "pw")
     assert response.status_code == 403
     assert b"Invalid login" in response.data
+
+
+def test_failed_login_attempts_accumulate_and_sixth_is_blocked(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_user("operator", "op-pass", "operator", True)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 1000)
+
+    for _ in range(5):
+        response = _login(client_with_temp_db, "operator", "wrong")
+        assert response.status_code == 403
+        assert b"Invalid login" in response.data
+
+    limited = _login(client_with_temp_db, "operator", "wrong")
+
+    assert limited.status_code == 403
+    assert b"Too many login attempts. Wait and try again." in limited.data
+
+
+def test_old_login_failures_outside_window_do_not_count(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    create_user("operator", "op-pass", "operator", True)
+
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 1000)
+    for _ in range(5):
+        response = _login(client_with_temp_db, "operator", "wrong")
+        assert response.status_code == 403
+
+    monkeypatch.setattr(
+        intake_app,
+        "now_seconds",
+        lambda: 1000 + intake_app.LOGIN_RATE_LIMIT_WINDOW_SECONDS + 1,
+    )
+    response = _login(client_with_temp_db, "operator", "wrong")
+
+    assert response.status_code == 403
+    assert b"Invalid login" in response.data
+    assert b"Too many login attempts. Wait and try again." not in response.data
+
+
+def test_successful_login_clears_failure_history(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    create_user("operator", "op-pass", "operator", True)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 1000)
+
+    for _ in range(4):
+        response = _login(client_with_temp_db, "operator", "wrong")
+        assert response.status_code == 403
+
+    success = _login(client_with_temp_db, "operator", "op-pass")
+    assert success.status_code == 302
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess.pop("user_id", None)
+        sess.pop("last_seen", None)
+        sess.pop("session_started_at", None)
+
+    retry = _login(client_with_temp_db, "operator", "wrong")
+    assert retry.status_code == 403
+    assert b"Invalid login" in retry.data
+    assert b"Too many login attempts. Wait and try again." not in retry.data
 
 
 def test_login_screen_renders_theme_toggle_without_persistence_storage(client_with_temp_db) -> None:
@@ -416,6 +478,31 @@ def test_logout_clears_auth_keys_and_preserves_workflow_state(client_with_temp_d
         assert sess["issue_mode"] is True
         assert sess["issue_building"] == "HQ North"
         assert sess["issue_room"] == "210"
+
+
+def test_authenticated_post_root_queue_action_is_not_rate_limited(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    created = create_user("operator", "op-pass", "operator", True)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: 1000)
+    monkeypatch.setattr(auth, "now_seconds", lambda: 1000)
+
+    for _ in range(5):
+        response = _login(client_with_temp_db, "operator", "wrong")
+        assert response.status_code == 403
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = int(created["id"])
+        sess["last_seen"] = 1000
+        sess["session_started_at"] = 1000
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"action": "clear", "return_to": "/add-assets"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/add-assets")
 
 
 def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Adds local, in-process rate limiting to the login branch of POST / to reduce brute-force attempts.

## Related Issue
Closes #582 

## Changes
- added login-only rate limiter scoped to unauthenticated POST / branch
- keyed by remote address and username
- enforced 5 failed attempts per 5 minutes
- clears failures on successful login
- leaves authenticated queue/workflow actions untouched

## Verification checklist
- [x] normal login works
- [x] repeated failed logins trigger limit
- [x] limiter resets after window
- [x] successful login clears failures
- [x] authenticated POST / workflow unaffected
- [x] tests pass

## Notes
- limiter is process-local and resets on restart
- intentionally scoped to login only (no global rate limiting)