### PR TITLE
Issue 27-72: add large-chevron expandable sections for secondary surf…

### DIFF
--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -79,64 +79,6 @@
   line-height: 1.55;
 }
 
-.workflow-summary--prereq {
-  margin-bottom: 0.35rem;
-  font-size: 1.02rem;
-  font-weight: 600;
-}
-
-.workflow-summary--prereq strong {
-  color: var(--color-primary);
-}
-
-.issue-location-status-title {
-  display: block;
-  margin-bottom: 0.35rem;
-  font-size: 0.84rem;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-.issue-location-status-value {
-  display: block;
-  width: 100%;
-  font-size: 1rem;
-  line-height: 1.45;
-}
-
-.issue-location-layout {
-  display: grid;
-  gap: 1rem;
-}
-
-.issue-location-form {
-  margin: 0;
-  min-width: 0;
-}
-
-.issue-location-status-panel {
-  display: grid;
-  width: 100%;
-  box-sizing: border-box;
-  align-content: start;
-  justify-items: stretch;
-  align-self: stretch;
-  gap: 0.55rem;
-  padding: 0.9rem 1rem;
-  border: 1px solid color-mix(in srgb, var(--color-primary) 18%, var(--color-surface));
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--color-primary-soft) 30%, var(--color-surface-bg));
-}
-
-.issue-location-status-panel > * {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.issue-location-status-note {
-  color: var(--color-text-muted);
-}
-
 .workflow-table td strong {
   color: var(--color-primary);
 }
@@ -235,6 +177,108 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 0.75rem;
+}
+
+details.disclosure-section,
+details.report-section {
+  margin-top: 1rem;
+  border: 1px solid var(--color-surface);
+  border-radius: 12px;
+  background: var(--color-surface-bg);
+  overflow: hidden;
+}
+
+details.disclosure-section > summary,
+details.report-section > summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 1rem 1.05rem;
+  background: var(--color-surface-soft);
+  color: var(--color-text);
+  font-weight: 700;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+details.disclosure-section > summary::-webkit-details-marker,
+details.report-section > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.disclosure-section > summary::marker,
+details.report-section > summary::marker {
+  content: "";
+}
+
+details.disclosure-section > summary:hover,
+details.report-section > summary:hover {
+  background: color-mix(in srgb, var(--color-primary-soft) 45%, var(--color-surface-bg));
+}
+
+details.disclosure-section > summary:focus-visible,
+details.report-section > summary:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--color-primary) 70%, white);
+  outline-offset: -3px;
+}
+
+details.disclosure-section > summary::before,
+details.report-section > summary::before {
+  content: "▸";
+  flex: 0 0 auto;
+  width: 1.45rem;
+  color: var(--color-primary);
+  font-size: 1.45rem;
+  font-weight: 900;
+  line-height: 1;
+  text-align: center;
+}
+
+details.disclosure-section[open] > summary::before,
+details.report-section[open] > summary::before {
+  content: "▾";
+}
+
+.disclosure-title,
+.report-section-title {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.3;
+  text-align: left;
+}
+
+.disclosure-hint,
+.report-section-hint {
+  margin-left: auto;
+  flex: 0 0 auto;
+  color: var(--color-text-muted);
+  font-size: 0.92rem;
+  font-weight: 600;
+  text-align: right;
+}
+
+.disclosure-body,
+.report-section-body {
+  padding: 1rem 1.05rem;
+}
+
+.disclosure-body > :first-child,
+.report-section-body > :first-child {
+  margin-top: 0;
+}
+
+.disclosure-body > :last-child,
+.report-section-body > :last-child {
+  margin-bottom: 0;
+}
+
+@media print {
+  details.disclosure-section > summary,
+  details.report-section > summary {
+    display: none !important;
+  }
 }
 
 .report-stat {
@@ -468,13 +512,6 @@ button.warn-button:focus-visible {
     margin-top: 0.4rem;
     min-width: 0;
     box-shadow: none;
-  }
-}
-
-@media (min-width: 821px) {
-  .issue-location-layout {
-    grid-template-columns: minmax(0, 1.5fr) minmax(220px, 0.95fr);
-    align-items: start;
   }
 }
 

