### PR TITLE
Issue 27-54: separate local codex docs from operator docs

### DIFF
--- a/docs/operator/workflow-model.md
+++ b/docs/operator/workflow-model.md
@@ -1,0 +1,53 @@
+# Workflow Model
+
+AssetTrack uses one operator workflow seam:
+
+`entry -> prerequisite selection -> scan queue -> preview -> commit`
+
+## Primary / Global Destinations
+
+These pages begin or anchor work:
+
+- `Dashboard`
+- `Issue`
+- `Return`
+- `Holders`
+- `Stage Assets` for admin intake
+- `Admin Tools` for admin maintenance
+
+## Workflow-Local Navigation
+
+These links help complete the active workflow and should return the operator to it:
+
+- holder search and holder selection during Issue
+- current-location setup during Issue
+- queue-local links such as jump-to-queue or jump-to-scan
+
+## Contextual / Admin Surfaces
+
+These pages support lookup, maintenance, or follow-up work but are not primary workflow entry points:
+
+- reports
+- receipts
+- search
+- admin drilldown pages such as users, imports, and reference data
+
+## Transitional Preview States
+
+These are review states between queue and commit:
+
+- `/preview`
+- `/issue/preview`
+- `/return/preview`
+
+Preview is a verification state, not a destination.
+
+## Commit Gravity
+
+Commit actions are terminal and high-gravity:
+
+- they finalize the queued batch
+- they append the resulting record
+- they must not compete with ordinary navigation
+
+Operators should not face multiple competing entry paths for the same workflow intent.


### PR DESCRIPTION
## Summary
Creates a committed operator documentation area while keeping Codex working docs local-only.

## Related Issue
Closes #688 

## Changes
- Added `docs/operator/workflow-model.md`.
- Documented the operator workflow seam and navigation hierarchy.
- Clarified the boundary between local Codex docs and committed operator/runtime docs.

## Verification checklist
- [x] `docs/operator/workflow-model.md` is trackable.
- [x] `docs/codex/CURRENT_STATE.md` remains locally ignored.
- [x] `docs/codex/PROJECT_MEMORY.md` remains locally ignored.
- [x] No Codex working-memory docs were force-added.
- [x] No application behavior changed.

## Notes
Docs-only repository hygiene issue.