### PR TITLE
Issue 26-132: extract shared terminal badge and confirmation helpers

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -167,6 +167,17 @@
   letter-spacing: 0.01em;
 }
 
+.warn {
+  color: #8a1f11;
+  font-weight: 700;
+}
+
+.check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .page.report-page .card h2 {
   margin-top: 0;
 }

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -7,22 +7,6 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    .state-badge {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.24rem 0.58rem;
-      border-radius: 999px;
-      font-weight: 700;
-      line-height: 1.2;
-      background: var(--color-surface-soft);
-      color: var(--color-text);
-    }
-    .state-badge.terminal {
-      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
-      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
-      color: var(--color-danger);
-      letter-spacing: 0.01em;
-    }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/admin_force_vacate.html
+++ b/assettrack/intake/templates/admin_force_vacate.html
@@ -9,8 +9,6 @@
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     input[type="text"], textarea { width: 100%; max-width: 720px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 120px; }
-    .warn { color: #8a1f11; font-weight: 700; }
-    .check { display: flex; align-items: center; gap: 0.5rem; }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -9,8 +9,6 @@
     .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 100px; }
-    .check { display: flex; align-items: center; gap: 0.5rem; }
-    .warn { color: #8a1f11; font-weight: 700; }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -41,24 +41,6 @@
 .results-table code { white-space: nowrap; }
     input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 120px; }
-    .warn { color: #8a1f11; font-weight: 700; }
-    .check { display: flex; align-items: center; gap: 0.5rem; }
-    .state-badge {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.24rem 0.58rem;
-      border-radius: 999px;
-      font-weight: 700;
-      line-height: 1.2;
-      background: var(--color-surface-soft);
-      color: var(--color-text);
-    }
-    .state-badge.terminal {
-      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
-      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
-      color: var(--color-danger);
-      letter-spacing: 0.01em;
-    }
   </style>
 {% endblock %}
 

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -37,22 +37,6 @@
     }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .results-table code { white-space: nowrap; }
-    .state-badge {
-      display: inline-flex;
-      align-items: center;
-      padding: 0.24rem 0.58rem;
-      border-radius: 999px;
-      font-weight: 700;
-      line-height: 1.2;
-      background: var(--color-surface-soft);
-      color: var(--color-text);
-    }
-    .state-badge.terminal {
-      background: color-mix(in srgb, var(--color-danger) 12%, var(--color-surface-bg));
-      border: 1px solid color-mix(in srgb, var(--color-danger) 40%, var(--color-surface));
-      color: var(--color-danger);
-      letter-spacing: 0.01em;
-    }
     @media (max-width: 720px) {
       .search-grid {
         grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
Extract shared terminal badge and confirmation helper styles into the shared CSS layer and remove duplicated local copies.

## Related Issue
Closes #560 

## Changes
- added shared `.warn` and `.check` helpers to base.css
- removed duplicated `.state-badge` and `.state-badge.terminal` from templates where already shared
- removed duplicated `.warn` and `.check` from admin templates using identical patterns
- no markup or behavior changes

## Verification checklist
- [x] targeted tests passed
- [x] `git diff --check` passed
- [x] asset search badge styling unchanged
- [x] admin edit/retire/replace/force vacate pages visually unchanged
- [x] warning and confirmation helpers render correctly
- [x] no workflow, auth, persistence, or event changes

## Notes
Visual parity preserved. Changes limited to safe duplicate extraction only.