### PR TITLE
Issue 27-62: add operational restore history surface

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -75,7 +75,9 @@ from assettrack.restore import (
     RestoreValidationError,
     clear_recovery_state,
     load_recovery_state,
+    load_restore_history,
     recovery_mode_is_active,
+    restore_history_path_for,
     recovery_state_path_for,
     restore_database,
     rollback_artifact_path_for,
@@ -1035,6 +1037,33 @@ def _recovery_mode_context() -> dict[str, object]:
 
 def _recovery_mode_send_block_message() -> str:
     return "Receipt resend is blocked during recovery mode. Admin acknowledgment is required before email delivery resumes."
+
+
+def _restore_history_context() -> dict[str, object]:
+    recovery_state = load_recovery_state(_resolved_runtime_db_path())
+    history_data = load_restore_history(_resolved_runtime_db_path())
+    active_restored_at = str(recovery_state.get("restored_at") or "").strip()
+    entries: list[dict[str, object]] = []
+    for entry in reversed(list(history_data.get("entries") or [])):
+        restored_at = str(entry.get("restored_at") or "").strip()
+        acknowledgment_state = "Cleared"
+        if recovery_state.get("active") and active_restored_at and restored_at == active_restored_at:
+            acknowledgment_state = "Required"
+        entries.append(
+            {
+                "restored_at": restored_at,
+                "restored_at_display": _receipt_display_timestamp(restored_at),
+                "source_filename": str(entry.get("source_filename") or "").strip(),
+                "rollback_db_path": str(entry.get("rollback_db_path") or "").strip(),
+                "result": str(entry.get("result") or "unknown").strip().title() or "Unknown",
+                "acknowledgment_state": acknowledgment_state,
+            }
+        )
+    return {
+        "entries": entries,
+        "parse_error": str(history_data.get("parse_error") or "").strip(),
+        "history_path": str(history_data.get("history_path") or restore_history_path_for(_resolved_runtime_db_path())),
+    }
 
 
 def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[str, object]:
@@ -6002,6 +6031,7 @@ def admin_system():
     holder_count: int | None = None
     asset_count: int | None = None
     schema_warning: str | None = None
+    restore_history = _restore_history_context()
 
     try:
         conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
@@ -6019,6 +6049,7 @@ def admin_system():
         holder_count=holder_count,
         asset_count=asset_count,
         schema_warning=schema_warning,
+        restore_history=restore_history,
     )
 
 

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -104,4 +104,51 @@
       </tbody>
     </table>
   </div>
+
+  <div class="card">
+    <h2>Restore History</h2>
+    <p>Operational restore records only. This surface does not modify custody or audit history.</p>
+    <p><strong>History file:</strong> <code id="restore-history-path">{{ restore_history.history_path }}</code></p>
+    {% if restore_history.parse_error %}
+      <p class="warn">Restore history file could not be read cleanly: {{ restore_history.parse_error }}</p>
+    {% endif %}
+    <table>
+      <thead>
+        <tr>
+          <th>Restore Timestamp</th>
+          <th>Uploaded Filename</th>
+          <th>Rollback Artifact</th>
+          <th>Acknowledgment</th>
+          <th>Result</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for entry in restore_history.entries %}
+          <tr>
+            <td>{{ entry.restored_at_display or "Unknown" }}</td>
+            <td>
+              {% if entry.source_filename %}
+                <code>{{ entry.source_filename }}</code>
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+            <td>
+              {% if entry.rollback_db_path %}
+                <code>{{ entry.rollback_db_path }}</code>
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+            <td>{{ entry.acknowledgment_state }}</td>
+            <td>{{ entry.result }}</td>
+          </tr>
+        {% else %}
+          <tr>
+            <td colspan="5">No restore history recorded.</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
 {% endblock %}

--- a/assettrack/restore.py
+++ b/assettrack/restore.py
@@ -56,6 +56,10 @@ def rollback_artifact_path_for(db_path: Path) -> Path:
     return db_path.with_name(f"{db_path.stem}-pre-restore{suffix}")
 
 
+def restore_history_path_for(db_path: Path) -> Path:
+    return db_path.with_name(f"{db_path.stem}-restore-history.jsonl")
+
+
 def recovery_state_path_for(db_path: Path) -> Path:
     return db_path.with_name(f"{db_path.stem}-recovery-state.json")
 
@@ -114,6 +118,29 @@ def clear_recovery_state(db_path: Path) -> bool:
         return False
     recovery_state_path.unlink()
     return True
