### PR TITLE
Issue 27-36: Finish residual Smart Brevity cleanup

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4294,7 +4294,7 @@ def issue():
         workflow_banner_outcome=workflow_banner_outcome,
         return_to=url_for("issue"),
         preview_url=url_for("issue_preview"),
-        preview_label="Open Issue Assets Preview / Confirm",
+        preview_label="Open Issue Preview",
         auth_enabled=auth_enabled(),
         authed=is_authed(),
         last_seen_age_seconds=seconds_since_last_seen(),
@@ -4454,7 +4454,7 @@ def issue_commit():
     if not asset_tags:
         if wants_json():
             return {"ok": False, "committed": 0, "error": "No assets in the queue to issue."}, 400
-        flash("No assets in the queue to issue..", "error")
+        flash("No assets in the queue to issue.", "error")
         return redirect(url_for("issue_preview"))
 
     responsibility_ack = {

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -116,7 +116,7 @@
         <p><strong>No holder selected.</strong></p>
       {% endif %}
       <p><a href="{{ url_for('holders_search') }}">Search/select holder</a></p>
-      <p><a href="{{ url_for('issue_preview') }}">Open Issue Assets Preview / Confirm</a></p>
+      <p><a href="{{ url_for('issue_preview') }}">Open Issue Preview</a></p>
     {% else %}
       <p style="margin-top: 12px;"><strong>Issue mode:</strong> OFF</p>
     {% endif %}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -208,7 +208,7 @@
   {% endif %}
 
   <div class="card workflow-card">
-    <p class="workflow-action"><a class="chip" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Open Return Assets Preview / Confirm" }}</a></p>
+    <p class="workflow-action"><a class="chip" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Open Return Preview" }}</a></p>
   </div>
 
   <div class="card workflow-card" id="queue-section">

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -97,7 +97,7 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     assert issue_queue.status_code == 200
     assert b'id="timeout-lock-panel"' in issue_queue.data
     assert b"20 minutes idle / 1 hour absolute" in issue_queue.data
-    assert b"Open Issue Assets Preview / Confirm" in issue_queue.data
+    assert b"Open Issue Preview" in issue_queue.data
     assert issue_queue.data.count(b"data-timeout-lock-target") >= 4
 
     issue_preview = client_with_temp_db.get("/issue/preview")
@@ -110,7 +110,7 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     return_queue = client_with_temp_db.get("/return")
     assert return_queue.status_code == 200
     assert b'id="timeout-lock-panel"' in return_queue.data
-    assert b"Open Return Assets Preview / Confirm" in return_queue.data
+    assert b"Open Return Preview" in return_queue.data
 
     return_preview = client_with_temp_db.get("/return/preview")
     assert return_preview.status_code == 200

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -84,7 +84,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
 
     issue_preview = client_with_temp_db.get("/issue/preview")
     assert issue_preview.status_code == 200
-    assert b"Confirm Issue" in issue_preview.data
+    assert b"Issue Preview" in issue_preview.data
     assert b"Ready to Issue" in issue_preview.data
     assert b"Issued to:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data
@@ -119,7 +119,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
         follow_redirects=True,
     )
     assert follow_up_scan.status_code == 200
-    assert b"Issuing Assets" in follow_up_scan.data
+    assert b">Issue<" in follow_up_scan.data
     assert b"Issue Holder" in follow_up_scan.data
     assert b"1 asset queued" in follow_up_scan.data
 

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -57,7 +57,7 @@ def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
     assert b"Issue" in issue_page.data
-    assert b"Open Issue Assets Preview / Confirm" in issue_page.data
+    assert b"Open Issue Preview" in issue_page.data
 
 
 def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_holder(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Completed the remaining Smart Brevity cleanup items from the 27-23 closure walkthrough.

## Related Issue
Closes #656 

## Changes
- Shortened remaining preview CTA labels
- Fixed empty issue queue flash typo
- Updated stale focused preview assertions
- Kept preview gating and commit separation clear

## Verification checklist
- [x] Focused regression suite passes (52 passed)
- [x] Manual Add Assets smoke test PASS
- [x] Manual Issue flow smoke test PASS
- [x] Manual Return flow smoke test PASS
- [x] Empty queue flash verified
- [x] Preview vs commit distinction remains clear
- [x] Workflow seam preserved

## Notes
This resolves the remaining residual Smart Brevity gaps identified during the 27-23 closure walkthrough.