### PR TITLE
Issue 27-106: Add read-only case filter

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4250,16 +4250,22 @@ def dashboard_holder_detail(holder_id: int):
 @require_login
 def dashboard_cases():
     return_to = _safe_local_return_to(request.args.get("return_to") or "")
+    case_query = (request.args.get("q") or "").strip()
     conn = get_connection()
     try:
         cases = list_case_summaries(conn)
     finally:
         conn.close()
 
+    if case_query:
+        query_upper = case_query.upper()
+        cases = [row for row in cases if query_upper in str(row.get("case_name") or "").upper()]
+
     return render_template(
         "dashboard_cases.html",
         cases=cases,
         return_to=return_to,
+        case_query=case_query,
     )
 
 

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -17,6 +17,17 @@
       text-decoration-thickness: 2px;
       text-underline-offset: 0.16em;
     }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
   </style>
 {% endblock %}
 
@@ -30,6 +41,34 @@
 
   <section class="card">
     <h2>Case Summary</h2>
+    <form method="get" action="{{ url_for('dashboard_cases') }}" class="row" style="margin: 0.5rem 0 1rem; gap: 0.75rem; align-items: flex-start;">
+      <div>
+        <label for="case-filter-query" class="sr-only">Case name filter</label>
+        <input
+          id="case-filter-query"
+          name="q"
+          type="text"
+          value="{{ case_query or '' }}"
+          placeholder="Enter case name"
+          aria-label="Case name filter"
+        />
+      </div>
+      {% if return_to %}
+        <input type="hidden" name="return_to" value="{{ return_to }}" />
+      {% endif %}
+      <div style="padding-top: 0.55rem;">
+        <button type="submit">Search</button>
+      </div>
+      {% if case_query %}
+        <div style="padding-top: 0.55rem;">
+          {% if return_to %}
+            <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=return_to) }}">Clear</a>
+          {% else %}
+            <a class="nav-link" href="{{ url_for('dashboard_cases') }}">Clear</a>
+          {% endif %}
+        </div>
+      {% endif %}
+    </form>
     <table>
       <thead>
         <tr>
@@ -59,7 +98,7 @@
           </tr>
         {% else %}
           <tr>
-            <td colspan="6">None</td>
+            <td colspan="6">{% if case_query %}No cases match that search.{% else %}None{% endif %}</td>
           </tr>
         {% endfor %}
       </tbody>

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -179,6 +179,41 @@ def test_dashboard_cases_route_200_and_missing_case_404(app_client) -> None:
     assert missing_response.status_code == 404
 
 
+def test_dashboard_cases_renders_case_filter_input(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 15, "CASE-FILTER", 1)
+    conn.commit()
+
+    response = client.get("/dashboard/cases")
+    assert response.status_code == 200
+    assert b'name="q"' in response.data
+    assert b"Find case" not in response.data
+
+
+def test_dashboard_cases_case_name_filter_shows_only_matches_and_keeps_read_only(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 21, "CASE-111", 1)
+    _insert_slot(conn, 22, "CASE-999", 1)
+    conn.commit()
+
+    response = client.get("/dashboard/cases?q=111")
+    assert response.status_code == 200
+    assert b'href="/dashboard/cases/CASE-111"' in response.data
+    assert b'CASE-999' not in response.data
+    assert _count_rows(conn, "asset_events") == 0
+    assert _count_rows(conn, "receipt_queue") == 0
+
+
+def test_dashboard_cases_case_name_filter_no_match_message(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 23, "CASE-ABC", 1)
+    conn.commit()
+
+    response = client.get("/dashboard/cases?q=ZZZ")
+    assert response.status_code == 200
+    assert b"No cases match that search." in response.data
+
+
 def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) -> None:
     conn, client = app_client
     _insert_slot(conn, 10, "CASE-A", 1)


### PR DESCRIPTION
## Summary

Adds a read-only case-name filter to the case summaries page.

Operators can now search `/dashboard/cases` by case name and open matching case detail pages without starting any workflow action.

## Related Issue

Closes #780 

## Changes

- Added `q` query param support to `/dashboard/cases`
- Added a case-name search input to the case summary page
- Added clear no-match messaging
- Preserved existing case detail links
- Removed visible `Find case` label while keeping accessibility support
- Adjusted spacing around the search controls
- Added focused dashboard/case tests

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_dashboard_drilldowns.py -q`
- [x] Manual smoke: case filter passed
- [x] Manual smoke: no visible `Find case` text
- [x] Manual smoke: search button spacing verified
- [x] Manual smoke: Clear restores full list
- [x] Manual smoke: case detail links still open correctly

## Notes

No queue, custody, slot, event, receipt, schema, persistence, auth, role, Issue, or Return workflow behavior changed.