### PR TITLE
Issue 26-133: extract shared admin form grid helpers

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -178,6 +178,38 @@
   gap: 0.5rem;
 }
 
+.admin-maintenance-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 0.75rem 1rem;
+}
+
+.admin-maintenance-grid > * {
+  min-width: 0;
+}
+
+.admin-maintenance-grid input[type="text"],
+.admin-maintenance-grid select,
+.admin-maintenance-grid textarea {
+  box-sizing: border-box;
+}
+
+.admin-maintenance-standard-fields input[type="text"] {
+  width: 100%;
+  max-width: 520px;
+  padding: 0.6rem;
+  font-size: 1rem;
+}
+
+.admin-maintenance-wide-fields input[type="text"],
+.admin-maintenance-wide-fields select,
+.admin-maintenance-wide-fields textarea {
+  width: 100%;
+  max-width: 640px;
+  padding: 0.6rem;
+  font-size: 1rem;
+}
+
 .page.report-page .card h2 {
   margin-top: 0;
 }

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -3,13 +3,7 @@
 
 {% block title %}Admin Assign Slot{% endblock %}
 {% block page_heading %}Admin: Assign Slot to Unslotted Asset{% endblock %}
-
-{% block extra_head %}
-  <style>
-    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
-  </style>
-{% endblock %}
+{% block page_class %} admin-maintenance-standard-fields{% endblock %}
 
 {% block content %}
   <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
@@ -46,7 +40,7 @@
   {% if asset %}
     <div class="card">
       <h2>2) Asset Details</h2>
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
         <div><strong>manufacturer:</strong> {{ asset.manufacturer or "" }}</div>
         <div><strong>model:</strong> {{ asset.model or "" }}</div>

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -4,12 +4,6 @@
 {% block title %}Admin Edit Asset{% endblock %}
 {% block page_heading %}Admin: Edit Asset{% endblock %}
 
-{% block extra_head %}
-  <style>
-    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-  </style>
-{% endblock %}
-
 {% block content %}
   <div class="actions">
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a>
@@ -55,7 +49,7 @@
       <form method="post" action="{{ url_for('admin_edit_asset') }}">
         <input type="hidden" name="action" value="update" />
         <input type="hidden" name="lookup_asset_tag" value="{{ form.lookup_asset_tag or asset.asset_tag }}" />
-        <div class="grid">
+        <div class="admin-maintenance-grid">
           <div class="row form-group">
             <label class="form-label" for="asset_tag"><strong>asset_tag</strong></label>
             <input class="form-input" type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" readonly />

--- a/assettrack/intake/templates/admin_force_vacate.html
+++ b/assettrack/intake/templates/admin_force_vacate.html
@@ -6,7 +6,6 @@
 
 {% block extra_head %}
   <style>
-    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     input[type="text"], textarea { width: 100%; max-width: 720px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 120px; }
   </style>
@@ -26,7 +25,7 @@
   <div class="card">
     <h2>Slot Detail</h2>
     {% if slot %}
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div><strong>slot_id:</strong> <code>{{ slot.slot_id }}</code></div>
         <div><strong>occupied:</strong> <code>{{ "yes" if slot.occupied else "no" }}</code></div>
         <div><strong>case_number:</strong> <code>{{ slot.case_name }}</code></div>
@@ -42,7 +41,7 @@
   {% if slot and slot.asset %}
     <div class="card">
       <h2>Occupied Asset</h2>
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div><strong>asset_tag:</strong> <code>{{ slot.asset.asset_tag }}</code></div>
         <div><strong>location_type:</strong> <code>{{ slot.asset.location_type }}</code></div>
         <div><strong>manufacturer:</strong> {{ slot.asset.manufacturer }}</div>

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -7,7 +7,6 @@
 
 {% block extra_head %}
   <style>
-    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     input[type="text"], select { width: 100%; max-width: none; padding: 0.6rem; font-size: 1rem; }
     .hidden { display: none; }
   </style>
