### PR TITLE
Issue 27-34: Move session timer block to bottom of layout

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -472,6 +472,17 @@ button.theme-toggle:hover {
   box-shadow: 0 1px 2px rgba(29, 53, 87, 0.04);
 }
 
+.page-footer {
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-surface);
+}
+
+.page-session-footer {
+  display: flex;
+  justify-content: flex-start;
+}
+
 .flash {
   padding: 0.75rem 1rem;
   border: 1px solid var(--color-surface);
@@ -548,6 +559,17 @@ button {
   border: 1px solid var(--color-surface);
   border-radius: 10px;
   background: var(--color-primary-soft);
+}
+
+.page-session-footer .timeout-panel {
+  width: 100%;
+  max-width: 32rem;
+  margin: 0;
+  background: var(--color-surface-bg);
+}
+
+.timeout-panel p {
+  margin: 0;
 }
 
 .timeout-panel.locked {

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -68,6 +68,12 @@
       {% endif %}
 
       {% block content %}{% endblock %}
+
+      {% if timeout_seconds is defined and timeout_seconds is not none and last_seen_age_seconds is not none %}
+        <footer class="page-footer page-session-footer" aria-label="Session status">
+          {% include "_timeout_status.html" %}
+        </footer>
+      {% endif %}
     </div>
     <script>
       const themeToggle = document.getElementById("theme-toggle");

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -68,7 +68,6 @@
     <p><strong>Status:</strong> {{ "Unlocked" if authed else "Locked" }}</p>
 
     {% if authed %}
-      {% include "_timeout_status.html" %}
     {% else %}
       <p>Locked. Enter access code to unlock.</p>
     {% endif %}

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -34,8 +34,6 @@
     <a class="nav-link" href="{{ url_for('preview') }}">Back to batch preview</a>
   </nav>
 
-  {% include "_timeout_status.html" %}
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -16,8 +16,6 @@
     <a href="{{ url_for('dashboard') }}">← Back to dashboard</a>
   </div>
 
-  {% include "_timeout_status.html" %}
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -17,8 +17,6 @@
     <a class="nav-link" href="{{ url_for('return_queue') }}">Back to Return Queue</a>
   </nav>
 
-  {% include "_timeout_status.html" %}
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -89,8 +89,6 @@
   {% set jump_to_queue_href = "#queue-section" %}
   <p><a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
 
-  {% include "_timeout_status.html" %}
-
   {% if message_ns.global_messages %}
     {% for category, message in message_ns.global_messages %}
       <div class="flash {{ category|e }}">{{ message }}</div>


### PR DESCRIPTION
## Summary
Moved the session timer/status block to the bottom of the shared layout so workflow actions remain primary and session status remains secondary.

## Related Issue
Closes #651 

## Changes
- Moved shared timeout/status block into footer-adjacent layout area
- Removed top-of-page timeout include from workflow templates
- Added footer/session layout styles for stable light/dark rendering
- Preserved existing timeout markup, IDs, countdown behavior, and JS hooks

## Verification checklist
- [x] Timeout behavior unchanged
- [x] Countdown updates correctly
- [x] Manual Add Assets smoke test PASS
- [x] Manual Issue smoke test PASS
- [x] Manual Return smoke test PASS
- [x] No auth/session behavior changes
- [x] Workflow seam preserved

## Notes
Session state remains visible without competing with queue, preview, and commit workflow actions.