### PR TITLE
Issue 26-71: implement admin-controlled password reset with temp pass…

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Optional
 from datetime import datetime, timezone, date, timedelta
 
-from flask import Flask, abort, flash, jsonify, redirect, render_template, request, send_file, session, url_for
+from flask import Flask, abort, flash, jsonify, make_response, redirect, render_template, request, send_file, session, url_for
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -75,6 +75,7 @@ from assettrack.users import (
     create_user,
     get_user_by_id,
     get_user_by_username,
+    is_temporary_password,
     list_users,
     reset_user_password,
     set_user_active,
@@ -141,10 +142,28 @@ def refresh_session_activity(response):
     if _should_refresh_session_activity():
         touch_session()
     if current_user() is not None:
-        response.headers["Cache-Control"] = "no-store"
+        if response.headers.pop("X-AssetTrack-Sensitive-Reveal", None) == "1":
+            response.headers["Cache-Control"] = "no-store, max-age=0"
+        else:
+            response.headers["Cache-Control"] = "no-store"
         response.headers["Pragma"] = "no-cache"
         response.headers["Expires"] = "0"
     return response
+
+
+@app.before_request
+def enforce_required_password_change():
+    endpoint = str(request.endpoint or "").strip()
+    if endpoint in {"account_change_password", "account_change_password_submit", "logout", "static"}:
+        return None
+
+    user = current_user()
+    if user is None or not is_temporary_password(user):
+        return None
+
+    if _prefers_json_error_response():
+        return {"ok": False, "error": "Password change required"}, 403
+    return redirect(url_for("account_change_password"))
 
 
 @app.context_processor
@@ -153,6 +172,7 @@ def inject_auth_user():
     return {
         "authenticated_user": user,
         "authenticated_role": None if user is None else user.get("role"),
+        "password_change_required": is_temporary_password(user),
         "case_status_summary": _case_status_summary,
         "asset_state_label": _asset_state_label,
         "asset_is_terminal": _is_terminal_location_type,
@@ -3841,6 +3861,7 @@ def account_change_password_submit():
     if user is None:
         return {"ok": False, "error": "Forbidden"}, 403
 
+    password_was_temporary = is_temporary_password(user)
     current_password = request.form.get("current_password") or ""
     new_password = request.form.get("new_password") or ""
     confirm_new_password = request.form.get("confirm_new_password") or ""
@@ -3856,6 +3877,8 @@ def account_change_password_submit():
         return redirect(url_for("account_change_password"))
 
     flash("Password updated.", "success")
+    if password_was_temporary:
+        return redirect(url_for("dashboard"))
     return redirect(url_for("account_change_password"))
 
 
@@ -5925,11 +5948,15 @@ def holders_toggle_active(holder_id: int):
 @require_login
 @require_role("admin")
 def admin_users():
+    return render_template("admin_users.html", **_admin_users_context())
+
+
+def _admin_users_context(**extra_context):
     users = list_users()
     for user in users:
         user["created_at_display"] = _receipt_display_timestamp(user.get("created_at"))
         user["updated_at_display"] = _receipt_display_timestamp(user.get("updated_at"))
-    return render_template("admin_users.html", users=users)
+    return {"users": users, **extra_context}
 
 
 @app.get("/admin/system")
@@ -6592,16 +6619,23 @@ def admin_users_reset_password(user_id: int):
     if rate_limit_response is not None:
         return rate_limit_response
 
-    new_password = request.form.get("new_password") or ""
-
     try:
-        updated = reset_user_password(user_id, new_password)
+        reset_result = reset_user_password(user_id)
     except ValueError as e:
         flash(str(e), "error")
+        return redirect(url_for("admin_users"))
     else:
+        updated = reset_result["user"]
         flash(f"Password reset for {updated['username']}.", "success")
-
-    return redirect(url_for("admin_users"))
+        response = make_response(render_template(
+            "admin_users.html",
+            **_admin_users_context(
+                temporary_password=reset_result["temporary_password"],
+                temporary_password_username=updated["username"],
+            ),
+        ))
+        response.headers["X-AssetTrack-Sensitive-Reveal"] = "1"
+        return response
 
 
 @app.post("/admin/users/<int:user_id>/set-role")

--- a/assettrack/intake/templates/account_change_password.html
+++ b/assettrack/intake/templates/account_change_password.html
@@ -6,7 +6,9 @@
 {% block page_class %} page-wide{% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  {% if not password_change_required %}
+    <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  {% endif %}
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -18,6 +20,9 @@
 
   <div class="card">
     <h2>Change Password</h2>
+    {% if password_change_required %}
+      <p class="flash error">You must set a new password before using AssetTrack.</p>
+    {% endif %}
     <form method="post" action="{{ url_for('account_change_password_submit') }}">
       <div class="row">
         <label for="current_password"><strong>Current password</strong></label><br />

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -23,6 +23,14 @@
     {% endif %}
   {% endwith %}
 
+  {% if temporary_password %}
+    <div class="flash success" role="status">
+      <strong>Temporary password for {{ temporary_password_username }}:</strong>
+      <code>{{ temporary_password }}</code>
+      <p class="muted">This password is shown once. Copy it now; it will not be shown again. Give it to the user through a trusted local channel.</p>
+    </div>
+  {% endif %}
+
   <div class="card">
     <h2>Create User</h2>
     <form method="post" action="{{ url_for('admin_users_create') }}">
@@ -87,8 +95,7 @@
               </form>
 
               <form class="inline-form" method="post" action="{{ url_for('admin_users_reset_password', user_id=user.id) }}">
-                <input type="password" name="new_password" placeholder="New password" required />
-                <button class="warn-button" type="submit">Reset Password</button>
+                <button class="warn-button" type="submit">Generate Temp Password</button>
               </form>
             </td>
           </tr>

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -32,19 +32,21 @@
 
       {% if authenticated_user %}
         <nav class="top-nav" aria-label="Primary">
-          <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
-          <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
-          <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
-          <a class="chip {% if request.path.startswith('/receipts') %}active{% endif %}" href="{{ url_for('receipts_list') }}">Receipts</a>
-          <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
-          <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
-          {% if authenticated_role == 'admin' %}
-            <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Stage Assets</a>
-            <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
-            <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
+          {% if not password_change_required %}
+            <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
+            <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
+            <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
+            <a class="chip {% if request.path.startswith('/receipts') %}active{% endif %}" href="{{ url_for('receipts_list') }}">Receipts</a>
+            <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
+            <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
+            {% if authenticated_role == 'admin' %}
+              <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Stage Assets</a>
+              <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
+              <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
+            {% endif %}
           {% endif %}
           <a class="chip {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
-          {% if authenticated_role == 'admin' %}
+          {% if authenticated_role == 'admin' and not password_change_required %}
             <span class="chip mode-badge" aria-label="Admin mode">ADMIN</span>
           {% endif %}
           <a class="chip" href="{{ url_for('logout') }}">Logout</a>

--- a/assettrack/users.py
+++ b/assettrack/users.py
@@ -2,12 +2,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import secrets
+import string
 
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from assettrack.db import get_connection
 
 ALLOWED_ROLES = {"admin", "operator"}
+TEMP_PASSWORD_HASH_PREFIX = "assettrack-temp-password:"
+TEMP_PASSWORD_LENGTH = 20
 
 
 def _now_iso() -> str:
@@ -21,6 +25,32 @@ def _password_hash(password: str) -> str:
     if not password_hash:
         raise ValueError("password hash generation failed")
     return password_hash
+
+
+def _stored_password_hash(user: dict | None) -> str:
+    password_hash = str((user or {}).get("password_hash") or "")
+    if password_hash.startswith(TEMP_PASSWORD_HASH_PREFIX):
+        return password_hash[len(TEMP_PASSWORD_HASH_PREFIX) :]
+    return password_hash
+
+
+def is_temporary_password(user: dict | None) -> bool:
+    password_hash = str((user or {}).get("password_hash") or "")
+    return password_hash.startswith(TEMP_PASSWORD_HASH_PREFIX)
+
+
+def generate_temporary_password() -> str:
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*()-_=+"
+    required = [
+        secrets.choice(string.ascii_lowercase),
+        secrets.choice(string.ascii_uppercase),
+        secrets.choice(string.digits),
+        secrets.choice("!@#$%^&*()-_=+"),
+    ]
+    remaining = [secrets.choice(alphabet) for _ in range(TEMP_PASSWORD_LENGTH - len(required))]
+    password_chars = required + remaining
+    secrets.SystemRandom().shuffle(password_chars)
+    return "".join(password_chars)
 
 
 def _validate_new_password(username: str, current_password: str, new_password: str) -> None:
@@ -225,9 +255,10 @@ def set_user_role(user_id: int, role: str) -> dict:
         conn.close()
 
 
-def reset_user_password(user_id: int, new_password: str) -> dict:
+def reset_user_password(user_id: int) -> dict:
     normalized_user_id = int(user_id)
-    password_hash = _password_hash(new_password)
+    temporary_password = generate_temporary_password()
+    password_hash = f"{TEMP_PASSWORD_HASH_PREFIX}{_password_hash(temporary_password)}"
     now_iso = _now_iso()
 
     conn = get_connection()
@@ -244,7 +275,7 @@ def reset_user_password(user_id: int, new_password: str) -> dict:
             raise ValueError("User not found.")
         conn.commit()
         row = conn.execute("SELECT * FROM users WHERE id = ?;", (normalized_user_id,)).fetchone()
-        return dict(row)
+        return {"user": dict(row), "temporary_password": temporary_password}
     finally:
         conn.close()
 
@@ -283,9 +314,14 @@ def change_own_password(user_id: int, current_password: str, new_password: str) 
 def verify_password(user: dict | None, password: str) -> bool:
     if not user or not password:
         return False
-    password_hash = str(user.get("password_hash") or "")
+    
+    password_hash = _stored_password_hash(user)
     if not password_hash:
         return False
+    
+    if password_hash.startswith(TEMP_PASSWORD_HASH_PREFIX):
+        password_hash = password_hash[len(TEMP_PASSWORD_HASH_PREFIX):]
+    
     try:
         return check_password_hash(password_hash, password)
     except ValueError:

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -1,6 +1,7 @@
 # file: tests/test_admin_user_management.py
 from __future__ import annotations
 
+from html import unescape
 from pathlib import Path
 
 import pytest
@@ -8,7 +9,7 @@ import pytest
 import assettrack.auth as auth
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from assettrack.users import get_user_by_id, get_user_by_username, verify_password
+from assettrack.users import get_user_by_id, get_user_by_username, is_temporary_password, verify_password
 from tests.auth_test_utils import create_test_user, login_session
 
 
@@ -18,6 +19,7 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     conn = db.get_connection()
     conn.close()
     intake_app.ADMIN_ROUTE_ATTEMPTS.clear()
+    intake_app.LOGIN_FAILURE_ATTEMPTS.clear()
     intake_app.app.testing = True
     return intake_app.app.test_client()
 
@@ -114,7 +116,7 @@ def test_admin_cannot_deactivate_last_active_admin(client_with_temp_db) -> None:
 
 
 
-def test_admin_can_reset_password_and_new_password_allows_login(client_with_temp_db) -> None:
+def test_admin_can_reset_password_and_generated_temp_password_forces_change(client_with_temp_db) -> None:
     admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
     target_username = "operator-a"
     target_user_id = create_test_user(username=target_username, password="old-pass", role="operator")
@@ -122,22 +124,98 @@ def test_admin_can_reset_password_and_new_password_allows_login(client_with_temp
 
     response = client_with_temp_db.post(
         f"/admin/users/{target_user_id}/reset-password",
-        data={"new_password": "new-pass-123"},
     )
 
-    assert response.status_code == 302
+    assert response.status_code == 200
+    assert b"Temporary password for operator-a" in response.data
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Expires"] == "0"
+    assert "X-AssetTrack-Sensitive-Reveal" not in response.headers
+    assert b"This password is shown once. Copy it now; it will not be shown again." in response.data
+
+    updated = get_user_by_id(target_user_id)
+    assert updated is not None
+    assert is_temporary_password(updated)
+    assert updated["role"] == "operator"
+    assert int(updated["active"]) == 1
+    assert not verify_password(updated, "old-pass")
+
+    response_text = response.get_data(as_text=True)
+    marker = "<code>"
+    start = response_text.index(marker) + len(marker)
+    end = response_text.index("</code>", start)
+    temporary_password = unescape(response_text[start:end])
 
     client_with_temp_db.get("/logout")
 
     old_login = client_with_temp_db.post("/", data={"username": target_username, "password": "old-pass"})
     assert old_login.status_code == 403
 
-    new_login = client_with_temp_db.post("/", data={"username": target_username, "password": "new-pass-123"})
+    temp_login = client_with_temp_db.post("/", data={"username": target_username, "password": temporary_password})
+    assert temp_login.status_code == 302
+    assert (temp_login.headers.get("Location") or "").endswith("/dashboard")
+
+    blocked_dashboard = client_with_temp_db.get("/dashboard")
+    assert blocked_dashboard.status_code == 302
+    assert (blocked_dashboard.headers.get("Location") or "").endswith("/account/change-password")
+
+    blocked_holders = client_with_temp_db.get("/holders")
+    assert blocked_holders.status_code == 302
+    assert (blocked_holders.headers.get("Location") or "").endswith("/account/change-password")
+
+    password_change = client_with_temp_db.post(
+        "/account/change-password",
+        data={
+            "current_password": temporary_password,
+            "new_password": "NewPassword456",
+            "confirm_new_password": "NewPassword456",
+        },
+    )
+    assert password_change.status_code == 302
+    assert (password_change.headers.get("Location") or "").endswith("/dashboard")
+
+    changed = get_user_by_id(target_user_id)
+    assert changed is not None
+    assert not is_temporary_password(changed)
+    assert verify_password(changed, "NewPassword456")
+    assert not verify_password(changed, temporary_password)
+    assert changed["role"] == "operator"
+    assert int(changed["active"]) == 1
+
+    dashboard = client_with_temp_db.get("/dashboard")
+    assert dashboard.status_code == 200
+
+    client_with_temp_db.get("/logout")
+    temp_login_after_change = client_with_temp_db.post(
+        "/", data={"username": target_username, "password": temporary_password}
+    )
+    new_login = client_with_temp_db.post("/", data={"username": target_username, "password": "NewPassword456"})
+    assert temp_login_after_change.status_code == 403
     assert new_login.status_code == 302
+
+
+def test_admin_temp_password_is_not_revealed_after_reset_response(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    target_user_id = create_test_user(username="operator-a", password="old-pass", role="operator")
+    login_session(client_with_temp_db, admin_user_id)
+
+    reset_response = client_with_temp_db.post(f"/admin/users/{target_user_id}/reset-password")
+    assert reset_response.status_code == 200
+    assert b"Temporary password for operator-a" in reset_response.data
+    response_text = reset_response.get_data(as_text=True)
+    marker = "<code>"
+    start = response_text.index(marker) + len(marker)
+    end = response_text.index("</code>", start)
+    temporary_password = unescape(response_text[start:end])
+
+    users_response = client_with_temp_db.get("/admin/users")
+
+    assert users_response.status_code == 200
+    assert temporary_password.encode("utf-8") not in users_response.data
     updated = get_user_by_id(target_user_id)
     assert updated is not None
-    assert verify_password(updated, "new-pass-123")
-    assert str(updated["password_hash"]).startswith("scrypt:")
+    assert temporary_password not in str(updated["password_hash"])
 
 
 def test_admin_can_change_role_and_persists(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Implements admin-controlled password reset using a temporary password with forced change on next login.

## Related Issue
Closes #427 

## Changes
- Added admin-triggered temp password reset flow
- Implemented one-time temp password reveal
- Enforced forced password change on next login
- Prevented plaintext password storage
- Added route-level no-store cache protection for temp password response
- Fixed temp password verification by stripping marker prefix
- Added tests for reset and change-password flow

## Verification checklist
- [x] Admin can generate temp password
- [x] Temp password works for login
- [x] Old password no longer works
- [x] User is forced to change password
- [x] New password works after change
- [x] Temp password no longer works after change
- [x] Non-admin cannot access reset
- [x] Smoke test PASS
- [x] Docker rebuild verified

## Notes
- Temp-password state implemented via prefix to avoid schema change
- Disabled users remain blocked from login (by design)