### PR TITLE
Issue 27-52: normalize admin surface visual density

### DIFF
--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -9,6 +9,18 @@
   <style>
     input[type="text"], input[type="password"], select { width: 100%; max-width: 320px; padding: 0.45rem; font-size: 0.95rem; }
     .inline-form { display: inline-block; margin: 0.15rem 0.35rem 0.15rem 0; }
+    .admin-user-actions {
+      display: grid;
+      gap: 0.45rem;
+      justify-items: start;
+    }
+    .admin-user-actions .inline-form {
+      margin: 0;
+    }
+    .admin-user-actions .inline-form select,
+    .admin-user-actions .inline-form button {
+      width: auto;
+    }
     .account-status-chip {
       display: inline-flex;
       align-items: center;
@@ -107,7 +119,7 @@
             </td>
             <td>{{ user.created_at_display }}</td>
             <td>{{ user.updated_at_display }}</td>
-            <td>
+            <td class="admin-user-actions">
               <form class="inline-form" method="post" action="{{ url_for('admin_users_toggle_active', user_id=user.id) }}">
                 <input type="hidden" name="active" value="{{ 0 if user.active else 1 }}" />
                 <button{% if user.active %} class="warn-button"{% endif %} type="submit">{{ "Disable" if user.active else "Enable" }}</button>


### PR DESCRIPTION
## Summary
Reduces visual density in the Manage Users action area so admin controls feel calmer and easier to scan.

## Related Issue
Closes #684 

## Changes
- Tightened the vertical rhythm of per-user admin actions in `admin_users.html`.
- Preserved all existing controls, labels, routes, and form behavior.

## Verification checklist
- [x] Targeted tests passed.
- [x] Full suite checked.
- [x] Same unrelated 63 failures still present on main.
- [x] Docker rebuilt with `docker compose up -d --build`.
- [x] Manual admin smoke test passed.
- [x] Disable/Enable, Set Role, and Generate Temp Password remain reachable.
- [x] No schema, auth, event, queue, preview, commit, or persistence behavior changed.

## Notes
This is a presentation-only density cleanup focused on calmer admin workflow scanning.