### PR TITLE
Issue 26-146: make session timeout display human readable

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -48,6 +48,7 @@ from assettrack.ingest.committer import BatchCommitError, commit_batch
 from assettrack.intake.scan import Scan
 from assettrack.intake.to_ingest import scan_to_ingest_row
 from assettrack.auth import (
+    SESSION_ABSOLUTE_TIMEOUT_SECONDS,
     SESSION_IDLE_TIMEOUT_SECONDS,
     begin_auth_session,
     clear_auth_session,
@@ -155,6 +156,8 @@ def inject_auth_user():
         "asset_is_terminal": _is_terminal_location_type,
         "holder_display_name": _holder_display_name,
         "holder_display_type": _holder_display_type,
+        "format_duration_label": _format_duration_label,
+        "session_absolute_timeout_seconds": SESSION_ABSOLUTE_TIMEOUT_SECONDS,
     }
 
 
@@ -162,6 +165,26 @@ def inject_auth_user():
 
 def now_seconds() -> int:
     return int(time.time())
+
+
+def _format_duration_label(total_seconds: object) -> str:
+    try:
+        seconds = max(0, int(total_seconds))
+    except (TypeError, ValueError):
+        return "0 seconds"
+
+    hours, remainder = divmod(seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    parts: list[str] = []
+
+    if hours:
+        parts.append(f"{hours} hour" + ("" if hours == 1 else "s"))
+    if minutes:
+        parts.append(f"{minutes} minute" + ("" if minutes == 1 else "s"))
+    if seconds or not parts:
+        parts.append(f"{seconds} second" + ("" if seconds == 1 else "s"))
+
+    return " ".join(parts)
 
 
 def touch_session() -> None:

--- a/assettrack/intake/templates/_timeout_lock_script.html
+++ b/assettrack/intake/templates/_timeout_lock_script.html
@@ -9,6 +9,25 @@
   const timeoutLockPanelEl = document.getElementById("timeout-lock-panel");
   const timeoutLockStateEl = document.getElementById("timeout-lock-state");
   const timeoutLockTargets = Array.from(document.querySelectorAll("[data-timeout-lock-target]"));
+  const formatDurationLabel = (totalSeconds) => {
+    const safeSeconds = Math.max(0, parseInt(totalSeconds, 10) || 0);
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.floor((safeSeconds % 3600) / 60);
+    const seconds = safeSeconds % 60;
+    const parts = [];
+
+    if (hours) {
+      parts.push(`${hours} hour${hours === 1 ? "" : "s"}`);
+    }
+    if (minutes) {
+      parts.push(`${minutes} minute${minutes === 1 ? "" : "s"}`);
+    }
+    if (seconds || parts.length === 0) {
+      parts.push(`${seconds} second${seconds === 1 ? "" : "s"}`);
+    }
+
+    return parts.join(" ");
+  };
   const setWarningState = (remainingSeconds) => {
     if (!countdownEl) {
       return;
@@ -63,15 +82,16 @@
   });
 
   if (lastActivityEl && timeoutSourceEl && countdownEl) {
-    let lastActivitySeconds = parseInt(lastActivityEl.textContent, 10);
+    let lastActivitySeconds = parseInt(lastActivityEl.dataset.lastActivitySeconds || "0", 10);
     const timeoutSeconds = parseInt(timeoutSourceEl.textContent, 10);
 
     const update = () => {
       lastActivitySeconds += 1;
-      lastActivityEl.textContent = lastActivitySeconds;
+      lastActivityEl.dataset.lastActivitySeconds = String(lastActivitySeconds);
+      lastActivityEl.textContent = `${formatDurationLabel(lastActivitySeconds)} ago`;
 
       const remaining = Math.max(0, timeoutSeconds - lastActivitySeconds);
-      countdownEl.textContent = remaining;
+      countdownEl.textContent = formatDurationLabel(remaining);
       setWarningState(remaining);
 
       if (remaining <= 0 && !timeoutLocked) {
@@ -83,7 +103,8 @@
     };
 
     const initialRemaining = Math.max(0, timeoutSeconds - lastActivitySeconds);
-    countdownEl.textContent = initialRemaining;
+    lastActivityEl.textContent = `${formatDurationLabel(lastActivitySeconds)} ago`;
+    countdownEl.textContent = formatDurationLabel(initialRemaining);
     setWarningState(initialRemaining);
 
     if (initialRemaining <= 0 && !timeoutLocked) {

--- a/assettrack/intake/templates/_timeout_status.html
+++ b/assettrack/intake/templates/_timeout_status.html
@@ -4,11 +4,14 @@
       <strong>Session status:</strong>
       <span id="timeout-lock-state">Active</span>
       <br />
+      <strong>Session timeout:</strong>
+      {{ format_duration_label(timeout_seconds) }} idle / {{ format_duration_label(session_absolute_timeout_seconds) }} absolute
+      <br />
       <strong>Timeout in:</strong>
-      <span id="timeout-countdown-seconds" class="timeout-countdown"></span>s
+      <span id="timeout-countdown-seconds" class="timeout-countdown">{{ format_duration_label([timeout_seconds - last_seen_age_seconds, 0]|max) }}</span>
       <br />
       <strong>Last activity:</strong>
-      <span id="last-activity-seconds">{{ last_seen_age_seconds }}</span>s ago
+      <span id="last-activity-seconds" data-last-activity-seconds="{{ last_seen_age_seconds }}">{{ format_duration_label(last_seen_age_seconds) }} ago</span>
     </p>
     <span id="timeout-seconds" hidden>{{ timeout_seconds }}</span>
   </div>

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -70,6 +70,8 @@ def test_add_assets_and_preview_render_timeout_lock_targets(client_with_temp_db)
     assert preview.status_code == 200
     assert b'id="timeout-lock-panel"' in preview.data
     assert b'id="timeout-lock-state">Active<' in preview.data
+    assert b"20 minutes idle / 1 hour absolute" in preview.data
+    assert b"0 seconds ago" in preview.data
     assert b'class="timeout-countdown"' in preview.data
     assert b'remainingSeconds <= 10 && remainingSeconds > 0' in preview.data
     assert b'classList.add("timeout-warning")' in preview.data
@@ -94,6 +96,7 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     issue_queue = client_with_temp_db.get("/issue")
     assert issue_queue.status_code == 200
     assert b'id="timeout-lock-panel"' in issue_queue.data
+    assert b"20 minutes idle / 1 hour absolute" in issue_queue.data
     assert b"Open Issue Assets Preview / Confirm" in issue_queue.data
     assert issue_queue.data.count(b"data-timeout-lock-target") >= 4
 


### PR DESCRIPTION
## Summary
Make the session timeout panel human readable instead of showing raw seconds.

## Related Issue
Closes #586 

## Changes
- format timeout durations as readable text
- keep live countdown text human readable as it updates
- preserve raw numeric values for lock timing logic
- update timeout UI tests for the new display

## Verification checklist
- [x] Targeted tests passed
- [x] Manual smoke test passed
- [x] Timeout panel shows readable durations
- [x] Timeout behavior unchanged

## Notes
Display-only change. No auth, schema, persistence, or workflow behavior changed.