### PR TITLE
Issue 26-68: add admin UI for holder CSV import

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -17,6 +17,7 @@ import os
 import re
 import sqlite3
 import smtplib
+import tempfile
 import time
 from email.message import EmailMessage
 from email.utils import getaddresses
@@ -57,6 +58,7 @@ from assettrack.auth import (
     require_role,
 )
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, update_holder
+from assettrack.holder_import import HolderImportReport, import_holders_csv
 from assettrack.reference_data import (
     create_building,
     create_organization,
@@ -5891,6 +5893,53 @@ def admin_system():
         asset_count=asset_count,
         schema_warning=schema_warning,
     )
+
+
+@app.route("/admin/holders/import", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_holder_import():
+    report: HolderImportReport | None = None
+
+    if request.method == "POST":
+        upload = request.files.get("csv_file")
+        filename = str((upload.filename if upload is not None else "") or "").strip()
+        if upload is None or not filename:
+            flash("Choose a CSV file to import.", "error")
+            return render_template("admin_holder_import.html", report=None)
+
+        suffix = Path(filename).suffix or ".csv"
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+                upload.save(handle)
+                temp_path = Path(handle.name)
+
+            report = import_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
+            summary = report.summary()
+            if report.errors:
+                flash(
+                    (
+                        f"Holder import failed. Processed {summary['processed']} row"
+                        f"{'' if summary['processed'] == 1 else 's'} with {summary['errors']} error"
+                        f"{'' if summary['errors'] == 1 else 's'}."
+                    ),
+                    "error",
+                )
+            else:
+                flash(
+                    (
+                        f"Holder import complete. Processed {summary['processed']} row"
+                        f"{'' if summary['processed'] == 1 else 's'}: created {summary['created']}, "
+                        f"updated {summary['updated']}."
+                    ),
+                    "success",
+                )
+        finally:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+
+    return render_template("admin_holder_import.html", report=report)
 
 
 def _load_admin_human_report_data(resolved_db_path: Path, *, include_retired_assets: bool = True) -> dict:

--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block title %}Import Holders{% endblock %}
+{% block page_heading %}Admin: Import Holders{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .import-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
+    .import-summary { margin: 0; }
+    .import-errors { margin: 0.75rem 0 0 1.25rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <p><a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a></p>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card">
+    <h2>Holder CSV Import</h2>
+    <p class="import-help">Upload a CSV with the existing holder import columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
+    <form method="post" enctype="multipart/form-data">
+      <div class="row">
+        <label for="csv_file"><strong>CSV file</strong></label><br />
+        <input id="csv_file" type="file" name="csv_file" accept=".csv,text/csv" required />
+      </div>
+      <button type="submit">Import Holders</button>
+    </form>
+  </div>
+
+  {% if report is not none %}
+    <div class="card">
+      <h2>Import Result</h2>
+      <p class="import-summary">
+        <strong>Processed:</strong> {{ report.processed }}
+        &nbsp;|&nbsp;
+        <strong>Created:</strong> {{ report.created }}
+        &nbsp;|&nbsp;
+        <strong>Updated:</strong> {{ report.updated }}
+        &nbsp;|&nbsp;
+        <strong>Errors:</strong> {{ report.errors|length }}
+      </p>
+      {% if report.errors %}
+        <ul class="import-errors">
+          {% for error in report.errors %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -14,6 +14,7 @@
   <div class="card">
     <h2>Admin Tools</h2>
     <p><a class="nav-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
+    <p><a class="nav-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a></p>
     <p><a class="nav-link" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
     <p><a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a></p>
     <table>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from io import BytesIO
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b'id="holder-count">1<' in response.data
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
+    assert b"Import Holders from CSV" in response.data
     assert b"Open Human-Readable Report" in response.data
     assert b"Download Database Backup" in response.data
 
@@ -124,6 +126,80 @@ def test_operator_is_forbidden_for_system_health(client_with_temp_db) -> None:
     response = client_with_temp_db.get("/admin/system")
 
     assert response.status_code == 403
+
+
+def test_operator_is_forbidden_for_holder_import_page(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-import", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.get("/admin/holders/import")
+
+    assert response.status_code == 403
+
+
+def test_admin_can_import_holders_from_csv(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-import", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.post(
+        "/admin/holders/import",
+        data={
+            "csv_file": (
+                BytesIO(b"organization,name,email\nOps Alpha,Jane Doe,jane@example.org\n"),
+                "holders.csv",
+            )
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Holder import complete. Processed 1 row: created 1, updated 0." in response.data
+    assert b"Processed:</strong> 1" in response.data
+    assert b"Created:</strong> 1" in response.data
+    assert b"Updated:</strong> 0" in response.data
+    assert b"Errors:</strong> 0" in response.data
+
+    conn = db.get_connection()
+    try:
+        holder = conn.execute(
+            "SELECT name, organization, email FROM holders WHERE email = ?;",
+            ("jane@example.org",),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert holder is not None
+    assert dict(holder) == {"name": "Jane Doe", "organization": "Ops Alpha", "email": "jane@example.org"}
+
+
+def test_admin_holder_import_surfaces_existing_validation_errors(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-import-error", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.post(
+        "/admin/holders/import",
+        data={
+            "csv_file": (
+                BytesIO(b"organization,name,email\nOps Alpha,,jane@example.org\n"),
+                "holders.csv",
+            )
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Holder import failed. Processed 1 row with 1 error." in response.data
+    assert b"Row 2: name is required" in response.data
+
+    conn = db.get_connection()
+    try:
+        holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+    finally:
+        conn.close()
+
+    assert holder_count == 0
 
 
 def test_operator_is_forbidden_for_human_readable_report(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Add an admin UI to upload a CSV and run the existing holder import from the browser.

## Related Issue
Closes #423 

## Changes
- add admin route for holder CSV upload
- add import UI with file upload and result display
- reuse existing import logic without modification
- surface success counts and validation errors clearly

## Verification checklist
- [x] Targeted tests passed
- [x] Manual upload test passed (valid + invalid CSV)
- [x] Import results displayed clearly
- [x] Non-admin access blocked

## Notes
Thin UI wrapper only. No import logic, schema, persistence, or workflow changes.