+
+
+def load_restore_history(db_path: Path) -> dict[str, object]:
+    db_path = db_path.expanduser().resolve()
+    history_path = restore_history_path_for(db_path)
+    if not history_path.exists() or not history_path.is_file():
+        return {"entries": [], "parse_error": "", "history_path": str(history_path)}
+
+    entries: list[dict[str, object]] = []
+    try:
+        with history_path.open("r", encoding="utf-8") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                payload = json.loads(line)
+                if not isinstance(payload, dict):
+                    raise ValueError(f"Line {line_number} is not a JSON object.")
+                entries.append(payload)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        return {"entries": [], "parse_error": str(exc), "history_path": str(history_path)}
+
+    return {"entries": entries, "parse_error": "", "history_path": str(history_path)}
 
 
 def _list_tables(conn: sqlite3.Connection) -> set[str]:
@@ -192,7 +219,7 @@ def _activate_recovery_mode(
     rollback_path: Path,
     recovery_state_path: Path,
     source_filename: str,
-) -> None:
+) -> dict[str, object]:
     state = {
         "active": True,
         "recovered_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -217,6 +244,41 @@ def _activate_recovery_mode(
     except Exception as exc:
         temp_path.unlink(missing_ok=True)
         raise RestoreOperationError(f"Recovery mode state could not be written: {exc}") from exc
+    return state
+
+
+def _append_restore_history_entry(
+    *,
+    db_path: Path,
+    recovery_state: dict[str, object],
+) -> None:
+    history_path = restore_history_path_for(db_path)
+    entry = {
+        "restored_at": str(recovery_state.get("recovered_at") or "").strip(),
+        "source_filename": str(recovery_state.get("source_filename") or "").strip(),
+        "rollback_db_path": str(recovery_state.get("rollback_db_path") or "").strip(),
+        "result": "success",
+    }
+    with tempfile.NamedTemporaryFile(
+        dir=history_path.parent,
+        prefix=f"{history_path.name}.",
+        suffix=".tmp",
+        delete=False,
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        temp_path = Path(handle.name)
+
+    try:
+        if history_path.exists():
+            temp_path.write_text(history_path.read_text(encoding="utf-8"), encoding="utf-8")
+        with temp_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry, sort_keys=True))
+            handle.write("\n")
+        temp_path.replace(history_path)
+    except Exception as exc:
+        temp_path.unlink(missing_ok=True)
+        raise RestoreOperationError(f"Restore history could not be written: {exc}") from exc
 
 
 def _restore_rollback_copy(db_path: Path, rollback_path: Path) -> None:
