### PR TITLE
Issue 27-74: Consolidate report action surfaces

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -290,12 +290,10 @@
         <div class="status-pill">
           <strong>{{ overview.holders_with_assets_out }}</strong>
           <span>Holders with assets out</span>
-          <a class="nav-link" href="{{ url_for('dashboard_holders') }}">View holders</a>
         </div>
         <div class="status-pill">
           <strong>{{ overview.open_storage_slots }}</strong>
           <span>Open storage slots</span>
-          <a class="nav-link" href="{{ url_for('human_report') }}">Open current status report</a>
         </div>
       </div>
     </div>
@@ -308,7 +306,6 @@
       <p class="metric">Unslotted Assets: <strong>{{ dashboard.summary.exceptions.unslotted_assets }}</strong></p>
       <p class="metric">Slot Conflicts: <strong>{{ dashboard.summary.exceptions.slot_conflicts }}</strong></p>
       <p class="metric">In Custody &gt; {{ custody_days_threshold }} Days: <strong>{{ dashboard.summary.exceptions.in_custody_over_threshold }}</strong></p>
-      <p class="card-link"><a class="nav-link" href="#problems-panel">Review problems</a></p>
     </section>
 
     <section class="card">
@@ -332,7 +329,6 @@
           <strong>None</strong>
         {% endif %}
       </p>
-      <p class="card-link"><a class="nav-link" href="{{ url_for('dashboard_holders') }}">Open outstanding holders</a></p>
     </section>
 
     <section class="card">
@@ -344,7 +340,6 @@
       <p class="metric">In Storage: <strong>{{ dashboard.summary.inventory.in_storage_assets }}</strong></p>
       <p class="metric">In Custody: <strong>{{ dashboard.summary.inventory.in_custody_assets }}</strong></p>
       <p class="metric">Unslotted (Storage): <strong>{{ dashboard.summary.inventory.unslotted_assets }}</strong></p>
-      <p class="card-link"><a class="nav-link" href="{{ url_for('human_report') }}">Open current status report</a></p>
     </section>
 
     <section class="card">
@@ -354,7 +349,6 @@
       <p class="metric">Occupied Slots: <strong>{{ dashboard.summary.slots.occupied_slots }}</strong></p>
       <p class="metric">Empty Slots: <strong>{{ dashboard.summary.slots.empty_slots }}</strong></p>
       <p class="metric">Utilization %: <strong>{{ dashboard.summary.slots.utilization_percent }}%</strong></p>
-      <p class="card-link"><a class="nav-link" href="{{ url_for('dashboard_cases') }}">Review case drilldown</a></p>
     </section>
   </div>
 

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -236,7 +236,6 @@
   {% endif %}
   <nav class="actions nav-row mixed-nav-row" aria-label="Receipt navigation">
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    <a class="nav-link" href="{{ url_for('human_report') }}">Open Current Status Report</a>
     <a class="chip" href="{{ url_for('receipt_pdf', receipt_id=receipt.id) }}">Download Receipt PDF</a>
     {% if receipt.delivery.state in ["pending", "failed"] %}
       {% if send_blocked_by_recovery %}

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -203,9 +203,6 @@
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
     {% endif %}
     <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-    {% if return_to != url_for('human_report') %}
-      <a class="nav-link" href="{{ url_for('human_report') }}">Open Current Status Report</a>
-    {% endif %}
   </nav>
 
   <section class="card">

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -15,29 +15,17 @@
       color: var(--color-text-muted);
       max-width: 60rem;
     }
-    .report-priority-links {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, max-content));
+    .report-utility-links {
+      display: flex;
+      flex-wrap: wrap;
       gap: 0.65rem 0.8rem;
-      align-items: start;
+      align-items: center;
       margin-top: 0.1rem;
     }
-    .report-priority-links .nav-link {
-      display: flex;
-      align-items: center;
-      min-height: 2.75rem;
-      padding: 0.55rem 0.8rem;
-      border: 1px solid var(--color-surface);
-      border-radius: 10px;
-      background: var(--color-surface-bg);
-      text-decoration: none;
-    }
-    .report-priority-links .nav-link:hover {
-      text-decoration: none;
-      background: color-mix(in srgb, var(--color-primary-soft) 30%, var(--color-surface-bg));
-    }
-    .report-priority-links .nav-link:focus-visible {
-      outline-offset: 1px;
+    .report-utility-label {
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
+      font-weight: 700;
     }
     .report-stat-link {
       color: inherit;
@@ -149,10 +137,8 @@
         {% endif %}
       </p>
     </div>
-    <div class="report-actions nav-row report-priority-links">
-      <a class="nav-link" href="{{ url_for('dashboard_holders', return_to=report_return_to) }}">Review holders with assets out</a>
-      <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=report_return_to) }}">Check case space</a>
-      <a class="nav-link" href="{{ url_for('asset_search', return_to=report_return_to) }}">Look up an asset</a>
+    <div class="report-actions report-utility-links" aria-label="Report utilities">
+      <span class="report-utility-label">Utilities</span>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Open receipts</a>
       {% if include_retired_assets %}
         <a class="nav-link" href="{{ url_for('human_report') }}">View active inventory only</a>
