### PR TITLE
Issue 27-100: Correct dashboard case space flags

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -6,10 +6,10 @@ from assettrack.audit import ACTIVE_EVENTS_WHERE
 from assettrack.event_types import issue_event_type_values, normalize_event_type
 
 from datetime import datetime, timezone
+import re
 import sqlite3
 
 MAX_DASHBOARD_TOP_HOLDERS = 5
-MAX_DASHBOARD_CASE_SUMMARIES = 10
 MAX_DASHBOARD_RECENT_ACTIVITY = 10
 MAX_DASHBOARD_EXCEPTION_PREVIEW = 10
 DOMAIN_SYSADMINS = "SysAdmins"
@@ -289,7 +289,23 @@ def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
     ]
 
 
-def _dashboard_case_utilization(conn: sqlite3.Connection, limit: int) -> list[dict]:
+def _case_name_natural_sort_key(case_name: object) -> tuple[int, int, str]:
+    label = str(case_name or "").strip()
+    match = re.fullmatch(r"CASE-(\d+)", label.upper())
+    if match:
+        return (0, int(match.group(1)), label.upper())
+    return (1, 0, label.upper())
+
+
+def _case_space_status_flag(available_slots: int) -> tuple[str, str]:
+    if available_slots <= 0:
+        return ("FULL", "full")
+    if available_slots <= 2:
+        return ("LOW", "low")
+    return ("OPEN", "open")
+
+
+def _dashboard_case_utilization(conn: sqlite3.Connection) -> list[dict]:
     rows = conn.execute(
         """
         SELECT
@@ -300,21 +316,29 @@ def _dashboard_case_utilization(conn: sqlite3.Connection, limit: int) -> list[di
         LEFT JOIN slot_occupancy so
           ON so.slot_id = s.id
         GROUP BY s.case_name
-        ORDER BY (COUNT(*) - COUNT(DISTINCT so.slot_id)) DESC, s.case_name ASC
-        LIMIT ?;
+        ORDER BY s.case_name ASC;
         """,
-        (limit,),
     ).fetchall()
 
-    return [
-        {
-            "case_name": str(row["case_name"]),
-            "total_slots": int(row["total_slots"] or 0),
-            "occupied_slots": int(row["occupied_slots"] or 0),
-            "empty_slots": max(0, int(row["total_slots"] or 0) - int(row["occupied_slots"] or 0)),
-        }
-        for row in rows
-    ]
+    results: list[dict] = []
+    for row in rows:
+        total_slots = int(row["total_slots"] or 0)
+        occupied_slots = int(row["occupied_slots"] or 0)
+        empty_slots = max(0, total_slots - occupied_slots)
+        status_flag, status_class = _case_space_status_flag(empty_slots)
+        results.append(
+            {
+                "case_name": str(row["case_name"]),
+                "total_slots": total_slots,
+                "occupied_slots": occupied_slots,
+                "empty_slots": empty_slots,
+                "status_flag": status_flag,
+                "status_class": status_class,
+            }
+        )
+
+    results.sort(key=lambda row: _case_name_natural_sort_key(row["case_name"]))
+    return results
 
 
 def _custody_summary(conn: sqlite3.Connection) -> dict:
