### PR TITLE
Issue 26-67B: add holder active flag and assignment filtering

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -172,6 +172,8 @@ def bootstrap_db(db_path: Path) -> bool:
     Returns True when first-run bootstrap was performed.
     """
     initialized = initialize_if_missing_or_empty(db_path)
+    if not initialized:
+        initialize_schema(db_path)
     assert_schema_present(db_path)
     return initialized
 
@@ -414,6 +416,7 @@ def _create_schema(conn: sqlite3.Connection):
             name TEXT NOT NULL,
             organization TEXT NULL,
             organization_id INTEGER NULL REFERENCES organizations(id),
+            is_active INTEGER NOT NULL DEFAULT 1 CHECK(is_active IN (0, 1)),
             identifier TEXT NULL,
             email TEXT NULL,
             contact_info TEXT NULL,
@@ -512,6 +515,13 @@ def _create_schema(conn: sqlite3.Connection):
             """
             ALTER TABLE holders
             ADD COLUMN email TEXT NULL;
+            """
+        )
+    if _table_exists(conn, "holders") and not _column_exists(conn, "holders", "is_active"):
+        cursor.execute(
+            """
+            ALTER TABLE holders
+            ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;
             """
         )
 

--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -47,7 +47,7 @@ def _ensure_unique_holder_email(
     raise ValueError("email already exists")
 
 
-def search_holders(query: str, limit: int = 20) -> list[dict]:
+def search_holders(query: str, limit: int = 20, *, active_only: bool = False) -> list[dict]:
     q = (query or "").strip()
     if not q:
         return []
@@ -59,14 +59,18 @@ def search_holders(query: str, limit: int = 20) -> list[dict]:
 
     conn = get_connection()
     try:
+        where_clauses = ["(name LIKE ? OR identifier LIKE ? OR organization LIKE ?)"]
+        params: list[object] = [pattern, pattern, pattern]
+        if active_only:
+            where_clauses.append("COALESCE(is_active, 1) = 1")
         cursor = conn.execute(
-            """
+            f"""
             SELECT * FROM holders
-            WHERE name LIKE ? OR identifier LIKE ? OR organization LIKE ?
+            WHERE {' AND '.join(where_clauses)}
             ORDER BY name ASC, id ASC
             LIMIT ?;
             """,
-            (pattern, pattern, pattern, limit),
+            (*params, limit),
         )
         rows = cursor.fetchall()
         return [dict(row) for row in rows]
@@ -74,16 +78,18 @@ def search_holders(query: str, limit: int = 20) -> list[dict]:
         conn.close()
 
 
-def list_holders() -> list[dict]:
+def list_holders(*, active_only: bool = False) -> list[dict]:
     conn = get_connection()
     try:
