### PR TITLE
Issue 26-150: add safe partial search to admin edit lookup

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1444,6 +1444,15 @@ def _lookup_retire_asset_matches(conn: sqlite3.Connection, asset_tag: str) -> tu
     return matches, error_message
 
 
+def _lookup_admin_edit_asset_matches(conn: sqlite3.Connection, asset_tag: str) -> tuple[list[dict], Optional[str]]:
+    matches, error_message, _ = _lookup_asset_for_verification(
+        conn,
+        asset_tag=asset_tag,
+        serial_number="",
+    )
+    return matches, error_message
+
+
 def _resolve_replacement_target_slot(
     conn: sqlite3.Connection,
     *,
@@ -6752,6 +6761,7 @@ def admin_edit_asset():
         "slot_id": "",
     }
     asset_view: Optional[dict] = None
+    asset_matches: list[dict] = []
     error_message: Optional[str] = None
 
     conn = get_connection()
@@ -6760,34 +6770,14 @@ def admin_edit_asset():
         case_options = _slot_case_options(slot_options)
 
         if form_state["lookup_asset_tag"]:
-            asset_view, blocking_errors = _build_admin_edit_asset_view(conn, form_state["lookup_asset_tag"])
-            if asset_view:
-                selected_home_slot = asset_view["home_slot"] or asset_view["current_slot"]
-                form_state.update(
-                    {
-                        "asset_tag": asset_view["asset_tag"],
-                        "serial_number": asset_view["serial_number"],
-                        "manufacturer": asset_view["manufacturer"],
-                        "equipment_type": asset_view["equipment_type"],
-                        "building": asset_view["building"],
-                        "room": asset_view["room"],
-                        "model": asset_view["model"],
-                        "model_code": asset_view["model_code"],
-                        "notes": asset_view["notes"],
-                        "case_name": "" if selected_home_slot is None else str(selected_home_slot["case_name"]),
-                        "slot_id": "" if selected_home_slot is None else str(selected_home_slot["slot_id"]),
-                    }
-                )
-            elif blocking_errors:
-                error_message = "; ".join(blocking_errors)
+            try:
+                exact_asset = _find_asset_for_scan_tag(conn, form_state["lookup_asset_tag"])
+            except ValueError as exc:
+                exact_asset = None
+                error_message = str(exc)
 
-        if request.method == "POST":
-            action = (request.form.get("action") or "lookup").strip().lower()
-            lookup_asset_tag = (request.form.get("lookup_asset_tag") or "").strip().upper()
-            form_state["lookup_asset_tag"] = lookup_asset_tag
-
-            if action == "lookup":
-                asset_view, blocking_errors = _build_admin_edit_asset_view(conn, lookup_asset_tag)
+            if exact_asset is not None:
+                asset_view, blocking_errors = _build_admin_edit_asset_view(conn, form_state["lookup_asset_tag"])
                 if asset_view:
                     selected_home_slot = asset_view["home_slot"] or asset_view["current_slot"]
                     form_state.update(
@@ -6805,10 +6795,49 @@ def admin_edit_asset():
                             "slot_id": "" if selected_home_slot is None else str(selected_home_slot["slot_id"]),
                         }
                     )
-                elif not lookup_asset_tag:
-                    error_message = "asset_tag is required."
                 elif blocking_errors:
                     error_message = "; ".join(blocking_errors)
