### PR TITLE
Issue 27-89: preserve issue queue position after add to queue

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1179,6 +1179,8 @@ def _queue_redirect_target(return_to: str) -> str:
         return target
 
     path, sep, fragment = target.partition("#")
+    if path == "/issue" and not fragment:
+        return f"{path}#queue-actions"
     if path == "/return" and not fragment:
         return f"{path}#queue-section"
     return target

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -204,7 +204,7 @@
     {% endif %}
 
     {% if issue_location_form is defined %}
-      <div class="queue-control-group">
+      <div class="queue-control-group" id="queue-actions">
         <div class="queue-entry-form">
           <form id="issue-queue-form" method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
             <input type="hidden" name="return_to" value="{{ queue_return_to }}" />

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -172,12 +172,17 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     assert b"Current location set to HQ North / 210." in location_response.data
     assert b"flash success" in location_response.data
 
-    scan_response = client_with_temp_db.post(
+    scan_redirect = client_with_temp_db.post(
         "/",
         data={"scan_text": "ISSUE-100", "return_to": "/issue"},
-        follow_redirects=True,
+        follow_redirects=False,
     )
+    assert scan_redirect.status_code == 302
+    assert (scan_redirect.headers.get("Location") or "").endswith("/issue#queue-actions")
+
+    scan_response = client_with_temp_db.get("/issue#queue-actions")
     assert scan_response.status_code == 200
+    assert b'id="queue-actions"' in scan_response.data
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
 
     preview = client_with_temp_db.get("/issue/preview")


### PR DESCRIPTION
## Summary

Preserved the operator’s position on the Issue workflow after adding an item to the queue.

## Related Issue

Closes #750 

## Changes

- Redirected successful Issue queue-add actions back to `/issue#queue-actions`.
- Added a stable `queue-actions` anchor near the Issue queue controls.
- Added a focused test assertion for the anchored Issue queue-add redirect.
- Left Return workflow behavior unchanged.

## Verification checklist

- [x] Focused Issue workflow tests passed.
- [x] Source-only compile passed.
- [x] Manual Issue workflow smoke passed.
- [x] Add to queue lands near the queue work area.
- [x] Queued item still appears correctly.
- [x] Preview Queue remains the review checkpoint.
- [x] No custody, event, auth, schema, persistence, or dependency changes.

## Notes

Small operator-flow fix discovered during Issue 27-88 smoke testing.