### PR TITLE
Issue 27-13: Replace equipment classification with simple equipment t…

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -110,7 +110,26 @@ INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", str(
 TERMINAL_LOCATION_TYPE = "DISPOSED"
 TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
-ASSET_EQUIPMENT_TYPE_OPTIONS = ("laptop", "tablet")
+ASSET_EQUIPMENT_TYPE_OPTIONS = (
+    "laptop",
+    "monitor",
+    "large tv",
+    "switch",
+    "other network equipment",
+    "peripheral",
+    "voip",
+    "other",
+)
+ASSET_EQUIPMENT_TYPE_LABELS = {
+    "laptop": "Laptop",
+    "monitor": "Monitor",
+    "large tv": "Large TV",
+    "switch": "Switch",
+    "other network equipment": "Other Network Equipment",
+    "peripheral": "Peripheral",
+    "voip": "VoIP",
+    "other": "Other",
+}
 DEMO_SUMMARY = {
     "assets_in_custody": 18,
     "pending_receipts": 2,
@@ -150,6 +169,36 @@ ADMIN_ROUTE_RATE_LIMIT_WINDOW_SECONDS = 60
 ADMIN_ROUTE_RATE_LIMIT_MAX_ACTIONS = 10
 ADMIN_ROUTE_ATTEMPTS: dict[str, list[int]] = {}
 PENDING_DB_RESTORE_SESSION_KEY = "pending_db_restore"
+
+
+def _equipment_type_form_options(current_value: object = "") -> list[dict[str, object]]:
+    current = str(current_value or "").strip()
+    options = [
+        {
+            "value": equipment_type,
+            "label": ASSET_EQUIPMENT_TYPE_LABELS[equipment_type],
+            "is_legacy": False,
+        }
+        for equipment_type in ASSET_EQUIPMENT_TYPE_OPTIONS
+    ]
+    if current and current not in ASSET_EQUIPMENT_TYPE_OPTIONS:
+        options.append(
+            {
+                "value": current,
+                "label": f"{current} (existing value)",
+                "is_legacy": True,
+            }
+        )
+    return options
+
+
+def _equipment_type_is_allowed(value: object, *, allow_current: object = "") -> bool:
+    selected = str(value or "").strip()
+    if not selected:
+        return False
+    if selected in ASSET_EQUIPMENT_TYPE_OPTIONS:
+        return True
+    return bool(str(allow_current or "").strip()) and selected == str(allow_current or "").strip()
 
 
 @app.after_request
@@ -3615,6 +3664,12 @@ def intake():
             selected_equipment_type = current_equipment_type
         else:
             selected_equipment_type = (submitted_equipment_type or "").strip() or "laptop"
+        if not _equipment_type_is_allowed(selected_equipment_type, allow_current=current_equipment_type):
+            flash("Choose a valid asset type.", "error")
+            touch_session()
+            if redirect_target.startswith("/") and not redirect_target.startswith("//"):
+                return redirect(redirect_target)
+            return redirect(url_for("add_assets"))
         session["equipment_type"] = selected_equipment_type
 
         if action == "clear":
@@ -3842,6 +3897,7 @@ def add_assets():
         queue_len=len(SCAN_QUEUE),
         latest=(SCAN_QUEUE[-1].asset_tag if SCAN_QUEUE else ""),
         equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+        equipment_type_options=_equipment_type_form_options((session.get("equipment_type") or "laptop").strip() or "laptop"),
         slot_options=slot_options,
         case_options=case_options,
     )
@@ -7140,6 +7196,7 @@ def admin_edit_asset():
                         asset=asset_view,
                         asset_matches=asset_matches,
                         error_message=error_message,
+                        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
                         slot_options=slot_options,
                         case_options=case_options,
                     )
@@ -7151,6 +7208,11 @@ def admin_edit_asset():
                     errors.append("manufacturer is required.")
                 if not form_state["equipment_type"]:
                     errors.append("equipment_type is required.")
+                elif not _equipment_type_is_allowed(
+                    form_state["equipment_type"],
+                    allow_current=asset_view["equipment_type"],
+                ):
+                    errors.append("Choose a valid asset type.")
                 if not form_state["building"]:
                     errors.append("building is required.")
                 if not form_state["room"]:
@@ -7171,6 +7233,7 @@ def admin_edit_asset():
                         asset=asset_view,
                         asset_matches=asset_matches,
                         error_message=error_message,
+                        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
                         slot_options=slot_options,
                         case_options=case_options,
                     )
