### PR TITLE
Issue 27-83: Standardize secondary workflow navigation spacing

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -517,7 +517,28 @@ a:hover {
 }
 
 .workflow-local-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 0.85rem;
+  margin: 0 0 1rem 0;
+}
+
+.workflow-local-nav .nav-link,
+.workflow-local-nav .action-secondary,
+.workflow-local-nav .action-quiet {
+  display: inline-flex;
+  align-items: center;
+}
+
+.card h2:first-child {
+  margin-top: 0;
+}
+
+.card-intro {
   margin: 0 0 0.85rem 0;
+  color: var(--color-text-muted);
+  line-height: 1.5;
 }
 
 .page {

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -6,7 +6,9 @@
 {% block page_class %} admin-maintenance-standard-fields{% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin slot assignment navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -18,7 +20,7 @@
 
   <div class="card">
     <h2>1) Scan or Enter Asset Tag</h2>
-    <p class="muted">Scanner-first flow: scan into asset_tag and submit lookup.</p>
+    <p class="card-intro">Scanner-first flow: scan into `asset_tag` and load the asset before assigning a home slot.</p>
     <form method="post" action="{{ url_for('admin_assign_slot') }}">
       <input type="hidden" name="action" value="lookup" />
       <div class="row">

--- a/assettrack/intake/templates/admin_db_restore.html
+++ b/assettrack/intake/templates/admin_db_restore.html
@@ -35,7 +35,7 @@
 
 {% block content %}
   <nav class="workflow-local-nav" aria-label="Admin restore navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to admin tools</a>
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
   </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
@@ -56,7 +56,7 @@
 
   <div class="card restore-primary-card">
     <h2>Restore SQLite Backup</h2>
-    <p>Use this only for recovery. AssetTrack validates the uploaded SQLite file first, then requires admin password confirmation before live replacement.</p>
+    <p class="card-intro">Use this only for recovery. AssetTrack validates the uploaded SQLite file first, then requires admin password confirmation before live replacement.</p>
     <form method="post" enctype="multipart/form-data">
       <input type="hidden" name="action" value="validate" />
       <div class="row form-group">

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -5,10 +5,10 @@
 {% block page_heading %}Admin: Edit Asset{% endblock %}
 
 {% block content %}
-  <div class="actions">
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to dashboard</a>
-    <a class="chip" href="{{ url_for('admin_new_asset') }}">Create asset</a>
-  </div>
+  <nav class="workflow-local-nav" aria-label="Admin asset navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+    <a class="action-secondary" href="{{ url_for('admin_new_asset') }}">Create Asset</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -180,7 +180,9 @@
       {% else %}
         <p>This asset must use the retire flow rather than removal from edit.</p>
       {% endif %}
-      <p><a class="nav-link" href="{{ url_for('admin_retire_asset') }}">Open Retire Asset</a></p>
+      <div class="workflow-action-row workflow-action-row--quiet">
+        <a class="action-secondary" href="{{ url_for('admin_retire_asset') }}">Open Retire Flow</a>
+      </div>
     </div>
   {% endif %}
 {% endblock %}

--- a/assettrack/intake/templates/admin_force_vacate.html
+++ b/assettrack/intake/templates/admin_force_vacate.html
@@ -12,7 +12,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin force vacate navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -12,7 +12,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin import navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -10,10 +10,10 @@
 {% endblock %}
 
 {% block content %}
-  <div class="report-actions nav-row mixed-nav-row">
+  <div class="report-actions nav-row">
     <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
-    <a class="chip" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
-    <a class="chip" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
+    <a class="action-secondary" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
+    <a class="action-secondary" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
   </div>
 
   {% if report_error %}
@@ -22,7 +22,7 @@
 
   <div class="card">
     <h2>Report Scope</h2>
-    <p>Read-only report. Not a database backup.</p>
+    <p class="card-intro">Read-only operational report. This surface does not replace a database backup.</p>
     <p><strong>Database path:</strong> <code>{{ db_path }}</code></p>
     <p><strong>Recent events:</strong> active events only.</p>
   </div>

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -13,8 +13,10 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
-  <p><a href="{{ url_for('admin_edit_asset') }}">Edit an existing asset</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin asset creation navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+    <a class="action-secondary" href="{{ url_for('admin_edit_asset') }}">Edit Existing Asset</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -30,7 +32,7 @@
 
   <div class="card">
     <h2>New Asset</h2>
-    <p class="muted">Fill in the required fields below. Asset type defaults to Laptop.</p>
+    <p class="card-intro">Fill in the required fields below. Asset type defaults to Laptop.</p>
     <form method="post" action="{{ url_for('admin_new_asset') }}">
       <div class="admin-maintenance-grid">
         <div class="row">

--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -11,7 +11,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('admin_system') }}">&larr; Back to Admin Tools</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin reference data navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -28,6 +30,7 @@
   <div class="grid">
     <div class="card">
       <h2>Organizations</h2>