--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -26,7 +26,6 @@
 
   <div class="card">
     <h2>Holder CSV Import</h2>
-    <p class="import-help">Required columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
     <form method="post" enctype="multipart/form-data">
       <div class="row">
         <label for="csv_file"><strong>CSV file</strong></label><br />
@@ -35,6 +34,17 @@
       <button type="submit">Import Holders</button>
     </form>
   </div>
+
+  <details class="disclosure-section">
+    <summary>
+      <span class="disclosure-title">CSV requirements</span>
+      <span class="disclosure-hint">Columns and import behavior</span>
+    </summary>
+    <div class="disclosure-body">
+      <p class="import-help">Required columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
+      <p class="import-help">Matching email addresses update existing holder records. New email addresses create new holders.</p>
+    </div>
+  </details>
 
   {% if report is not none %}
     <div class="card">

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -4,11 +4,6 @@
 {% block page_heading %}Admin: Current Status Report{% endblock %}
 {% block page_class %} report-page{% endblock %}
 
-{% block extra_head %}
-  <style>
-  </style>
-{% endblock %}
-
 {% block content %}
   <div class="report-actions nav-row">
     <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
@@ -27,213 +22,243 @@
     <p><strong>Recent events:</strong> active events only.</p>
   </div>
 
-  <div class="card">
-    <h2>Assets</h2>
-    <div class="report-grid">
-      <div class="report-stat">Total assets<strong>{{ asset_summary.total_assets }}</strong></div>
-      <div class="report-stat">In storage<strong>{{ asset_summary.storage_assets }}</strong></div>
-      <div class="report-stat">In custody<strong>{{ asset_summary.in_custody_assets }}</strong></div>
-      <div class="report-stat">Disposed<strong>{{ asset_summary.disposed_assets }}</strong></div>
-    </div>
-    <div class="table-wrap" style="margin-top: 1rem;">
-      <table>
-        <thead>
-          <tr>
-            <th>Asset Tag</th>
-            <th>Type</th>
-            <th>Make / Model</th>
-            <th>Location Type</th>
-            <th>Current Holder</th>
-            <th>Home Slot</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in assets %}
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Assets</span>
+      <span class="report-section-hint">{{ asset_summary.total_assets }} total records</span>
+    </summary>
+    <div class="report-section-body">
+      <div class="report-grid">
+        <div class="report-stat">Total assets<strong>{{ asset_summary.total_assets }}</strong></div>
+        <div class="report-stat">In storage<strong>{{ asset_summary.storage_assets }}</strong></div>
+        <div class="report-stat">In custody<strong>{{ asset_summary.in_custody_assets }}</strong></div>
+        <div class="report-stat">Disposed<strong>{{ asset_summary.disposed_assets }}</strong></div>
+      </div>
+      <div class="table-wrap" style="margin-top: 1rem;">
+        <table>
+          <thead>
             <tr>
-              <td><code>{{ row.asset_tag }}</code></td>
-              <td>{{ row.equipment_type or "" }}</td>
-              <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
-              <td>
-                <span class="state-badge{% if asset_is_terminal(row.location_type) %} terminal{% endif %}">{{ asset_state_label(row.location_type) }}</span>
-              </td>
-              <td>
-                {% if row.holder_name %}
-                  {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
-                {% endif %}
-              </td>
-              <td>{{ row.home_slot or "" }}</td>
+              <th>Asset Tag</th>
+              <th>Type</th>
+              <th>Make / Model</th>
+              <th>Location Type</th>
+              <th>Current Holder</th>
+              <th>Home Slot</th>
             </tr>
-          {% else %}
-            <tr><td colspan="6">No assets found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in assets %}
+              <tr>
+                <td><code>{{ row.asset_tag }}</code></td>
+                <td>{{ row.equipment_type or "" }}</td>
+                <td>{{ row.manufacturer }}{% if row.model %} / {{ row.model }}{% endif %}</td>
+                <td>
+                  <span class="state-badge{% if asset_is_terminal(row.location_type) %} terminal{% endif %}">{{ asset_state_label(row.location_type) }}</span>
+                </td>
+                <td>
+                  {% if row.holder_name %}
+                    {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                  {% endif %}
+                </td>
+                <td>{{ row.home_slot or "" }}</td>
+              </tr>
+            {% else %}
+              <tr><td colspan="6">No assets found.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  </details>
 
-  <div class="card">
-    <h2>Holders</h2>
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>Type</th>
-            <th>Name</th>
-            <th>Organization</th>
-            <th>Identifier</th>
-            <th>Assets In Custody</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in holders %}
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Holders</span>
+      <span class="report-section-hint">{{ holders|length }} records</span>
+    </summary>
+    <div class="report-section-body">
+      <div class="table-wrap">
+        <table>
+          <thead>
             <tr>
