### PR TITLE
Issue 27-46: Align workflow and admin container widths

### DIFF
--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -3,6 +3,7 @@
 
 {% block title %}AssetTrack — Add Assets{% endblock %}
 {% block page_heading %}Add Assets{% endblock %}
+{% block page_class %} page-wide{% endblock %}
 
 {% block extra_head %}
   <style>


### PR DESCRIPTION
## Summary

Aligned `/add-assets` with the shared wide container layout already used by workflow and admin pages.

## Related Issue

Closes #671 

## Changes

- applied shared `page-wide` layout class to `/add-assets`
- preserved existing workflow behavior and layout structure
- kept change scoped to presentation-only width alignment

## Verification

- [x] Targeted tests pass
- [x] Manual browser verification completed
- [x] `/add-assets` now visually aligns with `/issue` and `/return`
- [x] No workflow behavior changes observed

## Notes

Follow-on width inconsistencies were identified between some admin pages and workflow pages and should be handled separately.