### PR TITLE
Issue 27-60: add guarded admin database restore workflow

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -69,6 +69,14 @@ from assettrack.reference_data import (
 )
 from assettrack.audit import ACTIVE_EVENTS_WHERE, record_event
 from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
+from assettrack.restore import (
+    RestoreError,
+    RestoreOperationError,
+    RestoreValidationError,
+    recovery_state_path_for,
+    restore_database,
+    rollback_artifact_path_for,
+)
 from assettrack.users import (
     change_own_password,
     count_users,
@@ -6460,6 +6468,72 @@ def admin_db_export():
         download_name=download_name,
         mimetype="application/octet-stream",
         conditional=False,
+    )
+
+
+@app.route("/admin/db/restore", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_db_restore():
+    resolved_db_path = _resolved_runtime_db_path()
+    rollback_path = rollback_artifact_path_for(resolved_db_path)
+    recovery_state_path = recovery_state_path_for(resolved_db_path)
+    error_message: str | None = None
+    success_message: str | None = None
+    restore_result: dict[str, str] | None = None
+    status_code = 200
+
+    if request.method == "POST":
+        if not _consume_admin_route_rate_limit_slot():
+            error_message = "Too many requests. Wait and try again."
+            status_code = 429
+        else:
+            upload = request.files.get("db_file")
+            filename = str((upload.filename if upload is not None else "") or "").strip()
+
+            if upload is None or not filename:
+                error_message = "Choose a SQLite database file to restore."
+                status_code = 400
+            else:
+                suffix = Path(filename).suffix or ".db"
+                temp_path: Path | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+                        upload.save(handle)
+                        temp_path = Path(handle.name)
+
+                    restore_result = restore_database(
+                        uploaded_db_path=temp_path,
+                        live_db_path=resolved_db_path,
+                        source_filename=filename,
+                    )
+                    success_message = (
+                        "Database restore complete. Recovery mode is active and the previous database copy was preserved."
+                    )
+                except RestoreValidationError as exc:
+                    error_message = str(exc)
+                    status_code = 400
+                except RestoreOperationError as exc:
+                    error_message = str(exc)
+                    status_code = 500
+                except RestoreError as exc:
+                    error_message = str(exc)
+                    status_code = 500
+                finally:
+                    if temp_path is not None:
+                        temp_path.unlink(missing_ok=True)
+
+    return (
+        render_template(
+            "admin_db_restore.html",
+            db_path=str(resolved_db_path),
+            rollback_path=str(rollback_path),
+            recovery_state_path=str(recovery_state_path),
+            error_message=error_message,
+            success_message=success_message,
+            restore_result=restore_result,
+        ),
+        status_code,
     )
 
 

--- a/assettrack/intake/templates/admin_db_restore.html
+++ b/assettrack/intake/templates/admin_db_restore.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Database Restore{% endblock %}
+{% block page_heading %}Admin: Database Restore{% endblock %}
+{% block page_class %} admin-maintenance-wide-fields{% endblock %}
+
+{% block content %}
+  <nav class="workflow-local-nav" aria-label="Admin restore navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to admin tools</a>
+  </nav>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  {% if success_message %}
+    <div class="flash success">{{ success_message }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Restore SQLite Backup</h2>
+    <p>Use this only for recovery. AssetTrack will validate the uploaded SQLite file before replacing the live database.</p>
+    <form method="post" enctype="multipart/form-data">
+      <div class="row form-group">
+        <label class="form-label" for="db_file"><strong>SQLite backup file</strong></label>
+        <input id="db_file" name="db_file" type="file" accept=".db,.sqlite,.sqlite3,application/octet-stream" required />
+      </div>
+      <div class="search-actions">
+        <button type="submit">Validate and Restore</button>
+      </div>
+    </form>
+  </div>
+
+  <div class="card">
+    <h2>Operational Paths</h2>
+    <table>
+      <tbody>
+        <tr>
+          <th>Live DB path</th>
+          <td><code>{{ db_path }}</code></td>
+        </tr>
+        <tr>
+          <th>Rollback copy path</th>
+          <td><code>{{ rollback_path }}</code></td>
+        </tr>
+        <tr>
+          <th>Recovery state path</th>
+          <td><code>{{ recovery_state_path }}</code></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  {% if restore_result %}
+    <div class="card">
+      <h2>Restore Result</h2>
+      <table>
+        <tbody>
+          <tr>
+            <th>Live DB</th>
+            <td><code>{{ restore_result.live_db_path }}</code></td>
+          </tr>
+          <tr>
+            <th>Rollback copy</th>
+            <td><code>{{ restore_result.rollback_db_path }}</code></td>
+          </tr>
+          <tr>
+            <th>Recovery state</th>
+            <td><code>{{ restore_result.recovery_state_path }}</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -20,6 +20,7 @@
       <p><a class="nav-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_human_report') }}">Open Human-Readable Report</a></p>
+      <p><a class="nav-link" href="{{ url_for('admin_db_restore') }}">Restore Database Backup</a></p>
     </nav>
     <div class="actions" aria-label="Admin tool actions">
       <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>

--- a/assettrack/restore.py
+++ b/assettrack/restore.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assettrack.db import EVENT_TABLE_ALIASES
+
+RESTORE_REQUIRED_TABLES = {
+    "assets",
+    "holders",
+    "organizations",
+    "buildings",
+    "organization_buildings",
+    "slots",
+    "slot_occupancy",
+    "users",
+    "receipt_queue",
+}
+
+
+class RestoreError(RuntimeError):
+    """Base restore error."""
+
+
+class RestoreValidationError(RestoreError):
+    """Raised when an uploaded database fails validation."""
+
+
+class RestoreOperationError(RestoreError):
+    """Raised when replacement or rollback preservation fails."""
+
+
+def rollback_artifact_path_for(db_path: Path) -> Path:
+    suffix = db_path.suffix or ".db"
+    return db_path.with_name(f"{db_path.stem}-pre-restore{suffix}")
+
+
+def recovery_state_path_for(db_path: Path) -> Path:
+    return db_path.with_name(f"{db_path.stem}-recovery-state.json")
+
+
+def _list_tables(conn: sqlite3.Connection) -> set[str]:
+    cursor = conn.execute(
+        """
+        SELECT name
+        FROM sqlite_master
+        WHERE type = 'table';
+        """
+    )
+    return {str(row[0]) for row in cursor.fetchall()}
+
+
+def _validate_integrity(conn: sqlite3.Connection) -> None:
+    rows = [str(row[0]) for row in conn.execute("PRAGMA integrity_check;").fetchall()]
+    if rows != ["ok"]:
+        details = "; ".join(rows) if rows else "unknown integrity_check failure"
+        raise RestoreValidationError(f"SQLite integrity check failed: {details}")
+
+
+def validate_uploaded_database(candidate_path: Path) -> None:
+    candidate_path = candidate_path.expanduser().resolve()
+    if not candidate_path.exists() or not candidate_path.is_file():
+        raise RestoreValidationError("Uploaded database file was not saved correctly.")
+
+    try:
+        conn = sqlite3.connect(candidate_path)
+    except sqlite3.Error as exc:
+        raise RestoreValidationError(f"Uploaded file could not be opened as SQLite: {exc}") from exc
+
+    try:
+        _validate_integrity(conn)
+        existing_tables = _list_tables(conn)
+    except sqlite3.Error as exc:
+        raise RestoreValidationError(f"Uploaded file is not a valid SQLite database: {exc}") from exc
+    finally:
+        conn.close()
+
+    missing_tables = sorted(RESTORE_REQUIRED_TABLES - existing_tables)
+    if not any(name in existing_tables for name in EVENT_TABLE_ALIASES):
+        missing_tables.append("asset_events")
+    if missing_tables:
+        raise RestoreValidationError(
+            "Uploaded database is missing required AssetTrack tables: " + ", ".join(missing_tables)
+        )
+
+
+def _ensure_live_db_replaceable(db_path: Path) -> None:
+    if not db_path.exists() or not db_path.is_file():
+        raise RestoreOperationError("Current database file does not exist.")
+    if not os.access(db_path, os.W_OK):
+        raise RestoreOperationError("Current database file is not writable.")
+    if not os.access(db_path.parent, os.W_OK):
+        raise RestoreOperationError("Database directory is not writable.")
+
+
+def _copy_file(source: Path, destination: Path) -> None:
+    shutil.copy2(source, destination)
+
+
+def _create_rollback_copy(db_path: Path, rollback_path: Path) -> None:
+    with tempfile.NamedTemporaryFile(dir=db_path.parent, prefix=f"{rollback_path.name}.", suffix=".tmp", delete=False) as handle:
+        temp_path = Path(handle.name)
+
+    try:
+        _copy_file(db_path, temp_path)
+        temp_path.replace(rollback_path)
+    except Exception as exc:
+        temp_path.unlink(missing_ok=True)
+        raise RestoreOperationError(f"Rollback copy could not be created: {exc}") from exc
+
+
+def _activate_recovery_mode(
+    *,
+    db_path: Path,
+    rollback_path: Path,
+    recovery_state_path: Path,
+    source_filename: str,
+) -> None:
+    state = {
+        "active": True,
+        "recovered_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "db_path": str(db_path),
+        "rollback_db_path": str(rollback_path),
+        "source_filename": source_filename,
+    }
+    with tempfile.NamedTemporaryFile(
+        dir=recovery_state_path.parent,
+        prefix=f"{recovery_state_path.name}.",
+        suffix=".tmp",
+        delete=False,
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        temp_path = Path(handle.name)
+        json.dump(state, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+
+    try:
+        temp_path.replace(recovery_state_path)
+    except Exception as exc:
+        temp_path.unlink(missing_ok=True)
+        raise RestoreOperationError(f"Recovery mode state could not be written: {exc}") from exc
+
+
+def _restore_rollback_copy(db_path: Path, rollback_path: Path) -> None:
+    with tempfile.NamedTemporaryFile(dir=db_path.parent, prefix=f"{db_path.name}.", suffix=".rollback.tmp", delete=False) as handle:
+        temp_path = Path(handle.name)
+
+    try:
+        _copy_file(rollback_path, temp_path)
+        temp_path.replace(db_path)
+    except Exception as exc:
+        temp_path.unlink(missing_ok=True)
+        raise RestoreOperationError(f"Rollback restore failed after replacement error: {exc}") from exc
+
+
+def restore_database(
+    *,
+    uploaded_db_path: Path,
+    live_db_path: Path,
+    source_filename: str,
+) -> dict[str, str]:
+    uploaded_db_path = uploaded_db_path.expanduser().resolve()
+    live_db_path = live_db_path.expanduser().resolve()
+    rollback_path = rollback_artifact_path_for(live_db_path)
+    recovery_state_path = recovery_state_path_for(live_db_path)
+
+    validate_uploaded_database(uploaded_db_path)
+    _ensure_live_db_replaceable(live_db_path)
+    _create_rollback_copy(live_db_path, rollback_path)
+
+    with tempfile.NamedTemporaryFile(dir=live_db_path.parent, prefix=f"{live_db_path.name}.", suffix=".restore.tmp", delete=False) as handle:
+        replacement_temp_path = Path(handle.name)
+
+    try:
+        _copy_file(uploaded_db_path, replacement_temp_path)
+        validate_uploaded_database(replacement_temp_path)
+        replacement_temp_path.replace(live_db_path)
+    except Exception as exc:
+        replacement_temp_path.unlink(missing_ok=True)
+        if isinstance(exc, RestoreError):
+            raise
+        raise RestoreOperationError(f"Database replacement failed: {exc}") from exc
+
+    try:
+        validate_uploaded_database(live_db_path)
+        _activate_recovery_mode(
+            db_path=live_db_path,
+            rollback_path=rollback_path,
+            recovery_state_path=recovery_state_path,
+            source_filename=source_filename,
+        )
+    except Exception as exc:
+        _restore_rollback_copy(live_db_path, rollback_path)
+        if isinstance(exc, RestoreError):
+            raise
+        raise RestoreOperationError(f"Post-restore validation failed: {exc}") from exc
+
+    return {
+        "live_db_path": str(live_db_path),
+        "rollback_db_path": str(rollback_path),
+        "recovery_state_path": str(recovery_state_path),
+    }

--- a/tests/test_admin_db_restore.py
+++ b/tests/test_admin_db_restore.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+import assettrack.restore as restore_module
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.ADMIN_ROUTE_ATTEMPTS.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _insert_asset(conn: sqlite3.Connection, asset_tag: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag,
+            serial_number,
+            equipment_type,
+            manufacturer,
+            model,
+            custody_state,
+            accountability_status,
+            condition,
+            created_date,
+            updated_date,
+            location_type,
+            building,
+            room,
+            building_room
+        )
+        VALUES (?, ?, 'laptop', 'Dell', 'Latitude', 'in_stock', 'accountable', 'serviceable', ?, ?, 'STORAGE', 'HQ', '100', 'HQ/100');
+        """,
+        (
+            asset_tag,
+            f"SN-{asset_tag}",
+            "2026-05-11",
+            "2026-05-11T00:00:00Z",
+        ),
+    )
+
+
+def _insert_event(conn: sqlite3.Connection, asset_tag: str, actor: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO asset_events (
+            asset_tag,
+            event_type,
+            event_date,
+            actor,
+            notes,
+            payload
+        )
+        VALUES (?, 'ISSUE', '2026-05-11T00:00:00Z', ?, NULL, NULL);
+        """,
+        (asset_tag, actor),
+    )
+
+
+def _insert_admin_user(conn: sqlite3.Connection, user_id: int, username: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO users (id, username, password_hash, role, active, created_at, updated_at)
+        VALUES (?, ?, 'hash', 'admin', 1, '2026-05-11T00:00:00Z', '2026-05-11T00:00:00Z');
+        """,
+        (user_id, username),
+    )
+
+
+def _build_valid_restore_db(path: Path, *, asset_tag: str, admin_user_id: int = 1) -> Path:
+    db.initialize_schema(path)
+    conn = sqlite3.connect(path)
+    try:
+        _insert_admin_user(conn, admin_user_id, "restored-admin")
+        _insert_asset(conn, asset_tag)
+        _insert_event(conn, asset_tag, "restore-source")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _asset_tags(path: Path) -> list[str]:
+    conn = sqlite3.connect(path)
+    try:
+        rows = conn.execute("SELECT asset_tag FROM assets ORDER BY asset_tag ASC;").fetchall()
+        return [str(row[0]) for row in rows]
+    finally:
+        conn.close()
+
+
+def _event_count(path: Path) -> int:
+    conn = sqlite3.connect(path)
+    try:
+        return int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def test_admin_can_restore_valid_database_upload(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-restore", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-ONLY")
+        _insert_event(conn, "LIVE-ONLY", "live-admin")
+        conn.commit()
+    finally:
+        conn.close()
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-upload.db", asset_tag="RESTORE-ONLY")
+
+    with restore_upload_path.open("rb") as handle:
+        response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-upload.db")},
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 200
+    assert b"Database restore complete." in response.data
+    assert _asset_tags(live_db_path) == ["RESTORE-ONLY"]
+    assert _event_count(live_db_path) == 1
+
+    rollback_path = restore_module.rollback_artifact_path_for(live_db_path)
+    assert rollback_path.exists()
+    assert _asset_tags(rollback_path) == ["LIVE-ONLY"]
+    assert _event_count(rollback_path) == 1
+
+    recovery_state_path = restore_module.recovery_state_path_for(live_db_path)
+    assert recovery_state_path.exists()
+    recovery_state = json.loads(recovery_state_path.read_text(encoding="utf-8"))
+    assert recovery_state["active"] is True
+    assert recovery_state["rollback_db_path"] == str(rollback_path)
+    assert recovery_state["db_path"] == str(live_db_path)
+    assert recovery_state["source_filename"] == "restore-upload.db"
+
+
+def test_restore_rejects_non_sqlite_upload_without_replacing_live_db(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-invalid-upload", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-KEEP")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/db/restore",
+        data={"db_file": (BytesIO(b"not-a-sqlite-database"), "invalid.db")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert b"Uploaded file is not a valid SQLite database" in response.data
+    assert _asset_tags(live_db_path) == ["LIVE-KEEP"]
+    assert not restore_module.rollback_artifact_path_for(live_db_path).exists()
+    assert not restore_module.recovery_state_path_for(live_db_path).exists()
+
+
+def test_restore_rejects_sqlite_file_missing_required_tables(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-missing-tables", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-KEEP")
+        conn.commit()
+    finally:
+        conn.close()
+
+    incomplete_db_path = tmp_path / "missing-tables.db"
+    incomplete_conn = sqlite3.connect(incomplete_db_path)
+    try:
+        incomplete_conn.execute("CREATE TABLE unrelated (id INTEGER PRIMARY KEY);")
+        incomplete_conn.commit()
+    finally:
+        incomplete_conn.close()
+
+    with incomplete_db_path.open("rb") as handle:
+        response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "missing-tables.db")},
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 400
+    assert b"missing required AssetTrack tables" in response.data
+    assert _asset_tags(live_db_path) == ["LIVE-KEEP"]
+    assert not restore_module.rollback_artifact_path_for(live_db_path).exists()
+
+
+def test_restore_fails_closed_when_rollback_copy_cannot_be_created(
+    client_with_temp_db,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    admin_id = create_test_user(username="admin-rollback-blocked", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-ONLY")
+        conn.commit()
+    finally:
+        conn.close()
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-blocked.db", asset_tag="RESTORE-ONLY")
+
+    def fail_rollback(_db_path: Path, _rollback_path: Path) -> None:
+        raise restore_module.RestoreOperationError("Rollback copy could not be created: blocked")
+
+    monkeypatch.setattr(restore_module, "_create_rollback_copy", fail_rollback)
+
+    with restore_upload_path.open("rb") as handle:
+        response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-blocked.db")},
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 500
+    assert b"Rollback copy could not be created: blocked" in response.data
+    assert _asset_tags(live_db_path) == ["LIVE-ONLY"]
+    assert not restore_module.recovery_state_path_for(live_db_path).exists()
+
+
+def test_operator_cannot_access_restore_route(client_with_temp_db, tmp_path: Path) -> None:
+    operator_id = create_test_user(username="operator-restore", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    get_response = client_with_temp_db.get("/admin/db/restore")
+    assert get_response.status_code == 403
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-denied.db", asset_tag="RESTORE-ONLY")
+    with restore_upload_path.open("rb") as handle:
+        post_response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-denied.db")},
+            content_type="multipart/form-data",
+        )
+
+    assert post_response.status_code == 403

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -117,6 +117,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Manage Users" in response.data
     assert b"Import Holders from CSV" in response.data
     assert b"Open Human-Readable Report" in response.data
+    assert b"Restore Database Backup" in response.data
     assert b"Download Database Backup" in response.data
 
 


### PR DESCRIPTION
## Summary

Adds a guarded admin-only SQLite restore workflow with fail-closed validation, rollback preservation, and recovery mode activation.

## Related Issue
Closes #698 

## Changes

- Added admin-only `/admin/db/restore` workflow
- Added SQLite validation and integrity checks
- Added required-table validation
- Added deterministic rollback copy preservation
- Added guarded live DB replacement flow
- Added explicit recovery-state activation
- Added targeted restore workflow tests
- Adjusted restore page spacing/alignment to match existing admin surfaces

## Verification

- [x] Targeted restore/admin tests passed
- [x] Admin restore page manually verified
- [x] Invalid uploads fail closed
- [x] Rollback artifact creation verified
- [x] Recovery-state file creation verified
- [x] Non-admin access denied
- [x] No custody events created during restore
- [x] Restore page spacing manually verified

## Notes

Follow-on operational confirmation seam improvements tracked separately in Issue 27-64.