### PR TITLE
Issue 27-51: reduce duplicate workflow entry points

### DIFF
--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -117,7 +117,7 @@
       {% endif %}
       <nav class="workflow-local-nav" aria-label="Issue mode navigation">
         <p><a class="nav-link" href="{{ url_for('holders_search') }}">Search/select holder</a></p>
-        <p><a class="nav-link" href="{{ url_for('issue_preview') }}">Open Issue Preview</a></p>
+        <p><a class="nav-link" href="{{ url_for('issue_preview') }}">Review issue details</a></p>
       </nav>
     {% else %}
       <p style="margin-top: 12px;"><strong>Issue mode:</strong> OFF</p>


### PR DESCRIPTION
## Summary
Reduces duplicate workflow-entry phrasing on the preview surface.

## Related Issue
Closes #683 

## Changes
- Renamed the issue-mode link on `/preview` from `Open Issue Preview` to `Review issue details`.
- Preserved the same route and workflow behavior.

## Verification checklist
- [x] Targeted tests passed.
- [x] Full suite checked.
- [x] Same unrelated 63 failures still present on main.
- [x] Docker rebuilt with `docker compose up -d --build`.
- [x] Manual workflow smoke test passed.
- [x] Preview remains a review step, not a global destination.
- [x] No schema, auth, event, queue, preview, commit, or persistence behavior changed.

## Notes
This is a presentation-only cognition cleanup focused on reducing duplicate “preview” terminology inside the workflow.