@@ -261,14 +323,19 @@ def restore_database(
 
     try:
         validate_uploaded_database(live_db_path)
-        _activate_recovery_mode(
+        recovery_state = _activate_recovery_mode(
             db_path=live_db_path,
             rollback_path=rollback_path,
             recovery_state_path=recovery_state_path,
             source_filename=source_filename,
         )
+        _append_restore_history_entry(
+            db_path=live_db_path,
+            recovery_state=recovery_state,
+        )
     except Exception as exc:
         _restore_rollback_copy(live_db_path, rollback_path)
+        clear_recovery_state(live_db_path)
         if isinstance(exc, RestoreError):
             raise
         raise RestoreOperationError(f"Post-restore validation failed: {exc}") from exc
@@ -276,5 +343,6 @@ def restore_database(
     return {
         "live_db_path": str(live_db_path),
         "rollback_db_path": str(rollback_path),
+        "restore_history_path": str(restore_history_path_for(live_db_path)),
         "recovery_state_path": str(recovery_state_path),
     }

--- a/tests/test_admin_db_restore.py
+++ b/tests/test_admin_db_restore.py
@@ -110,6 +110,13 @@ def _event_count(path: Path) -> int:
         conn.close()
 
 
+def _restore_history_entries(path: Path) -> list[dict[str, object]]:
+    history_path = restore_module.restore_history_path_for(path)
+    if not history_path.exists():
+        return []
+    return [json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
 def test_admin_can_restore_valid_database_upload(client_with_temp_db, tmp_path: Path) -> None:
     admin_id = create_test_user(username="admin-restore", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
@@ -149,6 +156,12 @@ def test_admin_can_restore_valid_database_upload(client_with_temp_db, tmp_path: 
     assert recovery_state["rollback_db_path"] == str(rollback_path)
     assert recovery_state["db_path"] == str(live_db_path)
     assert recovery_state["source_filename"] == "restore-upload.db"
+
+    history_entries = _restore_history_entries(live_db_path)
+    assert len(history_entries) == 1
+    assert history_entries[0]["source_filename"] == "restore-upload.db"
+    assert history_entries[0]["rollback_db_path"] == str(rollback_path)
+    assert history_entries[0]["result"] == "success"
 
 
 def test_restore_rejects_non_sqlite_upload_without_replacing_live_db(client_with_temp_db) -> None:
@@ -245,6 +258,45 @@ def test_restore_fails_closed_when_rollback_copy_cannot_be_created(
     assert not restore_module.recovery_state_path_for(live_db_path).exists()
 
 
+def test_restore_fails_closed_when_history_write_cannot_be_completed(
+    client_with_temp_db,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    admin_id = create_test_user(username="admin-history-blocked", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-ONLY")
+        _insert_event(conn, "LIVE-ONLY", "live-admin")
+        conn.commit()
+    finally:
+        conn.close()
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-history-blocked.db", asset_tag="RESTORE-ONLY")
+
+    def fail_history(*, db_path: Path, recovery_state: dict[str, object]) -> None:
+        raise restore_module.RestoreOperationError("Restore history could not be written: blocked")
+
+    monkeypatch.setattr(restore_module, "_append_restore_history_entry", fail_history)
+
+    with restore_upload_path.open("rb") as handle:
+        response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-history-blocked.db")},
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 500
+    assert b"Restore history could not be written: blocked" in response.data
+    assert _asset_tags(live_db_path) == ["LIVE-ONLY"]
+    assert _event_count(live_db_path) == 1
+    assert not restore_module.recovery_state_path_for(live_db_path).exists()
+    assert _restore_history_entries(live_db_path) == []
+
+
 def test_operator_cannot_access_restore_route(client_with_temp_db, tmp_path: Path) -> None:
     operator_id = create_test_user(username="operator-restore", password="op-pass", role="operator")
     login_session(client_with_temp_db, operator_id)
@@ -287,6 +339,10 @@ def test_admin_system_surfaces_recovery_metadata_until_acknowledged(client_with_
     assert b"restore-meta.db" in system_response.data
     assert b"pre-restore" in system_response.data
     assert b"Acknowledge Recovery and Resume" in system_response.data
+    assert b"Restore History" in system_response.data
+    assert b'id="restore-history-path"' in system_response.data
+    assert b"Success" in system_response.data
+    assert b"Required" in system_response.data
 
     restarted_client = intake_app.app.test_client()
     login_session(restarted_client, admin_id)
@@ -319,6 +375,7 @@ def test_admin_acknowledgment_clears_recovery_state(client_with_temp_db, tmp_pat
     assert b'id="recovery-status">Inactive<' in acknowledge_response.data
     assert b'id="recovery-acknowledgment">Cleared<' in acknowledge_response.data
     assert b"Recovery Mode Active" not in acknowledge_response.data
+    assert b"Cleared" in acknowledge_response.data
     assert not restore_module.recovery_state_path_for(live_db_path).exists()
 
 
@@ -340,3 +397,49 @@ def test_operator_cannot_acknowledge_recovery_state(client_with_temp_db, tmp_pat
 
     response = client_with_temp_db.post("/admin/recovery/acknowledge")
     assert response.status_code == 403
+
+
+def test_multiple_restores_append_history_entries_and_preserve_latest_recovery_state(
+    client_with_temp_db,
+    tmp_path: Path,
+) -> None:
+    admin_id = create_test_user(username="admin-history-multi", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+
+    first_upload = _build_valid_restore_db(tmp_path / "restore-first.db", asset_tag="RESTORE-FIRST")
+    with first_upload.open("rb") as handle:
+        first_response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-first.db")},
+            content_type="multipart/form-data",
+        )
+    assert first_response.status_code == 200
+
+    second_upload = _build_valid_restore_db(tmp_path / "restore-second.db", asset_tag="RESTORE-SECOND")
+    with second_upload.open("rb") as handle:
+        second_response = client_with_temp_db.post(
+            "/admin/db/restore",
+            data={"db_file": (BytesIO(handle.read()), "restore-second.db")},
+            content_type="multipart/form-data",
+        )
+    assert second_response.status_code == 200
+
+    history_entries = _restore_history_entries(live_db_path)
+    assert len(history_entries) == 2
+    assert history_entries[0]["source_filename"] == "restore-first.db"
+    assert history_entries[1]["source_filename"] == "restore-second.db"
+
+    system_response = client_with_temp_db.get("/admin/system")
+    assert system_response.status_code == 200
+    assert b"restore-first.db" in system_response.data
+    assert b"restore-second.db" in system_response.data
+    assert b"Required" in system_response.data
+
+    restarted_client = intake_app.app.test_client()
+    login_session(restarted_client, admin_id)
+    restarted_response = restarted_client.get("/admin/system")
+    assert restarted_response.status_code == 200
+    assert b"restore-first.db" in restarted_response.data
+    assert b"restore-second.db" in restarted_response.data


### PR DESCRIPTION
## Summary

Adds an operational restore history surface for successful database restores.

## Related Issue

Closes #700 

## Changes

- Added append-only restore history JSONL persistence
- Wrote restore history only after successful restore and recovery activation
- Added fail-closed rollback behavior if history persistence fails
- Added compact restore history table on `/admin/system`
- Added restore history coverage for multiple restores and restart persistence

## Verification

- [x] Targeted restore/admin tests passed
- [x] Auth guard tests passed
- [x] Multiple restores create history entries
- [x] Restore history survives restart
- [x] Restore history remains operational metadata only
- [x] Manual smoke test completed

## Notes

Restore history is file-based operational metadata and remains separate from custody/audit history.