+        where_sql = "WHERE COALESCE(h.is_active, 1) = 1" if active_only else ""
         rows = conn.execute(
-            """
+            f"""
             SELECT
                 h.id,
                 h.holder_type,
                 h.name,
                 h.organization,
+                h.is_active,
                 h.identifier,
                 h.email,
                 h.contact_info,
@@ -91,7 +97,8 @@ def list_holders() -> list[dict]:
             FROM holders h
             LEFT JOIN assets a
               ON a.current_holder_id = h.id
-            GROUP BY h.id, h.holder_type, h.name, h.organization, h.identifier, h.email, h.contact_info
+            {where_sql}
+            GROUP BY h.id, h.holder_type, h.name, h.organization, h.is_active, h.identifier, h.email, h.contact_info
             ORDER BY h.name COLLATE NOCASE ASC, h.id ASC;
             """
         ).fetchall()
@@ -233,6 +240,40 @@ def update_holder(
                 now_iso,
                 normalized_id,
             ),
+        )
+        if cursor.rowcount != 1:
+            raise ValueError("holder not found")
+        conn.commit()
+        row = conn.execute(
+            """
+            SELECT * FROM holders
+            WHERE id = ?;
+            """,
+            (normalized_id,),
+        ).fetchone()
+        return dict(row)
+    finally:
+        conn.close()
+
+
+def set_holder_active(holder_id: int, is_active: bool) -> dict:
+    try:
+        normalized_id = int(holder_id)
+    except (TypeError, ValueError) as e:
+        raise ValueError("holder_id is required") from e
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    normalized_active = 1 if bool(is_active) else 0
+
+    conn = get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            UPDATE holders
+            SET is_active = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (normalized_active, now_iso, normalized_id),
         )
         if cursor.rowcount != 1:
             raise ValueError("holder not found")

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -57,7 +57,7 @@ from assettrack.auth import (
     require_login,
     require_role,
 )
-from assettrack.holders import create_holder, get_holder, list_holders, search_holders, update_holder
+from assettrack.holders import create_holder, get_holder, list_holders, search_holders, set_holder_active, update_holder
 from assettrack.holder_import import HolderImportReport, import_holders_csv
 from assettrack.reference_data import (
     create_building,
@@ -2247,15 +2247,27 @@ def _retire_admin_asset_in_tx(
     }
 
 
-def _selected_holder_from_session() -> Optional[dict]:
+def _holder_is_active(holder: Optional[dict]) -> bool:
+    if holder is None:
+        return False
+    return int(holder.get("is_active") or 0) == 1
+
+
+def _selected_holder_from_session(*, require_active: bool = False) -> Optional[dict]:
     holder_id = session.get("holder_id")
     if holder_id is None:
         return None
 
     holder = get_holder(holder_id)
-    if holder is None:
+    if holder is None or (require_active and not _holder_is_active(holder)):
         session.pop("holder_id", None)
+        return None
     return holder
+
+
+def _holder_selection_requires_active_filter(return_to: Optional[str]) -> bool:
+    normalized = str(return_to or "").strip()
+    return normalized.startswith("/issue")
 
 
 def _issue_location_form_from_session() -> dict[str, str]:
@@ -3506,7 +3518,7 @@ def intake():
 
         if scan_text:
             if return_to_path == "/issue":
-                selected_holder = _selected_holder_from_session()
+                selected_holder = _selected_holder_from_session(require_active=True)
                 issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
                     selected_holder,
                     _issue_location_form_from_session(),
@@ -3985,7 +3997,7 @@ def preview():
         valid=is_valid,
         validation=validation,
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
-        selected_holder=_selected_holder_from_session(),
+        selected_holder=_selected_holder_from_session(require_active=bool(session.get("issue_mode"))),
         issue_mode=bool(session.get("issue_mode")),
         last_seen_age_seconds=seconds_since_last_seen(),
         timeout_seconds=INTAKE_TIMEOUT_SECONDS,
@@ -4131,7 +4143,7 @@ def preview_commit():
 
     # Issue commit mode
 
-    holder = _selected_holder_from_session()
+    holder = _selected_holder_from_session(require_active=True)
     if holder is None:
         if wants_json():
             return {
@@ -4205,7 +4217,7 @@ def issue():
     if session.get("last_seen") is None:
         touch_session()
 
-    selected_holder = _selected_holder_from_session()
+    selected_holder = _selected_holder_from_session(require_active=True)
     if selected_holder is None:
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("holders_search", return_to=url_for("issue")))
@@ -4273,7 +4285,7 @@ def issue_location_update():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("add_assets"))
 
-    selected_holder = _selected_holder_from_session()
+    selected_holder = _selected_holder_from_session(require_active=True)
     if selected_holder is None:
         flash("Select a holder before issuing assets.", "error")
         return redirect(url_for("holders_search", return_to=url_for("issue")))
@@ -4305,7 +4317,7 @@ def issue_preview():
         flash("Use the Issue workflow before opening Issue Assets Preview.", "error")
         return redirect(url_for("issue"))
 
-    selected_holder = _selected_holder_from_session()
+    selected_holder = _selected_holder_from_session(require_active=True)
     issue_location_form, issue_location_errors, issue_location_context = _validate_issue_location_form(
         selected_holder,
         _issue_location_form_from_session(),
@@ -4375,7 +4387,7 @@ def issue_commit():
         preview_response = issue_preview()
         return preview_response, 400
 
-    holder = _selected_holder_from_session()
+    holder = _selected_holder_from_session(require_active=True)
     if holder is None:
         if wants_json():
             return {"ok": False, "committed": 0, "error": "Select a holder before issuing assets."}, 400
@@ -4615,14 +4627,16 @@ def holders_search():
 
     query = (request.args.get("q") or "").strip()
     return_to = _safe_local_return_to(request.args.get("return_to") or "")
-    results = search_holders(query) if query else list_holders()
+    active_only = _holder_selection_requires_active_filter(return_to)
+    results = search_holders(query, active_only=active_only) if query else list_holders(active_only=active_only)
 
     return render_template(
         "holders_search.html",
         query=query,
         return_to=return_to,
         results=results,
-        selected_holder=_selected_holder_from_session(),
+        selected_holder=_selected_holder_from_session(require_active=active_only),
+        selection_active_only=active_only,
     )
 
 
@@ -5819,25 +5833,31 @@ def holders_select():
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
-    return_to = (request.form.get("return_to") or "").strip()
+    return_to = _safe_local_return_to(request.form.get("return_to") or request.args.get("return_to") or "")
     holder_id_raw = (request.form.get("holder_id") or "").strip()
     if not holder_id_raw:
         flash("Select a holder first.", "error")
-        if return_to.startswith("/") and not return_to.startswith("//"):
+        if return_to is not None:
             return redirect(url_for("holders_search", return_to=return_to))
         return redirect(url_for("holders_search"))
 
     holder = get_holder(holder_id_raw)
     if holder is None:
         flash("Selected holder not found.", "error")
-        if return_to.startswith("/") and not return_to.startswith("//"):
+        if return_to is not None:
+            return redirect(url_for("holders_search", return_to=return_to))
+        return redirect(url_for("holders_search"))
+    if not _holder_is_active(holder):
+        session.pop("holder_id", None)
+        flash("Inactive holders cannot be selected for assignment.", "error")
+        if return_to is not None:
             return redirect(url_for("holders_search", return_to=return_to))
         return redirect(url_for("holders_search"))
 
     session["holder_id"] = holder["id"]
     touch_session()
     flash(f"Selected holder: {_holder_display_name(holder)}", "success")
-    if return_to.startswith("/") and not return_to.startswith("//"):
+    if return_to is not None:
         return redirect(return_to)
     return redirect(url_for("holders_search"))
 
@@ -5854,6 +5874,29 @@ def holders_clear():
     touch_session()
     flash("Cleared holder selection.", "success")
     return redirect(url_for("holders_search"))
+
+
+@app.post("/holders/<int:holder_id>/toggle-active")
+@require_login
+@require_role("admin")
+def holders_toggle_active(holder_id: int):
+    return_to = _safe_local_return_to(request.form.get("return_to") or "")
+    requested = request.form.get("is_active")
+    next_active = _is_truthy(requested)
+
+    try:
+        updated = set_holder_active(holder_id, next_active)
+    except ValueError as exc:
+        flash(str(exc), "error")
+    else:
+        state = "active" if _holder_is_active(updated) else "inactive"
+        flash(f"Holder { _holder_display_name(updated) } is now {state}.", "success")
+        if not _holder_is_active(updated) and session.get("holder_id") == int(updated["id"]):
+            session.pop("holder_id", None)
+
+    if return_to is not None:
+        return redirect(return_to)
+    return redirect(url_for("holder_detail", holder_id=holder_id))
 
 
 @app.get("/admin/users")

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -107,10 +107,32 @@
     .holder-detail-item {
       color: var(--color-text-muted);
     }
+    .holder-status-chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+      font-size: 0.88rem;
+      font-weight: 700;
+      background: var(--color-primary-soft);
+      color: var(--color-primary);
+    }
+    .holder-status-chip.inactive {
+      background: #fde9e7;
+      color: #8a2d2d;
+    }
   </style>
 {% endblock %}
 
 {% block content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
   <div class="page-header-bar">
     <nav class="page-header-nav" aria-label="Holder navigation">
       {% if return_to == url_for('human_report') %}
@@ -120,13 +142,17 @@
     </nav>
     <div class="page-header-actions" aria-label="Holder actions">
       {% set passive_return_target = url_for('holder_detail', holder_id=holder.id, return_to=return_to) %}
-      <form method="post" action="{{ url_for('holders_select') }}">
-        <input type="hidden" name="holder_id" value="{{ holder.id }}" />
-        {% if return_to and return_to != url_for('human_report') %}
-          <input type="hidden" name="return_to" value="{{ return_to }}" />
-        {% endif %}
-        <button type="submit">Select Holder</button>
-      </form>
+      {% if holder.get("is_active", 1) %}
+        <form method="post" action="{{ url_for('holders_select') }}">
+          <input type="hidden" name="holder_id" value="{{ holder.id }}" />
+          {% if return_to and return_to != url_for('human_report') %}
+            <input type="hidden" name="return_to" value="{{ return_to }}" />
+          {% endif %}
+          <button type="submit">Select Holder</button>
+        </form>
+      {% else %}
+        <span class="holder-status-chip inactive">Inactive holder</span>
+      {% endif %}
       {% if return_to == url_for('human_report') %}
         <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id, return_to=passive_return_target) }}">Edit Holder</a>
       {% elif return_to %}
@@ -134,12 +160,25 @@
       {% else %}
         <a class="chip" href="{{ url_for('holders_edit', holder_id=holder.id) }}">Edit Holder</a>
       {% endif %}
+      {% if authenticated_role == 'admin' %}
+        <form method="post" action="{{ url_for('holders_toggle_active', holder_id=holder.id) }}">
+          <input type="hidden" name="is_active" value="{{ 0 if holder.get('is_active', 1) else 1 }}" />
+          <input type="hidden" name="return_to" value="{{ request.full_path.rstrip('?') }}" />
+          <button type="submit">{{ "Deactivate Holder" if holder.get("is_active", 1) else "Reactivate Holder" }}</button>
+        </form>
+      {% endif %}
     </div>
   </div>
 
   <section class="holder-identity" aria-label="Holder identity">
     <div class="holder-kicker">{{ holder_display_type(holder) }}</div>
     <div class="holder-context">
+      <div class="holder-context-item">
+        <strong>Status:</strong>
+        <span class="holder-status-chip {% if not holder.get('is_active', 1) %}inactive{% endif %}">
+          {{ "Active" if holder.get("is_active", 1) else "Inactive" }}
+        </span>
+      </div>
       {% if holder.organization %}
         <div class="holder-context-item"><strong>Organization:</strong> {{ holder.organization }}</div>
       {% endif %}

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -15,6 +15,18 @@
       font-size: 1.2rem;
       font-weight: 700;
     }
+    .selected-holder-link,
+    .holder-name-link {
+      color: var(--color-primary);
+      text-decoration-thickness: 0.08em;
+      text-underline-offset: 0.16em;
+    }
+    .selected-holder-link:hover,
+    .selected-holder-link:focus-visible,
+    .holder-name-link:hover,
+    .holder-name-link:focus-visible {
+      color: color-mix(in srgb, var(--color-primary) 82%, var(--color-text));
+    }
     .selected-holder-subtle {
       margin: 0.22rem 0 0 0;
       color: var(--color-text-muted);
@@ -26,6 +38,34 @@
       margin-top: 0.65rem;
       color: var(--color-text-muted);
       font-size: 0.94rem;
+    }
+    .holder-status {
+      font-weight: 700;
+    }
+    .holder-status.inactive {
+      color: #8a2d2d;
+    }
+    .holder-select-form {
+      margin: 0;
+    }
+    .holder-select-button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 8.75rem;
+      cursor: pointer;
+      box-shadow: 0 1px 2px rgba(15, 23, 42, 0.16);
+      transition: background 0.16s ease, border-color 0.16s ease, box-shadow 0.16s ease, transform 0.16s ease;
+    }
+    .holder-select-button:hover,
+    .holder-select-button:focus-visible {
+      background: color-mix(in srgb, var(--color-primary) 88%, black);
+      border-color: color-mix(in srgb, var(--color-primary) 88%, black);
+      box-shadow: 0 4px 10px rgba(15, 23, 42, 0.2);
+    }
+    .holder-select-button:active {
+      transform: translateY(1px);
+      box-shadow: 0 1px 3px rgba(15, 23, 42, 0.18);
     }
   </style>
 {% endblock %}
@@ -67,13 +107,22 @@
       />
       <button type="submit">Search</button>
     </form>
+    {% if selection_active_only %}
+      <p class="muted" style="margin: 0.75rem 0 0 0;">Inactive holders are hidden during assignment selection.</p>
+    {% endif %}
   </div>
 
   <div class="card">
     <h2>Selected Holder</h2>
     {% if selected_holder %}
       <p class="muted" style="margin: 0 0 0.2rem 0; font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase;">Current selection</p>
-      <p class="selected-holder-name">{{ holder_display_name(selected_holder) }}</p>
+      <p class="selected-holder-name">
+        {% if return_to %}
+          <a class="selected-holder-link" href="{{ url_for('holder_detail', holder_id=selected_holder['id'], return_to=return_to) }}">{{ holder_display_name(selected_holder) }}</a>
+        {% else %}
+          <a class="selected-holder-link" href="{{ url_for('holder_detail', holder_id=selected_holder['id']) }}">{{ holder_display_name(selected_holder) }}</a>
+        {% endif %}
+      </p>
       {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
         <p class="selected-holder-subtle">{{ selected_holder["organization"] }}</p>
       {% endif %}
@@ -106,6 +155,7 @@
             <th style="width: 220px;">Name</th>
             <th style="width: 200px;">Organization</th>
             <th style="width: 220px;">Email</th>
+            <th style="width: 120px;">Status</th>
             <th style="width: 100px;">Assets</th>
             <th style="width: 120px;">Edit</th>
             <th style="width: 120px;">Select</th>
@@ -117,13 +167,18 @@
               <td>{{ holder_display_type(h) }}</td>
               <td>
                 {% if return_to %}
-                  <a href="{{ url_for('holder_detail', holder_id=h['id'], return_to=return_to) }}">{{ holder_display_name(h) }}</a>
+                  <a class="holder-name-link" href="{{ url_for('holder_detail', holder_id=h['id'], return_to=return_to) }}">{{ holder_display_name(h) }}</a>
                 {% else %}
-                  <a href="{{ url_for('holder_detail', holder_id=h['id']) }}">{{ holder_display_name(h) }}</a>
+                  <a class="holder-name-link" href="{{ url_for('holder_detail', holder_id=h['id']) }}">{{ holder_display_name(h) }}</a>
                 {% endif %}
               </td>
               <td>{{ h["organization"] or "" }}</td>
               <td>{{ h["email"] or "" }}</td>
+              <td>
+                <span class="holder-status {% if not h.get('is_active', 1) %}inactive{% endif %}">
+                  {{ "Active" if h.get("is_active", 1) else "Inactive" }}
+                </span>
+              </td>
               <td>{{ h.get("asset_count", "") }}</td>
               <td>
                 {% if return_to %}
@@ -133,13 +188,17 @@
                 {% endif %}
               </td>
               <td>
-                <form method="post" action="{{ url_for('holders_select') }}">
-                  <input type="hidden" name="holder_id" value="{{ h['id'] }}" />
-                  {% if return_to %}
-                    <input type="hidden" name="return_to" value="{{ return_to }}" />
-                  {% endif %}
-                  <button type="submit">Select</button>
-                </form>
+                {% if h.get("is_active", 1) %}
+                  <form class="holder-select-form" method="post" action="{{ url_for('holders_select', return_to=return_to) if return_to else url_for('holders_select') }}">
+                    <input type="hidden" name="holder_id" value="{{ h['id'] }}" />
+                    {% if return_to %}
+                      <input type="hidden" name="return_to" value="{{ return_to }}" />
+                    {% endif %}
+                    <button class="holder-select-button" type="submit">{{ "Select for Issue" if return_to == url_for('issue') else "Select" }}</button>
+                  </form>
+                {% else %}
+                  <span class="muted">Inactive</span>
+                {% endif %}
               </td>
             </tr>
           {% endfor %}

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -54,6 +54,118 @@ def test_bootstrap_db_bootstraps_missing_db(tmp_path: Path) -> None:
     db.assert_schema_present(db_path)
 
 
+def test_bootstrap_db_applies_holder_is_active_migration_to_existing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                organization_id INTEGER NULL,
+                identifier TEXT NULL,
+                email TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE organizations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE buildings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE organization_buildings (
+                organization_id INTEGER NOT NULL,
+                building_id INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (organization_id, building_id)
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE receipt_queue (
+                id INTEGER PRIMARY KEY,
+                receipt_key TEXT NOT NULL UNIQUE,
+                receipt_type TEXT NOT NULL,
+                source_event_ids_json TEXT NOT NULL,
+                snapshot_json TEXT NOT NULL,
+                commit_at TEXT NOT NULL,
+                commit_operator_user_id INTEGER NOT NULL,
+                holder_id INTEGER NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO holders (id, holder_type, name, organization, organization_id, identifier, email, contact_info, created_at, updated_at)
+            VALUES (1, 'PERSON', 'Jane Holder', 'Ops Alpha', NULL, NULL, 'jane@example.org', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    initialized = db.bootstrap_db(db_path)
+
+    assert initialized is False
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(holders);").fetchall()}
+        holder = conn.execute("SELECT is_active FROM holders WHERE id = 1;").fetchone()
+    finally:
+        conn.close()
+
+    assert "is_active" in columns
+    assert holder is not None
+    assert holder[0] == 1
+
+
 def test_get_connection_bootstraps_missing_db(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     db_path = tmp_path / "assettrack.db"
     monkeypatch.setattr(db, "DB_PATH", db_path)
@@ -67,6 +179,110 @@ def test_get_connection_bootstraps_missing_db(monkeypatch: pytest.MonkeyPatch, t
     assert "assets" in tables
     assert "asset_events" in tables
     assert "receipt_queue" in tables
+
+
+def test_get_connection_applies_holder_is_active_migration_to_existing_db(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                organization_id INTEGER NULL,
+                identifier TEXT NULL,
+                email TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE organizations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE buildings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE organization_buildings (
+                organization_id INTEGER NOT NULL,
+                building_id INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (organization_id, building_id)
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE receipt_queue (
+                id INTEGER PRIMARY KEY,
+                receipt_key TEXT NOT NULL UNIQUE,
+                receipt_type TEXT NOT NULL,
+                source_event_ids_json TEXT NOT NULL,
+                snapshot_json TEXT NOT NULL,
+                commit_at TEXT NOT NULL,
+                commit_operator_user_id INTEGER NOT NULL,
+                holder_id INTEGER NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(db, "DB_PATH", db_path)
+
+    conn = db.get_connection()
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(holders);").fetchall()}
+    finally:
+        conn.close()
+
+    assert "is_active" in columns
 
 
 def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> None:
@@ -83,6 +299,7 @@ def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> N
     assert "organization" in columns
     assert "organization_id" in columns
     assert "email" in columns
+    assert "is_active" in columns
     assert "organizations" in tables
     assert "buildings" in tables
     assert "organization_buildings" in tables
@@ -292,6 +509,70 @@ def test_initialize_schema_adds_holder_email_column_to_existing_db(tmp_path: Pat
         conn.close()
 
     assert "email" in columns
+
+
+def test_initialize_schema_adds_holder_is_active_column_to_existing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                organization_id INTEGER NULL,
+                identifier TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO holders (id, holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at)
+            VALUES (1, 'PERSON', 'Jane Holder', 'Ops Alpha', NULL, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(holders);").fetchall()}
+        holder = conn.execute("SELECT is_active FROM holders WHERE id = 1;").fetchone()
+    finally:
+        conn.close()
+
+    assert "is_active" in columns
+    assert holder is not None
+    assert holder[0] == 1
 
 
 def test_initialize_if_missing_or_empty_does_not_mask_invalid_nonempty_db(tmp_path: Path) -> None:

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -362,6 +362,125 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Bravo Holder", response.data)
         self.assertIn(b"Search by person name, group, organization, or identifier", response.data)
 
+    def test_inactive_holder_is_hidden_from_issue_selection_search(self) -> None:
+        organization_id = self._create_org("Issue Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Inactive Issue Holder", "organization_id": str(organization_id), "email": "inactive-issue@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Inactive Issue Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        admin_id = create_test_user(username="admin-holder-toggle", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        toggle_response = self.client.post(
+            f"/holders/{holder_id}/toggle-active",
+            data={"is_active": "0", "return_to": f"/holders/{holder_id}"},
+            follow_redirects=True,
+        )
+        self.assertEqual(toggle_response.status_code, 200)
+        self.assertIn(b"is now inactive", toggle_response.data)
+
+        operator_id = create_test_user(username="operator-holder-filter", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+        response = self.client.get("/holders?return_to=/issue")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Inactive holders are hidden during assignment selection.", response.data)
+        self.assertNotIn(b"Inactive Issue Holder", response.data)
+
+    def test_inactive_holder_cannot_be_selected_but_detail_still_renders(self) -> None:
+        organization_id = self._create_org("Issue Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Inactive Select Holder", "organization_id": str(organization_id), "email": "inactive-select@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Inactive Select Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        admin_id = create_test_user(username="admin-inactive-select", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.client.post(
+            f"/holders/{holder_id}/toggle-active",
+            data={"is_active": "0", "return_to": f"/holders/{holder_id}"},
+        )
+
+        operator_id = create_test_user(username="operator-inactive-select", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        select_response = self.client.post(
+            "/holders/select",
+            data={"holder_id": str(holder_id), "return_to": "/issue"},
+            follow_redirects=True,
+        )
+        self.assertEqual(select_response.status_code, 200)
+        self.assertIn(b"Inactive holders cannot be selected for assignment.", select_response.data)
+
+        detail_response = self.client.get(f"/holders/{holder_id}")
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertIn(b"Inactive holder", detail_response.data)
+        self.assertIn(b"Status:</strong>", detail_response.data)
+
+    def test_operator_cannot_toggle_holder_active_state(self) -> None:
+        organization_id = self._create_org("Ops Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Protected Holder", "organization_id": str(organization_id), "email": "protected@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Protected Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+
+        response = self.client.post(
+            f"/holders/{int(holder_row['id'])}/toggle-active",
+            data={"is_active": "0"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_issue_redirects_back_to_holder_selection_when_selected_holder_becomes_inactive(self) -> None:
+        organization_id = self._create_org("Issue Org")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Workflow Holder", "organization_id": str(organization_id), "email": "workflow-inactive@example.org"},
+        )
+        holder_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Workflow Holder",),
+        ).fetchone()
+        self.assertIsNotNone(holder_row)
+        holder_id = int(holder_row["id"])
+
+        with self.client.session_transaction() as sess:
+            sess["holder_id"] = holder_id
+
+        admin_id = create_test_user(username="admin-issue-inactive", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.client.post(
+            f"/holders/{holder_id}/toggle-active",
+            data={"is_active": "0", "return_to": f"/holders/{holder_id}"},
+        )
+
+        operator_id = create_test_user(username="operator-issue-inactive", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+        with self.client.session_transaction() as sess:
+            sess["holder_id"] = holder_id
+
+        response = self.client.get("/issue")
+
+        self.assertEqual(response.status_code, 302)
+        self.assertTrue((response.headers["Location"]).endswith("/holders?return_to=/issue"))
+
     def test_holder_detail_shows_metadata_and_assigned_assets(self) -> None:
         organization_id = self._create_org("Org Detail")
         self.client.post(

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import assettrack.db as db
-from assettrack.holders import create_holder, get_holder, list_holders, search_holders, update_holder
+from assettrack.holders import create_holder, get_holder, list_holders, search_holders, set_holder_active, update_holder
 
 
 class HoldersTests(unittest.TestCase):
@@ -33,10 +33,10 @@ class HoldersTests(unittest.TestCase):
         cursor = self.conn.execute(
             """
             INSERT INTO holders (
-                holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+                holder_type, name, organization, organization_id, is_active, identifier, contact_info, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
             """,
-            (holder_type, name, organization, organization_id, identifier, contact_info, now, now),
+            (holder_type, name, organization, organization_id, 1, identifier, contact_info, now, now),
         )
         self.conn.commit()
         return int(cursor.lastrowid)
@@ -93,6 +93,19 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual(len(by_organization), 1)
         self.assertEqual(by_organization[0]["name"], "Bravo Org")
 
+    def test_search_holders_active_only_excludes_inactive_rows(self) -> None:
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+        active_id = self._insert_holder("Person", "Active User", "Ad Hoc", ad_hoc_id, "A-001", None)
+        inactive_id = self._insert_holder("Person", "Inactive User", "Ad Hoc", ad_hoc_id, "I-001", None)
+        set_holder_active(inactive_id, False)
+
+        rows = search_holders("User", active_only=True)
+
+        self.assertEqual([row["name"] for row in rows], ["Active User"])
+        fetched_inactive = get_holder(inactive_id)
+        self.assertIsNotNone(fetched_inactive)
+        self.assertEqual(int(fetched_inactive["is_active"]), 0)
+
     def test_list_holders_includes_asset_count(self) -> None:
         ad_hoc_id = self._insert_organization("Ad Hoc")
         alpha_id = self._insert_holder("Person", "Alpha User", "Ad Hoc", ad_hoc_id, "A-001", None)
@@ -112,6 +125,28 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual([row["name"] for row in rows], ["Alpha User", "Bravo Org"])
         self.assertEqual(int(rows[0]["asset_count"]), 2)
         self.assertEqual(int(rows[1]["asset_count"]), 0)
+
+    def test_list_holders_active_only_excludes_inactive_rows(self) -> None:
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+        active_id = self._insert_holder("Person", "Alpha User", "Ad Hoc", ad_hoc_id, "A-001", None)
+        inactive_id = self._insert_holder("Person", "Bravo User", "Ad Hoc", ad_hoc_id, "B-001", None)
+        set_holder_active(inactive_id, False)
+
+        rows = list_holders(active_only=True)
+
+        self.assertEqual([row["name"] for row in rows], ["Alpha User"])
+        self.assertEqual(int(rows[0]["id"]), active_id)
+
+    def test_set_holder_active_toggles_flag_without_removing_holder(self) -> None:
+        organization_id = self._insert_organization("Support Org")
+        created = create_holder("Stable Holder", organization_id=organization_id, email="stable@example.org")
+
+        updated = set_holder_active(int(created["id"]), False)
+        fetched = get_holder(int(created["id"]))
+
+        self.assertEqual(int(updated["is_active"]), 0)
+        self.assertIsNotNone(fetched)
+        self.assertEqual(int(fetched["is_active"]), 0)
 
     def test_create_and_update_holder_organization(self) -> None:
         alpha_org_id = self._insert_organization("Alpha Org")

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -6,7 +6,7 @@ import pytest
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from tests.auth_test_utils import create_test_user
+from tests.auth_test_utils import create_test_user, login_session
 
 
 @pytest.fixture
@@ -30,9 +30,7 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 def test_issue_requires_holder_selection_before_queue_access(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-prereq", password="op-pass", role="operator")
-
-    with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
+    login_session(client_with_temp_db, operator_id)
 
     response = client_with_temp_db.get("/issue")
 
@@ -43,9 +41,7 @@ def test_issue_requires_holder_selection_before_queue_access(client_with_temp_db
 
 def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-return", password="op-pass", role="operator")
-
-    with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
+    login_session(client_with_temp_db, operator_id)
 
     issue_redirect = client_with_temp_db.get("/issue")
     assert issue_redirect.status_code == 302
@@ -66,9 +62,7 @@ def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
 
 def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_holder(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-holders-issue-nav", password="op-pass", role="operator")
-
-    with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
+    login_session(client_with_temp_db, operator_id)
 
     holders_page = client_with_temp_db.get("/holders")
     assert holders_page.status_code == 200
@@ -91,11 +85,48 @@ def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_hol
     assert b"Enable issue mode before using Issue Assets." not in issue_page.data
 
 
+def test_holders_issue_selection_page_uses_issue_specific_action_label(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-issue-action-label", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.get("/holders?return_to=/issue")
+
+    assert response.status_code == 200
+    assert b"Select for Issue" in response.data
+    assert b'class="holder-select-button"' in response.data
+    assert b'href="/holders/1?return_to=/issue"' in response.data
+
+
+def test_holders_issue_selection_page_links_selected_holder_with_return_to(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-selected-holder-link", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    with client_with_temp_db.session_transaction() as sess:
+        sess["holder_id"] = 1
+
+    response = client_with_temp_db.get("/holders?return_to=/issue")
+
+    assert response.status_code == 200
+    assert b'class="selected-holder-link"' in response.data
+    assert b'href="/holders/1?return_to=/issue"' in response.data
+
+
+def test_holder_select_accepts_return_to_from_action_url_for_issue_flow(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-return-query", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.post(
+        "/holders/select?return_to=/issue",
+        data={"holder_id": "1"},
+    )
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+
+
 def test_issue_preview_without_issue_mode_redirects_to_issue_entry(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-issue-preview-redirect", password="op-pass", role="operator")
-
+    login_session(client_with_temp_db, operator_id)
     with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = False
 
@@ -107,9 +138,8 @@ def test_issue_preview_without_issue_mode_redirects_to_issue_entry(client_with_t
 
 def test_issue_with_selected_holder_still_loads_normally(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-selected", password="op-pass", role="operator")
-
+    login_session(client_with_temp_db, operator_id)
     with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 1
 
     response = client_with_temp_db.get("/issue")
@@ -121,9 +151,8 @@ def test_issue_with_selected_holder_still_loads_normally(client_with_temp_db) ->
 
 def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-holder-display", password="op-pass", role="operator")
-
+    login_session(client_with_temp_db, operator_id)
     with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 1
 
     response = client_with_temp_db.get("/issue")
@@ -149,8 +178,8 @@ def test_issue_page_displays_selected_group_holder_context(client_with_temp_db) 
     conn.commit()
     conn.close()
 
+    login_session(client_with_temp_db, operator_id)
     with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 2
 
     response = client_with_temp_db.get("/issue")


### PR DESCRIPTION
## Summary
Add holder deactivation using an `is_active` flag so inactive holders cannot be selected in assignment workflows while historical references remain intact.

## Related Issue
Closes #592 

## Changes
- add lightweight startup migration for `holders.is_active`
- default existing and new holders to active
- exclude inactive holders from issue assignment selection
- keep inactive holders visible in detail and historical views
- add admin activate/deactivate control for holders
- harden startup migration path for existing databases
- restore issue holder selection return flow
- improve holder selection affordance and detail navigation

## Verification checklist
- [x] Targeted tests passed
- [x] Startup migration regression tests passed
- [x] Manual Docker verification passed
- [x] Inactive holders hidden from issue selection
- [x] Holder detail still available for inactive holders
- [x] Reactivation restores issue selection visibility
- [x] Issue workflow seam completed successfully

## Notes
Class 3 change implemented with lightweight SQLite migration. No holder deletion, no event-history changes, and no workflow redesign.