### PR TITLE
Issue 27-61: add recovery mode acknowledgment and resend guard

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -73,6 +73,9 @@ from assettrack.restore import (
     RestoreError,
     RestoreOperationError,
     RestoreValidationError,
+    clear_recovery_state,
+    load_recovery_state,
+    recovery_mode_is_active,
     recovery_state_path_for,
     restore_database,
     rollback_artifact_path_for,
@@ -177,10 +180,12 @@ def enforce_required_password_change():
 @app.context_processor
 def inject_auth_user():
     user = current_user()
+    recovery_mode = _recovery_mode_context()
     return {
         "authenticated_user": user,
         "authenticated_role": None if user is None else user.get("role"),
         "password_change_required": is_temporary_password(user),
+        "recovery_mode": recovery_mode,
         "case_status_summary": _case_status_summary,
         "asset_state_label": _asset_state_label,
         "asset_is_terminal": _is_terminal_location_type,
@@ -1015,6 +1020,21 @@ def _asset_state_label(location_type: object) -> str:
 
 def _resolved_runtime_db_path() -> Path:
     return db_module.DB_PATH.expanduser().resolve()
+
+
+def _recovery_mode_context() -> dict[str, object]:
+    state = load_recovery_state(_resolved_runtime_db_path())
+    restored_at = str(state.get("restored_at") or "").strip()
+    return {
+        **state,
+        "status_label": "Active" if state.get("active") else "Inactive",
+        "acknowledgment_label": "Required" if state.get("acknowledgment_required") else "Cleared",
+        "restored_at_display": _receipt_display_timestamp(restored_at),
+    }
+
+
+def _recovery_mode_send_block_message() -> str:
+    return "Receipt resend is blocked during recovery mode. Admin acknowledgment is required before email delivery resumes."
 
 
 def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[str, object]:
@@ -5668,6 +5688,13 @@ def receipt_send(receipt_id: int):
         flash("Locked. Re-enter access code.", "error")
         return redirect(url_for("intake"))
 
+    if recovery_mode_is_active(_resolved_runtime_db_path()):
+        message = _recovery_mode_send_block_message()
+        if wants_json():
+            return {"ok": False, "error": message}, 409
+        flash(message, "error")
+        return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+
     try:
         result = _send_queued_receipt(receipt_id)
     except ValueError as exc:
@@ -5993,6 +6020,22 @@ def admin_system():
         asset_count=asset_count,
         schema_warning=schema_warning,
     )
+
+
+@app.post("/admin/recovery/acknowledge")
+@require_login
+@require_role("admin")
+def admin_recovery_acknowledge():
+    rate_limit_response = _enforce_admin_route_rate_limit(html_redirect_endpoint="admin_system")
+    if rate_limit_response is not None:
+        return rate_limit_response
+
+    cleared = clear_recovery_state(_resolved_runtime_db_path())
+    if cleared:
+        flash("Recovery mode acknowledged and cleared. Normal receipt delivery actions may resume.", "success")
+    else:
+        flash("Recovery mode is already inactive.", "success")
+    return redirect(url_for("admin_system"))
 
 
 @app.route("/admin/holders/import", methods=["GET", "POST"])

--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -125,6 +125,28 @@
   margin-bottom: 1rem;
 }
 
+.recovery-banner {
+  display: grid;
+  gap: 0.45rem;
+  margin-bottom: 1rem;
+  border-left-width: 5px;
+}
+
+.recovery-banner p,
+.recovery-banner h2 {
+  margin: 0;
+}
+
+.recovery-status-line {
+  color: var(--color-text-muted);
+}
+
+.recovery-meta-list {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+}
+
 .report-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -9,9 +9,71 @@
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a>
   </nav>
 
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
   {% if schema_warning %}
     <div class="flash error">{{ schema_warning }}</div>
   {% endif %}