-              <td><code>{{ row.id }}</code></td>
-              <td>{{ row.holder_type }}</td>
-              <td>{{ row.name }}</td>
-              <td>{{ row.organization }}</td>
-              <td>{{ row.identifier }}</td>
-              <td>{{ row.assets_in_custody }}</td>
+              <th>ID</th>
+              <th>Type</th>
+              <th>Name</th>
+              <th>Organization</th>
+              <th>Identifier</th>
+              <th>Assets In Custody</th>
             </tr>
-          {% else %}
-            <tr><td colspan="6">No holders found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in holders %}
+              <tr>
+                <td><code>{{ row.id }}</code></td>
+                <td>{{ row.holder_type }}</td>
+                <td>{{ row.name }}</td>
+                <td>{{ row.organization }}</td>
+                <td>{{ row.identifier }}</td>
+                <td>{{ row.assets_in_custody }}</td>
+              </tr>
+            {% else %}
+              <tr><td colspan="6">No holders found.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  </details>
 
-  <div class="card">
-    <h2>Organizations and Building Access</h2>
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>Organization</th>
-            <th>Mapped Buildings</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in organizations %}
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Organizations and Building Access</span>
+      <span class="report-section-hint">{{ organizations|length }} organizations</span>
+    </summary>
+    <div class="report-section-body">
+      <div class="table-wrap">
+        <table>
+          <thead>
             <tr>
-              <td>{{ row.name }}</td>
-              <td>{{ row.building_count }}</td>
+              <th>Organization</th>
+              <th>Mapped Buildings</th>
             </tr>
-          {% else %}
-            <tr><td colspan="2">No organizations found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    <div class="table-wrap" style="margin-top: 1rem;">
-      <table>
-        <thead>
-          <tr>
-            <th>Organization</th>
-            <th>Building</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in organization_building_mappings %}
+          </thead>
+          <tbody>
+            {% for row in organizations %}
+              <tr>
+                <td>{{ row.name }}</td>
+                <td>{{ row.building_count }}</td>
+              </tr>
+            {% else %}
+              <tr><td colspan="2">No organizations found.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+      <div class="table-wrap" style="margin-top: 1rem;">
+        <table>
+          <thead>
             <tr>
-              <td>{{ row.organization_name }}</td>
-              <td>{{ row.building_name }}</td>
+              <th>Organization</th>
+              <th>Building</th>
             </tr>
-          {% else %}
-            <tr><td colspan="2">No organization-to-building mappings found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in organization_building_mappings %}
+              <tr>
+                <td>{{ row.organization_name }}</td>
+                <td>{{ row.building_name }}</td>
+              </tr>
+            {% else %}
+              <tr><td colspan="2">No organization-to-building mappings found.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  </details>
 
-  <div class="card">
-    <h2>Current Custody</h2>
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>Holder</th>
-            <th>Organization</th>
-            <th>Asset Tag</th>
-            <th>Type</th>
-            <th>Current Location</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in current_custody %}
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Current Custody</span>
+      <span class="report-section-hint">{{ current_custody|length }} assets out</span>
+    </summary>
+    <div class="report-section-body">
+      <div class="table-wrap">
+        <table>
+          <thead>
             <tr>
