### PR TITLE
Issue 27-108: Clarify receipt and follow-up email language

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -5711,11 +5711,11 @@ def _build_receipt_pdf(receipt: dict[str, object], *, for_email: bool = False) -
     if for_email:
         status_text = "Receipt attached for your records."
     elif delivery_state == "failed":
-        status_text = "Receipt email failed. Resend recommended."
+        status_text = "Receipt delivery failed. Custody is already recorded."
     elif delivery_state == "pending":
-        status_text = "Receipt email queued. No action needed unless delivery stalls."
+        status_text = "Receipt delivery queued. Custody is already recorded."
     else:
-        status_text = "No action needed."
+        status_text = "Custody is already recorded."
 
     recorded_at = _receipt_display_timestamp(ack_timestamp or receipt.get("commit_at"))
     summary_rows = [

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -222,16 +222,16 @@
     {% set context_parts = context_parts + ["Recorded by " ~ operator.username] %}
   {% endif %}
   {% if receipt.delivery.state == "failed" %}
-    {% set receipt_status_text = "Email failed — resend recommended" %}
+    {% set receipt_status_text = "Receipt delivery failed — custody already recorded" %}
     {% set receipt_status_tone = "action" %}
   {% elif receipt.delivery.state == "pending" %}
-    {% set receipt_status_text = "Email queued — no action needed unless delivery stalls" %}
+    {% set receipt_status_text = "Receipt delivery queued — custody already recorded" %}
     {% set receipt_status_tone = "calm" %}
   {% elif receipt.delivery.state == "sent" %}
-    {% set receipt_status_text = "No action needed" %}
+    {% set receipt_status_text = "Receipt delivered — custody already recorded" %}
     {% set receipt_status_tone = "calm" %}
   {% else %}
-    {% set receipt_status_text = "No action needed" %}
+    {% set receipt_status_text = "Custody already recorded" %}
     {% set receipt_status_tone = "calm" %}
   {% endif %}
   <nav class="actions nav-row mixed-nav-row" aria-label="Receipt navigation">
@@ -272,6 +272,7 @@
             · {{ email_timing_label }} {{ email_timing_value }}
           {% endif %}
         </p>
+        <p class="receipt-context-line">Holder follow-up emails are manual reminders only. They do not record or change custody.</p>
         {% if send_blocked_by_recovery %}
           <p class="receipt-context-line">Receipt resend and retry actions are paused until an admin acknowledges recovery mode.</p>
         {% endif %}

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -101,7 +101,7 @@
       <a class="report-stat report-stat-link" href="{{ url_for('dashboard_holders', return_to=report_return_to) }}">
         In custody
         <strong>{{ asset_summary.in_custody_assets }}</strong>
-        <span class="nav-link report-stat-action">Open holder follow-up</span>
+        <span class="nav-link report-stat-action">Open manual holder follow-up</span>
       </a>
       <div class="report-stat">
         {% if include_retired_assets %}Retired shown{% else %}Retired hidden{% endif %}

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -598,7 +598,7 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b"Current State" in response.data
     assert b"Active custody and storage first." in response.data
     assert b"Report Scope" not in response.data
-    assert b"Open holder follow-up" in response.data
+    assert b"Open manual holder follow-up" in response.data
     assert b"Review case space" in response.data
     assert b"Search active asset records" in response.data
     assert b"Utilities" in response.data

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -231,7 +231,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"AT-CUST", response.data)
         self.assertIn(b'href="/holders/1"', response.data)
         self.assertIn(b'href="/report">View Current Custody</a>', response.data)
-        self.assertNotIn(b"Open holder follow-up", response.data)
+        self.assertNotIn(b"Open manual holder follow-up", response.data)
         self.assertIn(b'href="/dashboard/cases"', response.data)
         self.assertIn(b'href="/report"', response.data)
         self.assertNotIn(b"Workflow Shortcuts", response.data)

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -699,7 +699,7 @@ def test_issue_receipt_pdf_download_uses_stored_snapshot_data(client_with_temp_d
     pdf_text = _extract_pdf_text(response.data)
     assert "Issue Receipt" in pdf_text
     assert "1 asset issued to Issue Holder" in pdf_text
-    assert "Receipt email queued. No action needed unless delivery stalls." in pdf_text
+    assert "Receipt delivery queued. Custody is already recorded." in pdf_text
     assert "What Happened" in pdf_text
     assert "Action" in pdf_text
     assert "Assets in this receipt" in pdf_text
@@ -1108,7 +1108,7 @@ def test_send_receipt_email_adds_configured_cc_recipient(monkeypatch: pytest.Mon
     assert "Receipt key" not in pdf_text
     assert "Recipient email" not in pdf_text
     assert "Delivery issue" not in pdf_text
-    assert "Receipt email queued. No action needed unless delivery stalls." not in pdf_text
+    assert "Receipt delivery queued. Custody is already recorded." not in pdf_text
 
 
 def test_send_receipt_email_omits_cc_when_config_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Clarifies operator-facing language so receipt delivery is not confused with holder follow-up emails.

## Related Issue

Closes #783 

## Changes

- Updated receipt status wording to make clear custody is already recorded.
- Added receipt detail copy stating holder follow-up emails are manual reminders only.
- Updated report wording from generic follow-up to manual holder follow-up.
- Updated focused tests for the changed copy.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_receipt_detail.py tests/test_admin_system_health.py tests/test_dashboard.py -q`
- [x] Confirmed no custody/event/receipt-queue logic changed
- [x] Confirmed no route/auth/schema/persistence/dependency changes
- [x] Confirmed no send/resend behavior changed
- [x] Confirmed queue → preview → commit seam unchanged

## Notes

Full suite currently reports 14 unrelated failures in issue/add-assets/workflow/session expectations. Those failures do not map to this branch’s changed files and should be tracked separately.