+
+  <div class="card">
+    <h2>Recovery State</h2>
+    <table>
+      <tbody>
+        <tr>
+          <th>Status</th>
+          <td id="recovery-status">{{ recovery_mode.status_label }}</td>
+        </tr>
+        <tr>
+          <th>Acknowledgment</th>
+          <td id="recovery-acknowledgment">{{ recovery_mode.acknowledgment_label }}</td>
+        </tr>
+        <tr>
+          <th>Restore timestamp</th>
+          <td id="recovery-restored-at">{{ recovery_mode.restored_at_display or "N/A" }}</td>
+        </tr>
+        <tr>
+          <th>Uploaded filename</th>
+          <td id="recovery-source-filename">
+            {% if recovery_mode.source_filename %}
+              <code>{{ recovery_mode.source_filename }}</code>
+            {% else %}
+              N/A
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>Rollback artifact</th>
+          <td id="recovery-rollback-path">
+            {% if recovery_mode.rollback_db_path %}
+              <code>{{ recovery_mode.rollback_db_path }}</code>
+            {% else %}
+              N/A
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>Recovery state file</th>
+          <td id="recovery-state-path"><code>{{ recovery_mode.recovery_state_path }}</code></td>
+        </tr>
+      </tbody>
+    </table>
+    {% if recovery_mode.parse_error %}
+      <p class="warn">Recovery state file could not be read cleanly: {{ recovery_mode.parse_error }}</p>
+    {% endif %}
+    {% if recovery_mode.active %}
+      <div class="actions" aria-label="Recovery actions">
+        <form method="post" action="{{ url_for('admin_recovery_acknowledge') }}">
+          <button type="submit">Acknowledge Recovery and Resume</button>
+        </form>
+      </div>
+    {% endif %}
+  </div>
 
   <div class="card">
     <h2>Admin Tools</h2>

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -62,6 +62,28 @@
         </nav>
       {% endif %}
 
+      {% if authenticated_role == 'admin' and recovery_mode.active %}
+        <section class="card warn-card recovery-banner" aria-label="Recovery mode">
+          <h2>Recovery Mode Active</h2>
+          <p class="recovery-status-line">
+            Recovery acknowledgment is required before receipt resend or retry actions resume.
+          </p>
+          <div class="recovery-meta-list">
+            <div>Status: <strong>{{ recovery_mode.status_label }}</strong></div>
+            <div>Acknowledgment: <strong>{{ recovery_mode.acknowledgment_label }}</strong></div>
+            {% if recovery_mode.restored_at_display %}
+              <div>Restore completed: <strong>{{ recovery_mode.restored_at_display }}</strong></div>
+            {% endif %}
+            {% if recovery_mode.source_filename %}
+              <div>Uploaded file: <code>{{ recovery_mode.source_filename }}</code></div>
+            {% endif %}
+          </div>
+          <div class="actions" aria-label="Recovery mode actions">
+            <a class="nav-link" href="{{ url_for('admin_system') }}">Review Recovery State</a>
+          </div>
+        </section>
+      {% endif %}
+
       {% block content %}{% endblock %}
 
       {% if timeout_seconds is defined and timeout_seconds is not none and last_seen_age_seconds is not none %}

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -207,6 +207,7 @@
   {% set receipt_action_word = "issued" if receipt.receipt_type == "ISSUE" else "returned" %}
   {% set receipt_direction = "to" if receipt.receipt_type == "ISSUE" else "from" %}
   {% set headline_subject = holder_display_name if holder_display_name else "recorded holder" %}
+  {% set send_blocked_by_recovery = recovery_mode.active and receipt.delivery.state in ["pending", "failed"] %}
   {% set context_parts = [] %}
   {% if holder_display_name %}
     {% set context_parts = context_parts + [holder_display_name] %}
@@ -238,9 +239,13 @@
     <a class="nav-link" href="{{ url_for('human_report') }}">Open Current Status Report</a>
     <a class="chip" href="{{ url_for('receipt_pdf', receipt_id=receipt.id) }}">Download Receipt PDF</a>
     {% if receipt.delivery.state in ["pending", "failed"] %}
-      <form method="post" action="{{ url_for('receipt_send', receipt_id=receipt.id) }}">
-        <button type="submit">{{ receipt_action_label }}</button>
-      </form>
+      {% if send_blocked_by_recovery %}
+        <span class="pill bad">Recovery mode blocks {{ receipt_action_label|lower }}</span>
+      {% else %}
+        <form method="post" action="{{ url_for('receipt_send', receipt_id=receipt.id) }}">
+          <button type="submit">{{ receipt_action_label }}</button>
+        </form>
+      {% endif %}
     {% endif %}
   </nav>
 
