### PR TITLE
Issue 27-88: Clarify blocked item hierarchy on issue workflow

### DIFF
--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -263,17 +263,6 @@
     {% endif %}
   </div>
 
-  {% if blocking_issues %}
-    <div class="card workflow-card">
-      <h2>Blocked Items</h2>
-      <div class="validation-messages">
-        {% for issue in blocking_issues %}
-          <p class="validation-message">{{ issue }}</p>
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
-
   {% if issue_location_form is not defined %}
     <div class="card workflow-card">
       <div class="workflow-action-row">
@@ -303,6 +292,17 @@
       <p class="queue-empty">No assets queued.</p>
     {% endif %}
   </div>
+
+  {% if blocking_issues %}
+    <div class="card workflow-card">
+      <h2>Blocked Items</h2>
+      <div class="validation-messages">
+        {% for issue in blocking_issues %}
+          <p class="validation-message">{{ issue }}</p>
+        {% endfor %}
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}
 
 {% block extra_scripts %}


### PR DESCRIPTION
## Summary

Clarified blocked item hierarchy on the Issue workflow page.

## Related Issue

Closes #749 

## Changes

- Moved Blocked Items below Queue.
- Kept blocked items separate from queue-ready items.
- Kept empty queue guidance neutral.
- Preserved Preview Queue placement from the Issue queue action layout.
- Verified Return still reads clearly after the shared-template order change.

## Verification checklist

- [x] Focused Issue/Return workflow tests passed.
- [x] Source-only compile passed.
- [x] Manual Issue workflow smoke passed.
- [x] Manual Return workflow smoke passed.
- [x] Queue appears before Blocked Items.
- [x] Blocked items remain separate from commit-ready queue items.
- [x] Empty queue message is not styled as an error.
- [x] Preview remains the review checkpoint.
- [x] No route, form action, auth, schema, persistence, custody, or event behavior changed.
- [x] No `data/`, DB, backup, or runtime files staged.

## Notes

Presentation-only hierarchy cleanup. Follow-on concerns remain: preserve Issue queue scroll position after Add to queue, and evaluate Return-specific queue control alignment separately.