+            elif error_message is None:
+                asset_matches, error_message = _lookup_admin_edit_asset_matches(conn, form_state["lookup_asset_tag"])
+
+        if request.method == "POST":
+            action = (request.form.get("action") or "lookup").strip().lower()
+            lookup_asset_tag = (request.form.get("lookup_asset_tag") or "").strip().upper()
+            form_state["lookup_asset_tag"] = lookup_asset_tag
+
+            if action == "lookup":
+                if not lookup_asset_tag:
+                    error_message = "asset_tag is required."
+                else:
+                    try:
+                        exact_asset = _find_asset_for_scan_tag(conn, lookup_asset_tag)
+                    except ValueError as exc:
+                        exact_asset = None
+                        error_message = str(exc)
+
+                    if exact_asset is not None:
+                        asset_view, blocking_errors = _build_admin_edit_asset_view(conn, lookup_asset_tag)
+                        if asset_view:
+                            selected_home_slot = asset_view["home_slot"] or asset_view["current_slot"]
+                            form_state.update(
+                                {
+                                    "asset_tag": asset_view["asset_tag"],
+                                    "serial_number": asset_view["serial_number"],
+                                    "manufacturer": asset_view["manufacturer"],
+                                    "equipment_type": asset_view["equipment_type"],
+                                    "building": asset_view["building"],
+                                    "room": asset_view["room"],
+                                    "model": asset_view["model"],
+                                    "model_code": asset_view["model_code"],
+                                    "notes": asset_view["notes"],
+                                    "case_name": "" if selected_home_slot is None else str(selected_home_slot["case_name"]),
+                                    "slot_id": "" if selected_home_slot is None else str(selected_home_slot["slot_id"]),
+                                }
+                            )
+                        elif blocking_errors:
+                            error_message = "; ".join(blocking_errors)
+                    elif error_message is None:
+                        asset_matches, error_message = _lookup_admin_edit_asset_matches(conn, lookup_asset_tag)
             elif action == "update":
                 form_state.update(
                     {
@@ -6832,6 +6861,7 @@ def admin_edit_asset():
                         "admin_edit_asset.html",
                         form=form_state,
                         asset=asset_view,
+                        asset_matches=asset_matches,
                         error_message=error_message,
                         slot_options=slot_options,
                         case_options=case_options,
@@ -6862,6 +6892,7 @@ def admin_edit_asset():
                         "admin_edit_asset.html",
                         form=form_state,
                         asset=asset_view,
+                        asset_matches=asset_matches,
                         error_message=error_message,
                         slot_options=slot_options,
                         case_options=case_options,
@@ -6891,6 +6922,7 @@ def admin_edit_asset():
                         "admin_edit_asset.html",
                         form=form_state,
                         asset=asset_view,
+                        asset_matches=asset_matches,
                         error_message=error_message,
                         slot_options=slot_options,
                         case_options=case_options,
@@ -6902,6 +6934,7 @@ def admin_edit_asset():
                         "admin_edit_asset.html",
                         form=form_state,
                         asset=asset_view,
+                        asset_matches=asset_matches,
                         error_message=error_message,
                         slot_options=slot_options,
                         case_options=case_options,
@@ -6921,6 +6954,7 @@ def admin_edit_asset():
                         "admin_edit_asset.html",
                         form=form_state,
                         asset=asset_view,
+                        asset_matches=asset_matches,
                         error_message=error_message,
                         slot_options=slot_options,
                         case_options=case_options,
@@ -6969,6 +7003,7 @@ def admin_edit_asset():
                         "admin_edit_asset.html",
                         form=form_state,
                         asset=asset_view,
+                        asset_matches=asset_matches,
                         error_message=error_message,
                         slot_options=slot_options,
                         case_options=case_options,
@@ -6988,6 +7023,7 @@ def admin_edit_asset():
         "admin_edit_asset.html",
         form=form_state,
         asset=asset_view,
+        asset_matches=asset_matches,
         error_message=error_message,
         slot_options=slot_options,
         case_options=case_options,

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -42,6 +42,53 @@
     </form>
   </div>
 
+  {% if asset_matches and not asset %}
+    <div class="card">
+      <h2>Select Asset</h2>
+      <p class="muted">{{ asset_matches|length }} matches found. Select one asset before loading the edit form.</p>
+      <table class="results-table">
+        <thead>
+          <tr>
+            <th>Asset tag</th>
+            <th>Serial number</th>
+            <th>Current state</th>
+            <th>Current holder</th>
+            <th>Home case</th>
+            <th>Home slot</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for match in asset_matches %}
+            <tr>
+              <td><code>{{ match.asset_tag }}</code></td>
+              <td>{{ match.serial_number or "Not recorded" }}</td>
+              <td>
+                <span class="state-badge{% if asset_is_terminal(match.location_type) %} terminal{% endif %}">{{ asset_state_label(match.location_type) }}</span>
+              </td>
+              <td>{{ match.holder_label or "Not assigned" }}</td>
+              <td>{{ match.home_case_name or "Not assigned" }}</td>
+              <td>
+                {% if match.home_slot_position is not none %}
+                  Slot {{ match.home_slot_position }}
+                {% else %}
+                  Not assigned
+                {% endif %}
+              </td>
+              <td>
+                <form method="post" action="{{ url_for('admin_edit_asset') }}">
+                  <input type="hidden" name="action" value="lookup" />
+                  <input type="hidden" name="lookup_asset_tag" value="{{ match.asset_tag }}" />
+                  <button type="submit">Select</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+
   {% if asset %}
     <div class="card">
       <h2>Edit Asset</h2>

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -102,6 +102,98 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Edit Asset", response.data)
 
+    def test_exact_lookup_loads_edit_form_directly(self) -> None:
+        self._insert_asset(
+            "AT-EXACT-EDIT-1",
+            serial_number="SER-EXACT-EDIT-1",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "lookup",
+                "lookup_asset_tag": "AT-EXACT-EDIT-1",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Edit Asset", response.data)
+        self.assertIn(b"AT-EXACT-EDIT-1", response.data)
+        self.assertIn(b"Save Asset", response.data)
+        self.assertNotIn(b"Select Asset", response.data)
+
+    def test_partial_lookup_requires_explicit_selection_before_edit(self) -> None:
+        self._insert_asset(
+            "AT-PART-EDIT-100",
+            serial_number="SER-PART-EDIT-100",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+        self._insert_asset(
+            "AT-PART-EDIT-101",
+            serial_number="SER-PART-EDIT-101",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "lookup",
+                "lookup_asset_tag": "AT-PART-EDIT-10",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Select Asset", response.data)
+        self.assertIn(b"AT-PART-EDIT-100", response.data)
+        self.assertIn(b"AT-PART-EDIT-101", response.data)
+        self.assertNotIn(b"Save Asset", response.data)
+        self.assertIn(b">Select<", response.data)
+
+        selected = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "lookup",
+                "lookup_asset_tag": "AT-PART-EDIT-100",
+            },
+        )
+
+        self.assertEqual(selected.status_code, 200)
+        self.assertIn(b"Edit Asset", selected.data)
+        self.assertIn(b"Save Asset", selected.data)
+        self.assertIn(b"AT-PART-EDIT-100", selected.data)
+        self.assertNotIn(b"AT-PART-EDIT-101", selected.data)
+
+    def test_partial_query_string_does_not_load_edit_form_directly(self) -> None:
+        self._insert_asset(
+            "AT-QUERY-EDIT-100",
+            serial_number="SER-QUERY-EDIT-100",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+        self._insert_asset(
+            "AT-QUERY-EDIT-101",
+            serial_number="SER-QUERY-EDIT-101",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.get("/admin/assets/edit?asset_tag=AT-QUERY-EDIT-10")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Select Asset", response.data)
+        self.assertIn(b"AT-QUERY-EDIT-100", response.data)
+        self.assertIn(b"AT-QUERY-EDIT-101", response.data)
+        self.assertNotIn(b"Save Asset", response.data)
+
     def test_edit_asset_ui_marks_retired_assets_as_not_in_service(self) -> None:
         self._insert_asset(
             "AT-RET-EDIT-1",


### PR DESCRIPTION
## Summary
Add safe partial search to the admin edit asset lookup so admins can find assets with partial input while still requiring explicit selection before loading the edit form.

## Related Issue
Closes #599 

## Changes
- kept exact asset-tag lookup as the direct fast path
- added partial lookup results to `/admin/assets/edit`
- required explicit Select before loading the edit form from partial matches
- added regression coverage for exact lookup, partial lookup, explicit selection, and partial GET guard behavior

## Verification checklist
- [x] targeted tests passed
- [x] related lookup-flow tests passed
- [x] `git diff --check` passed
- [x] exact tag still loads edit directly
- [x] partial tag shows a match list
- [x] selecting a result loads the normal edit form
- [x] no ambiguous direct edit path exists
- [x] admin protection remains enforced

## Notes
No schema, auth, persistence, receipt, report, custody, or event-history changes.