+      <p class="card-intro">Create reference values before using them in workflow or asset maintenance screens.</p>
       <form method="post" action="{{ url_for('admin_reference_data') }}">
         <input type="hidden" name="action" value="create_organization" />
         <div class="row">
@@ -61,6 +64,7 @@
 
     <div class="card">
       <h2>Buildings</h2>
+      <p class="card-intro">Building values appear in operator-facing location selection and maintenance forms.</p>
       <form method="post" action="{{ url_for('admin_reference_data') }}">
         <input type="hidden" name="action" value="create_building" />
         <div class="row">
@@ -95,6 +99,7 @@
 
   <div class="card">
     <h2>Organization to Building Mapping</h2>
+    <p class="card-intro">Map organizations to the buildings they can operate in.</p>
     <form method="post" action="{{ url_for('admin_reference_data') }}">
       <input type="hidden" name="action" value="map_organization_building" />
       <div class="grid">

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -12,7 +12,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin replacement navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -28,6 +30,7 @@
 
   <div class="card">
     <h2>1) Lookup Failed Asset</h2>
+    <p class="card-intro">Load the failed asset first, then record the replacement details as one maintenance operation.</p>
     <form method="post" action="{{ url_for('admin_replace_asset') }}">
       <input type="hidden" name="action" value="lookup" />
       <div class="row">

--- a/assettrack/intake/templates/admin_retire_asset.html
+++ b/assettrack/intake/templates/admin_retire_asset.html
@@ -30,7 +30,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin retire navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -46,7 +48,7 @@
 
   <div class="card">
   <h2>Find Asset</h2>
-  <p class="muted">
+  <p class="card-intro">
     Enter a full or partial asset tag. Exact matches load directly.
     Partial matches require you to select one asset before retiring.
   </p>
@@ -68,8 +70,6 @@
       {% endif %}
     </div>
   </form>
-</div>
-    </form>
   </div>
 
   {% if asset_matches and not asset %}

--- a/assettrack/intake/templates/admin_slot_move.html
+++ b/assettrack/intake/templates/admin_slot_move.html
@@ -12,7 +12,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin slot move navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -45,7 +45,9 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('dashboard') }}">&larr; Back to dashboard</a></p>
+  <nav class="workflow-local-nav" aria-label="Admin user navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
@@ -68,6 +70,7 @@
 
   <div class="card">
     <h2>Create User</h2>
+    <p class="card-intro">Create accounts here, then manage account state and password resets from the user list below.</p>
     <form method="post" action="{{ url_for('admin_users_create') }}">
       <div class="row">
         <label for="username"><strong>Username</strong></label><br />

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -176,6 +176,7 @@
 
   <div class="card workflow-card">
     <h2>Commit</h2>
+    <p class="card-intro">Commit only after the holder, current location, and queued assets are fully reviewed.</p>
     <div class="workflow-action-stack">
       <form method="post" action="{{ url_for('issue_commit') }}">
         <label style="display:block; margin-bottom: 10px;">

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -25,6 +25,7 @@
   {% endwith %}
 
   <div class="card">
+    <h2>Batch Status</h2>
     <p>
       <strong>Rows:</strong> {{ row_count }}
       &nbsp;|&nbsp;
@@ -80,6 +81,7 @@
   </div>
 
   <div class="card">
+    <h2>Commit</h2>
     <form method="post" action="{{ url_for('issue_commit') if issue_mode else url_for('preview_commit') }}" style="margin-top: 10px;">
       <label style="display:block; margin-bottom: 10px;">
         <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed">
@@ -87,7 +89,7 @@
       </label>
 
       <div class="workflow-action-row">
-        <button id="add_btn" type="submit" disabled data-timeout-lock-target>{{ "Commit Issue" if issue_mode else "Add to database" }}</button>
+        <button id="add_btn" type="submit" disabled data-timeout-lock-target>{{ "Commit Issue" if issue_mode else "Commit Staged Assets" }}</button>
       </div>
     </form>
   </div>

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -105,6 +105,7 @@
 
   <div class="card workflow-card">
     <h2>Commit</h2>
