### PR TITLE
Issue 26-149: standardize destructive action visual pattern

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -178,6 +178,29 @@
   gap: 0.5rem;
 }
 
+.warn-card {
+  border-color: color-mix(in srgb, var(--color-accent) 24%, var(--color-surface));
+  border-left-width: 6px;
+  border-left-color: color-mix(in srgb, var(--color-accent) 58%, var(--color-primary));
+  background: var(--color-surface-bg);
+}
+
+.warn-card h2 {
+  color: color-mix(in srgb, var(--color-accent) 46%, var(--color-text));
+}
+
+button.warn-button {
+  background: color-mix(in srgb, var(--color-accent) 78%, var(--color-primary));
+  border-color: color-mix(in srgb, var(--color-accent) 78%, var(--color-primary));
+  color: #fff;
+}
+
+button.warn-button:hover,
+button.warn-button:focus-visible {
+  background: color-mix(in srgb, var(--color-accent) 66%, var(--color-primary));
+  border-color: color-mix(in srgb, var(--color-accent) 66%, var(--color-primary));
+}
+
 .admin-maintenance-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(220px, 1fr));

--- a/assettrack/intake/templates/admin_force_vacate.html
+++ b/assettrack/intake/templates/admin_force_vacate.html
@@ -53,7 +53,7 @@
   {% endif %}
 
   {% if slot %}
-    <div class="card">
+    <div class="card warn-card">
       <h2>Force Vacate Confirmation</h2>
       <p class="warn">Use only when you physically verified the slot is empty and database state is wrong.</p>
 
@@ -87,7 +87,7 @@
           <label for="confirm_empty"><strong>I physically verified this slot is empty.</strong></label>
         </div>
 
-        <button type="submit">Force Vacate Slot</button>
+        <button class="warn-button" type="submit">Force Vacate Slot</button>
       </form>
     </div>
   {% endif %}

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -62,7 +62,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card warn-card">
       <h2>3) Replacement + Failure Details</h2>
       <p class="warn">This is one atomic operation: retire failed asset, create replacement, assign replacement to target slot.</p>
       <form method="post" action="{{ url_for('admin_replace_asset') }}">
@@ -128,7 +128,7 @@
           </label>
         </div>
 
-        <button type="submit">Replace Asset</button>
+        <button class="warn-button" type="submit">Replace Asset</button>
       </form>
     </div>
   {% endif %}

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -141,7 +141,7 @@
       </div>
     </div>
 
-    <div class="card">
+    <div class="card warn-card">
       <h2>Retire Asset</h2>
       <p class="warn">Retirement is terminal. This action marks the asset as DISPOSED.</p>
       <form method="post" action="{{ url_for('admin_retire_asset') }}">
@@ -175,7 +175,7 @@
           </div>
         {% endif %}
 
-        <button type="submit">Retire Asset</button>
+        <button class="warn-button" type="submit">Retire Asset</button>
       </form>
     </div>
   {% endif %}

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -75,7 +75,7 @@
             <td>
               <form class="inline-form" method="post" action="{{ url_for('admin_users_toggle_active', user_id=user.id) }}">
                 <input type="hidden" name="active" value="{{ 0 if user.active else 1 }}" />
-                <button type="submit">{{ "Disable" if user.active else "Enable" }}</button>
+                <button{% if user.active %} class="warn-button"{% endif %} type="submit">{{ "Disable" if user.active else "Enable" }}</button>
               </form>
 
               <form class="inline-form" method="post" action="{{ url_for('admin_users_set_role', user_id=user.id) }}">
@@ -88,7 +88,7 @@
 
               <form class="inline-form" method="post" action="{{ url_for('admin_users_reset_password', user_id=user.id) }}">
                 <input type="password" name="new_password" placeholder="New password" required />
-                <button type="submit">Reset Password</button>
+                <button class="warn-button" type="submit">Reset Password</button>
               </form>
             </td>
           </tr>

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -164,7 +164,7 @@
         <form method="post" action="{{ url_for('holders_toggle_active', holder_id=holder.id) }}">
           <input type="hidden" name="is_active" value="{{ 0 if holder.get('is_active', 1) else 1 }}" />
           <input type="hidden" name="return_to" value="{{ request.full_path.rstrip('?') }}" />
-          <button type="submit">{{ "Deactivate Holder" if holder.get("is_active", 1) else "Reactivate Holder" }}</button>
+          <button{% if holder.get('is_active', 1) %} class="warn-button"{% endif %} type="submit">{{ "Deactivate Holder" if holder.get("is_active", 1) else "Reactivate Holder" }}</button>
         </form>
       {% endif %}
     </div>


### PR DESCRIPTION
## Summary
Standardize the visual pattern for high-consequence actions so they feel serious and consistent without overpowering the UI.

## Related Issue
Closes #597 

## Changes
- added shared high-consequence action styling in `base.css`
- applied the pattern to retire, replace, force-vacate, admin user disable/reset, and holder deactivate surfaces
- refined the pattern to use a calmer, theme-native container with a restrained accent and clearer action button treatment

## Verification checklist
- [x] targeted tests passed
- [x] `git diff --check` passed
- [x] `docker compose up -d --build`
- [x] manual verification passed in light/dark mode
- [x] no route, auth, schema, persistence, event, or workflow behavior changed

## Notes
Kept scope to presentation only and avoided expanding into ambiguous action surfaces.