### PR TITLE
Issue 27-90: align queue review action wording and placement

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4440,7 +4440,7 @@ def issue():
         workflow_banner_outcome=workflow_banner_outcome,
         return_to=url_for("issue"),
         preview_url=url_for("issue_preview"),
-        preview_label="Preview Queue",
+        preview_label="Review Before Issue",
         auth_enabled=auth_enabled(),
         authed=is_authed(),
         last_seen_age_seconds=seconds_since_last_seen(),

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -110,6 +110,7 @@
 
 {% block content %}
   {% set queue_return_to = return_to or url_for('return_queue') %}
+  {% set review_action_label = "Review Before Issue" if issue_location_form is defined else "Review Before Return" %}
   {% set flashed_messages = get_flashed_messages(with_categories=true) %}
   {% set message_ns = namespace(global_messages=[], scan_messages=[], location_messages=[]) %}
   {% for category, message in flashed_messages %}
@@ -231,45 +232,44 @@
 
         <form method="get" action="{{ preview_url or url_for('return_preview') }}" class="queue-preview-form">
           <div class="workflow-action-row">
-            <button type="submit" class="preview-step" data-timeout-lock-target>{{ preview_label or "Preview Queue" }}</button>
+            <button type="submit" class="preview-step" data-timeout-lock-target>{{ preview_label or review_action_label }}</button>
           </div>
         </form>
       </div>
     {% else %}
-      <div class="workflow-action-stack">
-        <form method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
-          <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
-          <input
-            id="scan-input"
-            type="text"
-            name="scan_text"
-            placeholder="Scan or enter asset tag"
-            {% if issue_location_form is not defined %}autofocus{% endif %}
-            data-timeout-lock-target
-          />
-          <div class="workflow-action-row">
-            <button type="submit" data-timeout-lock-target>Add to queue</button>
+      <div class="queue-control-group">
+        <div class="queue-entry-form">
+          <form id="return-queue-form" method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
+            <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
+            <input
+              id="scan-input"
+              type="text"
+              name="scan_text"
+              placeholder="Scan or enter asset tag"
+              {% if issue_location_form is not defined %}autofocus{% endif %}
+              data-timeout-lock-target
+            />
+          </form>
+          <div class="workflow-action-row queue-action-cluster">
+            <button type="submit" form="return-queue-form" data-timeout-lock-target>Add to queue</button>
+            <form method="post" action="{{ url_for('intake') }}" class="queue-clear-form">
+              <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
+              <input type="hidden" name="action" value="clear" />
+              <div class="workflow-action-row workflow-action-row--danger">
+                <button type="submit" class="action-secondary" onclick="return confirm('Clear the queue?');" data-timeout-lock-target>Clear queue</button>
+              </div>
+            </form>
           </div>
-        </form>
+        </div>
 
-        <form method="post" action="{{ url_for('intake') }}">
-          <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
-          <input type="hidden" name="action" value="clear" />
-          <div class="workflow-action-row workflow-action-row--danger">
-            <button type="submit" class="action-secondary" onclick="return confirm('Clear the queue?');" data-timeout-lock-target>Clear queue</button>
+        <form method="get" action="{{ preview_url or url_for('return_preview') }}" class="queue-preview-form">
+          <div class="workflow-action-row">
+            <button type="submit" class="preview-step" data-timeout-lock-target>{{ preview_label or review_action_label }}</button>
           </div>
         </form>
       </div>
     {% endif %}
   </div>
-
-  {% if issue_location_form is not defined %}
-    <div class="card workflow-card">
-      <div class="workflow-action-row">
-        <a class="preview-step" href="{{ preview_url or url_for('return_preview') }}" data-timeout-lock-target>{{ preview_label or "Preview Queue" }}</a>
-      </div>
-    </div>
-  {% endif %}
 
   <div class="card workflow-card" id="queue-section">
     <h2>Queue ({{ queue_len }})</h2>
@@ -303,6 +303,7 @@
       </div>
     </div>
   {% endif %}
+
 {% endblock %}
 
 {% block extra_scripts %}

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -107,6 +107,8 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert b"Add to Queue" in issue_page.data
     assert b"Scan or enter asset tag" in issue_page.data
     assert b"Add to queue" in issue_page.data
+    assert b"Review Before Issue" in issue_page.data
+    assert b"Preview Queue" not in issue_page.data
     assert b"#issue-building," in issue_page.data
     assert b"max-width: 520px;" in issue_page.data
     assert b"box-sizing: border-box;" in issue_page.data

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -88,6 +88,8 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"Add to Queue", render.data)
         self.assertIn(b"Scan or enter asset tag", render.data)
         self.assertIn(b"Add to queue", render.data)
+        self.assertIn(b"Review Before Return", render.data)
+        self.assertNotIn(b"Preview Queue", render.data)
         self.assertIn(b"Home location: Home slots", render.data)
         self.assertIn(b"1 asset queued", render.data)
 


### PR DESCRIPTION
## Summary

Aligned the Issue and Return queue review actions so both workflows read more clearly.

## Related Issue

Closes #753 

## Changes

- Changed `Preview Queue` to `Review Before Issue` on the Issue workflow.
- Changed `Preview Queue` to `Review Before Return` on the Return workflow.
- Aligned Return with the same left-controls / right-review action pattern used by Issue.
- Kept Queue above Blocked Items.
- Kept blocked items visually separate from queue-ready items.
- Preserved the Issue queue anchor behavior from Issue 27-89.

## Verification checklist

- [x] Focused Return and preview seam tests passed.
- [x] Issue location wiring test passed.
- [x] Source-only compile passed.
- [x] Manual Issue workflow smoke passed.
- [x] Manual Return workflow smoke passed.
- [x] Issue shows `Review Before Issue`.
- [x] Return shows `Review Before Return`.
- [x] Queue remains above Blocked Items.
- [x] Blocked Items remain separate from commit-ready queue items.
- [x] Review buttons still open the existing preview pages.
- [x] No route, form action, queue, preview, commit, custody, event, auth, schema, persistence, or dependency behavior changed.

## Notes

Manual smoke confirmed the updated wording and layout are clearer for both workflows.