### PR TITLE
Issue 26-147: render admin user timestamps in human-readable format

### DIFF
--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -70,8 +70,8 @@
             <td>{{ user.username }}</td>
             <td>{{ user.role }}</td>
             <td>{{ "yes" if user.active else "no" }}</td>
-            <td><code>{{ user.created_at }}</code></td>
-            <td><code>{{ user.updated_at }}</code></td>
+            <td>{{ user.created_at_display }}</td>
+            <td>{{ user.updated_at_display }}</td>
             <td>
               <form class="inline-form" method="post" action="{{ url_for('admin_users_toggle_active', user_id=user.id) }}">
                 <input type="hidden" name="active" value="{{ 0 if user.active else 1 }}" />


### PR DESCRIPTION
## Summary
Render admin user timestamps using the existing human-readable display fields instead of raw ISO values.

## Related Issue
Closes #588 

## Changes
- update admin users template to use formatted timestamp fields
- keep Created and Updated columns readable and consistent
- reuse existing route-prepared display values

## Verification checklist
- [x] Targeted tests passed
- [x] Nearby admin user regression tests passed
- [x] Manual smoke test passed
- [x] Admin user timestamps display in readable format

## Notes
Template-only change. No auth, schema, persistence, timezone, or workflow behavior changed.