@@ -268,6 +273,9 @@
             · {{ email_timing_label }} {{ email_timing_value }}
           {% endif %}
         </p>
+        {% if send_blocked_by_recovery %}
+          <p class="receipt-context-line">Receipt resend and retry actions are paused until an admin acknowledges recovery mode.</p>
+        {% endif %}
       </section>
 
       <div class="receipt-summary">
@@ -316,7 +324,9 @@
           {% if receipt.delivery.state in ["pending", "failed"] %}
             <div class="summary-value">
               <div class="summary-label">Available action</div>
-              <div class="summary-copy">{{ receipt_action_label }}</div>
+              <div class="summary-copy">
+                {{ "Blocked during recovery mode" if send_blocked_by_recovery else receipt_action_label }}
+              </div>
             </div>
           {% endif %}
         </section>

--- a/assettrack/restore.py
+++ b/assettrack/restore.py
@@ -35,6 +35,22 @@ class RestoreOperationError(RestoreError):
     """Raised when replacement or rollback preservation fails."""
 
 
+def _default_recovery_state(db_path: Path) -> dict[str, object]:
+    recovery_state_path = recovery_state_path_for(db_path)
+    return {
+        "active": False,
+        "acknowledgment_required": False,
+        "acknowledgment_state": "not_required",
+        "restored_at": "",
+        "source_filename": "",
+        "rollback_db_path": "",
+        "db_path": str(db_path),
+        "recovery_state_path": str(recovery_state_path),
+        "recovery_state_exists": recovery_state_path.exists(),
+        "parse_error": "",
+    }
+
+
 def rollback_artifact_path_for(db_path: Path) -> Path:
     suffix = db_path.suffix or ".db"
     return db_path.with_name(f"{db_path.stem}-pre-restore{suffix}")
@@ -42,6 +58,62 @@ def rollback_artifact_path_for(db_path: Path) -> Path:
 
 def recovery_state_path_for(db_path: Path) -> Path:
     return db_path.with_name(f"{db_path.stem}-recovery-state.json")
