### PR TITLE
Issue 27-50: consolidate primary navbar destinations

### DIFF
--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -16,6 +16,7 @@
   <div class="card">
     <h2>Admin Tools</h2>
     <nav class="workflow-local-nav" aria-label="Admin tool navigation">
+      <p><a class="nav-link" href="{{ url_for('admin_users') }}">Manage Users</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -48,12 +48,9 @@
             <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
             <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
             <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
-            <a class="chip {% if request.path.startswith('/receipts') %}active{% endif %}" href="{{ url_for('receipts_list') }}">Receipts</a>
             <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
-            <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Asset Search</a>
             {% if authenticated_role == 'admin' %}
               <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Stage Assets</a>
-              <a class="chip {% if request.path.startswith('/admin/users') %}active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
               <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
             {% endif %}
           {% endif %}

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -110,10 +110,11 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     response = client_with_temp_db.get("/admin/system")
 
     assert response.status_code == 200
-    assert b"Admin: System Health" in response.data
+    assert b"Admin: Tools" in response.data
     assert b'id="holder-count">1<' in response.data
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
+    assert b"Manage Users" in response.data
     assert b"Import Holders from CSV" in response.data
     assert b"Open Human-Readable Report" in response.data
     assert b"Download Database Backup" in response.data

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -590,7 +590,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Preview</a>" not in dashboard_response.data
     assert b">Issue</a>" in dashboard_response.data
     assert b">Return</a>" in dashboard_response.data
-    assert b">Receipts</a>" in dashboard_response.data
+    assert b">Receipts</a>" not in dashboard_response.data
     assert b">Stage Assets</a>" not in dashboard_response.data
     assert b">Users</a>" not in dashboard_response.data
     assert b">Admin Tools</a>" not in dashboard_response.data
@@ -606,9 +606,9 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
     dashboard_response = client_with_temp_db.get("/dashboard")
 
     assert dashboard_response.status_code == 200
-    assert b">Receipts</a>" in dashboard_response.data
+    assert b">Receipts</a>" not in dashboard_response.data
     assert b">Stage Assets</a>" in dashboard_response.data
-    assert b">Users</a>" in dashboard_response.data
+    assert b">Users</a>" not in dashboard_response.data
     assert b">Admin Tools</a>" in dashboard_response.data
 
 

--- a/tests/test_issue_23_3_admin_system_nav.py
+++ b/tests/test_issue_23_3_admin_system_nav.py
@@ -26,7 +26,7 @@ def test_admin_navigation_exposes_system_health_link(client_with_temp_db) -> Non
 
     assert response.status_code == 200
     assert b'href="/admin/system"' in response.data
-    assert b">System Health<" in response.data
+    assert b">Admin Tools<" in response.data
 
 
 def test_operator_navigation_hides_system_health_link(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary
Consolidates the primary navbar so it only carries core workflow destinations.

## Related Issue
Closes #681 

## Changes
- Removed secondary/admin-support links from the shared top navbar.
- Kept Asset Search and Receipts reachable from existing contextual surfaces.
- Added Manage Users under Admin Tools.
- Updated nav/auth test expectations.

## Verification checklist
- [x] Targeted tests passed: 64 passed.
- [x] Full suite checked: 276 passed, 63 failed on branch.
- [x] Same 63 failures confirmed pre-existing on main.
- [x] Docker rebuilt with `docker compose up -d --build`.
- [x] Manual nav smoke test passed.
- [x] Issue, Return, and Stage Assets still enter at workflow start pages.
- [x] No schema, event, auth, custody, queue, preview, commit, or persistence behavior changed.

## Notes
The full-suite failures are pre-existing on main and unrelated to this Class 1 navbar change.