### PR TITLE
Issue 27-49: Simplify theme toggle to icon-only control

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -449,14 +449,17 @@ a:hover {
 button.theme-toggle {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.45rem 0.75rem;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  padding: 0;
   border: 1px solid var(--color-surface);
   border-radius: 999px;
   background: var(--color-surface-bg);
   color: var(--color-text);
   font: inherit;
   cursor: pointer;
+  flex: 0 0 auto;
 }
 
 button.theme-toggle:hover {
@@ -465,6 +468,7 @@ button.theme-toggle:hover {
 
 .theme-toggle-icon {
   line-height: 1;
+  font-size: 1rem;
 }
 
 .chip {

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -8,13 +8,11 @@
   {% set theme_aria_pressed = "true" %}
   {% set theme_aria_label = "Switch to light mode" %}
   {% set theme_icon = "☀️" %}
-  {% set theme_text = "Light mode" %}
 {% else %}
   {% set html_theme_attr = "" %}
   {% set theme_aria_pressed = "false" %}
   {% set theme_aria_label = "Switch to dark mode" %}
   {% set theme_icon = "🌙" %}
-  {% set theme_text = "Dark mode" %}
 {% endif %}
 <html lang="en"{{ html_theme_attr | safe }}>
   <head>
@@ -35,7 +33,6 @@
           aria-pressed="{{ theme_aria_pressed }}"
         >
           <span class="theme-toggle-icon" aria-hidden="true">{{ theme_icon }}</span>
-          <span class="theme-toggle-text">{{ theme_text }}</span>
         </button>
       </div>
       {% set heading = self.page_heading() | trim %}
@@ -85,12 +82,8 @@
         function syncThemeToggle() {
           const isDark = root.dataset.theme === "dark";
           const icon = themeToggle.querySelector(".theme-toggle-icon");
-          const text = themeToggle.querySelector(".theme-toggle-text");
           if (icon) {
             icon.textContent = isDark ? "☀️" : "🌙";
-          }
-          if (text) {
-            text.textContent = isDark ? "Light mode" : "Dark mode";
           }
           themeToggle.setAttribute("aria-pressed", isDark ? "true" : "false");
           themeToggle.setAttribute("aria-label", isDark ? "Switch to light mode" : "Switch to dark mode");

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -127,7 +127,7 @@ def test_login_screen_renders_theme_toggle_without_persistence_storage(client_wi
     assert b'img/curltech-badge-512.png' not in response.data
     assert b"AssetTrack by CurlTech LLC" not in response.data
     assert "🌙".encode("utf-8") in response.data
-    assert b"Dark mode" in response.data
+    assert b'aria-label="Switch to dark mode"' in response.data
     assert b"localStorage" not in response.data
     assert b"sessionStorage" not in response.data
 
@@ -427,7 +427,7 @@ def test_dark_theme_cookie_persists_across_authenticated_navigation(client_with_
     assert b'aria-pressed="true"' in dashboard_response.data
     assert b'aria-label="Switch to light mode"' in dashboard_response.data
     assert "\u2600\ufe0f".encode("utf-8") in dashboard_response.data
-    assert b"Light mode" in dashboard_response.data
+    assert b'aria-label="Switch to light mode"' in dashboard_response.data
 
     asset_search_response = client_with_temp_db.get("/assets/search")
     assert asset_search_response.status_code == 200
@@ -435,7 +435,7 @@ def test_dark_theme_cookie_persists_across_authenticated_navigation(client_with_
     assert b'aria-pressed="true"' in asset_search_response.data
     assert b'aria-label="Switch to light mode"' in asset_search_response.data
     assert "\u2600\ufe0f".encode("utf-8") in asset_search_response.data
-    assert b"Light mode" in asset_search_response.data
+    assert b'aria-label="Switch to light mode"' in asset_search_response.data
 
 
 def test_authenticated_file_download_sets_no_store_headers(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary

Simplified the theme toggle to an icon-only control.

## Related Issue

Closes #677 

## Changes

- removed visible theme toggle text
- kept `aria-label` and `aria-pressed`
- tightened toggle styling into a compact icon button
- updated focused tests for the accessible label

## Verification

- [x] Targeted tests pass
- [x] Manual light mode check completed
- [x] Manual dark mode check completed
- [x] Refresh check completed in both modes
- [x] Keyboard focus remains visible

## Notes

Presentation-only cleanup.