### PR TITLE
Issue 27-85: Reduce issue workflow prerequisite message duplication

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -3708,7 +3708,7 @@ def intake():
                     return redirect(url_for("holders_search", return_to=url_for("issue")))
                 if issue_location_errors:
                     flash(
-                        f"Scan not added. {issue_location_errors[0]} Set the current location, then scan again.",
+                        f"Scan not added. {issue_location_errors[0]}",
                         "error scan-feedback",
                     )
                     touch_session()

--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -79,6 +79,64 @@
   line-height: 1.55;
 }
 
+.workflow-summary--prereq {
+  margin-bottom: 0.35rem;
+  font-size: 1.02rem;
+  font-weight: 600;
+}
+
+.workflow-summary--prereq strong {
+  color: var(--color-primary);
+}
+
+.issue-location-status-title {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-size: 0.84rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.issue-location-status-value {
+  display: block;
+  width: 100%;
+  font-size: 1rem;
+  line-height: 1.45;
+}
+
+.issue-location-layout {
+  display: grid;
+  gap: 1rem;
+}
+
+.issue-location-form {
+  margin: 0;
+  min-width: 0;
+}
+
+.issue-location-status-panel {
+  display: grid;
+  width: 100%;
+  box-sizing: border-box;
+  align-content: start;
+  justify-items: stretch;
+  align-self: stretch;
+  gap: 0.55rem;
+  padding: 0.9rem 1rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary) 18%, var(--color-surface));
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--color-primary-soft) 30%, var(--color-surface-bg));
+}
+
+.issue-location-status-panel > * {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.issue-location-status-note {
+  color: var(--color-text-muted);
+}
+
 .workflow-table td strong {
   color: var(--color-primary);
 }
@@ -410,6 +468,13 @@ button.warn-button:focus-visible {
     margin-top: 0.4rem;
     min-width: 0;
     box-shadow: none;
+  }
+}
+
+@media (min-width: 821px) {
+  .issue-location-layout {
+    grid-template-columns: minmax(0, 1.5fr) minmax(220px, 0.95fr);
+    align-items: start;
   }
 }
 

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -82,7 +82,7 @@
         <strong>Current location:</strong> {{ issue_location_label }}
       </p>
     {% else %}
-      <p>No current location selected.</p>
+      <p>Current location required before issue.</p>
     {% endif %}
     {% if issue_location_constrained_by_org %}
       <p>Building choices are limited to the selected holder's organization.</p>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -107,61 +107,60 @@
   {% if issue_location_form is defined %}
     <div class="card workflow-card">
       <h2>Current Location</h2>
-      <p class="workflow-summary">
-        <strong>Current location:</strong>
-        {% if issue_location_ready %}
-          <code>{{ issue_location_label }}</code>
-        {% else %}
-          <span class="pill bad">required</span>
-        {% endif %}
-      </p>
-      <p class="workflow-summary">Required before issue scans.</p>
-      {% if message_ns.location_messages %}
-        {% for category, message in message_ns.location_messages %}
-          <div class="flash {{ category|e }}">{{ message }}</div>
-        {% endfor %}
-      {% endif %}
-      {% if issue_location_constrained_by_org %}
-        <p>Building choices are limited to the selected holder's organization.</p>
-      {% endif %}
-      {% if issue_location_errors %}
-        <div class="validation-messages">
-          {% for issue in issue_location_errors %}
-            <p class="validation-message">{{ issue }}</p>
-          {% endfor %}
-        </div>
-      {% endif %}
-      <form method="post" action="{{ url_for('issue_location_update') }}" style="margin-top: 10px;">
-        <label for="issue-building"><strong>Current building</strong></label><br />
-        {% if issue_location_building_options %}
-          <select id="issue-building" name="building" data-timeout-lock-target>
-            <option value="">Choose building</option>
-            {% for building_name in issue_location_building_options %}
-              <option value="{{ building_name }}" {% if issue_location_form.building == building_name %}selected{% endif %}>{{ building_name }}</option>
+      <div class="issue-location-layout">
+        <form method="post" action="{{ url_for('issue_location_update') }}" class="issue-location-form">
+          <label for="issue-building"><strong>Current building</strong></label><br />
+          {% if issue_location_building_options %}
+            <select id="issue-building" name="building" data-timeout-lock-target>
+              <option value="">Choose building</option>
+              {% for building_name in issue_location_building_options %}
+                <option value="{{ building_name }}" {% if issue_location_form.building == building_name %}selected{% endif %}>{{ building_name }}</option>
+              {% endfor %}
+            </select>
+          {% else %}
+            <input id="issue-building" type="text" name="building" value="{{ issue_location_form.building }}" data-timeout-lock-target />
+          {% endif %}
+          <br /><br />
+          <label for="issue-room"><strong>Current room / area</strong></label><br />
+          <input id="issue-room" type="text" name="room" value="{{ issue_location_form.room }}" data-timeout-lock-target />
+          <br /><br />
+          <div class="workflow-action-row">
+            <button type="submit" data-timeout-lock-target>Save current location</button>
+          </div>
+        </form>
+
+        <aside class="issue-location-status-panel" aria-label="Current location status">
+          <div class="workflow-summary workflow-summary--prereq">
+            <strong class="issue-location-status-title">Current location</strong>
+            {% if issue_location_ready %}
+              <code class="issue-location-status-value">{{ issue_location_label }}</code>
+            {% else %}
+              <span class="issue-location-status-value">Required before issue scans.</span>
+            {% endif %}
+          </div>
+          {% if message_ns.location_messages %}
+            {% for category, message in message_ns.location_messages %}
+              <div class="flash {{ category|e }}">{{ message }}</div>
             {% endfor %}
