### PR TITLE
Issue 27-98: Correct dashboard custody map hierarchy

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -120,6 +120,20 @@ def _map_holder_label(holder_name: object, holder_organization: object, current_
     return "Unassigned Holder"
 
 
+def _custody_map_thread_label(holder_organization: object) -> str:
+    label = str(holder_organization or "").strip()
+    return label or "Unknown Thread"
+
+
+def _custody_map_holder_label(holder_name: object, current_holder_id: object) -> str:
+    holder_label = str(holder_name or "").strip()
+    if holder_label:
+        return holder_label
+    if current_holder_id is not None:
+        return f"ID {current_holder_id}"
+    return "Unassigned Holder"
+
+
 def get_recent_activity(conn: sqlite3.Connection, limit: int = 10) -> list[dict]:
     active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
     rows = conn.execute(
@@ -509,13 +523,18 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
         """
     ).fetchall()
 
-    building_nodes: dict[str, dict] = {}
+    thread_nodes: dict[str, dict] = {}
     for row in rows:
+        thread_label = _custody_map_thread_label(row["holder_organization"])
         building_label = _building_label(row["building"])
         domain_label = _domain_label(row["equipment_type"])
-        holder_label = _map_holder_label(row["holder_name"], row["holder_organization"], row["current_holder_id"])
+        holder_label = _custody_map_holder_label(row["holder_name"], row["current_holder_id"])
 
-        building_node = building_nodes.setdefault(
+        thread_node = thread_nodes.setdefault(
+            thread_label,
+            {"label": thread_label, "_buildings": {}},
+        )
+        building_node = thread_node["_buildings"].setdefault(
             building_label,
             {"label": building_label, "_domains": {}},
         )
@@ -539,45 +558,54 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
             }
         )
 
-    buildings: list[dict] = []
-    for building_label in sorted(building_nodes):
-        building_node = building_nodes[building_label]
-        domains: list[dict] = []
-        for domain_label, domain_node in sorted(
-            building_node["_domains"].items(),
-            key=lambda item: _domain_sort_key(item[0]),
-        ):
-            holders: list[dict] = []
-            for holder_label in sorted(domain_node["_holders"]):
-                holder_node = domain_node["_holders"][holder_label]
-                holder_node["assets"].sort(key=lambda asset: (asset["asset_tag"], asset["equipment_type_label"]))
-                holders.append(
+    threads: list[dict] = []
+    for thread_label in sorted(thread_nodes):
+        thread_node = thread_nodes[thread_label]
+        buildings: list[dict] = []
+        for building_label in sorted(thread_node["_buildings"]):
+            building_node = thread_node["_buildings"][building_label]
+            domains: list[dict] = []
+            for domain_label, domain_node in sorted(
+                building_node["_domains"].items(),
+                key=lambda item: _domain_sort_key(item[0]),
+            ):
+                holders: list[dict] = []
+                for holder_label in sorted(domain_node["_holders"]):
+                    holder_node = domain_node["_holders"][holder_label]
+                    holder_node["assets"].sort(key=lambda asset: (asset["asset_tag"], asset["equipment_type_label"]))
+                    holders.append(
+                        {
+                            "label": holder_node["label"],
+                            "holder_detail_id": holder_node["holder_detail_id"],
+                            "asset_count": len(holder_node["assets"]),
+                            "assets": holder_node["assets"],
+                        }
+                    )
+                domains.append(
                     {
-                        "label": holder_node["label"],
-                        "holder_detail_id": holder_node["holder_detail_id"],
-                        "asset_count": len(holder_node["assets"]),
-                        "assets": holder_node["assets"],
+                        "label": domain_label,
+                        "holders": holders,
+                        "asset_count": sum(holder["asset_count"] for holder in holders),
                     }
                 )
-            domains.append(
+            buildings.append(
                 {
-                    "label": domain_label,
-                    "holders": holders,
-                    "asset_count": sum(holder["asset_count"] for holder in holders),
+                    "label": building_label,
+                    "domains": domains,
+                    "asset_count": sum(domain["asset_count"] for domain in domains),
                 }
             )
-        buildings.append(
+        threads.append(
             {
-                "label": building_label,
-                "domains": domains,
-                "asset_count": sum(domain["asset_count"] for domain in domains),
+                "label": thread_label,
+                "buildings": buildings,
+                "asset_count": sum(building["asset_count"] for building in buildings),
             }
         )
 
     return {
-        "thread_label": "THREAD",
-        "buildings": buildings,
-        "asset_count": sum(building["asset_count"] for building in buildings),
+        "threads": threads,
+        "asset_count": sum(thread["asset_count"] for thread in threads),
     }
 
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -260,52 +260,65 @@
   </div>
 
   <details class="disclosure-section dashboard-map-card">
-    <summary aria-label="Field operational custody map">
-      <span class="disclosure-title">Field Operational Custody Map</span>
-      <span class="disclosure-hint">{{ custody_map.thread_label }} → Building → Operational Domain → Custody Holder → Asset</span>
+    <summary aria-label="Custody map">
+      <span class="disclosure-title">Custody Map</span>
+      <span class="disclosure-hint">Thread → Building → Operational Domain → Custody Holder → Asset</span>
     </summary>
     <div class="disclosure-body">
       <p class="dashboard-map-intro">Use this map for rough inventory orientation only. It does not represent network topology or create new custody records.</p>
-      {% if custody_map.buildings %}
-        <p class="dashboard-thread-label">{{ custody_map.thread_label }}</p>
+      {% if custody_map.threads %}
         <ul class="custody-map-tree">
-          {% for building in custody_map.buildings %}
+          {% for thread in custody_map.threads %}
             <li>
               <details class="disclosure-section custody-map-node">
                 <summary>
-                  <span class="custody-map-label">Building: {{ building.label }}</span>
-                  <span class="custody-map-hint">{{ building.asset_count }} asset{% if building.asset_count != 1 %}s{% endif %}</span>
+                  <span class="custody-map-label">Thread: {{ thread.label }}</span>
+                  <span class="custody-map-hint">{{ thread.asset_count }} asset{% if thread.asset_count != 1 %}s{% endif %}</span>
                 </summary>
                 <div class="disclosure-body">
                   <ul class="custody-map-children">
-                    {% for domain in building.domains %}
+                    {% for building in thread.buildings %}
                       <li>
                         <details class="disclosure-section custody-map-node">
                           <summary>
-                            <span class="custody-map-label">Domain: {{ domain.label }}</span>
-                            <span class="custody-map-hint">{{ domain.asset_count }} asset{% if domain.asset_count != 1 %}s{% endif %}</span>
+                            <span class="custody-map-label">Building: {{ building.label }}</span>
+                            <span class="custody-map-hint">{{ building.asset_count }} asset{% if building.asset_count != 1 %}s{% endif %}</span>
                           </summary>
                           <div class="disclosure-body">
                             <ul class="custody-map-children">
-                              {% for holder in domain.holders %}
+                              {% for domain in building.domains %}
                                 <li>
                                   <details class="disclosure-section custody-map-node">
                                     <summary>
-                                      <span class="custody-map-label">Holder:
-                                        {% if holder.holder_detail_id %}
-                                          <a class="nav-link" href="{{ url_for('holder_detail', holder_id=holder.holder_detail_id) }}">{{ holder.label }}</a>
-                                        {% else %}
-                                          {{ holder.label }}
-                                        {% endif %}
-                                      </span>
-                                      <span class="custody-map-hint">{{ holder.asset_count }} asset{% if holder.asset_count != 1 %}s{% endif %}</span>
+                                      <span class="custody-map-label">Operational Domain: {{ domain.label }}</span>
+                                      <span class="custody-map-hint">{{ domain.asset_count }} asset{% if domain.asset_count != 1 %}s{% endif %}</span>
                                     </summary>
                                     <div class="disclosure-body">
-                                      <ul class="custody-map-assets">
-                                        {% for asset in holder.assets %}
-                                          <li class="custody-map-asset">
-                                            <span class="custody-map-label">Asset: <code>{{ asset.asset_tag }}</code></span>
-                                            <span class="custody-map-asset-type">{{ asset.equipment_type_label }}</span>
+                                      <ul class="custody-map-children">
+                                        {% for holder in domain.holders %}
+                                          <li>
+                                            <details class="disclosure-section custody-map-node">
+                                              <summary>
+                                                <span class="custody-map-label">Custody Holder:
+                                                  {% if holder.holder_detail_id %}
+                                                    <a class="nav-link" href="{{ url_for('holder_detail', holder_id=holder.holder_detail_id) }}">{{ holder.label }}</a>
+                                                  {% else %}
+                                                    {{ holder.label }}
+                                                  {% endif %}
+                                                </span>
+                                                <span class="custody-map-hint">{{ holder.asset_count }} asset{% if holder.asset_count != 1 %}s{% endif %}</span>
+                                              </summary>
+                                              <div class="disclosure-body">
+                                                <ul class="custody-map-assets">
+                                                  {% for asset in holder.assets %}
+                                                    <li class="custody-map-asset">
+                                                      <span class="custody-map-label">Asset: <code>{{ asset.asset_tag }}</code></span>
+                                                      <span class="custody-map-asset-type">{{ asset.equipment_type_label }}</span>
+                                                    </li>
+                                                  {% endfor %}
+                                                </ul>
+                                              </div>
+                                            </details>
                                           </li>
                                         {% endfor %}
                                       </ul>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -57,14 +57,14 @@ class DashboardTests(unittest.TestCase):
         self.conn.close()
         self.temp_dir.cleanup()
 
-    def _insert_holder(self, holder_id: int, name: str) -> None:
+    def _insert_holder(self, holder_id: int, name: str, *, organization: str | None = None) -> None:
         now = "2026-01-01T00:00:00Z"
         self.conn.execute(
             """
-            INSERT INTO holders (id, holder_type, name, identifier, contact_info, created_at, updated_at)
-            VALUES (?, 'PERSON', ?, NULL, NULL, ?, ?);
+            INSERT INTO holders (id, holder_type, name, organization, identifier, contact_info, created_at, updated_at)
+            VALUES (?, 'PERSON', ?, ?, NULL, NULL, ?, ?);
             """,
-            (holder_id, name, now, now),
+            (holder_id, name, organization, now, now),
         )
 
     def _insert_asset(
@@ -177,7 +177,7 @@ class DashboardTests(unittest.TestCase):
         self.conn.commit()
 
     def test_dashboard_route_smoke_renders_summary_sections(self) -> None:
-        self._insert_holder(1, "Alex Holder")
+        self._insert_holder(1, "Alex Holder", organization="CISR")
         self._insert_slot(10, "CASE-A", 1)
         storage_asset_id = self._insert_asset("AT-STORED", location_type="STORAGE", home_slot_id=10)
         self._insert_asset("AT-UNSLOT", location_type="STORAGE", home_slot_id=None)
@@ -205,16 +205,18 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Return Assets", response.data)
         self.assertIn(b"Open Issue Workflow", response.data)
         self.assertIn(b"Open Return Workflow", response.data)
-        self.assertIn(b"Field Operational Custody Map", response.data)
-        self.assertIn(b"THREAD", response.data)
+        self.assertIn(b"Custody Map", response.data)
+        self.assertNotIn(b"Field Operational Custody Map", response.data)
+        self.assertIn(b"Thread: CISR", response.data)
+        self.assertNotIn(b"Thread: <a", response.data)
         self.assertIn(b"Operational Domain", response.data)
         self.assertIn(b"SysAdmins", response.data)
         self.assertIn(b"Alex Holder", response.data)
         self.assertIn(b"Building: HQ", response.data)
-        self.assertIn(b"Domain: SysAdmins", response.data)
-        self.assertIn(b"Holder:", response.data)
+        self.assertIn(b"Operational Domain: SysAdmins", response.data)
+        self.assertIn(b"Custody Holder:", response.data)
         self.assertIn(b"Asset: <code>AT-CUST</code>", response.data)
-        self.assertGreaterEqual(response.data.count(b'class="disclosure-section custody-map-node"'), 3)
+        self.assertGreaterEqual(response.data.count(b'class="disclosure-section custody-map-node"'), 4)
         self.assertIn(b'id="problems-panel"', response.data)
         self.assertIn(b'id="problems-panel" open', response.data)
         self.assertIn(b"Available Space by Case", response.data)
@@ -244,7 +246,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Assets Out", response.data)
         self.assertIn(b"Open Issue Workflow", response.data)
         self.assertIn(b"Open Return Workflow", response.data)
-        self.assertIn(b"Field Operational Custody Map", response.data)
+        self.assertIn(b"Custody Map", response.data)
         self.assertIn(b"No active assets in the custody map.", response.data)
         self.assertIn(b'id="problems-panel"', response.data)
         self.assertNotIn(b'id="problems-panel" open', response.data)
@@ -442,7 +444,7 @@ class DashboardTests(unittest.TestCase):
         self.assertTrue((resp.headers.get("Location") or "").endswith("/dashboard"))
 
     def test_dashboard_holder_name_links_to_existing_holder_detail_page(self) -> None:
-        self._insert_holder(1, "Alex Holder")
+        self._insert_holder(1, "Alex Holder", organization="CISR")
         self._insert_asset("AT-CUST-1", location_type="IN_CUSTODY", current_holder_id=1)
         self.conn.commit()
 
@@ -523,7 +525,7 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(len(data["snapshots"]["recent_activity"]), MAX_DASHBOARD_RECENT_ACTIVITY)
 
     def test_custody_map_groups_assets_by_building_domain_holder_with_fallbacks(self) -> None:
-        self._insert_holder(1, "Alex Holder")
+        self._insert_holder(1, "Alex Holder", organization="CISR")
         self._insert_asset(
             "AT-LAPTOP",
             location_type="IN_CUSTODY",
@@ -551,27 +553,34 @@ class DashboardTests(unittest.TestCase):
         data = build_dashboard_data(self.conn, custody_days_threshold=30)
 
         custody_map = data["snapshots"]["custody_map"]
-        self.assertEqual(custody_map["thread_label"], "THREAD")
         self.assertEqual(custody_map["asset_count"], 3)
-        self.assertEqual([building["label"] for building in custody_map["buildings"]], ["HQ North", "Unknown Building"])
+        self.assertEqual([thread["label"] for thread in custody_map["threads"]], ["CISR", "Unknown Thread"])
 
-        hq_building = custody_map["buildings"][0]
-        self.assertEqual([domain["label"] for domain in hq_building["domains"]], ["SysAdmins", "Network"])
+        cisr_thread = custody_map["threads"][0]
+        self.assertEqual([building["label"] for building in cisr_thread["buildings"]], ["HQ North"])
+
+        hq_building = cisr_thread["buildings"][0]
+        self.assertEqual([domain["label"] for domain in hq_building["domains"]], ["SysAdmins"])
         sysadmins_holder = hq_building["domains"][0]["holders"][0]
         self.assertEqual(sysadmins_holder["label"], "Alex Holder")
         self.assertEqual(sysadmins_holder["assets"][0]["asset_tag"], "AT-LAPTOP")
         self.assertEqual(sysadmins_holder["assets"][0]["equipment_type_label"], "Laptop")
 
-        network_holder = hq_building["domains"][1]["holders"][0]
+        unknown_thread = custody_map["threads"][1]
+        self.assertEqual([building["label"] for building in unknown_thread["buildings"]], ["HQ North", "Unknown Building"])
+
+        hq_building = unknown_thread["buildings"][0]
+        self.assertEqual([domain["label"] for domain in hq_building["domains"]], ["Network"])
+        network_holder = hq_building["domains"][0]["holders"][0]
         self.assertEqual(network_holder["label"], "Unassigned Holder")
         self.assertEqual(network_holder["assets"][0]["asset_tag"], "AT-SWITCH")
 
-        unknown_building = custody_map["buildings"][1]
+        unknown_building = unknown_thread["buildings"][1]
         self.assertEqual(unknown_building["domains"][0]["label"], "Unclassified Asset")
         self.assertEqual(unknown_building["domains"][0]["holders"][0]["assets"][0]["asset_tag"], "AT-UNKNOWN")
 
     def test_custody_map_render_is_collapsible_at_each_hierarchy_level(self) -> None:
-        self._insert_holder(1, "Alex Holder")
+        self._insert_holder(1, "Alex Holder", organization="CISR")
         self._insert_asset(
             "AT-LAPTOP",
             location_type="IN_CUSTODY",
@@ -592,11 +601,14 @@ class DashboardTests(unittest.TestCase):
         response = self.client.get("/dashboard")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'aria-label="Field operational custody map"', response.data)
+        self.assertIn(b'aria-label="Custody map"', response.data)
+        self.assertIn(b"Thread: CISR", response.data)
+        self.assertIn(b"Thread: Unknown Thread", response.data)
+        self.assertNotIn(b"Thread: <a", response.data)
         self.assertIn(b"Building: HQ North", response.data)
-        self.assertIn(b"Domain: SysAdmins", response.data)
-        self.assertIn(b"Domain: Network", response.data)
-        self.assertIn(b"Holder:", response.data)
+        self.assertIn(b"Operational Domain: SysAdmins", response.data)
+        self.assertIn(b"Operational Domain: Network", response.data)
+        self.assertIn(b"Custody Holder:", response.data)
         self.assertIn(b"Asset: <code>AT-LAPTOP</code>", response.data)
         self.assertIn(b"Asset: <code>AT-SWITCH</code>", response.data)
         self.assertGreaterEqual(response.data.count(b'class="disclosure-section custody-map-node"'), 4)


### PR DESCRIPTION
## Summary

Corrected the dashboard custody map hierarchy so it now reads from Thread down to asset.

## Related Issue

Closes #766 

## Changes

- Kept the dashboard map title as “Custody Map”.
- Removed the standalone Thread header/link.
- Removed Thread links entirely.
- Updated the map hierarchy to render:
  - Thread
  - Building
  - Operational Domain
  - Custody Holder
  - Asset
- Used existing holder organization data as the visible Thread label.
- Kept asset rows as read-only leaves.
- Updated dashboard tests for the corrected hierarchy.

## Verification checklist

- [x] Ran `python3 -m compileall assettrack tests`
- [x] Ran `python3 -m pytest tests/test_dashboard.py -q`
- [x] Confirmed no Thread link remains
- [x] Confirmed dashboard custody map renders Thread → Building → Operational Domain → Custody Holder → Asset
- [x] Confirmed no custody, event, auth, schema, persistence, queue, preview, commit, report filtering, or receipt behavior changed
- [x] Browser smoke checked `/dashboard`

## Notes

This change is dashboard presentation only. No custody truth or workflow behavior changed.