### PR TITLE
Issue 27-64: add two-phase restore validation and reauth confirmation

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -74,6 +74,7 @@ from assettrack.restore import (
     RestoreOperationError,
     RestoreValidationError,
     clear_recovery_state,
+    inspect_uploaded_database,
     load_recovery_state,
     load_restore_history,
     recovery_mode_is_active,
@@ -148,6 +149,7 @@ LOGIN_FAILURE_ATTEMPTS: dict[str, list[int]] = {}
 ADMIN_ROUTE_RATE_LIMIT_WINDOW_SECONDS = 60
 ADMIN_ROUTE_RATE_LIMIT_MAX_ACTIONS = 10
 ADMIN_ROUTE_ATTEMPTS: dict[str, list[int]] = {}
+PENDING_DB_RESTORE_SESSION_KEY = "pending_db_restore"
 
 
 @app.after_request
@@ -226,6 +228,35 @@ def _format_duration_label(total_seconds: object) -> str:
 
 def touch_session() -> None:
     session["last_seen"] = now_seconds()
+
+
+def _clear_pending_db_restore(*, unlink_temp_file: bool = True) -> None:
+    pending_restore = session.pop(PENDING_DB_RESTORE_SESSION_KEY, None)
+    if not unlink_temp_file or not isinstance(pending_restore, dict):
+        return
+
+    temp_path_value = str(pending_restore.get("temp_path") or "").strip()
+    if not temp_path_value:
+        return
+    Path(temp_path_value).unlink(missing_ok=True)
+
+
+def _load_pending_db_restore() -> dict[str, object] | None:
+    pending_restore = session.get(PENDING_DB_RESTORE_SESSION_KEY)
+    if not isinstance(pending_restore, dict):
+        return None
+
+    temp_path_value = str(pending_restore.get("temp_path") or "").strip()
+    if not temp_path_value:
+        _clear_pending_db_restore(unlink_temp_file=False)
+        return None
+
+    temp_path = Path(temp_path_value)
+    if not temp_path.exists() or not temp_path.is_file():
+        _clear_pending_db_restore(unlink_temp_file=False)
+        return None
+
+    return pending_restore
 
 
 def _should_refresh_session_activity() -> bool:
@@ -6549,53 +6580,115 @@ def admin_db_export():
 @require_login
 @require_role("admin")
 def admin_db_restore():
+    user = current_user()
     resolved_db_path = _resolved_runtime_db_path()
     rollback_path = rollback_artifact_path_for(resolved_db_path)
     recovery_state_path = recovery_state_path_for(resolved_db_path)
     error_message: str | None = None
     success_message: str | None = None
     restore_result: dict[str, str] | None = None
+    validation_summary: dict[str, object] | None = None
     status_code = 200
+
+    pending_restore = _load_pending_db_restore()
+    if pending_restore is not None and int(pending_restore.get("validated_by_user_id") or 0) == int(user["id"]):
+        validation_summary = dict(pending_restore.get("validation_summary") or {})
+    elif pending_restore is not None:
+        _clear_pending_db_restore()
+        pending_restore = None
 
     if request.method == "POST":
         if not _consume_admin_route_rate_limit_slot():
             error_message = "Too many requests. Wait and try again."
             status_code = 429
         else:
-            upload = request.files.get("db_file")
-            filename = str((upload.filename if upload is not None else "") or "").strip()
-
-            if upload is None or not filename:
-                error_message = "Choose a SQLite database file to restore."
-                status_code = 400
-            else:
-                suffix = Path(filename).suffix or ".db"
-                temp_path: Path | None = None
-                try:
-                    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
-                        upload.save(handle)
-                        temp_path = Path(handle.name)
-
-                    restore_result = restore_database(
-                        uploaded_db_path=temp_path,
-                        live_db_path=resolved_db_path,
-                        source_filename=filename,
-                    )
-                    success_message = (
-                        "Database restore complete. Recovery mode is active and the previous database copy was preserved."
-                    )
-                except RestoreValidationError as exc:
-                    error_message = str(exc)
+            action = str(request.form.get("action") or "validate").strip().lower()
+            if action == "cancel_validation":
+                _clear_pending_db_restore()
+                validation_summary = None
+                pending_restore = None
+                success_message = "Pending restore validation was cleared."
+            elif action == "confirm_restore":
+                pending_restore = _load_pending_db_restore()
+                if pending_restore is None:
+                    error_message = "Validate a SQLite backup before replacing the live database."
                     status_code = 400
-                except RestoreOperationError as exc:
-                    error_message = str(exc)
-                    status_code = 500
-                except RestoreError as exc:
-                    error_message = str(exc)
-                    status_code = 500
-                finally:
-                    if temp_path is not None:
-                        temp_path.unlink(missing_ok=True)
+                elif int(pending_restore.get("validated_by_user_id") or 0) != int(user["id"]):
+                    _clear_pending_db_restore()
+                    error_message = "Pending restore validation does not match the current admin session."
+                    status_code = 403
+                else:
+                    admin_password = str(request.form.get("admin_password") or "")
+                    if not verify_password(user, admin_password):
+                        validation_summary = dict(pending_restore.get("validation_summary") or {})
+                        error_message = "Admin password is incorrect."
+                        status_code = 403
+                    else:
+                        temp_path = Path(str(pending_restore.get("temp_path") or "")).expanduser().resolve()
+                        source_filename = str(pending_restore.get("source_filename") or "").strip()
+                        try:
+                            restore_result = restore_database(
+                                uploaded_db_path=temp_path,
+                                live_db_path=resolved_db_path,
+                                source_filename=source_filename,
+                            )
+                            success_message = (
+                                "Database restore complete. Recovery mode is active and the previous database copy was preserved."
+                            )
+                            _clear_pending_db_restore()
+                            pending_restore = None
+                            validation_summary = None
+                        except RestoreValidationError as exc:
+                            validation_summary = dict(pending_restore.get("validation_summary") or {})
+                            error_message = str(exc)
+                            status_code = 400
+                        except RestoreOperationError as exc:
+                            validation_summary = dict(pending_restore.get("validation_summary") or {})
+                            error_message = str(exc)
+                            status_code = 500
+                        except RestoreError as exc:
+                            validation_summary = dict(pending_restore.get("validation_summary") or {})
+                            error_message = str(exc)
+                            status_code = 500
+            else:
+                upload = request.files.get("db_file")
+                filename = str((upload.filename if upload is not None else "") or "").strip()
+
+                if upload is None or not filename:
+                    error_message = "Choose a SQLite database file to validate."
+                    status_code = 400
+                else:
+                    suffix = Path(filename).suffix or ".db"
+                    temp_path: Path | None = None
+                    try:
+                        _clear_pending_db_restore()
+                        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+                            upload.save(handle)
+                            temp_path = Path(handle.name)
+
+                        validation_summary = {
+                            "source_filename": filename,
+                            "live_db_path": str(resolved_db_path),
+                            "rollback_db_path": str(rollback_path),
+                            **inspect_uploaded_database(temp_path),
+                        }
+                        session[PENDING_DB_RESTORE_SESSION_KEY] = {
+                            "temp_path": str(temp_path),
+                            "source_filename": filename,
+                            "validated_by_user_id": int(user["id"]),
+                            "validation_summary": validation_summary,
+                        }
+                        pending_restore = _load_pending_db_restore()
+                    except RestoreValidationError as exc:
+                        error_message = str(exc)
+                        status_code = 400
+                        if temp_path is not None:
+                            temp_path.unlink(missing_ok=True)
+                    except RestoreError as exc:
+                        error_message = str(exc)
+                        status_code = 500
+                        if temp_path is not None:
+                            temp_path.unlink(missing_ok=True)
 
     return (
         render_template(
@@ -6606,6 +6699,7 @@ def admin_db_restore():
             error_message=error_message,
             success_message=success_message,
             restore_result=restore_result,
+            validation_summary=validation_summary,
         ),
         status_code,
     )

--- a/assettrack/intake/templates/admin_db_restore.html
+++ b/assettrack/intake/templates/admin_db_restore.html
@@ -27,17 +27,86 @@
 
   <div class="card">
     <h2>Restore SQLite Backup</h2>
-    <p>Use this only for recovery. AssetTrack will validate the uploaded SQLite file before replacing the live database.</p>
+    <p>Use this only for recovery. AssetTrack validates the uploaded SQLite file first, then requires admin password confirmation before live replacement.</p>
     <form method="post" enctype="multipart/form-data">
+      <input type="hidden" name="action" value="validate" />
       <div class="row form-group">
         <label class="form-label" for="db_file"><strong>SQLite backup file</strong></label>
         <input id="db_file" name="db_file" type="file" accept=".db,.sqlite,.sqlite3,application/octet-stream" required />
       </div>
       <div class="search-actions">
-        <button type="submit">Validate and Restore</button>
+        <button type="submit">Validate Backup</button>
       </div>
     </form>
   </div>
+
+  {% if validation_summary %}
+    <div class="card">
+      <h2>Validation Summary</h2>
+      <p>Validation completed. No live replacement has occurred yet.</p>
+      <table>
+        <tbody>
+          <tr>
+            <th>Uploaded filename</th>
+            <td><code>{{ validation_summary.source_filename }}</code></td>
+          </tr>
+          <tr>
+            <th>SQLite integrity</th>
+            <td>{{ validation_summary.integrity_status }}</td>
+          </tr>
+          <tr>
+            <th>Required tables</th>
+            <td>{{ validation_summary.required_tables_status }}</td>
+          </tr>
+          <tr>
+            <th>Asset count</th>
+            <td>{{ validation_summary.asset_count }}</td>
+          </tr>
+          <tr>
+            <th>Holder count</th>
+            <td>{{ validation_summary.holder_count }}</td>
+          </tr>
+          <tr>
+            <th>Custody event count</th>
+            <td>{{ validation_summary.custody_event_count }}</td>
+          </tr>
+          <tr>
+            <th>Pending receipt count</th>
+            <td>{{ validation_summary.pending_receipt_count }}</td>
+          </tr>
+          <tr>
+            <th>Live DB target</th>
+            <td><code>{{ validation_summary.live_db_path }}</code></td>
+          </tr>
+          <tr>
+            <th>Rollback copy path</th>
+            <td><code>{{ validation_summary.rollback_db_path }}</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="card">
+      <h2>Confirm Live Replacement</h2>
+      <p>Replace the current live database only after you verify the backup details above. This action creates the rollback copy, activates recovery mode, and records restore history.</p>
+      <form method="post">
+        <input type="hidden" name="action" value="confirm_restore" />
+        <div class="row form-group">
+          <label class="form-label" for="admin_password"><strong>Admin password</strong></label>
+          <input id="admin_password" name="admin_password" type="password" autocomplete="current-password" required />
+        </div>
+        <div class="search-actions">
+          <button type="submit">Replace Live Database</button>
+        </div>
+      </form>
+      <form method="post">
+        <input type="hidden" name="action" value="cancel_validation" />
+        <div class="search-actions">
+          <button type="submit">Clear Validation</button>
+        </div>
+      </form>
+    </div>
+  {% endif %}
 
   <div class="card">
     <h2>Operational Paths</h2>

--- a/assettrack/restore.py
+++ b/assettrack/restore.py
@@ -161,7 +161,14 @@ def _validate_integrity(conn: sqlite3.Connection) -> None:
         raise RestoreValidationError(f"SQLite integrity check failed: {details}")
 
 
-def validate_uploaded_database(candidate_path: Path) -> None:
+def _event_table_name(existing_tables: set[str]) -> str:
+    for name in EVENT_TABLE_ALIASES:
+        if name in existing_tables:
+            return name
+    raise RestoreValidationError("Uploaded database is missing required AssetTrack tables: asset_events")
+
+
+def inspect_uploaded_database(candidate_path: Path) -> dict[str, object]:
     candidate_path = candidate_path.expanduser().resolve()
     if not candidate_path.exists() or not candidate_path.is_file():
         raise RestoreValidationError("Uploaded database file was not saved correctly.")
@@ -172,20 +179,42 @@ def validate_uploaded_database(candidate_path: Path) -> None:
         raise RestoreValidationError(f"Uploaded file could not be opened as SQLite: {exc}") from exc
 
     try:
-        _validate_integrity(conn)
-        existing_tables = _list_tables(conn)
-    except sqlite3.Error as exc:
-        raise RestoreValidationError(f"Uploaded file is not a valid SQLite database: {exc}") from exc
+        try:
+            _validate_integrity(conn)
+            existing_tables = _list_tables(conn)
+        except sqlite3.Error as exc:
+            raise RestoreValidationError(f"Uploaded file is not a valid SQLite database: {exc}") from exc
+
+        missing_tables = sorted(RESTORE_REQUIRED_TABLES - existing_tables)
+        if not any(name in existing_tables for name in EVENT_TABLE_ALIASES):
+            missing_tables.append("asset_events")
+        if missing_tables:
+            raise RestoreValidationError(
+                "Uploaded database is missing required AssetTrack tables: " + ", ".join(missing_tables)
+            )
+
+        event_table_name = _event_table_name(existing_tables)
+        asset_count = int(conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0])
+        holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        custody_event_count = int(conn.execute(f"SELECT COUNT(*) FROM {event_table_name};").fetchone()[0])
+        pending_receipt_count = int(
+            conn.execute("SELECT COUNT(*) FROM receipt_queue WHERE sent_at IS NULL;").fetchone()[0]
+        )
     finally:
         conn.close()
 
