### PR TITLE
Issue 27-47: Fix dark theme toggle server-rendered pressed state

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -32,6 +32,7 @@
           class="theme-toggle"
           id="theme-toggle"
           aria-label="{{ theme_aria_label }}"
+          aria-pressed="{{ theme_aria_pressed }}"
         >
           <span class="theme-toggle-icon" aria-hidden="true">{{ theme_icon }}</span>
           <span class="theme-toggle-text">{{ theme_text }}</span>


### PR DESCRIPTION
## Summary

Fixed the theme toggle’s server-rendered pressed state.

## Related Issue

Closes #672 

## Changes

- added the missing `aria-pressed` attribute to the shared theme toggle button
- used the existing server-side theme value already computed in `base.html`
- preserved existing theme behavior and client-side sync

## Verification

- [x] Targeted tests pass
- [x] Manual light mode check completed
- [x] Manual dark mode check completed
- [x] Refresh in dark mode preserves correct initial toggle state
- [x] Refresh in light mode preserves correct initial toggle state

## Notes

Follow-on issue proposed: simplify the theme toggle to an icon-only control.