### PR TITLE
Issue 27-69: quiet and consolidate global navigation

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -301,6 +301,14 @@ button.warn-button:focus-visible {
   .hero-support-image {
     max-width: 240px;
   }
+
+  .top-nav {
+    align-items: flex-start;
+  }
+
+  .top-nav-utility {
+    margin-left: 0;
+  }
 }
 
 :root {
@@ -439,9 +447,27 @@ a:hover {
 
 .top-nav {
   display: flex;
+  align-items: center;
+  justify-content: space-between;
   flex-wrap: wrap;
-  gap: 0.4rem 0.45rem;
+  gap: 0.5rem 0.9rem;
   margin: 0.65rem 0 0.9rem 0;
+}
+
+.top-nav-primary,
+.top-nav-utility {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.top-nav-primary {
+  gap: 0.4rem 0.45rem;
+}
+
+.top-nav-utility {
+  gap: 0.45rem 0.75rem;
+  margin-left: auto;
 }
 
 .top-nav .chip {
@@ -472,6 +498,22 @@ a:hover {
   border-color: var(--color-warning);
   color: var(--color-primary);
   font-weight: 700;
+}
+
+.top-nav-utility .nav-link {
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+  font-weight: 600;
+  text-decoration-thickness: 1px;
+}
+
+.top-nav-utility .nav-link:hover {
+  color: color-mix(in srgb, var(--color-primary) 74%, var(--color-text));
+}
+
+.top-nav-utility .nav-link.active {
+  color: var(--color-primary);
+  text-decoration-thickness: 2px;
 }
 
 button.theme-toggle {

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -78,6 +78,7 @@
   <div class="card">
     <h2>Admin Tools</h2>
     <nav class="workflow-local-nav" aria-label="Admin tool navigation">
+      <p><a class="nav-link" href="{{ url_for('add_assets') }}">Stage Assets</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_users') }}">Manage Users</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a></p>
       <p><a class="nav-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a></p>

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -45,20 +45,23 @@
       {% if authenticated_user %}
         <nav class="top-nav" aria-label="Primary">
           {% if not password_change_required %}
-            <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
-            <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
-            <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
-            <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
-            {% if authenticated_role == 'admin' %}
-              <a class="chip {% if request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('add_assets') }}">Stage Assets</a>
-              <a class="chip {% if request.path.startswith('/admin/system') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
+            <div class="top-nav-primary">
+              <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
+              <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
+              <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
+              <a class="chip {% if request.path.startswith('/report') or request.path.startswith('/receipts') or request.path.startswith('/assets/search') or request.path.startswith('/dashboard/holders') or request.path.startswith('/dashboard/cases') %}active{% endif %}" href="{{ url_for('human_report') }}">Reports</a>
+              {% if authenticated_role == 'admin' %}
+                <a class="chip {% if request.path.startswith('/admin') or request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin</a>
+              {% endif %}
+            </div>
+          {% endif %}
+          <div class="top-nav-utility">
+            <a class="nav-link {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
+            {% if authenticated_role == 'admin' and not password_change_required %}
+              <span class="chip mode-badge" aria-label="Admin mode">ADMIN</span>
             {% endif %}
-          {% endif %}
-          <a class="chip {% if request.path.startswith('/account/change-password') %}active{% endif %}" href="{{ url_for('account_change_password') }}">Account</a>
-          {% if authenticated_role == 'admin' and not password_change_required %}
-            <span class="chip mode-badge" aria-label="Admin mode">ADMIN</span>
-          {% endif %}
-          <a class="chip" href="{{ url_for('logout') }}">Logout</a>
+            <a class="nav-link" href="{{ url_for('logout') }}">Logout</a>
+          </div>
         </nav>
       {% endif %}
 


### PR DESCRIPTION
## Summary

Simplified and quieted the global navigation structure to reduce operator cognitive load and competing workflow destinations.

## Related Issue

Closes #713 

## Changes

- reduced persistent nav to Dashboard, Issue, Return, Reports, and Admin
- removed duplicated workflow destinations from top navigation
- demoted Account and Logout into quieter utility links
- standardized Admin wording
- made Stage Assets reachable from the Admin hub instead of persistent nav

## Verification

- manually smoke tested dashboard, issue, return, reports, and admin workflows
- verified preview and commit flows remained unchanged
- verified workflow seam preservation
- confirmed no auth, persistence, or routing changes

## Notes

This change establishes a calmer navigation baseline for upcoming workflow hierarchy and cognition cleanup work.