@@ -7201,6 +7264,7 @@ def admin_edit_asset():
                         asset=asset_view,
                         asset_matches=asset_matches,
                         error_message=error_message,
+                        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
                         slot_options=slot_options,
                         case_options=case_options,
                     )
@@ -7213,6 +7277,7 @@ def admin_edit_asset():
                         asset=asset_view,
                         asset_matches=asset_matches,
                         error_message=error_message,
+                        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
                         slot_options=slot_options,
                         case_options=case_options,
                     )
@@ -7233,6 +7298,7 @@ def admin_edit_asset():
                         asset=asset_view,
                         asset_matches=asset_matches,
                         error_message=error_message,
+                        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
                         slot_options=slot_options,
                         case_options=case_options,
                     )
@@ -7282,6 +7348,7 @@ def admin_edit_asset():
                         asset=asset_view,
                         asset_matches=asset_matches,
                         error_message=error_message,
+                        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
                         slot_options=slot_options,
                         case_options=case_options,
                     )
@@ -7302,6 +7369,7 @@ def admin_edit_asset():
         asset=asset_view,
         asset_matches=asset_matches,
         error_message=error_message,
+        equipment_type_options=_equipment_type_form_options(form_state["equipment_type"]),
         slot_options=slot_options,
         case_options=case_options,
     )

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -117,7 +117,13 @@
           </div>
           <div class="row form-group">
             <label class="form-label" for="equipment_type"><strong>equipment_type</strong> (required)</label>
-            <input class="form-input" type="text" id="equipment_type" name="equipment_type" value="{{ form.equipment_type or '' }}" required />
+            <select class="form-select" id="equipment_type" name="equipment_type" required>
+              {% for option in equipment_type_options %}
+                <option value="{{ option.value }}" {% if (form.equipment_type or '') == option.value %}selected{% endif %}>
+                  {{ option.label }}
+                </option>
+              {% endfor %}
+            </select>
           </div>
           <div class="row form-group">
             <label class="form-label" for="building"><strong>building</strong> (required)</label>

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -149,15 +149,13 @@
       <form id="intake-form" class="row" method="post" action="{{ url_for('intake') }}">
         <div class="row">
           <label for="equipment_type"><strong>Equipment type</strong></label><br />
-          <input
-            type="text"
-            id="equipment_type"
-            name="equipment_type"
-            placeholder="e.g. laptop"
-            value="{{ equipment_type or '' }}"
-            autocomplete="off"
-            data-timeout-lock-target
-          />
+          <select id="equipment_type" name="equipment_type" data-timeout-lock-target>
+            {% for option in equipment_type_options %}
+              <option value="{{ option.value }}" {% if (equipment_type or 'laptop') == option.value %}selected{% endif %}>
+                {{ option.label }}
+              </option>
+            {% endfor %}
+          </select>
         </div>
 
         {% if authenticated_role == 'admin' %}

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -94,7 +94,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Admin: Add Asset", response.data)
         self.assertIn(b"Asset type", response.data)
         self.assertIn(b'<option value="laptop"', response.data)
-        self.assertIn(b'<option value="tablet"', response.data)
+        self.assertIn(b'<option value="other network equipment"', response.data)
+        self.assertIn(b'<option value="voip"', response.data)
         self.assertIn(b'name="case_name"', response.data)
         self.assertIn(b'name="slot_id"', response.data)
 
@@ -137,7 +138,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         response = self.client.post(
             "/",
-            data={"scan_text": "", "equipment_type": "tablet", "return_to": "/add-assets"},
+            data={"scan_text": "", "equipment_type": "monitor", "return_to": "/add-assets"},
             follow_redirects=True,
         )
 
@@ -162,7 +163,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         first = self.client.post(
             "/",
-            data={"scan_text": "AT-QUEUE-1", "equipment_type": "tablet"},
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "monitor"},
         )
         self.assertEqual(first.status_code, 302)
 
@@ -172,12 +173,12 @@ class AdminAddAssetUiTests(unittest.TestCase):
         )
         self.assertEqual(second.status_code, 302)
 
-        self.assertEqual([scan.equipment_type for scan in intake_app.SCAN_QUEUE], ["tablet", "laptop"])
+        self.assertEqual([scan.equipment_type for scan in intake_app.SCAN_QUEUE], ["monitor", "laptop"])
 
         preview = self.client.get("/preview?json=1")
         self.assertEqual(preview.status_code, 200)
         rows = preview.json["rows"]
