### PR TITLE
Issue 27-105: Clarify Return home slot destination

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2941,7 +2941,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
 
             home_slot_id = asset_row["home_slot_id"]
             if home_slot_id is None:
-                row["asset_issues"].append("Asset has no home slot")
+                row["asset_issues"].append("No assigned home slot. Return cannot commit until a home slot is assigned.")
                 no_home_slot.append(canon_tag)
                 assets.append(row)
                 continue
@@ -2955,7 +2955,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
                 (home_slot_id,),
             ).fetchone()
             if not slot:
-                row["asset_issues"].append("Home slot not found")
+                row["asset_issues"].append("Assigned home slot not found. Return cannot commit until a valid home slot is assigned.")
                 no_home_slot.append(canon_tag)
                 assets.append(row)
                 continue
@@ -2963,7 +2963,9 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
             row["destination_case_name"] = str(slot["case_name"])
             row["destination_slot"] = f"{slot['case_name']} / {slot['slot_position']}"
             if slot["current_asset_tag"] is not None:
-                row["asset_issues"].append(f"Home slot occupied by {slot['current_asset_tag']}")
+                row["asset_issues"].append(
+                    f"Assigned home slot {row['destination_slot']} is occupied by {slot['current_asset_tag']}."
+                )
                 occupied_home_slot.append(canon_tag)
                 row["before_slot_occupancy"] = "occupied"
 
@@ -2979,9 +2981,9 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
     if retired_assets:
         blocking_issues.append(f"Retired/disposed: {', '.join(retired_assets)}")
     if no_home_slot:
-        blocking_issues.append(f"Missing home slot: {', '.join(no_home_slot)}")
+        blocking_issues.append(f"No assigned home slot: {', '.join(no_home_slot)}")
     if occupied_home_slot:
-        blocking_issues.append(f"Home slot occupied: {', '.join(occupied_home_slot)}")
+        blocking_issues.append(f"Assigned home slot occupied: {', '.join(occupied_home_slot)}")
 
     ready_count = sum(1 for row in assets if row["ready"])
     return {"assets": assets, "ready_count": ready_count, "blocking_issues": blocking_issues}