-    missing_tables = sorted(RESTORE_REQUIRED_TABLES - existing_tables)
-    if not any(name in existing_tables for name in EVENT_TABLE_ALIASES):
-        missing_tables.append("asset_events")
-    if missing_tables:
-        raise RestoreValidationError(
-            "Uploaded database is missing required AssetTrack tables: " + ", ".join(missing_tables)
-        )
+    return {
+        "integrity_status": "ok",
+        "required_tables_status": "ok",
+        "asset_count": asset_count,
+        "holder_count": holder_count,
+        "custody_event_count": custody_event_count,
+        "pending_receipt_count": pending_receipt_count,
+    }
+
+
+def validate_uploaded_database(candidate_path: Path) -> None:
+    inspect_uploaded_database(candidate_path)
 
 
 def _ensure_live_db_replaceable(db_path: Path) -> None:

--- a/tests/test_admin_db_restore.py
+++ b/tests/test_admin_db_restore.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
+from werkzeug.security import generate_password_hash
 
 import assettrack.db as db
 import assettrack.restore as restore_module
@@ -70,21 +71,28 @@ def _insert_event(conn: sqlite3.Connection, asset_tag: str, actor: str) -> None:
     )
 
 
-def _insert_admin_user(conn: sqlite3.Connection, user_id: int, username: str) -> None:
+def _insert_admin_user(conn: sqlite3.Connection, user_id: int, username: str, password: str) -> None:
     conn.execute(
         """
         INSERT INTO users (id, username, password_hash, role, active, created_at, updated_at)
-        VALUES (?, ?, 'hash', 'admin', 1, '2026-05-11T00:00:00Z', '2026-05-11T00:00:00Z');
+        VALUES (?, ?, ?, 'admin', 1, '2026-05-11T00:00:00Z', '2026-05-11T00:00:00Z');
         """,
-        (user_id, username),
+        (user_id, username, generate_password_hash(password)),
     )
 
 
