### PR TITLE
Issue 26-152: clarify admin user state and reset guidance

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -6632,6 +6632,7 @@ def admin_users_reset_password(user_id: int):
             **_admin_users_context(
                 temporary_password=reset_result["temporary_password"],
                 temporary_password_username=updated["username"],
+                temporary_password_user_active=int(updated.get("active") or 0) == 1,
             ),
         ))
         response.headers["X-AssetTrack-Sensitive-Reveal"] = "1"

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -9,6 +9,26 @@
   <style>
     input[type="text"], input[type="password"], select { width: 100%; max-width: 320px; padding: 0.45rem; font-size: 0.95rem; }
     .inline-form { display: inline-block; margin: 0.15rem 0.35rem 0.15rem 0; }
+    .account-status-chip {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.2rem 0.55rem;
+      border-radius: 999px;
+      font-size: 0.88rem;
+      font-weight: 700;
+      background: var(--color-primary-soft);
+      color: var(--color-primary);
+    }
+    .account-status-chip.disabled {
+      background: #fde9e7;
+      color: #8a2d2d;
+    }
+    .reset-helper {
+      margin: 0.25rem 0 0 0;
+      max-width: 24rem;
+      font-size: 0.9rem;
+      color: #8a2d2d;
+    }
   </style>
 {% endblock %}
 
@@ -28,6 +48,9 @@
       <strong>Temporary password for {{ temporary_password_username }}:</strong>
       <code>{{ temporary_password }}</code>
       <p class="muted">This password is shown once. Copy it now; it will not be shown again. Give it to the user through a trusted local channel.</p>
+      {% if temporary_password_user_active is sameas false %}
+        <p class="reset-helper">This account is disabled. Enable the user before they can log in with the temporary password.</p>
+      {% endif %}
     </div>
   {% endif %}
 
@@ -66,7 +89,7 @@
         <tr>
           <th>Username</th>
           <th>Role</th>
-          <th>Active</th>
+          <th>Account State</th>
           <th>Created</th>
           <th>Updated</th>
           <th>Actions</th>
@@ -77,7 +100,11 @@
           <tr>
             <td>{{ user.username }}</td>
             <td>{{ user.role }}</td>
-            <td>{{ "yes" if user.active else "no" }}</td>
+            <td>
+              <span class="account-status-chip {% if not user.active %}disabled{% endif %}">
+                {% if user.active %}Active &mdash; can log in{% else %}Disabled &mdash; cannot log in{% endif %}
+              </span>
+            </td>
             <td>{{ user.created_at_display }}</td>
             <td>{{ user.updated_at_display }}</td>
             <td>
@@ -97,6 +124,9 @@
               <form class="inline-form" method="post" action="{{ url_for('admin_users_reset_password', user_id=user.id) }}">
                 <button class="warn-button" type="submit">Generate Temp Password</button>
               </form>
+              {% if not user.active %}
+                <p class="reset-helper">A temp password will not allow login until this user is enabled.</p>
+              {% endif %}
             </td>
           </tr>
         {% endfor %}

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -47,10 +47,25 @@ def test_admin_can_view_user_table(client_with_temp_db) -> None:
     assert response.status_code == 200
     assert b"Admin: Users" in response.data
     assert b"operator-a" in response.data
+    assert b"Account State" in response.data
+    assert b"Active &mdash; can log in" in response.data
     assert b"Apr 5, 2026 at 13:15 UTC" in response.data
     assert b"Apr 6, 2026 at 09:45 UTC" in response.data
     assert b"2026-04-05T13:15:00+00:00" not in response.data
     assert b"2026-04-06T09:45:00+00:00" not in response.data
+
+
+def test_admin_users_page_explains_disabled_user_login_state(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    create_test_user(username="disabled-operator", password="op-pass", role="operator", active=False)
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.get("/admin/users")
+
+    assert response.status_code == 200
+    assert b"disabled-operator" in response.data
+    assert b"Disabled &mdash; cannot log in" in response.data
+    assert b"A temp password will not allow login until this user is enabled." in response.data
 
 
 def test_admin_users_page_formats_microsecond_timestamps(client_with_temp_db) -> None:
@@ -216,6 +231,29 @@ def test_admin_temp_password_is_not_revealed_after_reset_response(client_with_te
     updated = get_user_by_id(target_user_id)
     assert updated is not None
     assert temporary_password not in str(updated["password_hash"])
+
+
+def test_disabled_user_reset_explains_enablement_is_still_required(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+    target_user_id = create_test_user(
+        username="disabled-operator",
+        password="old-pass",
+        role="operator",
+        active=False,
+    )
+    login_session(client_with_temp_db, admin_user_id)
+
+    response = client_with_temp_db.post(f"/admin/users/{target_user_id}/reset-password")
+
+    assert response.status_code == 200
+    assert b"Temporary password for disabled-operator" in response.data
+    assert b"This account is disabled. Enable the user before they can log in with the temporary password." in response.data
+    assert b"Disabled &mdash; cannot log in" in response.data
+    assert b"A temp password will not allow login until this user is enabled." in response.data
+    updated = get_user_by_id(target_user_id)
+    assert updated is not None
+    assert is_temporary_password(updated)
+    assert int(updated["active"]) == 0
 
 
 def test_admin_can_change_role_and_persists(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Improves admin user management clarity by making account state explicit and guiding reset behavior for disabled users.

## Related Issue
Closes #607 

## Changes
- Added explicit account state per user (Active — can log in / Disabled — cannot log in)
- Added guidance that disabled users cannot log in even with a temp password
- Included same guidance in temp password reveal for disabled users

## Verification checklist
- [x] Active users clearly show they can log in
- [x] Disabled users clearly show they cannot log in
- [x] Temp password for disabled user shows enablement requirement
- [x] Enable/disable actions unchanged
- [x] Temp password flow unchanged
- [x] Smoke test PASS

## Notes
UI-only clarity improvement; no auth, schema, or behavior changes