-        self.assertEqual(rows[0]["equipment_type"], "tablet")
+        self.assertEqual(rows[0]["equipment_type"], "monitor")
         self.assertEqual(rows[1]["equipment_type"], "laptop")
 
     def test_add_assets_queue_rows_show_operator_verification_details(self) -> None:
@@ -186,7 +187,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             Scan(
                 asset_tag="AT-VERIFY-1",
                 scanned_at=datetime(2026, 1, 1, 14, 3, 22, tzinfo=timezone.utc),
-                equipment_type="tablet",
+                equipment_type="monitor",
                 case_name="CASE-V",
                 slot_position=3,
             )
@@ -203,7 +204,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"AT-VERIFY-1", response.data)
-        self.assertIn(b"Equipment type:</strong> tablet", response.data)
+        self.assertIn(b"Equipment type:</strong> monitor", response.data)
         self.assertIn(b"Case:</strong> CASE-V", response.data)
         self.assertIn(b"Slot:</strong> Slot 3", response.data)
         self.assertIn(b"AT-VERIFY-2", response.data)
@@ -216,7 +217,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             Scan(
                 asset_tag="AT-PREVIEW-1",
                 scanned_at=datetime(2026, 1, 1, 14, 5, 22, tzinfo=timezone.utc),
-                equipment_type="tablet",
+                equipment_type="monitor",
             )
         )
 
@@ -235,11 +236,11 @@ class AdminAddAssetUiTests(unittest.TestCase):
     def test_blank_equipment_type_uses_default_and_missing_field_preserves_selection(self) -> None:
         intake_app.SCAN_QUEUE.clear()
 
-        select_tablet = self.client.post(
+        select_monitor = self.client.post(
             "/",
-            data={"scan_text": "AT-QUEUE-1", "equipment_type": "tablet"},
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "monitor"},
         )
