### PR TITLE
Issue 27-45: Separate mixed navigation and action rows

### DIFF
--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -5,7 +5,9 @@
 {% block page_class %} page-wide{% endblock %}
 
 {% block content %}
-  <p><a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin navigation">
+    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a>
+  </nav>
 
   {% if schema_warning %}
     <div class="flash error">{{ schema_warning }}</div>
@@ -13,10 +15,14 @@
 
   <div class="card">
     <h2>Admin Tools</h2>
-    <p><a class="nav-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
-    <p><a class="nav-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a></p>
-    <p><a class="nav-link" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
-    <p><a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a></p>
+    <nav class="workflow-local-nav" aria-label="Admin tool navigation">
+      <p><a class="nav-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
+      <p><a class="nav-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a></p>
+      <p><a class="nav-link" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
+    </nav>
+    <div class="actions" aria-label="Admin tool actions">
+      <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
+    </div>
     <table>
       <tbody>
         <tr>

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -65,12 +65,12 @@
         {% endif %}
       </div>
       <div class="actions" style="margin-top: 0.75rem;">
-        <a class="chip" href="{{ url_for('holders_search') }}">Change holder</a>
+        <a class="nav-link" href="{{ url_for('holders_search') }}">Change holder</a>
       </div>
     {% else %}
       <p>No holder selected.</p>
       <div class="actions" style="margin-top: 0.75rem;">
-        <a class="chip" href="{{ url_for('holders_search') }}">Select holder</a>
+        <a class="nav-link" href="{{ url_for('holders_search') }}">Select holder</a>
       </div>
     {% endif %}
   </div>
@@ -95,7 +95,7 @@
       </ul>
     {% endif %}
     <div class="actions" style="margin-top: 0.75rem;">
-      <a class="chip" href="{{ url_for('issue') }}">Update current location</a>
+      <a class="nav-link" href="{{ url_for('issue') }}">Update current location</a>
     </div>
   </div>
 

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -115,8 +115,10 @@
       {% else %}
         <p><strong>No holder selected.</strong></p>
       {% endif %}
-      <p><a href="{{ url_for('holders_search') }}">Search/select holder</a></p>
-      <p><a href="{{ url_for('issue_preview') }}">Open Issue Preview</a></p>
+      <nav class="workflow-local-nav" aria-label="Issue mode navigation">
+        <p><a class="nav-link" href="{{ url_for('holders_search') }}">Search/select holder</a></p>
+        <p><a class="nav-link" href="{{ url_for('issue_preview') }}">Open Issue Preview</a></p>
+      </nav>
     {% else %}
       <p style="margin-top: 12px;"><strong>Issue mode:</strong> OFF</p>
     {% endif %}


### PR DESCRIPTION
## Summary

Separated navigation links from workflow/admin action rows.

## Related Issue

Closes #670 

## Changes

- grouped preview navigation links into local nav treatment
- changed movement links on issue preview from action chips to nav links
- separated admin navigation links from the database backup action

## Verification

- [x] Targeted tests pass
- [x] `git diff --check` passes
- [x] Manual browser verification completed
- [x] Primary workflow actions remain obvious
- [x] No route or workflow behavior changes observed

## Notes

Follow-on needed: consolidate primary navbar destinations so the app returns to a smaller set of core screens.