-              <td>{{ row.holder_name }}</td>
-              <td>{{ row.organization }}</td>
-              <td><code>{{ row.asset_tag }}</code></td>
-              <td>{{ row.equipment_type }}</td>
-              <td>{{ row.current_location }}</td>
+              <th>Holder</th>
+              <th>Organization</th>
+              <th>Asset Tag</th>
+              <th>Type</th>
+              <th>Current Location</th>
             </tr>
-          {% else %}
-            <tr><td colspan="5">No assets are currently in custody.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in current_custody %}
+              <tr>
+                <td>{{ row.holder_name }}</td>
+                <td>{{ row.organization }}</td>
+                <td><code>{{ row.asset_tag }}</code></td>
+                <td>{{ row.equipment_type }}</td>
+                <td>{{ row.current_location }}</td>
+              </tr>
+            {% else %}
+              <tr><td colspan="5">No assets are currently in custody.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  </details>
 
-  <div class="card">
-    <h2>Last 10 Events</h2>
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>When</th>
-            <th>Asset Tag</th>
-            <th>Event Type</th>
-            <th>Holder</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in recent_active_events %}
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Last 10 Events</span>
+      <span class="report-section-hint">{{ recent_active_events|length }} rows</span>
+    </summary>
+    <div class="report-section-body">
+      <div class="table-wrap">
+        <table>
+          <thead>
             <tr>
-              <td><code>{{ row.id }}</code></td>
-              <td>{{ row.event_date_display }}</td>
-              <td><code>{{ row.asset_tag }}</code></td>
-              <td>{{ row.event_type }}</td>
-              <td>
-                {% if row.holder_name %}
-                  {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
-                {% endif %}
-              </td>
+              <th>ID</th>
+              <th>When</th>
+              <th>Asset Tag</th>
+              <th>Event Type</th>
+              <th>Holder</th>
             </tr>
-          {% else %}
-            <tr><td colspan="5">No active events found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in recent_active_events %}
+              <tr>
+                <td><code>{{ row.id }}</code></td>
+                <td>{{ row.event_date_display }}</td>
+                <td><code>{{ row.asset_tag }}</code></td>
+                <td>{{ row.event_type }}</td>
+                <td>
+                  {% if row.holder_name %}
+                    {{ row.holder_name }}{% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                  {% endif %}
+                </td>
+              </tr>
+            {% else %}
+              <tr><td colspan="5">No active events found.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  </details>
 
-  <div class="card">
-    <h2>Location and Case Data</h2>
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>Case</th>
-            <th>Total Slots</th>
-            <th>Occupied Slots</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in cases %}
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Location and Case Data</span>
+      <span class="report-section-hint">{{ cases|length }} cases</span>
+    </summary>
+    <div class="report-section-body">
+      <div class="table-wrap">
+        <table>
+          <thead>
             <tr>
-              <td>{{ row.case_name }}</td>
-              <td>{{ row.total_slots }}</td>
-              <td>{{ row.occupied_slots }}</td>
+              <th>Case</th>
+              <th>Total Slots</th>
+              <th>Occupied Slots</th>
             </tr>
-          {% else %}
-            <tr><td colspan="3">No case or slot data found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in cases %}
+              <tr>
+                <td>{{ row.case_name }}</td>
+                <td>{{ row.total_slots }}</td>
+                <td>{{ row.occupied_slots }}</td>
+              </tr>
+            {% else %}
+              <tr><td colspan="3">No case or slot data found.</td></tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
     </div>
