### PR TITLE
Issue 26-151: clarify staged asset intake workflow

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -269,7 +269,7 @@
           <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
           <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
           {% if authenticated_role == 'admin' %}
-            <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Add Assets</a>
+            <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Stage Assets</a>
             <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
             <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
           {% endif %}

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -1,8 +1,8 @@
 <!-- assettrack/intake/templates/index.html -->
 {% extends "base.html" %}
 
-{% block title %}AssetTrack — Add Assets{% endblock %}
-{% block page_heading %}Add Assets{% endblock %}
+{% block title %}AssetTrack — Stage Asset Intake{% endblock %}
+{% block page_heading %}Stage Asset Intake{% endblock %}
 
 {% block extra_head %}
   <style>
@@ -80,8 +80,9 @@
   {% endwith %}
 
   <div class="card">
-    <p><strong>How to use:</strong> click the box once, then scan. The scanner “types” and hits Enter.</p>
-    <p><a href="{{ url_for('preview') }}" data-timeout-lock-target>Preview batch</a></p>
+    <p><strong>What this does:</strong> scans are staged in a queue first. Inventory records are written only after you review and commit the batch.</p>
+    <p><strong>How to use:</strong> click the scan box once, then scan. The scanner “types” and hits Enter.</p>
+    <p><a href="{{ url_for('preview') }}" data-timeout-lock-target>Open batch preview</a></p>
     <p><a href="{{ url_for('return_queue') }}">Return Assets</a></p>
 
     {% if auth_enabled and not authed %}
@@ -92,7 +93,7 @@
     {% else %}
       <form id="intake-form" class="row" method="post" action="{{ url_for('intake') }}">
         <div class="row">
-          <label for="equipment_type"><strong>Equipment type</strong> (required to create new assets)</label><br />
+          <label for="equipment_type"><strong>Equipment type</strong> (used when commit creates new inventory records)</label><br />
           <input
             type="text"
             id="equipment_type"
@@ -107,7 +108,7 @@
         {% if authenticated_role == 'admin' %}
           <div class="grid">
             <div class="row">
-              <label for="case_name"><strong>Case</strong> (optional per scanned asset)</label><br />
+              <label for="case_name"><strong>Case</strong> (optional staging detail)</label><br />
               <select id="case_name" name="case_name" data-timeout-lock-target>
                 <option value="">Unassigned</option>
                 {% for case_name in case_options %}
@@ -116,7 +117,7 @@
               </select>
             </div>
             <div class="row">
-              <label for="slot_id"><strong>Slot</strong> (optional per scanned asset)</label><br />
+              <label for="slot_id"><strong>Slot</strong> (optional staging detail)</label><br />
               <select id="slot_id" name="slot_id" data-timeout-lock-target>
                 <option value="">Unassigned</option>
                 {% for slot in slot_options %}
@@ -134,28 +135,28 @@
             type="text"
             id="scan-input"
             name="scan_text"
-            placeholder="Scan here..."
+            placeholder="Scan or enter asset tag"
             autofocus
             autocomplete="off"
             data-timeout-lock-target
           />
-          <button id="submit-scan" type="submit" data-timeout-lock-target>Add to queue</button>
+          <button id="submit-scan" type="submit" data-timeout-lock-target>Stage in queue</button>
           <button id="clear-queue" type="submit" name="action" value="clear" data-timeout-lock-target>Clear queue</button>
         </div>
       </form>
     {% endif %}
     <form method="post" action="{{ url_for('add_assets_review') }}" class="queue-actions">
-      <button id="review-batch" type="submit" data-timeout-lock-target>Review batch</button>
+      <button id="review-batch" type="submit" data-timeout-lock-target>Review staged batch</button>
     </form>
   </div>
 
   <div class="card">
-    <h2>Latest scan</h2>
+    <h2>Latest staged scan</h2>
     <p><code>{{ latest }}</code></p>
   </div>
 
   <div class="card">
-    <h2 id="queue-section">Queue ({{ queue_len }})</h2>
+    <h2 id="queue-section">Staged queue ({{ queue_len }})</h2>
     {% if queue %}
       <ul id="queue-list" class="queue-list" role="list">
         {% for s in queue %}
@@ -181,7 +182,7 @@
         {% endfor %}
       </ul>
     {% else %}
-      <p class="queue-empty">No assets are queued yet. Scan or enter an asset tag, then add it to the queue for review.</p>
+      <p class="queue-empty">No assets are staged yet. Scan or enter an asset tag, then stage it in the queue for review.</p>
     {% endif %}
   </div>
 {% endblock %}

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -122,8 +122,11 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b'name="case_name"', response.data)
         self.assertIn(b'name="slot_id"', response.data)
         self.assertIn(b"CASE-LIVE", response.data)
-        self.assertIn(b"Add to queue", response.data)
-        self.assertIn(b"Review batch", response.data)
+        self.assertIn(b"Stage Asset Intake", response.data)
+        self.assertIn(b"scans are staged in a queue first", response.data)
+        self.assertIn(b"Inventory records are written only after you review and commit the batch", response.data)
+        self.assertIn(b"Stage in queue", response.data)
+        self.assertIn(b"Review staged batch", response.data)
         self.assertNotIn(b"Add to database", response.data)
 
     def test_add_assets_empty_scan_submission_shows_validation_message(self) -> None:
@@ -149,7 +152,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Queue is empty. Add at least one asset to the queue before reviewing the batch.", response.data)
-        self.assertIn(b"No assets are queued yet.", response.data)
+        self.assertIn(b"No assets are staged yet.", response.data)
 
     def test_scans_keep_equipment_type_captured_at_scan_time(self) -> None:
         intake_app.SCAN_QUEUE.clear()

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -591,7 +591,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Issue</a>" in dashboard_response.data
     assert b">Return</a>" in dashboard_response.data
     assert b">Receipts</a>" in dashboard_response.data
-    assert b">Add Assets</a>" not in dashboard_response.data
+    assert b">Stage Assets</a>" not in dashboard_response.data
     assert b">Users</a>" not in dashboard_response.data
     assert b">Admin Tools</a>" not in dashboard_response.data
 
@@ -607,7 +607,7 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
 
     assert dashboard_response.status_code == 200
     assert b">Receipts</a>" in dashboard_response.data
-    assert b">Add Assets</a>" in dashboard_response.data
+    assert b">Stage Assets</a>" in dashboard_response.data
     assert b">Users</a>" in dashboard_response.data
     assert b">Admin Tools</a>" in dashboard_response.data
 


### PR DESCRIPTION
## Summary
Clarify the `/add-assets` workflow so operators understand that asset scans are staged in a queue and inventory records are only written after review and commit.

## Related Issue
Closes #600 

## Changes
- renamed the `/add-assets` page title and heading to **Stage Asset Intake**
- updated helper copy to explain the staged queue and commit flow truthfully
- changed CTA and queue labels to match actual workflow behavior
- updated the primary nav label from **Add Assets** to **Stage Assets**
- updated focused tests for the new wording

## Verification checklist
- [x] targeted tests passed
- [x] `git diff --check` passed
- [x] `/add-assets` now reads as a staging workflow
- [x] heading and helper text explain queue/review/commit clearly
- [x] CTA labels match actual behavior
- [x] no route, auth, schema, persistence, or workflow logic changes

## Notes
This is a wording and navigation clarity fix only. The underlying staged intake workflow remains unchanged.