### PR TITLE
Issue 27-84: Compress duplicate workflow navigation chrome

### DIFF
--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -114,20 +114,15 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="workflow-local-nav" aria-label="Workflow navigation">
-    <a class="nav-link" href="{{ url_for('return_queue') }}">Back to Return</a>
-  </nav>
-
   {% if auth_enabled %}
-    <p><strong>Status:</strong> {{ "Unlocked" if authed else "Locked" }}</p>
-
-    {% if authed %}
-    {% else %}
-      <p>Locked. Enter access code to unlock.</p>
-    {% endif %}
-  {% endif %}
-  {% if auth_enabled and authed %}
-    <p><a href="{{ url_for('lock') }}">Lock</a></p>
+    <p class="workflow-summary">
+      <strong>Status:</strong> {{ "Unlocked" if authed else "Locked" }}
+      {% if auth_enabled and authed %}
+        &nbsp;|&nbsp;<a class="action-quiet" href="{{ url_for('lock') }}">Lock</a>
+      {% else %}
+        &nbsp;|&nbsp;Enter access code to unlock.
+      {% endif %}
+    </p>
   {% endif %}
 
   {% with messages = get_flashed_messages(with_categories=true) %}
@@ -139,7 +134,7 @@
   {% endwith %}
 
   <div class="card workflow-entry-card">
-    <p class="card-intro">Add assets to the queue first, then review the queued batch before committing.</p>
+    <p class="card-intro">Add assets to the queue, then review the batch before commit.</p>
     {% if auth_enabled and not authed %}
       <form method="post">
         <input type="password" name="access_code" placeholder="Access code" autofocus />
@@ -235,11 +230,6 @@
     <form method="post" action="{{ url_for('add_assets_review') }}" class="queue-actions">
       <button id="review-batch" class="preview-step" type="submit" data-timeout-lock-target>Preview Queue</button>
     </form>
-  </div>
-
-  <div class="card">
-    <h2>Latest</h2>
-    <p><code>{{ latest }}</code></p>
   </div>
 {% endblock %}
 

--- a/assettrack/intake/templates/preview.html
+++ b/assettrack/intake/templates/preview.html
@@ -12,10 +12,6 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="workflow-local-nav" aria-label="Workflow navigation">
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </nav>
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -12,7 +12,6 @@
 {% endblock %}
 
 {% block content %}
-  {% set blocked_count = queued_count - ready_count %}
   <nav class="workflow-local-nav" aria-label="Workflow navigation">
     <a class="nav-link" href="{{ url_for('return_queue') }}">Back to Return Queue</a>
   </nav>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -85,12 +85,6 @@
       {% set message_ns.global_messages = message_ns.global_messages + [(category, message)] %}
     {% endif %}
   {% endfor %}
-  {% set jump_to_scan_href = "#scan-input" %}
-  {% set jump_to_queue_href = "#queue-section" %}
-  <nav class="workflow-local-nav" aria-label="Workflow navigation">
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </nav>
-
   {% if message_ns.global_messages %}
     {% for category, message in message_ns.global_messages %}
       <div class="flash {{ category|e }}">{{ message }}</div>
@@ -108,12 +102,6 @@
 
   {% if workflow_banner_title %}
     {% include "_workflow_context_banner.html" %}
-  {% endif %}
-
-  {% if issue_location_form is defined %}
-    <div class="workflow-action-row workflow-action-row--quiet">
-      <a class="nav-link action-quiet" href="{{ jump_to_scan_href }}">Jump to Scan</a>
-    </div>
   {% endif %}
 
   {% if issue_location_form is defined %}
@@ -168,7 +156,7 @@
 
   <div class="card workflow-card">
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
-    <p class="card-intro">Stage return scans in the queue, then review the queued batch before commit.</p>
+    <p class="card-intro">Stage scans in the queue, then review the batch before commit.</p>
     {% if issue_location_form is defined and not issue_location_ready %}
       <div class="flash error">
         <strong>Scanning is blocked.</strong> Set current location first.
@@ -178,11 +166,6 @@
       {% for category, message in message_ns.scan_messages %}
         <div class="flash {{ category|e }}">{{ message }}</div>
       {% endfor %}
-    {% endif %}
-    {% if queue_len > 0 %}
-      <div class="workflow-action-row workflow-action-row--quiet">
-        <a class="nav-link action-quiet" href="{{ jump_to_queue_href }}">Jump to Queue</a>
-      </div>
     {% endif %}
 
     <div class="workflow-action-stack">


### PR DESCRIPTION
## Summary

Compressed duplicate navigation and helper chrome across workflow pages.

## Related Issue

Closes #741 

## Changes

- Removed duplicate local back-links where global navigation already covers the same destination.
- Removed redundant in-page jump links from the shared queue surface.
- Shortened non-safety helper copy.
- Compressed Add Assets lock/unlock helper text.
- Removed the duplicate Latest card from Add Assets.
- Preserved unique preview back-links and safety-critical review language.

## Verification checklist

- [x] Focused workflow tests passed.
- [x] Source-only compile passed.
- [x] Manual Add Assets smoke passed.
- [x] Manual Return Queue smoke passed.
- [x] Queue → preview → commit seam unchanged.
- [x] No route, form action, auth, schema, persistence, custody, or event behavior changed.
- [x] No `data/`, DB, backup, or runtime files staged.

## Notes

Presentation-only cleanup from the Issue 27-73 recon. Issue Preview was intentionally left alone to avoid drifting into Issue 27-86.