### PR TITLE
Issue 27-104: Start case detail Issue and Return queues

### DIFF
--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -223,7 +223,8 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
         SELECT
             s.id AS slot_id,
             s.slot_position,
-            a.asset_tag
+            a.asset_tag,
+            a.location_type AS asset_location_type
         FROM slots s
         LEFT JOIN (
             SELECT so.slot_id, so.asset_id
@@ -244,6 +245,22 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
         (case_name,),
     ).fetchall()
 
+    return_candidate_rows = conn.execute(
+        """
+        SELECT
+            a.asset_tag,
+            a.location_type,
+            s.slot_position
+        FROM assets a
+        JOIN slots s
+          ON s.id = a.home_slot_id
+        WHERE s.case_name = ?
+          AND UPPER(COALESCE(a.location_type, '')) = 'IN_CUSTODY'
+        ORDER BY s.slot_position ASC, UPPER(a.asset_tag) ASC, a.id ASC;
+        """,
+        (case_name,),
+    ).fetchall()
+
     return {
         "case_name": case_name,
         "slots": [
@@ -251,7 +268,16 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
                 "slot_id": int(row["slot_id"]),
                 "slot_position": int(row["slot_position"]),
                 "asset_tag": row["asset_tag"],
+                "asset_location_type": "" if row["asset_location_type"] is None else str(row["asset_location_type"]),
             }
             for row in slot_rows
+        ],
+        "return_candidates": [
+            {
+                "asset_tag": str(row["asset_tag"] or ""),
+                "location_type": str(row["location_type"] or ""),
+                "slot_position": int(row["slot_position"]),
+            }
+            for row in return_candidate_rows
         ],
     }

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -105,6 +105,7 @@ bootstrap_db(db_module.DB_PATH)
 
 # In-memory only: wiped on restart
 SCAN_QUEUE: list[Scan] = []
+CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY = "case_detail_queue_workflow"
 
 INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", str(SESSION_IDLE_TIMEOUT_SECONDS)))
 TERMINAL_LOCATION_TYPE = "DISPOSED"
@@ -920,6 +921,159 @@ def _find_return_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]
         "case_name": case_name,
         "assets": assets,
     }
