### PR TITLE
Issue 27-44: Standardize workflow-local back links

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -378,6 +378,10 @@ a:hover {
   border-radius: 4px;
 }
 
+.workflow-local-nav {
+  margin: 0 0 0.85rem 0;
+}
+
 .page {
   max-width: 1200px;
   margin: 0 auto;

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -62,12 +62,6 @@
       justify-content: flex-start;
       margin: 0;
     }
-    .secondary-actions {
-      margin: 0 0 0.85rem 0;
-      font-size: 0.9rem;
-      color: color-mix(in srgb, var(--color-primary) 58%, var(--color-text));
-    }
-    .secondary-actions a { color: inherit; }
     .queue-list { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.9rem; }
     .queue-row {
       display: flex;
@@ -119,7 +113,9 @@
 {% endblock %}
 
 {% block content %}
-  <p class="secondary-actions"><a href="{{ url_for('return_queue') }}">Back to Return</a></p>
+  <nav class="workflow-local-nav" aria-label="Workflow navigation">
+    <a class="nav-link" href="{{ url_for('return_queue') }}">Back to Return</a>
+  </nav>
 
   {% if auth_enabled %}
     <p><strong>Status:</strong> {{ "Unlocked" if authed else "Locked" }}</p>

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -30,8 +30,8 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Issue preview navigation">
-    <a class="nav-link" href="{{ url_for('preview') }}">Back to batch preview</a>
+  <nav class="workflow-local-nav" aria-label="Workflow navigation">
+    <a class="nav-link" href="{{ url_for('preview') }}">Back to Batch Preview</a>
   </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -12,9 +12,9 @@
 {% endblock %}
 
 {% block content %}
-  <div class="row">
-    <a href="{{ url_for('dashboard') }}">← Back to dashboard</a>
-  </div>
+  <nav class="workflow-local-nav" aria-label="Workflow navigation">
+    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   {% set blocked_count = queued_count - ready_count %}
-  <nav class="actions" aria-label="Return preview navigation">
+  <nav class="workflow-local-nav" aria-label="Workflow navigation">
     <a class="nav-link" href="{{ url_for('return_queue') }}">Back to Return Queue</a>
   </nav>
 

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -87,7 +87,9 @@
   {% endfor %}
   {% set jump_to_scan_href = "#scan-input" %}
   {% set jump_to_queue_href = "#queue-section" %}
-  <p><a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Workflow navigation">
+    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
+  </nav>
 
   {% if message_ns.global_messages %}
     {% for category, message in message_ns.global_messages %}
@@ -109,7 +111,7 @@
   {% endif %}
 
   {% if issue_location_form is defined %}
-    <p><a class="nav-link" href="{{ jump_to_scan_href }}">Jump to scan</a></p>
+    <p><a class="nav-link" href="{{ jump_to_scan_href }}">Jump to Scan</a></p>
   {% endif %}
 
   {% if issue_location_form is defined %}
@@ -173,7 +175,7 @@
       {% endfor %}
     {% endif %}
     {% if queue_len > 0 %}
-      <p><a class="nav-link" href="{{ jump_to_queue_href }}">Jump to queue</a></p>
+      <p><a class="nav-link" href="{{ jump_to_queue_href }}">Jump to Queue</a></p>
     {% endif %}
 
     <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">


### PR DESCRIPTION
## Summary

Standardizes workflow-local back navigation so local links consistently read as lightweight navigation instead of workflow actions.

## Related Issue

Closes #669 

## Changes

- added shared `.workflow-local-nav` styling
- standardized local workflow back-link treatment across queue and preview pages
- normalized local navigation wording to title case
- updated preview and queue context links for consistency
- preserved workflow-action visual dominance

## Verification

- [x] Tests pass
- [x] Docker rebuild completed
- [x] Add Assets smoke tested
- [x] Issue smoke tested
- [x] Return smoke tested
- [x] Preview-page navigation smoke tested
- [x] Local back links read as navigation
- [x] Workflow actions remain visually dominant
- [x] No route changes
- [x] No workflow/auth/persistence changes

## Notes

This completes the workflow-local navigation consistency pass separate from shared top-nav cleanup.