### PR TITLE
Issue 27-76: add expandable admin navigation menu

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -400,6 +400,17 @@ button.warn-button:focus-visible {
   .top-nav-utility {
     margin-left: 0;
   }
+
+  .top-nav-admin {
+    width: 100%;
+  }
+
+  .top-nav-admin-panel {
+    position: static;
+    margin-top: 0.4rem;
+    min-width: 0;
+    box-shadow: none;
+  }
 }
 
 :root {
@@ -554,6 +565,98 @@ a:hover {
 
 .top-nav-primary {
   gap: 0.4rem 0.45rem;
+}
+
+.top-nav-admin {
+  position: relative;
+  margin: 0;
+}
+
+.top-nav-admin summary {
+  list-style: none;
+}
+
+.top-nav-admin summary::-webkit-details-marker {
+  display: none;
+}
+
+.top-nav-admin-summary {
+  cursor: pointer;
+  user-select: none;
+  gap: 0.36rem;
+  padding-right: 0.5rem;
+}
+
+.top-nav-admin-summary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.top-nav-admin-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  min-width: 1rem;
+  color: currentColor;
+  font-size: 1rem;
+  font-weight: 900;
+  line-height: 1;
+  opacity: 0.9;
+  transition: transform 140ms ease;
+}
+
+.top-nav-admin[open] .top-nav-admin-arrow {
+  transform: rotate(180deg);
+}
+
+.top-nav-admin.active .top-nav-admin-summary,
+.top-nav-admin[open] .top-nav-admin-summary {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  font-weight: 700;
+}
+
+.top-nav-admin-panel {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  left: 0;
+  z-index: 30;
+  min-width: 14.5rem;
+  display: grid;
+  gap: 0.3rem;
+  padding: 0.55rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 18%, var(--color-surface));
+  border-radius: 12px;
+  background: var(--color-surface-bg);
+  box-shadow: 0 10px 22px rgba(18, 32, 47, 0.14);
+}
+
+.top-nav-admin-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.2rem;
+  padding: 0.4rem 0.55rem;
+  border-radius: 8px;
+  color: color-mix(in srgb, var(--color-primary) 74%, var(--color-text));
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.top-nav-admin-link:hover,
+.top-nav-admin-link:focus-visible {
+  background: color-mix(in srgb, var(--color-primary-soft) 32%, var(--color-surface-bg));
+  color: color-mix(in srgb, var(--color-primary) 90%, var(--color-text));
+  text-decoration: none;
+  outline: none;
+}
+
+.top-nav-admin-link.active {
+  background: color-mix(in srgb, var(--color-primary-soft) 46%, var(--color-surface-bg));
+  color: color-mix(in srgb, var(--color-primary) 90%, var(--color-text));
+  font-weight: 700;
 }
 
 .top-nav-utility {

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -51,7 +51,22 @@
               <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
               <a class="chip {% if request.path.startswith('/report') or request.path.startswith('/receipts') or request.path.startswith('/assets/search') or request.path.startswith('/dashboard/holders') or request.path.startswith('/dashboard/cases') %}active{% endif %}" href="{{ url_for('human_report') }}">Reports</a>
               {% if authenticated_role == 'admin' %}
-                <a class="chip {% if request.path.startswith('/admin') or request.path.startswith('/add-assets') %}active{% endif %}" href="{{ url_for('admin_system') }}">Admin</a>
+                {% set admin_menu_active = request.path.startswith('/admin') or request.path.startswith('/add-assets') %}
+                <details class="top-nav-admin{% if admin_menu_active %} active{% endif %}">
+                  <summary class="chip top-nav-admin-summary" aria-label="Admin menu">
+                    <span>Admin</span>
+                    <span class="top-nav-admin-arrow" aria-hidden="true">▼</span>
+                  </summary>
+                  <nav class="top-nav-admin-panel" aria-label="Admin destinations">
+                    <a class="top-nav-admin-link{% if request.path.startswith('/add-assets') %} active{% endif %}" href="{{ url_for('add_assets') }}">Add Assets</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/users') %} active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/system') %} active{% endif %}" href="{{ url_for('admin_system') }}">System / Admin Tools</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/reference-data') %} active{% endif %}" href="{{ url_for('admin_reference_data') }}">Reference Data</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/holders/import') %} active{% endif %}" href="{{ url_for('admin_holder_import') }}">Import Holders</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/report') %} active{% endif %}" href="{{ url_for('admin_human_report') }}">Admin Report</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/db/restore') %} active{% endif %}" href="{{ url_for('admin_db_restore') }}">Restore Database</a>
+                  </nav>
+                </details>
               {% endif %}
             </div>
           {% endif %}
@@ -124,6 +139,16 @@
         });
 
         syncThemeToggle();
+      }
+
+      const adminNavMenu = document.querySelector(".top-nav-admin");
+
+      if (adminNavMenu) {
+        adminNavMenu.querySelectorAll(".top-nav-admin-link").forEach((link) => {
+          link.addEventListener("click", () => {
+            adminNavMenu.removeAttribute("open");
+          });
+        });
       }
     </script>
     {% block extra_scripts %}{% endblock %}


### PR DESCRIPTION
## Summary

Added an expandable Admin navigation menu to keep top-level navigation quiet while preserving access to admin utilities.

## Related Issue

Closes #720 

## Changes

- replaced the Admin nav chip with an expandable menu
- grouped admin destinations under Admin
- added Add Assets to the Admin menu
- improved disclosure arrow visibility and behavior
- folded the menu after selecting a menu item
- preserved existing routes and workflow behavior

## Verification

- manually verified Admin menu open/close behavior
- verified Add Assets, Users, System/Admin Tools, Reference Data, Import Holders, Admin Report, and Restore Database remain reachable
- verified arrow visibility and behavior
- verified no route, auth, persistence, queue, preview, or commit behavior changed

## Notes

This keeps the primary nav focused while making admin utilities easier to reach.