### PR TITLE
Issue 26-145C: rate limit sensitive admin post routes

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -128,6 +128,9 @@ DEMO_RECEIPT_COOLDOWN_SECONDS = 30
 LOGIN_RATE_LIMIT_WINDOW_SECONDS = 5 * 60
 LOGIN_RATE_LIMIT_MAX_FAILURES = 5
 LOGIN_FAILURE_ATTEMPTS: dict[str, list[int]] = {}
+ADMIN_ROUTE_RATE_LIMIT_WINDOW_SECONDS = 60
+ADMIN_ROUTE_RATE_LIMIT_MAX_ACTIONS = 10
+ADMIN_ROUTE_ATTEMPTS: dict[str, list[int]] = {}
 
 
 @app.after_request
@@ -510,6 +513,51 @@ def _record_login_failure(rate_limit_key: str) -> None:
 
 def _clear_login_failures(rate_limit_key: str) -> None:
     LOGIN_FAILURE_ATTEMPTS.pop(rate_limit_key, None)
+
+
+def _admin_route_rate_limit_key() -> Optional[str]:
+    user = current_user()
+    endpoint = str(request.endpoint or "").strip()
+    if user is None or not endpoint:
+        return None
+    return f"{int(user['id'])}|{endpoint}"
+
+
+def _prune_admin_route_attempts(rate_limit_key: str, *, current_time: Optional[int] = None) -> list[int]:
+    now = now_seconds() if current_time is None else int(current_time)
+    attempts = ADMIN_ROUTE_ATTEMPTS.get(rate_limit_key, [])
+    window_start = now - ADMIN_ROUTE_RATE_LIMIT_WINDOW_SECONDS
+    pruned = [attempt for attempt in attempts if attempt > window_start]
+    if pruned:
+        ADMIN_ROUTE_ATTEMPTS[rate_limit_key] = pruned
+    else:
+        ADMIN_ROUTE_ATTEMPTS.pop(rate_limit_key, None)
+    return pruned
+
+
+def _consume_admin_route_rate_limit_slot() -> bool:
+    rate_limit_key = _admin_route_rate_limit_key()
+    if not rate_limit_key:
+        return True
+
+    attempts = _prune_admin_route_attempts(rate_limit_key)
+    if len(attempts) >= ADMIN_ROUTE_RATE_LIMIT_MAX_ACTIONS:
+        return False
+
+    attempts.append(now_seconds())
+    ADMIN_ROUTE_ATTEMPTS[rate_limit_key] = attempts
+    return True
+
+
+def _enforce_admin_route_rate_limit(*, html_redirect_endpoint: Optional[str] = None):
+    if _consume_admin_route_rate_limit_slot():
+        return None
+
+    message = "Too many requests. Wait and try again."
+    if html_redirect_endpoint:
+        flash(message, "error")
+        return redirect(url_for(html_redirect_endpoint))
+    return {"ok": False, "error": message}, 429
 
 
 def build_parsed_rows_from_queue() -> list[dict]:
@@ -6351,6 +6399,10 @@ def admin_human_report_pdf():
 @require_login
 @require_role("admin")
 def admin_users_create():
+    rate_limit_response = _enforce_admin_route_rate_limit(html_redirect_endpoint="admin_users")
+    if rate_limit_response is not None:
+        return rate_limit_response
+
     username = (request.form.get("username") or "").strip()
     password = request.form.get("password") or ""
     role = (request.form.get("role") or "").strip().lower()
@@ -6372,6 +6424,10 @@ def admin_users_create():
 @require_login
 @require_role("admin")
 def admin_users_toggle_active(user_id: int):
+    rate_limit_response = _enforce_admin_route_rate_limit(html_redirect_endpoint="admin_users")
+    if rate_limit_response is not None:
+        return rate_limit_response
+
     target = get_user_by_id(user_id)
     if target is None:
         flash("User not found.", "error")
@@ -6395,6 +6451,10 @@ def admin_users_toggle_active(user_id: int):
 @require_login
 @require_role("admin")
 def admin_users_reset_password(user_id: int):
+    rate_limit_response = _enforce_admin_route_rate_limit(html_redirect_endpoint="admin_users")
+    if rate_limit_response is not None:
+        return rate_limit_response
+
     new_password = request.form.get("new_password") or ""
 
     try:
@@ -6411,6 +6471,10 @@ def admin_users_reset_password(user_id: int):
 @require_login
 @require_role("admin")
 def admin_users_set_role(user_id: int):
+    rate_limit_response = _enforce_admin_route_rate_limit(html_redirect_endpoint="admin_users")
+    if rate_limit_response is not None:
+        return rate_limit_response
+
     role = (request.form.get("role") or "").strip().lower()
 
     try:
@@ -7157,6 +7221,10 @@ def admin_correct_event():
     guard_result = _require_admin_for_api()
     if guard_result:
         return guard_result
+
+    rate_limit_response = _enforce_admin_route_rate_limit()
+    if rate_limit_response is not None:
+        return rate_limit_response
 
     data = request.get_json(silent=True) or {}
     if not isinstance(data, dict):

--- a/tests/auth_test_utils.py
+++ b/tests/auth_test_utils.py
@@ -1,6 +1,7 @@
 # tests/auth_test_utils.py
 from __future__ import annotations
 