+
+
+def _selected_case_asset_tags() -> list[str]:
+    seen: set[str] = set()
+    selected: list[str] = []
+    for raw in request.form.getlist("asset_tag"):
+        normalized = sanitize_scan(str(raw or ""))
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        selected.append(str(raw or "").strip())
+    return selected
+
+
+def _case_detail_existing_queue_workflow() -> str:
+    if not SCAN_QUEUE:
+        return ""
+
+    session_workflow = str(session.get(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY) or "").strip().lower()
+    if session_workflow in {"issue", "return"}:
+        return session_workflow
+
+    if bool(session.get("issue_mode")):
+        return "issue"
+
+    return ""
+
+
+def _queue_case_detail_issue_selection(conn: sqlite3.Connection, case_name: str, selected_tags: list[str]) -> tuple[int, list[str]]:
+    invalid: list[str] = []
+    queued_rows: list[dict[str, object]] = []
+
+    for selected_tag in selected_tags:
+        normalized = sanitize_scan(selected_tag)
+        row = conn.execute(
+            """
+            SELECT
+                a.id AS asset_id,
+                a.asset_tag,
+                a.location_type,
+                s.id AS slot_id,
+                s.case_name,
+                s.slot_position
+            FROM assets a
+            JOIN slot_occupancy so
+              ON so.asset_id = a.id
+            JOIN slots s
+              ON s.id = so.slot_id
+            WHERE s.case_name = ?
+              AND (
+                UPPER(a.asset_tag) = UPPER(?)
+                OR REPLACE(UPPER(a.asset_tag), '-', '') = UPPER(?)
+              )
+            LIMIT 1;
+            """,
+            (case_name, selected_tag, normalized),
+        ).fetchone()
+        if row is None:
+            invalid.append(normalized)
+            continue
+
+        location_type = str(row["location_type"] or "").strip().upper()
+        if location_type != "STORAGE" or _is_terminal_location_type(location_type):
+            invalid.append(str(row["asset_tag"] or normalized))
+            continue
+
+        queued_rows.append(dict(row))
+
+    if invalid:
+        return 0, invalid
+
+    added_count = 0
+    for row in queued_rows:
+        asset_tag = str(row["asset_tag"] or "").strip().upper()
+        if _queue_contains_asset_tag(asset_tag):
+            continue
+        SCAN_QUEUE.append(
+            Scan.now(
+                asset_tag,
+                equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+                home_slot_id=int(row["slot_id"]),
+                case_name=str(row["case_name"] or ""),
+                slot_position=int(row["slot_position"]),
+            )
+        )
+        added_count += 1
+
+    return added_count, []
+
+
+def _queue_case_detail_return_selection(conn: sqlite3.Connection, case_name: str, selected_tags: list[str]) -> tuple[int, list[str]]:
+    invalid: list[str] = []
+    queued_rows: list[dict[str, object]] = []
+
+    for selected_tag in selected_tags:
+        normalized = sanitize_scan(selected_tag)
+        row = conn.execute(
+            """
+            SELECT
+                a.id AS asset_id,
+                a.asset_tag,
+                a.location_type,
+                a.home_slot_id,
+                s.case_name,
+                s.slot_position,
+                s.current_asset_tag,
+                so.asset_id AS occupied_asset_id
+            FROM assets a
+            JOIN slots s
+              ON s.id = a.home_slot_id
+            LEFT JOIN slot_occupancy so
+              ON so.slot_id = s.id
+            WHERE s.case_name = ?
+              AND (
+                UPPER(a.asset_tag) = UPPER(?)
+                OR REPLACE(UPPER(a.asset_tag), '-', '') = UPPER(?)
+              )
+            LIMIT 1;
+            """,
+            (case_name, selected_tag, normalized),
+        ).fetchone()
+        if row is None:
+            invalid.append(normalized)
+            continue
+
+        location_type = str(row["location_type"] or "").strip().upper()
+        home_slot_occupied = row["current_asset_tag"] is not None or row["occupied_asset_id"] is not None
+        if location_type != "IN_CUSTODY" or _is_terminal_location_type(location_type) or home_slot_occupied:
+            invalid.append(str(row["asset_tag"] or normalized))
+            continue
+
+        queued_rows.append(dict(row))
+
+    if invalid:
+        return 0, invalid
+
+    added_count = 0
+    for row in queued_rows:
+        asset_tag = str(row["asset_tag"] or "").strip().upper()
+        if _queue_contains_asset_tag(asset_tag):
+            continue
+        SCAN_QUEUE.append(
+            Scan.now(
+                asset_tag,
+                equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
+                home_slot_id=int(row["home_slot_id"]),
+                case_name=str(row["case_name"] or ""),
+                slot_position=int(row["slot_position"]),
+            )
+        )
+        added_count += 1
+
+    return added_count, []
 
 
 def _asset_current_slot(conn, asset_id: int, asset_tag: str) -> Optional[dict]:
@@ -3676,6 +3830,7 @@ def intake():
 
         if action == "clear":
             SCAN_QUEUE.clear()
+            session.pop(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY, None)
         elif action == "remove":
             try:
                 queue_index = int(queue_index_raw)
@@ -4126,6 +4281,67 @@ def dashboard_case_detail(case_name: str):
     )
 
 
+@app.post("/dashboard/cases/<case_name>/queue")
+@require_login
+def dashboard_case_queue_start(case_name: str):
+    action = str(request.form.get("workflow_action") or "").strip().lower()
+    return_to = _safe_local_return_to(request.form.get("return_to") or "")
+    selected_tags = _selected_case_asset_tags()
+
+    def _case_detail_redirect():
+        if return_to is not None:
+            return redirect(url_for("dashboard_case_detail", case_name=case_name, return_to=return_to))
+        return redirect(url_for("dashboard_case_detail", case_name=case_name))
+
+    if action not in {"issue", "return"}:
+        flash("Choose Start Issue or Start Return.", "error")
+        return _case_detail_redirect()
+
+    if not selected_tags:
+        flash("Select at least one asset before starting a queue.", "error")
+        return _case_detail_redirect()
+
+    existing_queue_workflow = _case_detail_existing_queue_workflow()
+    if existing_queue_workflow and existing_queue_workflow != action:
+        flash("Finish or clear the current queue before starting a different action.", "error")
+        return _case_detail_redirect()
+
+    conn = get_connection()
+    try:
+        detail = get_case_slot_detail(conn, case_name)
+        if detail is None:
+            abort(404)
+        if action == "issue":
+            added_count, invalid_tags = _queue_case_detail_issue_selection(conn, case_name, selected_tags)
+        else:
+            added_count, invalid_tags = _queue_case_detail_return_selection(conn, case_name, selected_tags)
+    finally:
+        conn.close()
+
+    if invalid_tags:
+        flash(
+            "Queue not started. These assets are no longer eligible: "
+            + ", ".join(invalid_tags)
+            + ".",
+            "error",
+        )
+        return _case_detail_redirect()
+
+    if added_count == 0:
+        flash("Selected assets are already queued.", "error")
+        return _case_detail_redirect()
+
+    touch_session()
+    session[CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY] = action
+    if action == "issue":
+        session["issue_mode"] = True
+        flash(f"Added {added_count} selected assets to the Issue queue.", "success")
+        return redirect(url_for("issue"))
+
+    flash(f"Added {added_count} selected assets to the Return queue.", "success")
+    return redirect(url_for("return_queue"))
+
+
 @app.get("/assets/search")
 @require_login
 def asset_search():