@@ -176,11 +162,10 @@
         <strong>{{ asset_summary.in_custody_assets }}</strong>
         <span class="nav-link report-stat-action">Open holder follow-up</span>
       </a>
-      <a class="report-stat report-stat-link" href="{% if include_retired_assets %}{{ url_for('human_report') }}{% else %}{{ url_for('human_report', include_retired='1') }}{% endif %}">
+      <div class="report-stat">
         {% if include_retired_assets %}Retired shown{% else %}Retired hidden{% endif %}
         <strong>{{ asset_summary.disposed_assets }}</strong>
-        <span class="nav-link report-stat-action">{% if include_retired_assets %}Return to active-first view{% else %}Include retired assets{% endif %}</span>
-      </a>
+      </div>
     </div>
   </div>
 

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -581,12 +581,14 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b"Current State" in response.data
     assert b"Active custody and storage first." in response.data
     assert b"Report Scope" not in response.data
-    assert b"Review holders with assets out" in response.data
-    assert b"Check case space" in response.data
-    assert b"Look up an asset" in response.data
+    assert b"Open holder follow-up" in response.data
+    assert b"Review case space" in response.data
+    assert b"Search active asset records" in response.data
+    assert b"Utilities" in response.data
+    assert b"Open receipts" in response.data
     assert b"Include retired assets" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
-    assert response.data.count(b'href="/assets/search?return_to=/report"') >= 2
+    assert response.data.count(b'href="/assets/search?return_to=/report"') == 1
     assert b'href="/dashboard/cases?return_to=/report"' in response.data
     assert b'href="/dashboard/holders?return_to=/report"' in response.data
     assert b'href="/receipts?return_to=/report"' in response.data

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -10,7 +10,7 @@ from pypdf import PdfReader
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from tests.auth_test_utils import create_test_user
+from tests.auth_test_utils import create_test_user, login_session
 
 
 @pytest.fixture
@@ -132,8 +132,8 @@ def _occupy_slot(slot_id: int, asset_id: int) -> None:
 
 def _login_issue_operator(client, *, username: str = "issue-operator") -> int:
     operator_id = create_test_user(username=username, password="op-pass", role="operator")
+    login_session(client, operator_id)
     with client.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -143,8 +143,7 @@ def _login_issue_operator(client, *, username: str = "issue-operator") -> int:
 
 def _login_user(client, *, username: str, role: str) -> int:
     user_id = create_test_user(username=username, password="op-pass", role=role)
-    with client.session_transaction() as sess:
-        sess["user_id"] = user_id
+    login_session(client, user_id)
     return user_id
 
 
@@ -498,8 +497,7 @@ def test_mixed_holder_return_renders_safely(client_with_temp_db) -> None:
 
 def test_missing_receipt_returns_404(client_with_temp_db) -> None:
     operator_id = create_test_user(username="missing-operator", password="op-pass", role="operator")
-    with client_with_temp_db.session_transaction() as sess:
-        sess["user_id"] = operator_id
+    login_session(client_with_temp_db, operator_id)
 
     response = client_with_temp_db.get("/receipts/9999")
 


### PR DESCRIPTION
## Summary

Reduced duplicated report/dashboard launch surfaces and strengthened primary report drilldown hierarchy.

Closes #723 

## Changes

- removed duplicate report CTAs
- consolidated report drilldowns into primary metric surfaces
- demoted report utilities into quieter utility actions
- removed repeated report launch links from receipt surfaces
- updated focused tests for reduced launcher behavior

## Verification

- [x] Focused tests passing
- [x] Docker rebuild verified
- [x] Container healthy
- [x] App reachable
- [x] Manual authenticated smoke test completed

## Notes

Class 1 presentation-only refinement.

No route, auth, persistence, schema, queue, preview, or commit behavior changes.