### PR TITLE
Issue 26-145: add holder directory status filtering

### DIFF
--- a/assettrack/holders.py
+++ b/assettrack/holders.py
@@ -47,7 +47,21 @@ def _ensure_unique_holder_email(
     raise ValueError("email already exists")
 
 
-def search_holders(query: str, limit: int = 20, *, active_only: bool = False) -> list[dict]:
+def _holder_status_where_clause(status: str, *, column: str = "is_active") -> str:
+    if status == "active":
+        return f"COALESCE({column}, 1) = 1"
+    if status == "inactive":
+        return f"COALESCE({column}, 1) = 0"
+    return ""
+
+
+def search_holders(
+    query: str,
+    limit: int = 20,
+    *,
+    active_only: bool = False,
+    status: str = "all",
+) -> list[dict]:
     q = (query or "").strip()
     if not q:
         return []
@@ -59,10 +73,12 @@ def search_holders(query: str, limit: int = 20, *, active_only: bool = False) ->
 
     conn = get_connection()
     try:
+        normalized_status = "active" if active_only else str(status or "all").strip().lower()
         where_clauses = ["(name LIKE ? OR identifier LIKE ? OR organization LIKE ?)"]
         params: list[object] = [pattern, pattern, pattern]
-        if active_only:
-            where_clauses.append("COALESCE(is_active, 1) = 1")
+        status_clause = _holder_status_where_clause(normalized_status)
+        if status_clause:
+            where_clauses.append(status_clause)
         cursor = conn.execute(
             f"""
             SELECT * FROM holders
@@ -78,10 +94,12 @@ def search_holders(query: str, limit: int = 20, *, active_only: bool = False) ->
         conn.close()
 
 
-def list_holders(*, active_only: bool = False) -> list[dict]:
+def list_holders(*, active_only: bool = False, status: str = "all") -> list[dict]:
     conn = get_connection()
     try:
-        where_sql = "WHERE COALESCE(h.is_active, 1) = 1" if active_only else ""
+        normalized_status = "active" if active_only else str(status or "all").strip().lower()
+        status_clause = _holder_status_where_clause(normalized_status, column="h.is_active")
+        where_sql = f"WHERE {status_clause}" if status_clause else ""
         rows = conn.execute(
             f"""
             SELECT

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2270,6 +2270,13 @@ def _holder_selection_requires_active_filter(return_to: Optional[str]) -> bool:
     return normalized.startswith("/issue")
 
 
+def _holder_directory_status_filter(value: object) -> str:
+    normalized = str(value or "all").strip().lower()
+    if normalized in {"active", "inactive"}:
+        return normalized
+    return "all"
+
+
 def _issue_location_form_from_session() -> dict[str, str]:
     return {
         "building": str(session.get("issue_building") or "").strip(),
@@ -4628,7 +4635,12 @@ def holders_search():
     query = (request.args.get("q") or "").strip()
     return_to = _safe_local_return_to(request.args.get("return_to") or "")
     active_only = _holder_selection_requires_active_filter(return_to)
-    results = search_holders(query, active_only=active_only) if query else list_holders(active_only=active_only)
+    status_filter = "active" if active_only else _holder_directory_status_filter(request.args.get("status"))
+    results = (
+        search_holders(query, active_only=active_only, status=status_filter)
+        if query
+        else list_holders(active_only=active_only, status=status_filter)
+    )
 
     return render_template(
         "holders_search.html",
@@ -4637,6 +4649,7 @@ def holders_search():
         results=results,
         selected_holder=_selected_holder_from_session(require_active=active_only),
         selection_active_only=active_only,
+        status_filter=status_filter,
     )
 
 

--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -45,6 +45,27 @@
     .holder-status.inactive {
       color: #8a2d2d;
     }
+    .holder-status-filter {
+      display: flex;
+      align-items: end;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-top: 0.85rem;
+    }
+    .holder-status-filter label {
+      display: grid;
+      gap: 0.25rem;
+      font-weight: 700;
+    }
+    .holder-status-filter select {
+      min-width: 10rem;
+      min-height: 2.5rem;
+      padding: 0.5rem;
+      font-size: 1rem;
+    }
+    .holder-row-inactive {
+      background: var(--color-accent-soft);
+    }
     .holder-select-form {
       margin: 0;
     }
@@ -89,12 +110,19 @@
         <a class="chip" href="{{ url_for('holders_new') }}">Add Holder</a>
       {% endif %}
       {% if query %}
-        <a class="chip" href="{{ url_for('holders_search', return_to=return_to) }}">Clear Search</a>
+        {% if return_to %}
+          <a class="chip" href="{{ url_for('holders_search', return_to=return_to, status=status_filter) }}">Clear Search</a>
+        {% else %}
+          <a class="chip" href="{{ url_for('holders_search', status=status_filter) }}">Clear Search</a>
+        {% endif %}
       {% endif %}
     </div>
     <form method="get" action="{{ url_for('holders_search') }}">
       {% if return_to %}
         <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
+      {% if not selection_active_only %}
+        <input type="hidden" name="status" value="{{ status_filter }}" />
       {% endif %}
       <label for="q"><strong>Search by person name, group, organization, or identifier</strong></label><br />
       <input
@@ -107,6 +135,22 @@
       />
       <button type="submit">Search</button>
     </form>
+    {% if not selection_active_only %}
+      <form class="holder-status-filter" method="get" action="{{ url_for('holders_search') }}">
+        {% if query %}
+          <input type="hidden" name="q" value="{{ query }}" />
+        {% endif %}
+        <label for="status">
+          Holder status
+          <select id="status" name="status">
+            <option value="all" {% if status_filter == "all" %}selected{% endif %}>All holders</option>
+            <option value="active" {% if status_filter == "active" %}selected{% endif %}>Active only</option>
+            <option value="inactive" {% if status_filter == "inactive" %}selected{% endif %}>Inactive only</option>
+          </select>
+        </label>
+        <button type="submit">Apply Filter</button>
+      </form>
+    {% endif %}
     {% if selection_active_only %}
       <p class="muted" style="margin: 0.75rem 0 0 0;">Inactive holders are hidden during assignment selection.</p>
     {% endif %}
@@ -163,7 +207,7 @@
         </thead>
         <tbody>
           {% for h in results %}
-            <tr>
+            <tr class="{% if not h.get('is_active', 1) %}holder-row-inactive{% endif %}">
               <td>{{ holder_display_type(h) }}</td>
               <td>
                 {% if return_to %}

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -362,6 +362,46 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"Bravo Holder", response.data)
         self.assertIn(b"Search by person name, group, organization, or identifier", response.data)
 
+    def test_holders_directory_status_filter_shows_all_active_and_inactive(self) -> None:
+        organization_id = self._create_org("Ad Hoc")
+        self.client.post(
+            "/holders/new",
+            data={"name": "Active Directory Holder", "organization_id": str(organization_id), "email": "active-dir@example.org"},
+        )
+        self.client.post(
+            "/holders/new",
+            data={"name": "Inactive Directory Holder", "organization_id": str(organization_id), "email": "inactive-dir@example.org"},
+        )
+        inactive_row = self.conn.execute(
+            "SELECT id FROM holders WHERE name = ?;",
+            ("Inactive Directory Holder",),
+        ).fetchone()
+        self.assertIsNotNone(inactive_row)
+        inactive_id = int(inactive_row["id"])
+        self.conn.execute("UPDATE holders SET is_active = 0 WHERE id = ?;", (inactive_id,))
+        self.conn.commit()
+
+        all_response = self.client.get("/holders")
+        self.assertEqual(all_response.status_code, 200)
+        self.assertIn(b"Active Directory Holder", all_response.data)
+        self.assertIn(b"Inactive Directory Holder", all_response.data)
+        self.assertIn(b"Inactive", all_response.data)
+        self.assertIn(b"Holder status", all_response.data)
+
+        active_response = self.client.get("/holders?status=active")
+        self.assertEqual(active_response.status_code, 200)
+        self.assertIn(b"Active Directory Holder", active_response.data)
+        self.assertNotIn(b"Inactive Directory Holder", active_response.data)
+
+        inactive_response = self.client.get("/holders?status=inactive")
+        self.assertEqual(inactive_response.status_code, 200)
+        self.assertNotIn(b"Active Directory Holder", inactive_response.data)
+        self.assertIn(b"Inactive Directory Holder", inactive_response.data)
+
+        detail_response = self.client.get(f"/holders/{inactive_id}")
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertIn(b"Inactive holder", detail_response.data)
+
     def test_inactive_holder_is_hidden_from_issue_selection_search(self) -> None:
         organization_id = self._create_org("Issue Org")
         self.client.post(

--- a/tests/test_holders.py
+++ b/tests/test_holders.py
@@ -137,6 +137,30 @@ class HoldersTests(unittest.TestCase):
         self.assertEqual([row["name"] for row in rows], ["Alpha User"])
         self.assertEqual(int(rows[0]["id"]), active_id)
 
+    def test_list_holders_status_filter_can_show_only_inactive_rows(self) -> None:
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+        self._insert_holder("Person", "Active User", "Ad Hoc", ad_hoc_id, "A-001", None)
+        inactive_id = self._insert_holder("Person", "Inactive User", "Ad Hoc", ad_hoc_id, "I-001", None)
+        set_holder_active(inactive_id, False)
+
+        rows = list_holders(status="inactive")
+
+        self.assertEqual([row["name"] for row in rows], ["Inactive User"])
+        self.assertEqual(int(rows[0]["id"]), inactive_id)
+        self.assertEqual(int(rows[0]["is_active"]), 0)
+
+    def test_search_holders_status_filter_can_show_inactive_rows(self) -> None:
+        ad_hoc_id = self._insert_organization("Ad Hoc")
+        self._insert_holder("Person", "Active User", "Ad Hoc", ad_hoc_id, "A-001", None)
+        inactive_id = self._insert_holder("Person", "Inactive User", "Ad Hoc", ad_hoc_id, "I-001", None)
+        set_holder_active(inactive_id, False)
+
+        rows = search_holders("User", status="inactive")
+
+        self.assertEqual([row["name"] for row in rows], ["Inactive User"])
+        self.assertEqual(int(rows[0]["id"]), inactive_id)
+        self.assertEqual(int(rows[0]["is_active"]), 0)
+
     def test_set_holder_active_toggles_flag_without_removing_holder(self) -> None:
         organization_id = self._insert_organization("Support Org")
         created = create_holder("Stable Holder", organization_id=organization_id, email="stable@example.org")


### PR DESCRIPTION
## Summary
Add holder directory status filtering so operators can view all, active-only, or inactive-only holders while keeping inactive holders excluded from assignment selection.

## Related Issue
Closes #594 

## Changes
- added status filtering to the existing `/holders` directory
- kept `/holders?return_to=/issue` active-only for assignment safety
- added visible active/inactive filter controls and inactive row treatment
- added regression coverage for directory filtering and issue selection behavior

## Verification checklist
- [x] targeted tests passed
- [x] `git diff --check` passed
- [x] `/holders` shows all holders
- [x] active/inactive filters work
- [x] inactive holder detail opens correctly
- [x] `/holders?return_to=/issue` excludes inactive holders
- [x] active holder selection returns cleanly to `/issue`

## Notes
No schema, auth, persistence, receipt, report, or event-history changes.