@@ -4236,6 +4452,7 @@ def preview_discard():
 
     discarded = len(SCAN_QUEUE)
     SCAN_QUEUE.clear()
+    session.pop(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY, None)
     if return_to_path != "/issue":
         session.pop("holder_id", None)
 
@@ -4315,6 +4532,7 @@ def preview_commit():
             return redirect(url_for("preview"))
 
         SCAN_QUEUE.clear()
+        session.pop(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY, None)
         session.pop("holder_id", None)  # keep tidy; holder is only meaningful for issue mode
         touch_session()
 
@@ -4379,6 +4597,7 @@ def preview_commit():
         return redirect(url_for("preview"))
 
     SCAN_QUEUE.clear()
+    session.pop(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY, None)
     touch_session()
 
     if wants_json():
@@ -4626,6 +4845,7 @@ def issue_commit():
         return redirect(url_for("issue_preview"))
 
     SCAN_QUEUE.clear()
+    session.pop(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY, None)
     touch_session()
 
     if wants_json():
@@ -4771,6 +4991,7 @@ def return_commit():
         return redirect(url_for("return_preview"))
 
     SCAN_QUEUE.clear()
+    session.pop(CASE_DETAIL_QUEUE_WORKFLOW_SESSION_KEY, None)
     touch_session()
     returned_cases: list[str] = []
     for row in state["assets"]:

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -24,6 +24,32 @@
     .status-dot.full { background: #12b76a; }
     .status-dot.low { background: #f79009; }
     .status-dot.open { background: #b42318; }
+    .workflow-note {
+      margin: 0.35rem 0 0;
+      color: var(--color-text-muted);
+    }
+    .case-action-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-top: 1rem;
+    }
+    .select-cell {
+      width: 4.5rem;
+      text-align: center;
+    }
+    .case-section-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 0.75rem 1rem;
+      flex-wrap: wrap;
+      margin-bottom: 0.75rem;
+    }
+    .case-section-header h2 {
+      margin-bottom: 0.25rem;
+    }
   </style>
 {% endblock %}
 
@@ -41,6 +67,14 @@
     </nav>
   </div>
 
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
   <section class="card status-card">
     <h2>Case Status</h2>
     <p>
@@ -56,26 +90,122 @@
   </section>
 
   <section class="card">
-    <h2>Slot Layout</h2>
-    <table>
-      <thead>
-        <tr>
-          <th>Slot Position</th>
-          <th>Asset Tag</th>
-        </tr>
-      </thead>
-      <tbody>
-        {% for row in case_detail.slots %}
+    <div class="case-section-header">
+      <div>
+        <h2>Slot Layout</h2>
+        <p class="workflow-note">Check boxes to select assets.</p>
+      </div>
+      <button type="button" class="action-secondary" data-select-all-eligible="issue">Select all</button>
+    </div>
+    <form id="case-issue-selection-form" method="post" action="{{ url_for('dashboard_case_queue_start', case_name=case_detail.case_name) }}">
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
+      <table>
+        <thead>
           <tr>
-            <td>{{ row.slot_position }}</td>
-            <td class="mono">{{ row.asset_tag if row.asset_tag else "Empty" }}</td>
+            <th class="select-cell">Issue</th>
+            <th>Slot Position</th>
+            <th>Asset Tag</th>
           </tr>
-        {% else %}
-          <tr>
-            <td colspan="2">None</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {% for row in case_detail.slots %}
+            {% set can_issue = row.asset_tag and row.asset_location_type|upper == "STORAGE" %}
+            <tr>
+              <td class="select-cell">
+                {% if can_issue %}
+                  <input type="checkbox" name="asset_tag" value="{{ row.asset_tag }}" aria-label="Select {{ row.asset_tag }} for issue" data-eligible-asset="issue" />
+                {% else %}
+                  -
+                {% endif %}
+              </td>
+              <td>{{ row.slot_position }}</td>
+              <td class="mono">{{ row.asset_tag if row.asset_tag else "Empty" }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="3">None</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="case-action-row">
+        <button type="submit" name="workflow_action" value="issue">Start Issue</button>
+        <p class="workflow-note">Selected assets will be reviewed before commit.</p>
+      </div>
+    </form>
   </section>
+
+  <section class="card">
+    <div class="case-section-header">
+      <div>
+        <h2>Assets Issued Out</h2>
+        <p class="workflow-note">Check boxes to select assets.</p>
+      </div>
+      <button type="button" class="action-secondary" data-select-all-eligible="return">Select all</button>
+    </div>
+    <form id="case-return-selection-form" method="post" action="{{ url_for('dashboard_case_queue_start', case_name=case_detail.case_name) }}">
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
+      <table>
+        <thead>
+          <tr>
+            <th class="select-cell">Return</th>
+            <th>Home Slot</th>
+            <th>Asset Tag</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in case_detail.return_candidates %}
+            <tr>
+              <td class="select-cell">
+                <input type="checkbox" name="asset_tag" value="{{ row.asset_tag }}" aria-label="Select {{ row.asset_tag }} for return" data-eligible-asset="return" />
+              </td>
+              <td>{{ row.slot_position }}</td>
+              <td class="mono">{{ row.asset_tag }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="3">No assets currently out from this case.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="case-action-row">
+        <button type="submit" name="workflow_action" value="return">Start Return</button>
+        <p class="workflow-note">Selected assets will be reviewed before commit.</p>
+      </div>
+    </form>
+  </section>
+{% endblock %}
+
+{% block extra_scripts %}
+  <script>
+    const caseIssueSelectAll = document.querySelector('[data-select-all-eligible="issue"]');
+    const caseReturnSelectAll = document.querySelector('[data-select-all-eligible="return"]');
+    const caseIssueForm = document.getElementById("case-issue-selection-form");
+    const caseReturnForm = document.getElementById("case-return-selection-form");
+
+    if (caseIssueSelectAll && caseIssueForm) {
+      caseIssueSelectAll.addEventListener("click", () => {
+        caseIssueForm
+          .querySelectorAll('input[type="checkbox"][data-eligible-asset="issue"]:not(:disabled)')
+          .forEach((checkbox) => {
+            checkbox.checked = true;
+          });
+      });
+    }
+
+    if (caseReturnSelectAll && caseReturnForm) {
+      caseReturnSelectAll.addEventListener("click", () => {
+        caseReturnForm
+          .querySelectorAll('input[type="checkbox"][data-eligible-asset="return"]:not(:disabled)')
+          .forEach((checkbox) => {
+            checkbox.checked = true;
+          });
+      });
+    }
+  </script>
 {% endblock %}

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -40,7 +40,9 @@ def app_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     client = intake_app.app.test_client()
     operator_user_id = create_test_user(username="operator", password="op-pass", role="operator")
     login_session(client, operator_user_id)
+    intake_app.SCAN_QUEUE.clear()
     yield conn, client
+    intake_app.SCAN_QUEUE.clear()
     conn.close()
 
 
@@ -106,6 +108,20 @@ def _insert_slot(conn, slot_id: int, case_name: str, slot_position: int) -> None
     )
 
 
+def _occupy_slot(conn, slot_id: int, asset_id: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (?, ?, '2026-01-01T00:00:00Z');
+        """,
+        (slot_id, asset_id),
+    )
+
+
+def _count_rows(conn, table_name: str) -> int:
+    return int(conn.execute(f"SELECT COUNT(*) AS c FROM {table_name};").fetchone()["c"])
+
+
 def test_dashboard_holders_route_returns_200_and_is_read_only(app_client) -> None:
     conn, client = app_client
     _insert_holder(conn, 1, "Alpha")
@@ -167,7 +183,9 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
     conn, client = app_client
     _insert_slot(conn, 10, "CASE-A", 1)
     _insert_slot(conn, 11, "CASE-A", 2)
+    _insert_slot(conn, 12, "CASE-A", 3)
     asset_id = _insert_asset(conn, "AT-SLOTTED", location_type="STORAGE")
+    _insert_asset(conn, "AT-OUT", location_type="IN_CUSTODY", holder_id=1, home_slot_id=12)
     conn.execute(
         """
         INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
@@ -182,14 +200,167 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
     assert b"Case Status" in response.data
     assert b"LOW - Getting tight" in response.data
     assert b"status-dot low" in response.data
-    assert b"Total slots:</strong> 2" in response.data
+    assert b"Total slots:</strong> 3" in response.data
     assert b"Occupied slots:</strong> 1" in response.data
-    assert b"Empty slots:</strong> 1" in response.data
+    assert b"Empty slots:</strong> 2" in response.data
+    assert b"Check boxes to select assets." in response.data
+    assert b"Select all" in response.data
+    assert b"Select all eligible assets" not in response.data
+    assert b'data-select-all-eligible="issue"' in response.data
+    assert b'data-select-all-eligible="return"' in response.data
+    assert b'data-eligible-asset="issue"' in response.data
+    assert b'data-eligible-asset="return"' in response.data
+    assert b'case-return-selection-form' in response.data
+    assert b"Assets Issued Out" in response.data
+    assert b"Assets Out From This Case" not in response.data
     assert b"Slot Position" in response.data
     assert b">1<" in response.data
     assert b">2<" in response.data
     assert b"AT-SLOTTED" in response.data
+    assert b"AT-OUT" in response.data
     assert b"Empty" in response.data
+
+
+def test_case_detail_start_issue_populates_queue_without_events_or_receipts(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 20, "CASE-I", 1)
+    asset_id = _insert_asset(conn, "ISSUE-READY", location_type="STORAGE", home_slot_id=20)
+    _occupy_slot(conn, 20, asset_id)
+    conn.commit()
+
+    response = client.post(
+        "/dashboard/cases/CASE-I/queue",
+        data={"workflow_action": "issue", "asset_tag": "ISSUE-READY"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/issue")
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE-READY"]
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
+
+
+def test_case_detail_start_return_populates_queue_without_events_or_receipts(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 30, "CASE-R", 1)
+    _insert_asset(conn, "RETURN-READY", location_type="IN_CUSTODY", holder_id=1, home_slot_id=30)
+    conn.commit()
+
+    response = client.post(
+        "/dashboard/cases/CASE-R/queue",
+        data={"workflow_action": "return", "asset_tag": "RETURN-READY"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/return")
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["RETURN-READY"]
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
+
+
+def test_case_detail_rejects_stale_or_ineligible_issue_selection(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 40, "CASE-STALE", 1)
+    asset_id = _insert_asset(conn, "STALE-ISSUE", location_type="IN_CUSTODY", holder_id=1, home_slot_id=40)
+    _occupy_slot(conn, 40, asset_id)
+    conn.commit()
+
+    response = client.post(
+        "/dashboard/cases/CASE-STALE/queue",
+        data={"workflow_action": "issue", "asset_tag": "STALE-ISSUE"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Queue not started." in response.data
+    assert intake_app.SCAN_QUEUE == []
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
+
+
+def test_case_detail_mixed_issue_selection_does_not_queue_partial_batch(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 50, "CASE-MIX", 1)
+    _insert_slot(conn, 51, "CASE-MIX", 2)
+    ready_asset_id = _insert_asset(conn, "MIX-READY", location_type="STORAGE", home_slot_id=50)
+    blocked_asset_id = _insert_asset(conn, "MIX-BLOCKED", location_type="IN_CUSTODY", holder_id=1, home_slot_id=51)
+    _occupy_slot(conn, 50, ready_asset_id)
+    _occupy_slot(conn, 51, blocked_asset_id)
+    conn.commit()
+
+    response = client.post(
+        "/dashboard/cases/CASE-MIX/queue",
+        data={"workflow_action": "issue", "asset_tag": ["MIX-READY", "MIX-BLOCKED"]},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Queue not started." in response.data
+    assert intake_app.SCAN_QUEUE == []
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
+
+
+def test_case_detail_blocks_return_when_issue_queue_exists(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 60, "CASE-BLOCK", 1)
+    _insert_slot(conn, 61, "CASE-BLOCK", 2)
+    issue_asset_id = _insert_asset(conn, "BLOCK-ISSUE", location_type="STORAGE", home_slot_id=60)
+    _insert_asset(conn, "BLOCK-RETURN", location_type="IN_CUSTODY", holder_id=1, home_slot_id=61)
+    _occupy_slot(conn, 60, issue_asset_id)
+    conn.commit()
+
+    issue_response = client.post(
+        "/dashboard/cases/CASE-BLOCK/queue",
+        data={"workflow_action": "issue", "asset_tag": "BLOCK-ISSUE"},
+        follow_redirects=False,
+    )
+    assert issue_response.status_code == 302
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["BLOCK-ISSUE"]
+
+    return_response = client.post(
+        "/dashboard/cases/CASE-BLOCK/queue",
+        data={"workflow_action": "return", "asset_tag": "BLOCK-RETURN"},
+        follow_redirects=True,
+    )
+
+    assert return_response.status_code == 200
+    assert b"Finish or clear the current queue before starting a different action." in return_response.data
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["BLOCK-ISSUE"]
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
+
+
+def test_case_detail_blocks_issue_when_return_queue_exists(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 70, "CASE-BLOCK-R", 1)
+    _insert_slot(conn, 71, "CASE-BLOCK-R", 2)
+    issue_asset_id = _insert_asset(conn, "BLOCK-R-ISSUE", location_type="STORAGE", home_slot_id=70)
+    _insert_asset(conn, "BLOCK-R-RETURN", location_type="IN_CUSTODY", holder_id=1, home_slot_id=71)
+    _occupy_slot(conn, 70, issue_asset_id)
+    conn.commit()
+
+    return_response = client.post(
+        "/dashboard/cases/CASE-BLOCK-R/queue",
+        data={"workflow_action": "return", "asset_tag": "BLOCK-R-RETURN"},
+        follow_redirects=False,
+    )
+    assert return_response.status_code == 302
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["BLOCK-R-RETURN"]
+
+    issue_response = client.post(
+        "/dashboard/cases/CASE-BLOCK-R/queue",
+        data={"workflow_action": "issue", "asset_tag": "BLOCK-R-ISSUE"},
+        follow_redirects=True,
+    )
+
+    assert issue_response.status_code == 200
+    assert b"Finish or clear the current queue before starting a different action." in issue_response.data
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["BLOCK-R-RETURN"]
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
 
 
 def test_holders_and_cases_deterministic_ordering(app_client) -> None:

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -7,7 +7,7 @@ import pytest
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from tests.auth_test_utils import create_test_user
+from tests.auth_test_utils import create_test_user, login_session
 
 
 @pytest.fixture
@@ -31,8 +31,8 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 def _login_issue_operator(client, username: str) -> None:
     operator_id = create_test_user(username=username, password="op-pass", role="operator")
+    login_session(client, operator_id)
     with client.session_transaction() as sess:
-        sess["user_id"] = operator_id
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"


### PR DESCRIPTION
## Summary

Adds a safe queue-entry bridge from case detail pages.

Operators can now select eligible assets from a case detail page and start an Issue or Return queue without committing custody changes from the case page.

## Related Issue

Closes #777 

## Changes

- Added case detail asset selection for Issue and Return workflows
- Added Start Issue and Start Return actions
- Populates existing scan queue only
- Redirects into existing `/issue` or `/return` workflows
- Blocks mixed Issue/Return queue actions
- Added local Select all controls for Issue and Return sections
- Renamed return section to `Assets Issued Out`
- Added tests for queue population, stale selections, mixed queue blocking, and no event/receipt creation

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_dashboard_drilldowns.py tests/test_issue_case_scan.py tests/test_return_batch.py -q`
- [x] `python3 -m pytest tests/test_issue_23_2_preview_commit_seam.py -q`
- [x] Manual smoke: Issue select-all passed
- [x] Manual smoke: Return select-all passed
- [x] Manual smoke: Issue queue path passed
- [x] Manual smoke: Return queue path passed
- [x] Manual smoke: Mixed queue guard passed

## Notes

No schema, persistence, auth, role, event, receipt, preview, or commit behavior changed.