@@ -3700,9 +3702,9 @@ def _return_batch(
                 if retired_assets:
                     parts.append(f"Retired/disposed: {', '.join(retired_assets)}")
                 if no_home_slot:
-                    parts.append(f"Missing home slot: {', '.join(no_home_slot)}")
+                    parts.append(f"No assigned home slot: {', '.join(no_home_slot)}")
                 if occupied_home_slot:
-                    parts.append(f"Home slot occupied: {', '.join(occupied_home_slot)}")
+                    parts.append(f"Assigned home slot occupied: {', '.join(occupied_home_slot)}")
                 raise ValueError("; ".join(parts))
 
             now_iso = datetime.now(timezone.utc).isoformat()

--- a/assettrack/intake/templates/return_preview.html
+++ b/assettrack/intake/templates/return_preview.html
@@ -24,12 +24,12 @@
     {% endif %}
   {% endwith %}
 
-  {% if workflow_banner_title %}
-    {% include "_workflow_context_banner.html" %}
-  {% endif %}
-
   <div class="card workflow-card review-signal {% if blocking_issues %}blocked{% endif %}">
     <h2>{% if blocking_issues %}Needs Review{% else %}Ready to Return{% endif %}</h2>
+    <p class="card-intro">
+      Returns go to each asset's assigned home slot.<br />
+      Review the destination below before commit.
+    </p>
   </div>
 
   {% if blocking_issues %}
@@ -52,7 +52,7 @@
           <tr>
             <th>Asset</th>
             <th>Current State</th>
-            <th>After Return</th>
+            <th>Return Destination</th>
             <th>Status</th>
           </tr>
         </thead>
@@ -74,10 +74,10 @@
 
               <td>
                 <div class="state-block">
-                  <strong>After Return</strong><br />
+                  <strong>Return Destination</strong><br />
                   Location: {{ row.after_location_type }}<br />
                   Issued to: Not assigned<br />
-                  Home location: {{ destination_slot_display }}
+                  Assigned home slot: {{ destination_slot_display }}
                 </div>
               </td>
 

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -98,13 +98,16 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIn(b"Return Preview", preview_render.data)
         self.assertIn(b"Commit", preview_render.data)
         self.assertIn(b"Ready to Return", preview_render.data)
-        self.assertIn(b"Home location: Home slots", preview_render.data)
-        self.assertIn(b"1 asset queued", preview_render.data)
+        self.assertNotIn(b"Home location: Home slots", preview_render.data)
+        self.assertNotIn(b"1 asset queued", preview_render.data)
         self.assertIn(b"Current State", preview_render.data)
-        self.assertIn(b"After Return", preview_render.data)
+        self.assertIn(b"Returns go to each asset's assigned home slot.", preview_render.data)
+        self.assertIn(b"Review the destination below before commit.", preview_render.data)
+        self.assertIn(b"Return Destination", preview_render.data)
         self.assertIn(b"Location: IN_CUSTODY", preview_render.data)
         self.assertIn(b"Issued to: Return Holder Five", preview_render.data)
         self.assertIn(b"Home location: A / 1", preview_render.data)
+        self.assertIn(b"Assigned home slot: A / 1", preview_render.data)
         self.assertIn(b'name="confirm_responsibility_ack"', preview_render.data)
         self.assertIn(b"responsibility for this return batch was acknowledged before commit", preview_render.data)
         self.assertNotIn(b"null", preview_render.data)
@@ -241,6 +244,37 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertIsNone(receipt_row["sent_at"])
         self.assertIsNone(receipt_row["last_attempt_at"])
         self.assertIsNone(receipt_row["last_error"])
+
+    def test_return_preview_explains_missing_assigned_home_slot_blocker(self) -> None:
+        self._insert_asset("NO-HOME", location_type="IN_CUSTODY", holder_id=5, home_slot_id=None)
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="NO-HOME", equipment_type="laptop"))
+
+        preview = self.client.get("/return/preview")
+
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"Returns go to each asset's assigned home slot.", preview.data)
+        self.assertIn(b"Review the destination below before commit.", preview.data)
+        self.assertIn(b"No assigned home slot: NO-HOME", preview.data)
+        self.assertIn(
+            b"No assigned home slot. Return cannot commit until a home slot is assigned.",
+            preview.data,
+        )
+        self.assertIn(b"Conflicts must be resolved before committing this batch.", preview.data)
+
+    def test_return_preview_explains_occupied_assigned_home_slot_blocker(self) -> None:
+        self._insert_slot(12, "CASE-BLOCKED", 4, "OTHER-ASSET")
+        self._insert_asset("OCCUPIED-HOME", location_type="IN_CUSTODY", holder_id=5, home_slot_id=12)
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="OCCUPIED-HOME", equipment_type="laptop"))
+
+        preview = self.client.get("/return/preview")
+
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"Assigned home slot occupied: OCCUPIED-HOME", preview.data)
+        self.assertIn(
+            b"Assigned home slot CASE-BLOCKED / 4 is occupied by OTHER-ASSET.",
+            preview.data,
+        )
+        self.assertIn(b"Conflicts must be resolved before committing this batch.", preview.data)
 
     def test_return_queue_and_preview_empty_states_show_next_step_guidance(self) -> None:
         render = self.client.get("/return")


### PR DESCRIPTION
## Summary

Clarifies where returned assets go during the Return workflow.

Return preview now tells operators that assets return to their assigned home slot, and blocker messages use clearer assigned-home-slot language.

## Related Issue

Closes #778 

## Changes

- Updated Return preview destination messaging
- Renamed destination column to `Return Destination`
- Removed duplicate top summary card from Return preview
- Clarified missing assigned home slot blocker
- Clarified occupied assigned home slot blocker
- Updated Return workflow tests

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_return_batch.py -q`
- [x] `python3 -m pytest tests/test_issue_23_2_preview_commit_seam.py -q`
- [x] `python3 -m pytest tests/test_dashboard_drilldowns.py tests/test_issue_case_scan.py tests/test_return_batch.py -q`
- [x] Manual smoke: Return preview consolidation passed
- [x] Manual smoke: Return Destination still visible
- [x] Manual smoke: Return commit works
- [x] Manual smoke: queue clears after commit

## Notes

No schema, persistence, event, receipt, auth, role, queue, preview seam, or commit behavior changed.