### PR TITLE
Issue 27-37: Improve first-time operator workflow clarity

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4288,7 +4288,7 @@ def issue():
         "return_queue.html",
         page_title="Issue",
         page_heading="Issue",
-        scan_heading="Scan",
+        scan_heading="Add to Queue",
         workflow_banner_title="Issue",
         workflow_banner_queued_count=len(asset_tags),
         workflow_banner_outcome=workflow_banner_outcome,

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -170,7 +170,7 @@
         </tbody>
       </table>
     {% else %}
-      <p>No assets queued.</p>
+      <p>No assets queued. Return to the queue and scan or enter an asset tag.</p>
     {% endif %}
   </div>
 
@@ -179,7 +179,7 @@
     <form method="post" action="{{ url_for('issue_commit') }}">
       <label style="display:block; margin-bottom: 10px;">
         <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
-        I reviewed this batch and want to add it to the database.
+        I reviewed this batch and want to issue these assets to the selected holder.
       </label>
       <label style="display:block; margin-bottom: 10px;">
         <input type="checkbox" id="confirm_responsibility_ack" name="confirm_responsibility_ack" />

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -83,7 +83,7 @@
     <form method="post" action="{{ url_for('issue_commit') if issue_mode else url_for('preview_commit') }}" style="margin-top: 10px;">
       <label style="display:block; margin-bottom: 10px;">
         <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed">
-        I reviewed this batch and want to add it to the database.
+        {{ "I reviewed this batch and want to issue these assets to the selected holder." if issue_mode else "I reviewed this batch and want to add it to the database." }}
       </label>
 
       <button id="add_btn" type="submit" disabled data-timeout-lock-target>{{ "Commit Issue" if issue_mode else "Add to database" }}</button>

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -99,7 +99,7 @@
         </tbody>
       </table>
     {% else %}
-      <p>No assets queued.</p>
+      <p>No assets queued. Return to the queue and scan or enter an asset tag.</p>
     {% endif %}
   </div>
 

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -161,7 +161,7 @@
   {% endif %}
 
   <div class="card workflow-card">
-    <h2>{{ scan_heading or "Scan" }}</h2>
+    <h2>{{ scan_heading or "Add to Queue" }}</h2>
     {% if issue_location_form is defined and not issue_location_ready %}
       <div class="flash error">
         <strong>Scanning is blocked.</strong> Set the current building and current room / area above, then scan again.
@@ -182,11 +182,11 @@
         id="scan-input"
         type="text"
         name="scan_text"
-        placeholder="Scan here..."
+        placeholder="Scan or enter asset tag"
         {% if issue_location_form is not defined %}autofocus{% endif %}
         data-timeout-lock-target
       />
-      <button type="submit" data-timeout-lock-target>Submit</button>
+      <button type="submit" data-timeout-lock-target>Add to queue</button>
     </form>
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
@@ -213,20 +213,24 @@
 
   <div class="card workflow-card" id="queue-section">
     <h2>Queue ({{ queue_len }})</h2>
-    <ul id="queue-list" class="queue-list" role="list">
-      {% for s in queue %}
-        <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
-          <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
-          <code>{{ s.asset_tag }}</code>
-          <form method="post" action="{{ url_for('intake') }}">
-            <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
-            <input type="hidden" name="action" value="remove" />
-            <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
-            <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>
-          </form>
-        </li>
-      {% endfor %}
-    </ul>
+    {% if queue %}
+      <ul id="queue-list" class="queue-list" role="list">
+        {% for s in queue %}
+          <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
+            <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
+            <code>{{ s.asset_tag }}</code>
+            <form method="post" action="{{ url_for('intake') }}">
+              <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
+              <input type="hidden" name="action" value="remove" />
+              <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
+              <button type="submit" class="queue-remove" data-timeout-lock-target>Remove</button>
+            </form>
+          </li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p class="queue-empty">No assets queued yet. Scan or enter an asset tag, then add it to the queue.</p>
+    {% endif %}
   </div>
 {% endblock %}
 

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -81,6 +81,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert preview.status_code == 200
     assert b'action="/issue/commit"' in preview.data
     assert b"Commit Issue" in preview.data