-        self.assertEqual(select_tablet.status_code, 302)
+        self.assertEqual(select_monitor.status_code, 302)
 
         preserve_selection = self.client.post(
             "/",
@@ -248,7 +249,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertEqual(preserve_selection.status_code, 302)
 
         with self.client.session_transaction() as sess:
-            self.assertEqual(sess["equipment_type"], "tablet")
+            self.assertEqual(sess["equipment_type"], "monitor")
 
         default_scan = self.client.post(
             "/",
@@ -318,7 +319,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
                 "asset_tag": "AT-600",
                 "serial_number": "SER-600",
                 "manufacturer": "HP",
-                "equipment_type": "tablet",
+                "equipment_type": "monitor",
                 "building": "HQ",
                 "room": "220",
                 "case_name": "CASE-A",
@@ -448,7 +449,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             "/",
             data={
                 "scan_text": "AT-LIVE-1",
-                "equipment_type": "tablet",
+                "equipment_type": "monitor",
                 "case_name": "CASE-Q",
                 "slot_id": "120",
                 "return_to": "/add-assets",
@@ -481,7 +482,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             ).fetchone()
             self.assertIsNotNone(asset_row)
             self.assertEqual(asset_row["asset_tag"], stored_tag)
-            self.assertEqual(asset_row["equipment_type"], "tablet")
+            self.assertEqual(asset_row["equipment_type"], "monitor")
             self.assertEqual(asset_row["location_type"], "STORAGE")
             self.assertIsNone(asset_row["current_holder_id"])
             self.assertEqual(asset_row["home_slot_id"], 120)
@@ -497,6 +498,29 @@ class AdminAddAssetUiTests(unittest.TestCase):
             self.assertEqual(slot["current_asset_tag"], stored_tag)
         finally:
             verify_conn.close()
+
+    def test_add_assets_route_rejects_invalid_equipment_type_submission(self) -> None:
+        intake_app.SCAN_QUEUE.clear()
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "tablet", "return_to": "/add-assets"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Choose a valid asset type.", response.data)
+        self.assertEqual(len(intake_app.SCAN_QUEUE), 0)
+
+    def test_add_assets_route_preserves_legacy_session_equipment_type_in_dropdown(self) -> None:
+        with self.client.session_transaction() as sess:
+            sess["equipment_type"] = "tablet"
+
+        response = self.client.get("/add-assets")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<option value="tablet" selected>', response.data)
+        self.assertIn(b"tablet (existing value)", response.data)
 
     def test_add_assets_live_seam_rejects_occupied_slot_on_commit(self) -> None:
         existing_id = self._insert_asset("AT-OCC-LIVE", "SER-OCC-LIVE")

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -101,6 +101,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         response = self.client.get("/admin/assets/edit")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Edit Asset", response.data)
+        self.assertNotIn(b'<option value="tablet"', response.data)
 
     def test_exact_lookup_loads_edit_form_directly(self) -> None:
         self._insert_asset(
@@ -229,7 +230,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
                 "asset_tag": "AT-EDIT-1",
                 "serial_number": "SER-EDIT-1A",
                 "manufacturer": "Lenovo",
-                "equipment_type": "tablet",
+                "equipment_type": "monitor",
                 "building": "HQ",
                 "room": "210",
                 "model": "X1",
@@ -251,7 +252,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         ).fetchone()
         self.assertEqual(asset_row["serial_number"], "SER-EDIT-1A")
         self.assertEqual(asset_row["manufacturer"], "Lenovo")
-        self.assertEqual(asset_row["equipment_type"], "tablet")
+        self.assertEqual(asset_row["equipment_type"], "monitor")
         self.assertEqual(asset_row["building_room"], "HQ/210")
         self.assertEqual(asset_row["home_slot_id"], 202)
         self.assertEqual(asset_row["case_number"], "CASE-B")
@@ -276,6 +277,81 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertTrue(any(row["event_type"] == "ASSET_UPDATED" for row in events))
         payloads = [json.loads(row["payload"]) for row in events if row["payload"]]
         self.assertTrue(any(payload.get("home_slot_id") == 202 for payload in payloads))
+
+    def test_edit_form_preserves_existing_legacy_equipment_type(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-EDIT-LEGACY-1",
+            serial_number="SER-EDIT-LEGACY-1",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+        self.conn.execute("UPDATE assets SET equipment_type = 'tablet' WHERE id = ?;", (asset_id,))
+        self.conn.commit()
+
+        loaded = self.client.get("/admin/assets/edit?asset_tag=AT-EDIT-LEGACY-1")
+        self.assertEqual(loaded.status_code, 200)
+        self.assertIn(b'<option value="tablet" selected>', loaded.data)
+        self.assertIn(b"tablet (existing value)", loaded.data)
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-LEGACY-1",
+                "asset_tag": "AT-EDIT-LEGACY-1",
+                "serial_number": "SER-EDIT-LEGACY-1A",
+                "manufacturer": "Dell",
+                "equipment_type": "tablet",
+                "building": "HQ",
+                "room": "112",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "legacy type preserved",
+                "case_name": "",
+                "slot_id": "",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            "SELECT serial_number, equipment_type, building_room FROM assets WHERE id = ?;",
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset_row["serial_number"], "SER-EDIT-LEGACY-1A")
+        self.assertEqual(asset_row["equipment_type"], "tablet")
+        self.assertEqual(asset_row["building_room"], "HQ/112")
+
+    def test_edit_rejects_invalid_new_equipment_type(self) -> None:
+        self._insert_asset(
+            "AT-EDIT-INVALID-1",
+            serial_number="SER-EDIT-INVALID-1",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-INVALID-1",
+                "asset_tag": "AT-EDIT-INVALID-1",
+                "serial_number": "SER-EDIT-INVALID-1",
+                "manufacturer": "Dell",
+                "equipment_type": "tablet",
+                "building": "HQ",
+                "room": "110",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "invalid new type",
+                "case_name": "",
+                "slot_id": "",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Choose a valid asset type.", response.data)
 
     def test_edit_in_custody_asset_updates_home_slot_without_occupancy(self) -> None:
         self._insert_slot(301, "CASE-C", 3)


### PR DESCRIPTION
## Summary

Replaced equipment classification text entry with a simple equipment type dropdown.

## Related Issue

Closes #629 

## Changes

- Added a shared allowed equipment type set.
- Added dropdowns on Add Assets and Admin Edit Asset.
- Preserved Laptop as the default.
- Kept legacy out-of-list values from being silently rewritten.
- Added server-side validation for new submitted equipment type values.
- Updated focused UI tests.

## Verification checklist

- [x] Focused pytest suite passed.
- [x] Source-only compile passed.
- [x] Manual smoke passed on Add Assets.
- [x] Preview seam confirmed selected equipment type.
- [x] No schema, route, auth, persistence, custody, or event behavior changed.
- [x] No `data/`, DB, backup, or runtime files staged.

## Notes

Approved dropdown values are:

- Laptop
- Monitor
- Large TV
- Switch
- Other Network Equipment
- Peripheral
- VoIP
- Other