@@ -33,7 +32,7 @@
     <h2>New Asset</h2>
     <p class="muted">Fill in the required fields below. Asset type defaults to Laptop.</p>
     <form method="post" action="{{ url_for('admin_new_asset') }}">
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div class="row">
           <label for="asset_tag"><strong>Asset tag</strong> (required)</label><br />
           <input type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" required autofocus />
@@ -78,7 +77,7 @@
         </div>
       </div>
 
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div class="row">
           <label for="case_name"><strong>Case</strong> (optional)</label><br />
           <select id="case_name" name="case_name">

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -3,11 +3,10 @@
 
 {% block title %}Admin Replace Asset{% endblock %}
 {% block page_heading %}Admin: Replace Failed Asset{% endblock %}
+{% block page_class %} admin-maintenance-wide-fields{% endblock %}
 
 {% block extra_head %}
   <style>
-    .grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-    input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 100px; }
   </style>
 {% endblock %}
@@ -42,7 +41,7 @@
   {% if failed_asset %}
     <div class="card">
       <h2>2) Failed Asset + Target Slot</h2>
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div><strong>asset_tag:</strong> <code>{{ failed_asset.asset_tag }}</code></div>
         <div><strong>location_type:</strong> <code>{{ failed_asset.location_type }}</code></div>
         <div><strong>manufacturer:</strong> {{ failed_asset.manufacturer or "" }}</div>
@@ -70,7 +69,7 @@
         <input type="hidden" name="action" value="replace" />
         <input type="hidden" name="failed_asset_tag" value="{{ failed_asset.asset_tag }}" />
 
-        <div class="grid">
+        <div class="admin-maintenance-grid">
           <div class="row">
             <label for="failure_type"><strong>failure_type</strong> (required)</label><br />
             <select id="failure_type" name="failure_type" required>

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -3,11 +3,10 @@
 
 {% block title %}Admin Retire Asset{% endblock %}
 {% block page_heading %}Admin: Retire Asset{% endblock %}
+{% block page_class %} admin-maintenance-wide-fields{% endblock %}
 
 {% block extra_head %}
   <style>
-.grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
-
 .asset-retire-lookup {
   width: 100%;
 }
@@ -39,7 +38,6 @@
   font-weight: 600;
 }
 .results-table code { white-space: nowrap; }
-    input[type="text"], select, textarea { width: 100%; max-width: 640px; padding: 0.6rem; font-size: 1rem; }
     textarea { min-height: 120px; }
   </style>
 {% endblock %}
@@ -137,7 +135,7 @@
   {% if asset %}
     <div class="card">
       <h2>Current Asset State</h2>
-      <div class="grid">
+      <div class="admin-maintenance-grid">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
         <div><strong>location_type:</strong> <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span></div>
         <div><strong>manufacturer:</strong> {{ asset.manufacturer or "" }}</div>

--- a/assettrack/intake/templates/admin_slot_move.html
+++ b/assettrack/intake/templates/admin_slot_move.html
@@ -3,11 +3,11 @@
 
 {% block title %}Admin Slot Move{% endblock %}
 {% block page_heading %}Admin: Move Asset to Another Slot{% endblock %}
+{% block page_class %} admin-maintenance-standard-fields{% endblock %}
 
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(240px, 1fr)); gap: 0.75rem 1rem; }
-    input[type="text"] { width: 100%; max-width: 520px; padding: 0.6rem; font-size: 1rem; }
   </style>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
Extract shared admin form grid and field helper styles into the shared CSS layer and fix the spacing regression so admin maintenance forms keep their intended layout.

## Related Issue
Closes #561 

## Changes
- added shared admin maintenance form helpers to `base.css`
- replaced duplicated equivalent admin grid and field sizing rules with shared utilities
- left non-equivalent local sizing rules in place to avoid visual drift
- fixed the `/admin/assets/new` column-gap regression by scoping box sizing and allowing grid children to shrink correctly

## Verification checklist
- [x] targeted tests passed
- [x] `git diff --check` passed
- [x] `/admin/assets/new` two-column fields no longer touch
- [x] shared admin form layout has visible column separation
- [x] labels and fields remain aligned
- [x] no workflow, auth, persistence, schema, or event changes

## Notes
Changes were limited to equivalent shared admin form utilities and a small CSS-only regression fix.