+    assert b"I reviewed this batch and want to issue these assets to the selected holder." in preview.data
 
     issue_preview = client_with_temp_db.get("/issue/preview")
     assert issue_preview.status_code == 200
@@ -92,6 +93,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Current location:</strong> <code>HQ North / 210</code>" in issue_preview.data
     assert b"Issued to:</strong> <code>Not assigned</code>" in issue_preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in issue_preview.data
+    assert b"I reviewed this batch and want to issue these assets to the selected holder." in issue_preview.data
     assert b'name="confirm_responsibility_ack"' in issue_preview.data
     assert b"accepted responsibility for this issue batch" in issue_preview.data
     assert b'id="issue_btn" type="submit" data-timeout-lock-target' in issue_preview.data
@@ -138,6 +140,22 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert str(asset["location_type"]) == "IN_CUSTODY"
     assert int(asset["current_holder_id"]) == 1
     assert occupancy is None
+
+
+def test_issue_preview_empty_queue_shows_next_step_guidance(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-preview-empty", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
+
+    issue_preview = client_with_temp_db.get("/issue/preview")
+
+    assert issue_preview.status_code == 200
+    assert b"No assets queued. Return to the queue and scan or enter an asset tag." in issue_preview.data
 
 
 def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(client_with_temp_db) -> None:

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -105,6 +105,9 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert b"Current Location" in issue_page.data
     assert b"Before scanning, set the current building and current room / area." in issue_page.data
     assert b"Scanning is blocked." in issue_page.data
+    assert b"Add to Queue" in issue_page.data
+    assert b"Scan or enter asset tag" in issue_page.data
+    assert b"Add to queue" in issue_page.data
     assert b"#issue-building," in issue_page.data
     assert b"max-width: 520px;" in issue_page.data
     assert b"box-sizing: border-box;" in issue_page.data

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -85,6 +85,9 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(render.status_code, 200)
         self.assertIn(b"Return", render.data)
         self.assertIn(b">Return<", render.data)
+        self.assertIn(b"Add to Queue", render.data)
+        self.assertIn(b"Scan or enter asset tag", render.data)
+        self.assertIn(b"Add to queue", render.data)
         self.assertIn(b"Home location: Home slots", render.data)
         self.assertIn(b"1 asset queued", render.data)
 
@@ -236,6 +239,21 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIsNone(receipt_row["sent_at"])
         self.assertIsNone(receipt_row["last_attempt_at"])
         self.assertIsNone(receipt_row["last_error"])
+
+    def test_return_queue_and_preview_empty_states_show_next_step_guidance(self) -> None:
+        render = self.client.get("/return")
+        self.assertEqual(render.status_code, 200)
+        self.assertIn(
+            b"No assets queued yet. Scan or enter an asset tag, then add it to the queue.",
+            render.data,
+        )
+
+        preview_render = self.client.get("/return/preview")
+        self.assertEqual(preview_render.status_code, 200)
+        self.assertIn(
+            b"No assets queued. Return to the queue and scan or enter an asset tag.",
+            preview_render.data,
+        )
 
     def test_return_commit_restores_slot_occupancy_after_issue_path_removal(self) -> None:
         self._insert_holder(5, "Return Holder Five")


### PR DESCRIPTION
## Summary
Improved first-time operator workflow clarity after the Smart Brevity risk review.

## Related Issue
Closes #658 

## Changes
- Clarified queue-entry actions so operators understand scans are added to the queue
- Added concise next-step guidance for empty queue and preview states
- Updated Issue-mode commit wording to reflect custody issuance instead of database intake
- Updated focused tests and added narrow coverage for the new workflow cues

## Verification checklist
- [x] Focused regression suite passes (54 passed)
- [x] Manual Issue flow smoke test PASS
- [x] Manual Return flow smoke test PASS
- [x] Queue actions clearly read as queueing, not committing
- [x] Empty states provide next-step guidance
- [x] Preview remains distinct from commit
- [x] Workflow seam preserved

## Notes
Issue 27-38 remains open for separate review of Issue preview back-navigation clarity.