+
+
+def load_recovery_state(db_path: Path) -> dict[str, object]:
+    db_path = db_path.expanduser().resolve()
+    recovery_state_path = recovery_state_path_for(db_path)
+    default_state = _default_recovery_state(db_path)
+    if not recovery_state_path.exists() or not recovery_state_path.is_file():
+        return default_state
+
+    try:
+        raw_state = json.loads(recovery_state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        default_state["active"] = True
+        default_state["acknowledgment_required"] = True
+        default_state["acknowledgment_state"] = "required"
+        default_state["recovery_state_exists"] = True
+        default_state["parse_error"] = str(exc)
+        return default_state
+
+    if not isinstance(raw_state, dict):
+        default_state["active"] = True
+        default_state["acknowledgment_required"] = True
+        default_state["acknowledgment_state"] = "required"
+        default_state["recovery_state_exists"] = True
+        default_state["parse_error"] = "Recovery state file must contain a JSON object."
+        return default_state
+
+    active = bool(raw_state.get("active", True))
+    restored_at = str(raw_state.get("recovered_at") or raw_state.get("restored_at") or "").strip()
+    source_filename = str(raw_state.get("source_filename") or "").strip()
+    rollback_db_path = str(raw_state.get("rollback_db_path") or "").strip()
+
+    return {
+        "active": active,
+        "acknowledgment_required": active,
+        "acknowledgment_state": "required" if active else "cleared",
+        "restored_at": restored_at,
+        "source_filename": source_filename,
+        "rollback_db_path": rollback_db_path,
+        "db_path": str(raw_state.get("db_path") or db_path),
+        "recovery_state_path": str(recovery_state_path),
+        "recovery_state_exists": True,
+        "parse_error": "",
+    }
+
+
+def recovery_mode_is_active(db_path: Path) -> bool:
+    return bool(load_recovery_state(db_path).get("active"))
+
+
+def clear_recovery_state(db_path: Path) -> bool:
+    recovery_state_path = recovery_state_path_for(db_path.expanduser().resolve())
+    if not recovery_state_path.exists():
+        return False
+    recovery_state_path.unlink()
+    return True
 
 
 def _list_tables(conn: sqlite3.Connection) -> set[str]:

--- a/tests/test_admin_db_restore.py
+++ b/tests/test_admin_db_restore.py
@@ -261,3 +261,82 @@ def test_operator_cannot_access_restore_route(client_with_temp_db, tmp_path: Pat
         )
 
     assert post_response.status_code == 403
+
+
+def test_admin_system_surfaces_recovery_metadata_until_acknowledged(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-recovery-meta", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-meta.db", asset_tag="RESTORE-ONLY")
+
+    with restore_upload_path.open("rb") as handle:
+        restore_response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-meta.db")},
+            content_type="multipart/form-data",
+        )
+
+    assert restore_response.status_code == 200
+
+    system_response = client_with_temp_db.get("/admin/system")
+    assert system_response.status_code == 200
+    assert b"Recovery Mode Active" in system_response.data
+    assert b'id="recovery-status">Active<' in system_response.data
+    assert b'id="recovery-acknowledgment">Required<' in system_response.data
+    assert b"restore-meta.db" in system_response.data
+    assert b"pre-restore" in system_response.data
+    assert b"Acknowledge Recovery and Resume" in system_response.data
+
+    restarted_client = intake_app.app.test_client()
+    login_session(restarted_client, admin_id)
+    restarted_response = restarted_client.get("/admin/system")
+    assert restarted_response.status_code == 200
+    assert b"Recovery Mode Active" in restarted_response.data
+    assert b'id="recovery-status">Active<' in restarted_response.data
+
+    recovery_state_path = restore_module.recovery_state_path_for(live_db_path)
+    assert recovery_state_path.exists()
+
+
+def test_admin_acknowledgment_clears_recovery_state(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-recovery-clear", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-clear.db", asset_tag="RESTORE-ONLY")
+    with restore_upload_path.open("rb") as handle:
+        restore_response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-clear.db")},
+            content_type="multipart/form-data",
+        )
+    assert restore_response.status_code == 200
+
+    acknowledge_response = client_with_temp_db.post("/admin/recovery/acknowledge", follow_redirects=True)
+    assert acknowledge_response.status_code == 200
+    assert b"Recovery mode acknowledged and cleared." in acknowledge_response.data
+    assert b'id="recovery-status">Inactive<' in acknowledge_response.data
+    assert b'id="recovery-acknowledgment">Cleared<' in acknowledge_response.data
+    assert b"Recovery Mode Active" not in acknowledge_response.data
+    assert not restore_module.recovery_state_path_for(live_db_path).exists()
+
+
+def test_operator_cannot_acknowledge_recovery_state(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-recovery-seed", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-seed.db", asset_tag="RESTORE-ONLY")
+    with restore_upload_path.open("rb") as handle:
+        restore_response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-seed.db")},
+            content_type="multipart/form-data",
+        )
+    assert restore_response.status_code == 200
+
+    operator_id = create_test_user(username="operator-recovery-ack", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.post("/admin/recovery/acknowledge")
+    assert response.status_code == 403

--- a/tests/test_recovery_mode.py
+++ b/tests/test_recovery_mode.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import assettrack.auth as auth
+import assettrack.db as db
+import assettrack.restore as restore_module
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.ADMIN_ROUTE_ATTEMPTS.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _write_recovery_state(db_path: Path, *, source_filename: str = "restore-upload.db") -> None:
+    state_path = restore_module.recovery_state_path_for(db_path)
+    state_path.write_text(
+        json.dumps(
+            {
+                "active": True,
+                "recovered_at": "2026-05-11T12:00:00Z",
+                "db_path": str(db_path),
+                "rollback_db_path": str(restore_module.rollback_artifact_path_for(db_path)),
+                "source_filename": source_filename,
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _insert_holder() -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO organizations (id, name, created_at, updated_at)
+            VALUES (9, 'Operations', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO holders (
+                id, holder_type, name, organization, organization_id, identifier, email, contact_info, created_at, updated_at
+            )
+            VALUES (
+                1, 'PERSON', 'Issue Holder', 'Operations', 9, 'IH-1', 'issue@example.org', '', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_issue_asset() -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute("INSERT INTO slots (id, case_name, slot_position, current_asset_tag) VALUES (10, 'CASE-10', 1, NULL);")
+        conn.execute(
+            """
+            INSERT INTO assets (
+                id, asset_tag, serial_number, equipment_type, manufacturer, model, model_code, notes,
+                location_type, current_holder_id, home_slot_id, building_room
+            )
+            VALUES (
+                100, 'ISSUE-100', 'SN-ISSUE-100', 'Laptop', 'Dell', 'Latitude', 'LAT-14', 'Original issue note',
+                'STORAGE', NULL, 10, 'Storage/A1'
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (10, 100, '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _login_issue_operator(client, *, username: str = "issue-operator") -> int:
+    operator_id = create_test_user(username=username, password="op-pass", role="operator")
+    current_time = auth.now_seconds()
+    with client.session_transaction() as sess:
+        sess["user_id"] = operator_id
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
+    return operator_id
+
+
+def _create_issue_receipt(client) -> int:
+    _insert_holder()
+    _insert_issue_asset()
+    _login_issue_operator(client)
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="ISSUE-100", equipment_type="laptop"))
+
+    response = client.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT id FROM receipt_queue ORDER BY id DESC LIMIT 1;").fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return int(row["id"])
+
+
+def test_receipt_detail_shows_recovery_block_message_for_resend_action(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "failed",
+            "sent_at": None,
+            "last_attempt_at": "2026-03-29T12:00:00+00:00",
+            "last_error": "smtp offline",
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = NULL, last_attempt_at = ?, last_error = ?
+            WHERE id = ?;
+            """,
+            (json.dumps(snapshot, sort_keys=True), "2026-03-29T12:00:00+00:00", "smtp offline", receipt_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    _write_recovery_state(db.DB_PATH, source_filename="restore-block.db")
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Recovery mode blocks retry send" in response.data
+    assert b"Receipt resend and retry actions are paused until an admin acknowledges recovery mode." in response.data
+    assert b"Blocked during recovery mode" in response.data
+
+
+def test_receipt_send_is_blocked_during_recovery_mode(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    _write_recovery_state(db.DB_PATH)
+
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 409
+    assert response.json == {
+        "ok": False,
+        "error": "Receipt resend is blocked during recovery mode. Admin acknowledgment is required before email delivery resumes.",
+    }
+    assert send_calls == []
+
+
+def test_admin_banner_is_visible_only_to_admins_during_recovery_mode(client_with_temp_db) -> None:
+    _write_recovery_state(db.DB_PATH, source_filename="restore-banner.db")
+
+    admin_id = create_test_user(username="admin-banner", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    admin_response = client_with_temp_db.get("/dashboard")
+    assert admin_response.status_code == 200
+    assert b"Recovery Mode Active" in admin_response.data
+    assert b"restore-banner.db" in admin_response.data
+
+    operator_id = create_test_user(username="operator-banner", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    operator_response = client_with_temp_db.get("/dashboard")
+    assert operator_response.status_code == 200
+    assert b"Recovery Mode Active" not in operator_response.data


### PR DESCRIPTION
## Summary

Adds explicit recovery mode after restore, with admin visibility, acknowledgment, and resend/retry protection.

## Related Issue

Closes #699 

## Changes

- Added centralized recovery-state helpers
- Added admin recovery banner across the app
- Added recovery status card on `/admin/system`
- Added admin-only recovery acknowledgment action
- Blocked receipt resend/retry while recovery mode is active
- Added visible resend/retry block message on receipt detail
- Added focused recovery-mode tests

## Verification

- [x] Targeted recovery/admin tests passed
- [x] Auth guard tests passed
- [x] Restore activates recovery mode
- [x] Recovery mode survives restart before acknowledgment
- [x] Receipt resend/retry blocked during recovery mode
- [x] Admin acknowledgment clears recovery mode
- [x] Recovery state remains operational file state, not custody history
- [x] Manual smoke test completed

## Notes

Malformed recovery-state JSON fails closed by treating recovery mode as active until admin acknowledgment clears it.