### PR TITLE
Issue 27-71: reduce workflow verbosity

### DIFF
--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -24,7 +24,7 @@
 
   <div class="card">
     <h2>Holder CSV Import</h2>
-    <p class="import-help">Upload a CSV with the existing holder import columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
+    <p class="import-help">Required columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
     <form method="post" enctype="multipart/form-data">
       <div class="row">
         <label for="csv_file"><strong>CSV file</strong></label><br />

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -22,9 +22,9 @@
 
   <div class="card">
     <h2>Report Scope</h2>
-    <p>This page is a read-only human-readable report for operators and admins. It does not replace the raw SQLite database backup.</p>
+    <p>Read-only report. Not a database backup.</p>
     <p><strong>Database path:</strong> <code>{{ db_path }}</code></p>
-    <p><strong>Recent events section:</strong> showing recent active events only.</p>
+    <p><strong>Recent events:</strong> active events only.</p>
   </div>
 
   <div class="card">

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -147,7 +147,7 @@
     {% else %}
       <form id="intake-form" class="row" method="post" action="{{ url_for('intake') }}">
         <div class="row">
-          <label for="equipment_type"><strong>Equipment type</strong> (used when commit creates new inventory records)</label><br />
+          <label for="equipment_type"><strong>Equipment type</strong></label><br />
           <input
             type="text"
             id="equipment_type"
@@ -162,7 +162,7 @@
         {% if authenticated_role == 'admin' %}
           <div class="grid">
             <div class="row">
-              <label for="case_name"><strong>Case</strong> (optional staging detail)</label><br />
+              <label for="case_name"><strong>Case</strong> (optional)</label><br />
               <select id="case_name" name="case_name" data-timeout-lock-target>
                 <option value="">Unassigned</option>
                 {% for case_name in case_options %}
@@ -171,7 +171,7 @@
               </select>
             </div>
             <div class="row">
-              <label for="slot_id"><strong>Slot</strong> (optional staging detail)</label><br />
+              <label for="slot_id"><strong>Slot</strong> (optional)</label><br />
               <select id="slot_id" name="slot_id" data-timeout-lock-target>
                 <option value="">Unassigned</option>
                 {% for slot in slot_options %}
@@ -228,7 +228,7 @@
         {% endfor %}
       </ul>
     {% else %}
-      <p class="queue-empty">No assets are staged yet. Scan or enter an asset tag, then stage it in the queue for review.</p>
+      <p class="queue-empty">No assets staged.</p>
     {% endif %}
   </div>
 
@@ -239,7 +239,7 @@
   </div>
 
   <div class="card">
-    <h2>Latest Scan</h2>
+    <h2>Latest</h2>
     <p><code>{{ latest }}</code></p>
   </div>
 {% endblock %}

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -53,7 +53,7 @@
   <div class="card workflow-card">
     <h2>Holder</h2>
     {% if selected_holder %}