-  </div>
+  </details>
 {% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -149,118 +149,133 @@
   </div>
 
   {% if not recovery_mode.active %}
-  <div class="card admin-meta-card recovery-state-card">
-    <h2>Recovery State</h2>
-    <table>
-      <tbody>
-        <tr>
-          <th>Status</th>
-          <td id="recovery-status">{{ recovery_mode.status_label }}</td>
-        </tr>
-        <tr>
-          <th>Acknowledgment</th>
-          <td id="recovery-acknowledgment">{{ recovery_mode.acknowledgment_label }}</td>
-        </tr>
-        <tr>
-          <th>Restore timestamp</th>
-          <td id="recovery-restored-at">{{ recovery_mode.restored_at_display or "N/A" }}</td>
-        </tr>
-        <tr>
-          <th>Uploaded filename</th>
-          <td id="recovery-source-filename">
-            {% if recovery_mode.source_filename %}
-              <code>{{ recovery_mode.source_filename }}</code>
-            {% else %}
-              N/A
-            {% endif %}
-          </td>
-        </tr>
-        <tr>
-          <th>Rollback artifact</th>
-          <td id="recovery-rollback-path">
-            {% if recovery_mode.rollback_db_path %}
-              <code>{{ recovery_mode.rollback_db_path }}</code>
-            {% else %}
-              N/A
-            {% endif %}
-          </td>
-        </tr>
-        <tr>
-          <th>Recovery state file</th>
-          <td id="recovery-state-path"><code>{{ recovery_mode.recovery_state_path }}</code></td>
-        </tr>
-      </tbody>
-    </table>
-    {% if recovery_mode.parse_error %}
-      <p class="warn">Recovery state file could not be read cleanly: {{ recovery_mode.parse_error }}</p>
-    {% endif %}
-  </div>
+  <details class="disclosure-section admin-meta-card recovery-state-card" {% if recovery_mode.parse_error %}open{% endif %}>
+    <summary>
+      <span class="disclosure-title">Recovery State</span>
+      <span class="disclosure-hint">{{ recovery_mode.status_label }} / {{ recovery_mode.acknowledgment_label }}</span>
+    </summary>
+    <div class="disclosure-body">
+      <table>
+        <tbody>
+          <tr>
+            <th>Status</th>
+            <td id="recovery-status">{{ recovery_mode.status_label }}</td>
+          </tr>
+          <tr>
+            <th>Acknowledgment</th>
+            <td id="recovery-acknowledgment">{{ recovery_mode.acknowledgment_label }}</td>
+          </tr>
+          <tr>
+            <th>Restore timestamp</th>
+            <td id="recovery-restored-at">{{ recovery_mode.restored_at_display or "N/A" }}</td>
+          </tr>
+          <tr>
+            <th>Uploaded filename</th>
+            <td id="recovery-source-filename">
+              {% if recovery_mode.source_filename %}
+                <code>{{ recovery_mode.source_filename }}</code>
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th>Rollback artifact</th>
+            <td id="recovery-rollback-path">
+              {% if recovery_mode.rollback_db_path %}
+                <code>{{ recovery_mode.rollback_db_path }}</code>
+              {% else %}
+                N/A
+              {% endif %}
+            </td>
+          </tr>
+          <tr>
+            <th>Recovery state file</th>
+            <td id="recovery-state-path"><code>{{ recovery_mode.recovery_state_path }}</code></td>
+          </tr>
+        </tbody>
+      </table>
+      {% if recovery_mode.parse_error %}
+        <p class="warn">Recovery state file could not be read cleanly: {{ recovery_mode.parse_error }}</p>
+      {% endif %}
+    </div>
+  </details>
   {% endif %}
 
-  <div class="card admin-meta-card">
-    <h2>System Snapshot</h2>
-    <table>
-      <tbody>
-        <tr>
-          <th>DB path</th>
-          <td><code id="db-path">{{ db_path }}</code></td>
-        </tr>
-        <tr>
-          <th>Holder count</th>
-          <td id="holder-count">{{ holder_count if holder_count is not none else "N/A" }}</td>
-        </tr>
-        <tr>
-          <th>Asset count</th>
-          <td id="asset-count">{{ asset_count if asset_count is not none else "N/A" }}</td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
+  <details class="disclosure-section admin-meta-card">
+    <summary>
+      <span class="disclosure-title">System Snapshot</span>
+      <span class="disclosure-hint">{{ holder_count if holder_count is not none else "N/A" }} holders / {{ asset_count if asset_count is not none else "N/A" }} assets</span>
+    </summary>
+    <div class="disclosure-body">
+      <table>
+        <tbody>
+          <tr>
+            <th>DB path</th>
+            <td><code id="db-path">{{ db_path }}</code></td>
+          </tr>
+          <tr>
+            <th>Holder count</th>
+            <td id="holder-count">{{ holder_count if holder_count is not none else "N/A" }}</td>
+          </tr>
+          <tr>
+            <th>Asset count</th>
+            <td id="asset-count">{{ asset_count if asset_count is not none else "N/A" }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </details>
 
-  <div class="card admin-meta-card">
-    <h2>Restore History</h2>
-    <p>Operational restore records only. This surface does not modify custody or audit history.</p>
-    <p><strong>History file:</strong> <code id="restore-history-path">{{ restore_history.history_path }}</code></p>
-    {% if restore_history.parse_error %}
-      <p class="warn">Restore history file could not be read cleanly: {{ restore_history.parse_error }}</p>
-    {% endif %}
-    <table>
-      <thead>
-        <tr>
-          <th>Restore Timestamp</th>
-          <th>Uploaded Filename</th>
-          <th>Rollback Artifact</th>
-          <th>Acknowledgment</th>
-          <th>Result</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for entry in restore_history.entries %}
+  <details class="disclosure-section admin-meta-card" {% if restore_history.parse_error %}open{% endif %}>
+    <summary>
+      <span class="disclosure-title">Restore History</span>
+      <span class="disclosure-hint">{{ restore_history.entries|length }} records</span>
+    </summary>
+    <div class="disclosure-body">
+      <p>Operational restore records only. This surface does not modify custody or audit history.</p>
+      <p><strong>History file:</strong> <code id="restore-history-path">{{ restore_history.history_path }}</code></p>
+      {% if restore_history.parse_error %}
+        <p class="warn">Restore history file could not be read cleanly: {{ restore_history.parse_error }}</p>
+      {% endif %}
+      <table>
+        <thead>
           <tr>
-            <td>{{ entry.restored_at_display or "Unknown" }}</td>
-            <td>
-              {% if entry.source_filename %}
-                <code>{{ entry.source_filename }}</code>
-              {% else %}
-                N/A
-              {% endif %}
-            </td>
-            <td>
-              {% if entry.rollback_db_path %}
-                <code>{{ entry.rollback_db_path }}</code>
-              {% else %}
-                N/A
-              {% endif %}
-            </td>
-            <td>{{ entry.acknowledgment_state }}</td>
-            <td>{{ entry.result }}</td>
+            <th>Restore Timestamp</th>
+            <th>Uploaded Filename</th>
+            <th>Rollback Artifact</th>
+            <th>Acknowledgment</th>
+            <th>Result</th>
           </tr>
-        {% else %}
-          <tr>
-            <td colspan="5">No restore history recorded.</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+        </thead>
+        <tbody>
+          {% for entry in restore_history.entries %}
+            <tr>
+              <td>{{ entry.restored_at_display or "Unknown" }}</td>
+              <td>
+                {% if entry.source_filename %}
+                  <code>{{ entry.source_filename }}</code>
+                {% else %}
+                  N/A
+                {% endif %}
+              </td>
+              <td>
+                {% if entry.rollback_db_path %}
+                  <code>{{ entry.rollback_db_path }}</code>
+                {% else %}
+                  N/A
+                {% endif %}
+              </td>
+              <td>{{ entry.acknowledgment_state }}</td>
+              <td>{{ entry.result }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="5">No restore history recorded.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </details>
 {% endblock %}

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -47,71 +47,12 @@
       margin-top: 0.65rem;
       width: fit-content;
     }
-    details.report-section {
-      margin-top: 1rem;
-      border: 1px solid var(--color-surface);
-      border-radius: 10px;
-      background: var(--color-surface-bg);
-      overflow: hidden;
-    }
-    details.report-section summary {
-      cursor: pointer;
-      list-style: none;
-      padding: 1rem;
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-      background: var(--color-surface-soft);
-      font-weight: 700;
-      transition: background 120ms ease, color 120ms ease;
-    }
-    details.report-section summary::-webkit-details-marker {
-      display: none;
-    }
-    details.report-section summary:hover {
-      background: color-mix(in srgb, var(--color-primary-soft) 45%, var(--color-surface-bg));
-    }
-    details.report-section summary::before {
-      content: "▸";
-      flex: 0 0 auto;
-      color: var(--color-primary);
-      font-size: 1rem;
-      line-height: 1;
-      transform: translateY(0.02rem);
-    }
-    details.report-section[open] summary::before {
-      content: "▾";
-    }
-    .report-section-title {
-      flex: 1 1 auto;
-      margin: 0;
-      font-size: 1.02rem;
-      line-height: 1.3;
-      text-align: left;
-    }
-    .report-section-hint {
-      margin-left: auto;
-      flex: 0 0 auto;
-      color: var(--color-text-muted);
-      font-size: 0.92rem;
-      font-weight: 500;
-      text-align: right;
-    }
-    .report-section-body {
-      padding: 1rem;
-    }
     .report-drill-link {
       display: inline-flex;
       align-items: center;
       font-weight: 600;
       text-decoration-thickness: 2px;
       text-underline-offset: 0.16em;
-    }
-    @media print {
-      details.report-section summary {
-        display: none !important;
-      }
     }
   </style>
 {% endblock %}

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -119,6 +119,9 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Open Operational Report" in response.data
     assert b"Restore Database Backup" in response.data
     assert b"Download Database Backup" in response.data
+    assert response.data.count(b"<details class=\"disclosure-section") >= 3
+    assert b"System Snapshot" in response.data
+    assert b"Restore History" in response.data
 
 
 def test_operator_is_forbidden_for_system_health(client_with_temp_db) -> None:
@@ -173,6 +176,19 @@ def test_admin_can_import_holders_from_csv(client_with_temp_db) -> None:
 
     assert holder is not None
     assert dict(holder) == {"name": "Jane Doe", "organization": "Ops Alpha", "email": "jane@example.org"}
+
+
+def test_admin_holder_import_page_exposes_collapsible_csv_requirements(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-import-page", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/holders/import")
+
+    assert response.status_code == 200
+    assert b"Holder CSV Import" in response.data
+    assert b"CSV requirements" in response.data
+    assert b"Columns and import behavior" in response.data
+    assert b'<details class="disclosure-section">' in response.data
 
 
 def test_admin_holder_import_surfaces_existing_validation_errors(client_with_temp_db) -> None:
@@ -406,6 +422,7 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
     assert b"Current Custody" in response.data
     assert b"Last 10 Events" in response.data
     assert b"Location and Case Data" in response.data
+    assert response.data.count(b"<details class=\"report-section\"") >= 5
     assert b"AT-100" in response.data
     assert b"Jane Operator" in response.data
     assert b"Report Ops" in response.data


### PR DESCRIPTION
## Summary

Added large-chevron expandable sections for secondary operational surfaces.

## Related Issue

Closes #716 

## Changes

- Added a shared disclosure style with large custom chevrons.
- Updated `/report` to use the shared disclosure pattern.
- Made secondary sections collapsible on `/admin/report`.
- Made non-active metadata sections collapsible on `/admin/system`.
- Added a collapsible CSV requirements section on `/admin/holders/import`.
- Kept critical warnings, restore actions, recovery actions, and import forms visible.

## Verification checklist

- [x] Focused affected-surface tests passed.
- [x] Source-only compile passed.
- [x] Manual smoke passed on `/admin/system`.
- [x] Manual smoke passed on `/admin/report`.
- [x] Manual smoke passed on `/report`.
- [x] Manual smoke passed on `/admin/holders/import`.
- [x] Disclosure arrows are large and obvious.
- [x] Sections open and close with mouse.
- [x] Sections open and close with keyboard.
- [x] Critical warnings/actions remain visible.
- [x] `/issue` and `/return` still render normally.
- [x] No custody, event, auth, schema, persistence, route, or dependency behavior changed.

## Notes

Dashboard disclosure cleanup is intentionally deferred to Issue 27-78.