-def _build_valid_restore_db(path: Path, *, asset_tag: str, admin_user_id: int = 1) -> Path:
+def _build_valid_restore_db(
+    path: Path,
+    *,
+    asset_tag: str,
+    admin_user_id: int = 1,
+    admin_username: str = "restored-admin",
+    admin_password: str = "admin-pass",
+) -> Path:
     db.initialize_schema(path)
     conn = sqlite3.connect(path)
     try:
-        _insert_admin_user(conn, admin_user_id, "restored-admin")
+        _insert_admin_user(conn, admin_user_id, admin_username, admin_password)
         _insert_asset(conn, asset_tag)
         _insert_event(conn, asset_tag, "restore-source")
         conn.commit()
@@ -117,7 +125,29 @@ def _restore_history_entries(path: Path) -> list[dict[str, object]]:
     return [json.loads(line) for line in history_path.read_text(encoding="utf-8").splitlines() if line.strip()]
 
 
-def test_admin_can_restore_valid_database_upload(client_with_temp_db, tmp_path: Path) -> None:
+def _validate_restore_upload(client, restore_upload_path: Path, upload_name: str):
+    with restore_upload_path.open("rb") as handle:
+        return client.post(
+            "/admin/db/restore",
+            data={
+                "action": "validate",
+                "db_file": (BytesIO(handle.read()), upload_name),
+            },
+            content_type="multipart/form-data",
+        )
+
+
+def _confirm_restore(client, password: str):
+    return client.post(
+        "/admin/db/restore",
+        data={
+            "action": "confirm_restore",
+            "admin_password": password,
+        },
+    )
+
+
+def test_validation_phase_shows_summary_without_replacing_live_db(client_with_temp_db, tmp_path: Path) -> None:
     admin_id = create_test_user(username="admin-restore", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
 
@@ -131,13 +161,44 @@ def test_admin_can_restore_valid_database_upload(client_with_temp_db, tmp_path: 
         conn.close()
 
     restore_upload_path = _build_valid_restore_db(tmp_path / "restore-upload.db", asset_tag="RESTORE-ONLY")
+    response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-upload.db")
 
-    with restore_upload_path.open("rb") as handle:
-        response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-upload.db")},
-            content_type="multipart/form-data",
-        )
+    assert response.status_code == 200
+    assert b"Validation Summary" in response.data
+    assert b"No live replacement has occurred yet." in response.data
+    assert b"restore-upload.db" in response.data
+    assert b"SQLite integrity" in response.data
+    assert b"Required tables" in response.data
+    assert b"Custody event count" in response.data
+    assert b"Pending receipt count" in response.data
+    assert b"Replace Live Database" in response.data
+    assert _asset_tags(live_db_path) == ["LIVE-ONLY"]
+    assert _event_count(live_db_path) == 1
+    assert not restore_module.rollback_artifact_path_for(live_db_path).exists()
+    assert not restore_module.recovery_state_path_for(live_db_path).exists()
+    assert _restore_history_entries(live_db_path) == []
+
+
+def test_admin_can_restore_valid_database_after_reauth_confirmation(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-confirm-restore", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-ONLY")
+        _insert_event(conn, "LIVE-ONLY", "live-admin")
+        conn.commit()
+    finally:
+        conn.close()
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-upload.db", asset_tag="RESTORE-ONLY")
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-upload.db")
+
+    assert validate_response.status_code == 200
+    assert _asset_tags(live_db_path) == ["LIVE-ONLY"]
+
+    response = _confirm_restore(client_with_temp_db, "admin-pass")
 
     assert response.status_code == 200
     assert b"Database restore complete." in response.data
@@ -162,6 +223,36 @@ def test_admin_can_restore_valid_database_upload(client_with_temp_db, tmp_path: 
     assert history_entries[0]["source_filename"] == "restore-upload.db"
     assert history_entries[0]["rollback_db_path"] == str(rollback_path)
     assert history_entries[0]["result"] == "success"
+    assert b"Validation Summary" not in response.data
+
+
+def test_restore_confirmation_rejects_wrong_admin_password(client_with_temp_db, tmp_path: Path) -> None:
+    admin_id = create_test_user(username="admin-wrong-password", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    live_db_path = db.DB_PATH
+    conn = db.get_connection()
+    try:
+        _insert_asset(conn, "LIVE-ONLY")
+        _insert_event(conn, "LIVE-ONLY", "live-admin")
+        conn.commit()
+    finally:
+        conn.close()
+
+    restore_upload_path = _build_valid_restore_db(tmp_path / "restore-upload.db", asset_tag="RESTORE-ONLY")
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-upload.db")
+    assert validate_response.status_code == 200
+
+    response = _confirm_restore(client_with_temp_db, "wrong-pass")
+
+    assert response.status_code == 403
+    assert b"Admin password is incorrect." in response.data
+    assert b"Validation Summary" in response.data
+    assert _asset_tags(live_db_path) == ["LIVE-ONLY"]
+    assert _event_count(live_db_path) == 1
+    assert not restore_module.rollback_artifact_path_for(live_db_path).exists()
+    assert not restore_module.recovery_state_path_for(live_db_path).exists()
+    assert _restore_history_entries(live_db_path) == []
 
 
 def test_restore_rejects_non_sqlite_upload_without_replacing_live_db(client_with_temp_db) -> None:
@@ -178,7 +269,7 @@ def test_restore_rejects_non_sqlite_upload_without_replacing_live_db(client_with
 
     response = client_with_temp_db.post(
         "/admin/db/restore",
-        data={"db_file": (BytesIO(b"not-a-sqlite-database"), "invalid.db")},
+        data={"action": "validate", "db_file": (BytesIO(b"not-a-sqlite-database"), "invalid.db")},
         content_type="multipart/form-data",
     )
 
@@ -212,7 +303,7 @@ def test_restore_rejects_sqlite_file_missing_required_tables(client_with_temp_db
     with incomplete_db_path.open("rb") as handle:
         response = client_with_temp_db.post(
             "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "missing-tables.db")},
+            data={"action": "validate", "db_file": (BytesIO(handle.read()), "missing-tables.db")},
             content_type="multipart/form-data",
         )
 
@@ -245,12 +336,10 @@ def test_restore_fails_closed_when_rollback_copy_cannot_be_created(
 
     monkeypatch.setattr(restore_module, "_create_rollback_copy", fail_rollback)
 
-    with restore_upload_path.open("rb") as handle:
-        response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-blocked.db")},
-            content_type="multipart/form-data",
-        )
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-blocked.db")
+    assert validate_response.status_code == 200
+
+    response = _confirm_restore(client_with_temp_db, "admin-pass")
 
     assert response.status_code == 500
     assert b"Rollback copy could not be created: blocked" in response.data
@@ -282,12 +371,10 @@ def test_restore_fails_closed_when_history_write_cannot_be_completed(
 
     monkeypatch.setattr(restore_module, "_append_restore_history_entry", fail_history)
 
-    with restore_upload_path.open("rb") as handle:
-        response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-history-blocked.db")},
-            content_type="multipart/form-data",
-        )
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-history-blocked.db")
+    assert validate_response.status_code == 200
+
+    response = _confirm_restore(client_with_temp_db, "admin-pass")
 
     assert response.status_code == 500
     assert b"Restore history could not be written: blocked" in response.data
@@ -308,7 +395,7 @@ def test_operator_cannot_access_restore_route(client_with_temp_db, tmp_path: Pat
     with restore_upload_path.open("rb") as handle:
         post_response = client_with_temp_db.post(
             "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-denied.db")},
+            data={"action": "validate", "db_file": (BytesIO(handle.read()), "restore-denied.db")},
             content_type="multipart/form-data",
         )
 
@@ -321,13 +408,9 @@ def test_admin_system_surfaces_recovery_metadata_until_acknowledged(client_with_
 
     live_db_path = db.DB_PATH
     restore_upload_path = _build_valid_restore_db(tmp_path / "restore-meta.db", asset_tag="RESTORE-ONLY")
-
-    with restore_upload_path.open("rb") as handle:
-        restore_response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-meta.db")},
-            content_type="multipart/form-data",
-        )
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-meta.db")
+    assert validate_response.status_code == 200
+    restore_response = _confirm_restore(client_with_temp_db, "admin-pass")
 
     assert restore_response.status_code == 200
 
@@ -361,12 +444,9 @@ def test_admin_acknowledgment_clears_recovery_state(client_with_temp_db, tmp_pat
 
     live_db_path = db.DB_PATH
     restore_upload_path = _build_valid_restore_db(tmp_path / "restore-clear.db", asset_tag="RESTORE-ONLY")
-    with restore_upload_path.open("rb") as handle:
-        restore_response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-clear.db")},
-            content_type="multipart/form-data",
-        )
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-clear.db")
+    assert validate_response.status_code == 200
+    restore_response = _confirm_restore(client_with_temp_db, "admin-pass")
     assert restore_response.status_code == 200
 
     acknowledge_response = client_with_temp_db.post("/admin/recovery/acknowledge", follow_redirects=True)
@@ -384,12 +464,9 @@ def test_operator_cannot_acknowledge_recovery_state(client_with_temp_db, tmp_pat
     login_session(client_with_temp_db, admin_id)
 
     restore_upload_path = _build_valid_restore_db(tmp_path / "restore-seed.db", asset_tag="RESTORE-ONLY")
-    with restore_upload_path.open("rb") as handle:
-        restore_response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-seed.db")},
-            content_type="multipart/form-data",
-        )
+    validate_response = _validate_restore_upload(client_with_temp_db, restore_upload_path, "restore-seed.db")
+    assert validate_response.status_code == 200
+    restore_response = _confirm_restore(client_with_temp_db, "admin-pass")
     assert restore_response.status_code == 200
 
     operator_id = create_test_user(username="operator-recovery-ack", password="op-pass", role="operator")
@@ -409,21 +486,15 @@ def test_multiple_restores_append_history_entries_and_preserve_latest_recovery_s
     live_db_path = db.DB_PATH
 
     first_upload = _build_valid_restore_db(tmp_path / "restore-first.db", asset_tag="RESTORE-FIRST")
-    with first_upload.open("rb") as handle:
-        first_response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-first.db")},
-            content_type="multipart/form-data",
-        )
+    first_validate = _validate_restore_upload(client_with_temp_db, first_upload, "restore-first.db")
+    assert first_validate.status_code == 200
+    first_response = _confirm_restore(client_with_temp_db, "admin-pass")
     assert first_response.status_code == 200
 
     second_upload = _build_valid_restore_db(tmp_path / "restore-second.db", asset_tag="RESTORE-SECOND")
-    with second_upload.open("rb") as handle:
-        second_response = client_with_temp_db.post(
-            "/admin/db/restore",
-            data={"db_file": (BytesIO(handle.read()), "restore-second.db")},
-            content_type="multipart/form-data",
-        )
+    second_validate = _validate_restore_upload(client_with_temp_db, second_upload, "restore-second.db")
+    assert second_validate.status_code == 200
+    second_response = _confirm_restore(client_with_temp_db, "admin-pass")
     assert second_response.status_code == 200
 
     history_entries = _restore_history_entries(live_db_path)


### PR DESCRIPTION
## Summary

Adds a two-phase database restore flow with validation review and admin password confirmation.

## Related Issue

Closes #702 

## Changes

- Split `/admin/db/restore` into validation and confirmation phases
- Added non-mutating validation summary before replacement
- Added admin password re-authentication before restore
- Added explicit `Replace Live Database` confirmation action
- Preserved rollback, recovery mode, and restore history behavior after confirmed restore
- Added focused restore workflow tests

## Verification

- [x] Targeted restore/recovery/admin/auth tests passed
- [x] Invalid upload failed closed
- [x] Valid upload showed validation summary without replacing DB
- [x] Wrong admin password blocked replacement
- [x] Correct admin password completed restore
- [x] Rollback artifact created after confirmation
- [x] Recovery mode activated after confirmation
- [x] Restore history created after confirmation
- [x] Operator access denied

## Notes

Pending validation state is session-bound. Restore confirmation remains tied to the current authenticated admin session.