### PR TITLE
Issue 27-66: fix recovery acknowledgment action layout

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -263,6 +263,12 @@ button.warn-button:focus-visible {
   margin-top: 0.25rem;
 }
 
+.recovery-action-area {
+  margin-top: 1rem;
+  padding-top: 0.85rem;
+  border-top: 1px solid var(--color-surface);
+}
+
 .search-clear {
   display: inline-flex;
   align-items: center;

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -67,7 +67,7 @@
       <p class="warn">Recovery state file could not be read cleanly: {{ recovery_mode.parse_error }}</p>
     {% endif %}
     {% if recovery_mode.active %}
-      <div class="actions" aria-label="Recovery actions">
+      <div class="recovery-action-area search-actions" aria-label="Recovery actions">
         <form method="post" action="{{ url_for('admin_recovery_acknowledge') }}">
           <button type="submit">Acknowledge Recovery and Resume</button>
         </form>


### PR DESCRIPTION
## Summary

Improves the recovery acknowledgment action layout on `/admin/system`.

## Related Issue

Closes #709 

## Changes

- Moved the recovery acknowledgment action into a visually separated action area
- Added divider and spacing between recovery metadata and acknowledgment action
- Reused existing admin action alignment patterns
- Kept recovery behavior and wording unchanged

## Verification

- [x] Recovery metadata remains readable
- [x] Acknowledgment action visually separated from metadata table
- [x] Recovery acknowledgment still clears recovery mode
- [x] Admin system page remains visually clean after recovery clears
- [x] Manual visual smoke test completed

## Notes

Presentation-only change. No recovery, auth, persistence, or workflow behavior changed.