### PR TITLE
Issue 27-109: Repair workflow/session test baseline for issue/return …

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4737,6 +4737,9 @@ def issue_preview():
     session["issue_building"] = issue_location_form["building"]
     session["issue_room"] = issue_location_form["room"]
     asset_tags = _queue_asset_tags()
+    if not asset_tags:
+        flash("Queue is empty. Scan assets before opening Issue Preview.", "error")
+        return redirect(url_for("issue"))
     issue_preview_state = _build_issue_preview_state(asset_tags, selected_holder)
 
     return render_template(

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -127,7 +127,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Stage in queue", response.data)
         self.assertIn(b"Preview Queue", response.data)
         self.assertIn(b'id="review-batch" class="preview-step"', response.data)
-        self.assertIn(b"Back to Return", response.data)
+        self.assertIn(b'href="/return"', response.data)
         self.assertNotIn(b"Open batch preview", response.data)
         self.assertNotIn(b"What this does:", response.data)
         self.assertNotIn(b"How to use:", response.data)

--- a/tests/test_issue_22_2_timeout_ui_lock.py
+++ b/tests/test_issue_22_2_timeout_ui_lock.py
@@ -97,7 +97,7 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     assert issue_queue.status_code == 200
     assert b'id="timeout-lock-panel"' in issue_queue.data
     assert b"20 minutes idle / 1 hour absolute" in issue_queue.data
-    assert b"Preview Queue" in issue_queue.data
+    assert b"Review Before Issue" in issue_queue.data
     assert issue_queue.data.count(b"data-timeout-lock-target") >= 4
 
     issue_preview = client_with_temp_db.get("/issue/preview")
@@ -110,7 +110,7 @@ def test_issue_and_return_flows_render_timeout_lock_targets(client_with_temp_db)
     return_queue = client_with_temp_db.get("/return")
     assert return_queue.status_code == 200
     assert b'id="timeout-lock-panel"' in return_queue.data
-    assert b"Preview Queue" in return_queue.data
+    assert b"Review Before Return" in return_queue.data
 
     return_preview = client_with_temp_db.get("/return/preview")
     assert return_preview.status_code == 200

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -142,7 +142,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert occupancy is None
 
 
-def test_issue_preview_empty_queue_shows_next_step_guidance(client_with_temp_db) -> None:
+def test_issue_preview_empty_queue_redirects_to_issue_entry(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-preview-empty", password="op-pass", role="operator")
     login_session(client_with_temp_db, operator_id)
 
@@ -154,8 +154,8 @@ def test_issue_preview_empty_queue_shows_next_step_guidance(client_with_temp_db)
 
     issue_preview = client_with_temp_db.get("/issue/preview")
 
-    assert issue_preview.status_code == 200
-    assert b"No assets queued." in issue_preview.data
+    assert issue_preview.status_code == 302
+    assert (issue_preview.headers.get("Location") or "").endswith("/issue")
 
 
 def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(client_with_temp_db) -> None:

--- a/tests/test_issue_clear_queue.py
+++ b/tests/test_issue_clear_queue.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import assettrack.auth as auth
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from assettrack.intake.scan import Scan
@@ -43,6 +44,9 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -56,7 +60,7 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-actions")
     assert len(intake_app.SCAN_QUEUE) == 0
 
     with client_with_temp_db.session_transaction() as sess:
@@ -64,9 +68,9 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
 
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
-    assert b"Issued to:</strong>" in issue_page.data
     assert b"Issue Holder" in issue_page.data
-    assert b"Queued assets:</strong> 0" in issue_page.data
+    assert b"Issue Holder" in issue_page.data
+    assert b"0 assets queued" in issue_page.data
 
     rescan = client_with_temp_db.post(
         "/",
@@ -76,7 +80,7 @@ def test_operator_clear_queue_from_issue_returns_to_issue(client_with_temp_db) -
 
     assert rescan.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["RESCANAFTERCLEAR"]
-    assert b"Issued to:</strong>" in rescan.data
+    assert b"Issue Holder" in rescan.data
     assert b"Issue Holder" in rescan.data
     assert b"Queue (1)" in rescan.data
 
@@ -86,6 +90,9 @@ def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicate
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -105,7 +112,7 @@ def test_operator_can_remove_one_queue_item_by_index_without_affecting_duplicate
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-actions")
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DUP-TAG", "KEEP-TAG"]
 
     issue_page = client_with_temp_db.get("/issue")
@@ -118,6 +125,9 @@ def test_operator_can_clear_queue_from_issue_preview_and_return_to_issue(client_
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -137,9 +147,9 @@ def test_operator_can_clear_queue_from_issue_preview_and_return_to_issue(client_
 
     assert response.status_code == 200
     assert len(intake_app.SCAN_QUEUE) == 0
-    assert b"Issuing Assets" in response.data
+    assert b"<h2>Issue</h2>" in response.data
     assert b"Queue (0)" in response.data
-    assert b"Queued assets:</strong> 0" in response.data
+    assert b"0 assets queued" in response.data
 
 
 def test_issue_preview_discard_preserves_selected_holder_and_allows_rescan(client_with_temp_db) -> None:
@@ -157,6 +167,9 @@ def test_issue_preview_discard_preserves_selected_holder_and_allows_rescan(clien
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -172,11 +185,11 @@ def test_issue_preview_discard_preserves_selected_holder_and_allows_rescan(clien
 
     assert response.status_code == 200
     assert len(intake_app.SCAN_QUEUE) == 0
-    assert b"Issuing Assets" in response.data
-    assert b"Issued to:</strong>" in response.data
+    assert b"<h2>Issue</h2>" in response.data
+    assert b"Issue Holder" in response.data
     assert b"Issue Holder" in response.data
     assert b"Queue (0)" in response.data
-    assert b"Queued assets:</strong> 0" in response.data
+    assert b"0 assets queued" in response.data
 
     with client_with_temp_db.session_transaction() as sess:
         assert sess.get("holder_id") == 1
@@ -190,7 +203,7 @@ def test_issue_preview_discard_preserves_selected_holder_and_allows_rescan(clien
     assert rescan.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["TAGRESCAN"]
     assert b"Queue (1)" in rescan.data
-    assert b"Issued to:</strong>" in rescan.data
+    assert b"Issue Holder" in rescan.data
     assert b"Issue Holder" in rescan.data
 
 
@@ -229,6 +242,9 @@ def test_issue_preview_discard_preserves_holder_through_rescan_preview_and_commi
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -269,7 +285,7 @@ def test_issue_preview_discard_preserves_holder_through_rescan_preview_and_commi
     )
 
     assert commit.status_code == 200
-    assert b"Issued 1 assets." in commit.data
+    assert b"Issue Receipt" in commit.data
     assert b"Issue Holder" in commit.data
     assert len(intake_app.SCAN_QUEUE) == 0
 
@@ -298,6 +314,9 @@ def test_non_issue_preview_discard_still_clears_holder_selection(client_with_tem
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -338,6 +357,9 @@ def test_issue_scan_normalizes_asset_tag_to_uppercase_and_blocks_case_variant_du
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -57,7 +57,7 @@ def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     issue_page = client_with_temp_db.get("/issue")
     assert issue_page.status_code == 200
     assert b"Issue" in issue_page.data
-    assert b"Preview Queue" in issue_page.data
+    assert b"Review Before Issue" in issue_page.data
 
 
 def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_holder(client_with_temp_db) -> None:
@@ -129,6 +129,21 @@ def test_issue_preview_without_issue_mode_redirects_to_issue_entry(client_with_t
     with client_with_temp_db.session_transaction() as sess:
         sess["holder_id"] = 1
         sess["issue_mode"] = False
+
+    response = client_with_temp_db.get("/issue/preview")
+
+    assert response.status_code == 302
+    assert (response.headers.get("Location") or "").endswith("/issue")
+
+
+def test_issue_preview_with_empty_queue_redirects_to_issue_entry(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-empty-issue-preview", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    with client_with_temp_db.session_transaction() as sess:
+        sess["holder_id"] = 1
+        sess["issue_mode"] = True
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
 
     response = client_with_temp_db.get("/issue/preview")
 

--- a/tests/test_issue_slot_occupancy_consistency.py
+++ b/tests/test_issue_slot_occupancy_consistency.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+import assettrack.auth as auth
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from assettrack.intake.scan import Scan
@@ -57,6 +58,9 @@ def test_issue_preview_and_commit_use_slot_occupancy_when_slot_marker_is_null(cl
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"
@@ -101,6 +105,9 @@ def test_issue_commit_redirect_shows_success_without_holder_warning(client_with_
 
     with client_with_temp_db.session_transaction() as sess:
         sess["user_id"] = operator_id
+        current_time = auth.now_seconds()
+        sess["last_seen"] = current_time
+        sess["session_started_at"] = current_time
         sess["holder_id"] = 1
         sess["issue_mode"] = True
         sess["issue_building"] = "HQ North"

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -98,7 +98,7 @@ def test_scan_submission_refreshes_last_seen(client_with_temp_db, monkeypatch: p
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-actions")
     assert len(intake_app.SCAN_QUEUE) == 1
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 220
@@ -116,7 +116,7 @@ def test_queue_action_refreshes_last_seen(client_with_temp_db, monkeypatch: pyte
     )
 
     assert response.status_code == 302
-    assert (response.headers.get("Location") or "").endswith("/issue")
+    assert (response.headers.get("Location") or "").endswith("/issue#queue-actions")
     assert len(intake_app.SCAN_QUEUE) == 0
     with client_with_temp_db.session_transaction() as sess:
         assert sess["last_seen"] == 230


### PR DESCRIPTION
## Summary

Repairs the workflow/session test baseline and tightens the Issue preview seam so empty Issue Preview no longer renders.

## Related Issue

Closes #785 

## Changes

- Updated stale Add Assets, Issue, Return, and session redirect test expectations.
- Added required auth timing session setup to affected issue-flow tests.
- Updated tests to match current queue CTA and anchored redirect behavior.
- Added an empty Issue Preview guard that redirects back to `/issue`.
- Preserved populated Issue Preview behavior.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual smoke: `/issue` loads with holder/current location context
- [x] Manual smoke: add scan updates queue and returns near queue action area
- [x] Manual smoke: clear queue works with no 403
- [x] Manual smoke: empty Issue Preview redirects back to `/issue`
- [x] Manual smoke: populated Issue Preview opens normally
- [x] Manual smoke: `/return` loads Review Before Return normally
- [x] Confirmed no custody/event/receipt/email/schema/persistence changes
- [x] Confirmed queue → preview → commit seam is preserved and tightened

## Notes

Issue Preview density was identified during smoke testing and tracked separately as Issue 27-110.