@@ -648,7 +672,7 @@ def build_dashboard_data(
         },
         "snapshots": {
             "top_custody_holders": _top_custody_holders(conn, limit=MAX_DASHBOARD_TOP_HOLDERS),
-            "case_utilization": _dashboard_case_utilization(conn, limit=MAX_DASHBOARD_CASE_SUMMARIES),
+            "case_utilization": _dashboard_case_utilization(conn),
             "recent_activity": get_recent_activity(conn, limit=MAX_DASHBOARD_RECENT_ACTIVITY),
             "custody_map": _custody_map(conn),
             "exceptions": {

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -198,9 +198,9 @@
     .dashboard-section-table tr:last-child td {
       border-bottom: 0;
     }
-    .status-dot.full { background: var(--color-primary); }
-    .status-dot.low { background: var(--color-surface); }
-    .status-dot.open { background: var(--color-accent); }
+    .status-dot.full { background: #c2410c; }
+    .status-dot.low { background: #f59e0b; }
+    .status-dot.open { background: #16a34a; }
 
     @media (max-width: 1180px) {
       .dashboard-primary-grid {
@@ -441,19 +441,18 @@
               <tr>
                 <th>Case Name</th>
                 <th>Available Slots</th>
-                <th>Stoplight Status</th>
+                <th>Status Flag</th>
               </tr>
             </thead>
             <tbody>
               {% for row in dashboard.snapshots.case_utilization %}
-                {% set status = case_status_summary(row.total_slots, row.occupied_slots) %}
                 <tr>
                   <td><a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=row.case_name) }}">{{ row.case_name }}</a></td>
-                  <td>{{ status.available_slots }} open</td>
+                  <td>{{ row.empty_slots }} open</td>
                   <td class="status-cell">
                     <span class="status-badge">
-                      <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>
-                      <span>{{ status.text }}</span>
+                      <span class="status-dot {{ row.status_class }}" aria-hidden="true"></span>
+                      <span>{{ row.status_flag }}</span>
                     </span>
                   </td>
                 </tr>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import assettrack.db as db
 from assettrack.dashboard import (
-    MAX_DASHBOARD_CASE_SUMMARIES,
     MAX_DASHBOARD_RECENT_ACTIVITY,
     build_dashboard_data,
 )
@@ -258,7 +257,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"No overdue in-custody assets.", response.data)
         self.assertIn(b"No slot conflicts detected.", response.data)
 
-    def test_available_space_summary_and_stoplight_statuses(self) -> None:
+    def test_available_space_summary_flags_and_case_links(self) -> None:
         self._insert_slot(1, "CASE-B", 1)
         self._insert_slot(2, "CASE-B", 2)
         self._insert_slot(3, "CASE-B", 3)
@@ -268,6 +267,8 @@ class DashboardTests(unittest.TestCase):
         self._insert_slot(12, "CASE-C", 3)
         self._insert_slot(13, "CASE-C", 4)
         self._insert_slot(14, "CASE-C", 5)
+        self._insert_slot(15, "CASE-D", 1)
+        self._insert_slot(16, "CASE-D", 2)
         self._insert_slot(20, "CASE-A", 1)
         self._insert_slot(21, "CASE-A", 2)
 
@@ -302,20 +303,47 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Based on open slots. Best available case: CASE-B with 3 open", response.data)
         self.assertIn(b'href="/dashboard/cases/CASE-A">CASE-A</a>', response.data)
         self.assertIn(b"0 open", response.data)
-        self.assertIn(b"FULL - No space", response.data)
+        self.assertIn(b"FULL", response.data)
         self.assertIn(b'href="/dashboard/cases/CASE-B">CASE-B</a>', response.data)
         self.assertIn(b"3 open", response.data)
-        self.assertIn(b"LOW - Getting tight", response.data)
+        self.assertIn(b"OPEN", response.data)
         self.assertIn(b'href="/dashboard/cases/CASE-C">CASE-C</a>', response.data)
         self.assertIn(b"1 open", response.data)
+        self.assertIn(b"LOW", response.data)
+        self.assertIn(b'href="/dashboard/cases/CASE-D">CASE-D</a>', response.data)
+        self.assertIn(b"2 open", response.data)
+        self.assertNotIn(b"OPEN - Use now", response.data)
+        self.assertNotIn(b"LOW - Getting tight", response.data)
+        self.assertNotIn(b"FULL - No space", response.data)
+        self.assertNotIn(b"Stoplight Status", response.data)
         self.assertNotIn(b"0 / 2", response.data)
-        self.assertIn(b".status-dot.full { background: var(--color-primary); }", response.data)
-        self.assertIn(b".status-dot.low { background: var(--color-surface); }", response.data)
-        self.assertIn(b".status-dot.open { background: var(--color-accent); }", response.data)
+        self.assertIn(b".status-dot.full { background: #c2410c; }", response.data)
+        self.assertIn(b".status-dot.low { background: #f59e0b; }", response.data)
+        self.assertIn(b".status-dot.open { background: #16a34a; }", response.data)
         self.assertIn(b'status-dot full', response.data)
         self.assertIn(b'status-dot low', response.data)
 
-    def test_dashboard_case_snapshot_is_bounded_and_keeps_best_available_case(self) -> None:
+    def test_available_space_cases_sort_naturally_by_case_number(self) -> None:
+        for slot_id, case_name in enumerate(
+            ["CASE-13", "CASE-2", "CASE-111", "CASE-1", "CASE-16", "ALPHA"],
+            start=1,
+        ):
+            self._insert_slot(slot_id, case_name, 1)
+        self.conn.commit()
+
+        data = build_dashboard_data(self.conn, custody_days_threshold=30)
+        response = self.client.get("/dashboard")
+
+        self.assertEqual(
+            [row["case_name"] for row in data["snapshots"]["case_utilization"]],
+            ["CASE-1", "CASE-2", "CASE-13", "CASE-16", "CASE-111", "ALPHA"],
+        )
+        self.assertLess(
+            response.data.index(b'href="/dashboard/cases/CASE-16">CASE-16</a>'),
+            response.data.index(b'href="/dashboard/cases/CASE-111">CASE-111</a>'),
+        )
+
+    def test_dashboard_case_snapshot_keeps_all_cases_and_best_available_case(self) -> None:
         slot_id = 1
         cases: list[tuple[str, int]] = []
         for index in range(1, 16):
@@ -341,15 +369,19 @@ class DashboardTests(unittest.TestCase):
         data = build_dashboard_data(self.conn, custody_days_threshold=30)
         rendered = self.client.get("/dashboard")
 
-        self.assertLessEqual(len(data["snapshots"]["case_utilization"]), MAX_DASHBOARD_CASE_SUMMARIES)
-        self.assertIn("CASE-6", [row["case_name"] for row in data["snapshots"]["case_utilization"]])
+        self.assertEqual(len(data["snapshots"]["case_utilization"]), 15)
+        self.assertEqual(
+            [row["case_name"] for row in data["snapshots"]["case_utilization"]],
+            [f"CASE-{index}" for index in range(1, 16)],
+        )
         self.assertEqual(
             next(row for row in data["snapshots"]["case_utilization"] if row["case_name"] == "CASE-6")["empty_slots"],
             10,
         )
         self.assertEqual(rendered.status_code, 200)
         self.assertIn(b"Based on open slots. Best available case: CASE-6 with 10 open", rendered.data)
-        self.assertIn(b"CASE-6", rendered.data)
+        self.assertIn(b'href="/dashboard/cases/CASE-6">CASE-6</a>', rendered.data)
+        self.assertIn(b'href="/dashboard/cases/CASE-15">CASE-15</a>', rendered.data)
 
     def test_dashboard_metrics_use_distinct_and_most_recent_issue_event(self) -> None:
         self._replace_slot_occupancy_without_unique_constraints()
@@ -436,7 +468,8 @@ class DashboardTests(unittest.TestCase):
         response = self.client.get("/dashboard")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"FULL - No space", response.data)
+        self.assertIn(b"FULL", response.data)
+        self.assertNotIn(b"FULL - No space", response.data)
 
     def test_root_redirects_to_dashboard_when_logged_in(self):
         resp = self.client.get("/", follow_redirects=False)


### PR DESCRIPTION
## Summary

Updated the dashboard Available Space by Case table to use clear status flags, correct colors, natural case-number ordering, and full case visibility.

## Related Issue

Closes #768 

## Changes

- Replaced stoplight-style wording with plain FULL, LOW, and OPEN flags.
- Set flag colors to:
  - OPEN = green
  - LOW = amber
  - FULL = red
- Preserved available slot counts.
- Preserved case detail links from Issue 27-99.
- Sorted numbered cases naturally by case number.
- Added deterministic fallback sorting for non-numbered case names.
- Removed the case summary row cap so all cases render, including CASE-111.
- Updated dashboard tests for flags, colors, counts, links, ordering, and full case visibility.

## Verification checklist

- [x] Ran `python3 -m compileall assettrack tests`
- [x] Ran `python3 -m pytest tests/test_dashboard.py -q`
- [x] Confirmed Available Space by Case shows FULL, LOW, or OPEN
- [x] Confirmed OPEN is green, LOW is amber, and FULL is red
- [x] Confirmed available slot counts remain visible
- [x] Confirmed case links remain present
- [x] Confirmed CASE-111 sorts after lower-numbered cases
- [x] Confirmed all case rows render after sorting
- [x] Confirmed no custody, event, auth, schema, persistence, queue, preview, commit, slot, or capacity calculation behavior changed

## Notes

Dashboard display cleanup only. No custody truth or workflow behavior changed.