-      <p class="muted" style="margin: 0 0 0.2rem 0; font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase;">Ready to issue to</p>
+      <p class="muted" style="margin: 0 0 0.2rem 0; font-size: 0.78rem; letter-spacing: 0.04em; text-transform: uppercase;">Issue to</p>
       <p class="holder-name">{{ holder_display_name(selected_holder) }}</p>
       {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
         <p class="holder-subtle">{{ selected_holder["organization"] }}</p>
@@ -170,7 +170,7 @@
         </tbody>
       </table>
     {% else %}
-      <p>No assets queued. Return to the queue and scan or enter an asset tag.</p>
+      <p>No assets queued.</p>
     {% endif %}
   </div>
 

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -140,12 +140,12 @@
 
   <div class="card report-priority">
     <div>
-      <h2>Use Current State to Decide the Next Step</h2>
+      <h2>Current State</h2>
       <p class="report-priority-copy">
         {% if include_retired_assets %}
-          This page shows the full inventory picture, including retired assets. Use the links below to move from status into the next existing view without re-searching.
+          Full inventory, including retired assets.
         {% else %}
-          This page shows the active custody and storage picture first. Use the links below to move from status into the next existing view without re-searching.
+          Active custody and storage first.
         {% endif %}
       </p>
     </div>

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -99,7 +99,7 @@
         </tbody>
       </table>
     {% else %}
-      <p>No assets queued. Return to the queue and scan or enter an asset tag.</p>
+      <p>No assets queued.</p>
     {% endif %}
   </div>
 

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -127,7 +127,7 @@
           <span class="pill bad">required</span>
         {% endif %}
       </p>
-      <p class="workflow-summary">Before scanning, set the current building and current room / area. Issue scans stay blocked until both are filled in.</p>
+      <p class="workflow-summary">Required before issue scans.</p>
       {% if message_ns.location_messages %}
         {% for category, message in message_ns.location_messages %}
           <div class="flash {{ category|e }}">{{ message }}</div>
@@ -170,7 +170,7 @@
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
     {% if issue_location_form is defined and not issue_location_ready %}
       <div class="flash error">
-        <strong>Scanning is blocked.</strong> Set the current building and current room / area above, then scan again.
+        <strong>Scanning is blocked.</strong> Set current location first.
       </div>
     {% endif %}
     {% if message_ns.scan_messages %}
@@ -233,7 +233,7 @@
       <ul id="queue-list" class="queue-list" role="list">
         {% for s in queue %}
           <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
-            <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">Queued at {{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
+            <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
             <code>{{ s.asset_tag }}</code>
             <form method="post" action="{{ url_for('intake') }}">
               <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
@@ -245,7 +245,7 @@
         {% endfor %}
       </ul>
     {% else %}
-      <p class="queue-empty">No assets queued yet. Scan or enter an asset tag, then add it to the queue.</p>
+      <p class="queue-empty">No assets queued.</p>
     {% endif %}
   </div>
 {% endblock %}

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -155,7 +155,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Queue is empty. Add at least one asset to the queue before reviewing the batch.", response.data)
-        self.assertIn(b"No assets are staged yet.", response.data)
+        self.assertIn(b"No assets staged.", response.data)
 
     def test_scans_keep_equipment_type_captured_at_scan_time(self) -> None:
         intake_app.SCAN_QUEUE.clear()

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -398,7 +398,8 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     assert b"Admin: Current Status Report" in response.data
     assert b"Download PDF" in response.data
     assert b"Download Database Backup" in response.data
-    assert b"showing recent active events only" in response.data
+    assert b"Recent events:" in response.data
+    assert b"active events only." in response.data
     assert b"Assets" in response.data
     assert b"Holders" in response.data
     assert b"Organizations and Building Access" in response.data
@@ -577,8 +578,8 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     response = client_with_temp_db.get("/report")
 
     assert response.status_code == 200
-    assert b"Use Current State to Decide the Next Step" in response.data
-    assert b"This page shows the active custody and storage picture first." in response.data
+    assert b"Current State" in response.data
+    assert b"Active custody and storage first." in response.data
     assert b"Report Scope" not in response.data
     assert b"Review holders with assets out" in response.data
     assert b"Check case space" in response.data

--- a/tests/test_issue_23_1_active_queue_timestamps.py
+++ b/tests/test_issue_23_1_active_queue_timestamps.py
@@ -8,7 +8,7 @@ import pytest
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from assettrack.intake.scan import Scan
-from tests.auth_test_utils import create_test_user
+from tests.auth_test_utils import create_test_user, login_session
 
 
 @pytest.fixture
@@ -32,9 +32,9 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 def test_issue_and_return_queue_pages_show_scan_timestamps(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-queue-ts", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
 
     with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -49,7 +49,7 @@ def test_issue_and_return_queue_pages_show_scan_timestamps(client_with_temp_db) 
 
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
-    assert b"Queued at 14:03:22 UTC" in issue_page.data
+    assert b"14:03:22 UTC" in issue_page.data
     assert b"QUEUE-TAG-1" in issue_page.data
 
     with client_with_temp_db.session_transaction() as sess:
@@ -57,5 +57,5 @@ def test_issue_and_return_queue_pages_show_scan_timestamps(client_with_temp_db) 
 
     return_page = client_with_temp_db.get("/return")
     assert return_page.status_code == 200
-    assert b"Queued at 14:03:22 UTC" in return_page.data
+    assert b"14:03:22 UTC" in return_page.data
     assert b"QUEUE-TAG-1" in return_page.data

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -155,7 +155,7 @@ def test_issue_preview_empty_queue_shows_next_step_guidance(client_with_temp_db)
     issue_preview = client_with_temp_db.get("/issue/preview")
 
     assert issue_preview.status_code == 200
-    assert b"No assets queued. Return to the queue and scan or enter an asset tag." in issue_preview.data
+    assert b"No assets queued." in issue_preview.data
 
 
 def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(client_with_temp_db) -> None:

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -103,7 +103,7 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
 
     assert issue_page.status_code == 200
     assert b"Current Location" in issue_page.data
-    assert b"Before scanning, set the current building and current room / area." in issue_page.data
+    assert b"Required before issue scans." in issue_page.data
     assert b"Scanning is blocked." in issue_page.data
     assert b"Add to Queue" in issue_page.data
     assert b"Scan or enter asset tag" in issue_page.data

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -244,14 +244,14 @@ class ReturnBatchTests(unittest.TestCase):
         render = self.client.get("/return")
         self.assertEqual(render.status_code, 200)
         self.assertIn(
-            b"No assets queued yet. Scan or enter an asset tag, then add it to the queue.",
+            b"No assets queued.",
             render.data,
         )
 
         preview_render = self.client.get("/return/preview")
         self.assertEqual(preview_render.status_code, 200)
         self.assertIn(
-            b"No assets queued. Return to the queue and scan or enter an asset tag.",
+            b"No assets queued.",
             preview_render.data,
         )
 


### PR DESCRIPTION
## Summary

Reduced workflow/helper text across core operator surfaces to make AssetTrack calmer and easier to scan.

## Related Issue

Closes #715 

## Changes

- shortened instructional copy across add-assets, issue, return, preview, report, and admin support surfaces
- removed repeated helper wording where hierarchy already communicates the action
- preserved safety-critical wording around preview, commit, recovery, and admin actions
- updated tests to match the cleaner copy

## Verification

- ran focused AssetTrack test suite: 59 passed
- ran `git diff --check`
- rebuilt Docker successfully
- verified container health
- confirmed login page served locally
- manually reviewed dashboard/operator surfaces for reduced clutter

## Notes

No route, auth, persistence, queue, preview, commit, or event behavior changed.