### PR TITLE
Issue 26-134: extract shared search action row styles

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -210,6 +210,21 @@
   font-size: 1rem;
 }
 
+.search-actions {
+  display: flex;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 0.25rem;
+}
+
+.search-clear {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
 .page.report-page .card h2 {
   margin-top: 0;
 }

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -24,19 +24,6 @@
   max-width: none;
 }
 
-.search-actions {
-  display: flex;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-  align-items: center;
-  margin-top: 0.25rem;
-}
-.search-clear {
-  display: inline-flex;
-  align-items: center;
-  color: var(--color-text-muted);
-  font-weight: 600;
-}
 .results-table code { white-space: nowrap; }
     textarea { min-height: 120px; }
   </style>

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -22,19 +22,6 @@
       display: block;
       max-width: none;
     }
-    .search-actions {
-      display: flex;
-      gap: 0.6rem;
-      flex-wrap: wrap;
-      align-items: center;
-      margin-top: 0.25rem;
-    }
-    .search-clear {
-      display: inline-flex;
-      align-items: center;
-      color: var(--color-text-muted);
-      font-weight: 600;
-    }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .results-table code { white-space: nowrap; }
     @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
Extract shared search action row styles into the shared CSS layer so asset lookup flows use the same search and clear control presentation.

## Related Issue
Closes #562 

## Changes
- moved shared `.search-actions` and `.search-clear` styles into `base.css`
- removed duplicated local copies from asset search and admin retire search
- preserved existing markup and search behavior

## Verification checklist
- [x] targeted tests passed
- [x] `git diff --check` passed
- [x] `/assets/search` search action row renders correctly
- [x] `/admin/assets/retire` search action row renders correctly
- [x] visual affordance and spacing match across both flows
- [x] no workflow, auth, persistence, schema, or event changes

## Notes
Changes were limited to exact duplicate CSS extraction for shared search action helpers.