+    <p class="card-intro">Commit only after the queued returns and any blocked items have been reviewed.</p>
 
     {% if not blocking_issues %}
       <form method="post" action="{{ url_for('return_commit') }}">

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -168,6 +168,7 @@
 
   <div class="card workflow-card">
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
+    <p class="card-intro">Stage return scans in the queue, then review the queued batch before commit.</p>
     {% if issue_location_form is defined and not issue_location_ready %}
       <div class="flash error">
         <strong>Scanning is blocked.</strong> Set current location first.
@@ -223,7 +224,7 @@
 
   <div class="card workflow-card">
     <div class="workflow-action-row">
-      <a class="chip preview-step" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Preview Queue" }}</a>
+      <a class="preview-step" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Preview Queue" }}</a>
     </div>
   </div>
 

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -407,7 +407,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertIn(b"Asset Removal", response.data)
         self.assertIn(b"Asset records are not removed from the admin UI.", response.data)
         self.assertIn(b"Use the retire flow for asset removal handling.", response.data)
-        self.assertIn(b"Open Retire Asset", response.data)
+        self.assertIn(b"Open Retire Flow", response.data)
         self.assertIn(b'href="/admin/assets/retire"', response.data)
         self.assertNotIn(b"Delete Orphan / Junk Asset", response.data)
 
@@ -433,7 +433,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Asset has event history and cannot be removed.", response.data)
         self.assertIn(b"This asset must use the retire flow rather than removal from edit.", response.data)
-        self.assertIn(b"Open Retire Asset", response.data)
+        self.assertIn(b"Open Retire Flow", response.data)
         self.assertIn(b'href="/admin/assets/retire"', response.data)
         still_present = self.conn.execute("SELECT 1 FROM assets WHERE id = ?;", (asset_id,)).fetchone()
         self.assertIsNotNone(still_present)

--- a/tests/test_admin_retire_asset.py
+++ b/tests/test_admin_retire_asset.py
@@ -85,7 +85,7 @@ class AdminRetireAssetTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Retire Asset", response.data)
         self.assertIn(b"Find Asset", response.data)
-        self.assertIn(b"Search by asset tag", response.data)
+        self.assertIn(b"Enter a full or partial asset tag", response.data)
         self.assertIn(b">Search<", response.data)
 
     def test_retire_from_storage_is_atomic_and_logs_event(self) -> None:

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -116,7 +116,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"assettrack.db" in response.data
     assert b"Manage Users" in response.data
     assert b"Import Holders from CSV" in response.data
-    assert b"Open Human-Readable Report" in response.data
+    assert b"Open Operational Report" in response.data
     assert b"Restore Database Backup" in response.data
     assert b"Download Database Backup" in response.data
 

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -78,7 +78,7 @@ def test_add_assets_and_preview_render_timeout_lock_targets(client_with_temp_db)
     assert b"Session expired. Redirecting to login..." in preview.data
     assert b'let timeoutLocked = false;' in preview.data
     assert b'window.location = "/logout";' in preview.data
-    assert b'data-timeout-lock-target>Add to database<' in preview.data
+    assert b'data-timeout-lock-target>Commit Staged Assets<' in preview.data
     assert b"Discard batch" not in preview.data
     assert b'action="/preview/discard"' not in preview.data
 

--- a/tests/test_issue_23_3_admin_system_nav.py
+++ b/tests/test_issue_23_3_admin_system_nav.py
@@ -26,7 +26,7 @@ def test_admin_navigation_exposes_system_health_link(client_with_temp_db) -> Non
 
     assert response.status_code == 200
     assert b'href="/admin/system"' in response.data
-    assert b">System / Admin Tools<" in response.data
+    assert b">Admin Tools<" in response.data
 
 
 def test_operator_navigation_hides_system_health_link(client_with_temp_db) -> None:
@@ -37,4 +37,4 @@ def test_operator_navigation_hides_system_health_link(client_with_temp_db) -> No
 
     assert response.status_code == 200
     assert b'href="/admin/system"' not in response.data
-    assert b">System / Admin Tools<" not in response.data
+    assert b">Admin Tools<" not in response.data


### PR DESCRIPTION
## Summary

Standardized secondary workflow navigation spacing across admin and workflow pages.

## Related Issue

Closes #737 

## Changes

- Added shared spacing/layout behavior for local workflow navigation.
- Improved card intro spacing and readability.
- Updated affected admin/workflow templates.
- Updated UI tests to match the presentation changes.

## Verification checklist

- [x] Focused pytest suite passed.
- [x] Manual smoke passed for affected admin/workflow pages.
- [x] Navigation links still work.
- [x] No route, auth, schema, persistence, or custody/event behavior changed.
- [x] `data/` was not staged.

## Notes

Presentation-only cleanup recovered under its own issue before returning to 27-80.