+import assettrack.auth as auth
 from assettrack.users import create_user
 
 def create_test_user(
@@ -15,5 +16,8 @@ def create_test_user(
 
 
 def login_session(client, user_id: int) -> None:
+    current_time = auth.now_seconds()
     with client.session_transaction() as sess:
         sess["user_id"] = int(user_id)
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+import assettrack.auth as auth
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from assettrack.users import get_user_by_id, get_user_by_username, verify_password
@@ -16,6 +17,7 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
     conn = db.get_connection()
     conn.close()
+    intake_app.ADMIN_ROUTE_ATTEMPTS.clear()
     intake_app.app.testing = True
     return intake_app.app.test_client()
 
@@ -185,3 +187,82 @@ def test_operator_is_forbidden_for_admin_user_routes(client_with_temp_db) -> Non
         data={"new_password": "new-pass"},
     ).status_code == 403
     assert client_with_temp_db.post(f"/admin/users/{target_id}/set-role", data={"role": "admin"}).status_code == 403
+
+
+def test_admin_user_create_rate_limit_blocks_when_threshold_is_exceeded(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+    base_time = auth.now_seconds()
+    monkeypatch.setattr(auth, "now_seconds", lambda: base_time)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: base_time)
+    intake_app.ADMIN_ROUTE_ATTEMPTS[f"{admin_user_id}|admin_users_create"] = [base_time] * 10
+
+    response = client_with_temp_db.post(
+        "/admin/users/create",
+        data={"username": "blocked-user", "password": "new-pass", "role": "operator", "active": "1"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Too many requests. Wait and try again." in response.data
+    assert get_user_by_username("blocked-user") is None
+
+
+def test_admin_route_rate_limit_is_endpoint_scoped_and_non_target_post_is_unaffected(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+    base_time = auth.now_seconds()
+    monkeypatch.setattr(auth, "now_seconds", lambda: base_time)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: base_time)
+    intake_app.ADMIN_ROUTE_ATTEMPTS[f"{admin_user_id}|admin_users_create"] = [base_time] * 10
+
+    response = client_with_temp_db.post(
+        "/admin/reference-data",
+        data={"action": "create_organization", "organization_name": "Operations"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Created organization." in response.data
+
+
+def test_admin_event_correction_rate_limit_returns_429_json(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+    base_time = auth.now_seconds()
+    monkeypatch.setattr(auth, "now_seconds", lambda: base_time)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: base_time)
+    intake_app.ADMIN_ROUTE_ATTEMPTS[f"{admin_user_id}|admin_correct_event"] = [base_time] * 10
+
+    response = client_with_temp_db.post("/admin/events/correct", json={})
+
+    assert response.status_code == 429
+    assert response.json == {"ok": False, "error": "Too many requests. Wait and try again."}
+
+
+def test_admin_route_rate_limit_prunes_old_timestamps(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_user_id)
+    base_time = auth.now_seconds()
+    monkeypatch.setattr(auth, "now_seconds", lambda: base_time)
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: base_time)
+    rate_limit_key = f"{admin_user_id}|admin_users_create"
+    intake_app.ADMIN_ROUTE_ATTEMPTS[rate_limit_key] = [
+        base_time - intake_app.ADMIN_ROUTE_RATE_LIMIT_WINDOW_SECONDS - 1
+    ] * 10
+
+    response = client_with_temp_db.post(
+        "/admin/users/create",
+        data={"username": "", "password": "new-pass", "role": "operator", "active": "1"},
+    )
+
+    assert response.status_code == 302
+    assert len(intake_app.ADMIN_ROUTE_ATTEMPTS[rate_limit_key]) == 1

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -19,6 +19,7 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     conn = db.get_connection()
     conn.close()
     intake_app.LOGIN_FAILURE_ATTEMPTS.clear()
+    intake_app.ADMIN_ROUTE_ATTEMPTS.clear()
     intake_app.app.testing = True
     client = intake_app.app.test_client()
     return client
@@ -495,6 +496,29 @@ def test_authenticated_post_root_queue_action_is_not_rate_limited(
         sess["user_id"] = int(created["id"])
         sess["last_seen"] = 1000
         sess["session_started_at"] = 1000
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"action": "clear", "return_to": "/add-assets"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/add-assets")
+
+
+def test_operator_workflow_post_root_is_unaffected_by_admin_route_rate_limit_state(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    created = create_user("operator", "op-pass", "operator", True)
+    base_time = 1000
+    monkeypatch.setattr(intake_app, "now_seconds", lambda: base_time)
+    monkeypatch.setattr(auth, "now_seconds", lambda: base_time)
+    intake_app.ADMIN_ROUTE_ATTEMPTS[f"{int(created['id'])}|admin_users_create"] = [base_time] * 10
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["user_id"] = int(created["id"])
+        sess["last_seen"] = base_time
+        sess["session_started_at"] = base_time
 
     response = client_with_temp_db.post(
         "/",


### PR DESCRIPTION
## Summary
Adds a narrow in-process rate limiter for a small allowlist of sensitive admin POST routes.

## Related Issue
Closes #583 

## Changes
- added local rate limiting for selected admin mutation routes only
- keyed limits by authenticated user and endpoint
- enforced 10 actions per minute per endpoint
- preserved existing HTML and JSON response styles when limited
- left non-target admin routes and operator workflows unchanged
- updated focused admin/auth test helpers and coverage

## Verification checklist
- [x] normal admin actions still work
- [x] non-target admin POST routes are unaffected
- [x] operator workflow is unaffected
- [x] limited admin route trips cleanly under burst use
- [x] focused tests pass

## Notes
- limiter is process-local and resets on restart
- scope is limited to the explicit admin POST allowlist only
- two broader admin timestamp-formatting test failures remain pre-existing and unrelated to this change