-          </select>
-        {% else %}
-          <input id="issue-building" type="text" name="building" value="{{ issue_location_form.building }}" data-timeout-lock-target />
-        {% endif %}
-        <br /><br />
-        <label for="issue-room"><strong>Current room / area</strong></label><br />
-        <input id="issue-room" type="text" name="room" value="{{ issue_location_form.room }}" data-timeout-lock-target />
-        <br /><br />
-        <div class="workflow-action-row">
-          <button type="submit" data-timeout-lock-target>Save current location</button>
-        </div>
-      </form>
+          {% endif %}
+          {% if issue_location_constrained_by_org %}
+            <p class="workflow-summary issue-location-status-note">Building choices are limited to the selected holder's organization.</p>
+          {% endif %}
+          {% if issue_location_errors %}
+            <div class="validation-messages">
+              {% for issue in issue_location_errors %}
+                <p class="validation-message">{{ issue }}</p>
+              {% endfor %}
+            </div>
+          {% endif %}
+        </aside>
+      </div>
     </div>
   {% endif %}
 
   <div class="card workflow-card">
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
     <p class="card-intro">Stage scans in the queue, then review the batch before commit.</p>
-    {% if issue_location_form is defined and not issue_location_ready %}
-      <div class="flash error">
-        <strong>Scanning is blocked.</strong> Set current location first.
-      </div>
-    {% endif %}
     {% if message_ns.scan_messages %}
       {% for category, message in message_ns.scan_messages %}
         <div class="flash {{ category|e }}">{{ message }}</div>

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -104,7 +104,6 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert issue_page.status_code == 200
     assert b"Current Location" in issue_page.data
     assert b"Required before issue scans." in issue_page.data
-    assert b"Scanning is blocked." in issue_page.data
     assert b"Add to Queue" in issue_page.data
     assert b"Scan or enter asset tag" in issue_page.data
     assert b"Add to queue" in issue_page.data
@@ -113,7 +112,6 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert b"box-sizing: border-box;" in issue_page.data
     assert b"padding: 0.6rem;" in issue_page.data
     assert b"font-size: 1rem;" in issue_page.data
-    assert b'href="#scan-input"' in issue_page.data
     assert b'id="scan-input"' in issue_page.data
     assert b"autofocus" not in issue_page.data
     assert b"HQ North" in issue_page.data
@@ -127,8 +125,7 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
 
     assert scan_response.status_code == 200
     assert len(intake_app.SCAN_QUEUE) == 0
-    assert b"Scan not added. Choose the current building. Set the current location, then scan again." in scan_response.data
-    assert b"Scanning is blocked." in scan_response.data
+    assert b"Scan not added. Choose the current building." in scan_response.data
 
 
 def test_issue_commit_rejects_building_outside_selected_holder_org(client_with_temp_db) -> None:
@@ -182,7 +179,6 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     )
     assert scan_response.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
-    assert b'href="#queue-section"' in scan_response.data
 
     preview = client_with_temp_db.get("/issue/preview")
     assert preview.status_code == 200


### PR DESCRIPTION
## Summary

Reduced duplicate Issue workflow prerequisite messaging and made the Current Location status easier to see.

## Related Issue

Closes #742 

## Changes

- Consolidated repeated Issue prerequisite messaging.
- Shortened scan feedback copy for missing prerequisites.
- Tightened missing-location copy on Issue Preview.
- Moved Current Location status into a clearer side panel.
- Kept the saved location visible without adding more helper text.
- Preserved holder/location selection, redirects, queue, preview, and commit behavior.

## Verification checklist

- [x] Focused Issue workflow tests passed.
- [x] Source-only compile passed.
- [x] Manual `/issue` smoke passed.
- [x] Current Location status panel reviewed and adjusted.
- [x] Issue preview/commit review remains intact.
- [x] No route, redirect, auth, schema, persistence, custody, or event behavior changed.
- [x] No `data/`, DB, backup, or runtime files staged.

## Notes

Presentation and copy cleanup only. The Current Location side panel was added because the duplicate scan-card warning was removed, making the saved-location status more important.