### PR TITLE
Issue 27-33: Reduce queue and preview status duplication

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -101,29 +101,16 @@
     </div>
   </div>
 
-  <div class="card workflow-card">
-    <h2>Validation Summary</h2>
-    <p class="workflow-summary">
-      <strong>Queued assets:</strong> {{ queued_count }}
-      &nbsp;|&nbsp;
-      <strong>Ready to commit:</strong> {{ ready_count }}
-      &nbsp;|&nbsp;
-      <strong>Status:</strong>
-      {% if blocking_issues %}
-        <span class="pill bad">blocked</span>
-      {% else %}
-        <span class="pill good">ready</span>
-      {% endif %}
-    </p>
-
-    {% if blocking_issues %}
+  {% if blocking_issues %}
+    <div class="card workflow-card">
+      <h2>Blocked Items</h2>
       <ul><template>
         {% for issue in blocking_issues %}
           <li>{{ issue }}</li>
         {% endfor %}
       </template></ul>
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 
   <div class="card workflow-card">
     <h2>Items to Be Issued</h2>

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -35,29 +35,16 @@
     <h2>{% if blocking_issues %}Batch Return Needs Review{% else %}Confirm This Return Batch{% endif %}</h2>
   </div>
 
-  <div class="card workflow-card">
-    <h2>Batch Confirmation</h2>
-    <p class="workflow-summary">
-      <strong>Queued assets:</strong> {{ queued_count }}
-      &nbsp;|&nbsp;
-      <strong>Ready:</strong> {{ ready_count }}
-      &nbsp;|&nbsp;
-      <strong>Status:</strong>
-      {% if blocking_issues %}
-        <span class="pill bad">blocked</span>
-      {% else %}
-        <span class="pill good">ready</span>
-      {% endif %}
-    </p>
-
-    {% if blocking_issues %}
+  {% if blocking_issues %}
+    <div class="card workflow-card">
+      <h2>Blocked Items</h2>
       <ul><template>
         {% for issue in blocking_issues %}
           <li>{{ issue }}</li>
         {% endfor %}
       </template></ul>
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 
   <div class="card workflow-card">
     <h2>Items to Be Returned</h2>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -198,28 +198,16 @@
     </form>
   </div>
 
-  <div class="card workflow-card">
-    <h2>Validation Summary</h2>
-    <p class="workflow-summary">
-      <strong>Queued assets:</strong> {{ queued_count }}
-      &nbsp;|&nbsp;
-      <strong>Ready:</strong> {{ ready_count }}
-      &nbsp;|&nbsp;
-      <strong>Status:</strong>
-      {% if blocking_issues %}
-        <span class="pill bad">blocked</span>
-      {% else %}
-        <span class="pill good">ready</span>
-      {% endif %}
-    </p>
-    {% if blocking_issues %}
+  {% if blocking_issues %}
+    <div class="card workflow-card">
+      <h2>Blocked Items</h2>
       <div class="validation-messages">
         {% for issue in blocking_issues %}
           <p class="validation-message">{{ issue }}</p>
         {% endfor %}
       </div>
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 
   <div class="card workflow-card">
     <p class="workflow-action"><a class="chip" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Open Return Assets Preview / Confirm" }}</a></p>

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -198,7 +198,7 @@ def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(clien
     assert remove.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DDC4CY002645", "DDC4CY002647"]
     assert b"Queue (2)" in remove.data
-    assert b"Queued assets:</strong> 2" in remove.data
+    assert b"Blocked Items" not in remove.data
 
     issue_preview = client_with_temp_db.get("/issue/preview")
     assert issue_preview.status_code == 200

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -93,7 +93,6 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn("Return Assets — Preview / Confirm".encode("utf-8"), preview_render.data)
         self.assertIn(b"Confirm Return", preview_render.data)
         self.assertIn(b"Confirm This Return Batch", preview_render.data)
-        self.assertIn(b"Batch Confirmation", preview_render.data)
         self.assertIn(b"Home location: Home slots", preview_render.data)
         self.assertIn(b"1 asset queued", preview_render.data)
         self.assertIn(b"Current State", preview_render.data)


### PR DESCRIPTION
## Summary
Reduced duplicate status messaging between queue and preview pages so workflow state is clearer with fewer words.

## Related Issue
Closes #650 

## Changes
- Removed duplicate status summary cards from Issue and Return workflow pages
- Kept banner, headings, and blocked-item lists as the main state signals
- Preserved prerequisite warnings, validation errors, blocked-item details, and commit safety language
- Updated tests for the reduced copy

## Verification checklist
- [x] Tests pass
- [x] Manual Issue flow smoke test PASS
- [x] Workflow seam preserved
- [x] No auth or prerequisite weakening

## Notes
Recovered the work onto the proper 27-33 branch before commit.