### PR TITLE
Issue 27-110: Simplify Issue Preview asset detail density

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -26,6 +26,52 @@
       color: var(--color-text-muted);
       font-size: 0.94rem;
     }
+    .asset-review-list {
+      display: grid;
+      gap: 0.85rem;
+    }
+    .asset-review-card {
+      border: 1px solid var(--color-surface);
+      border-radius: 12px;
+      padding: 0.8rem 0.9rem;
+      background: var(--color-surface-bg);
+    }
+    .asset-review-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.7rem;
+      flex-wrap: wrap;
+    }
+    .asset-review-tag {
+      margin: 0;
+      font-size: 1.02rem;
+      font-weight: 700;
+    }
+    .asset-review-core {
+      margin: 0.6rem 0 0 0;
+      display: grid;
+      gap: 0.45rem;
+    }
+    .asset-review-core p {
+      margin: 0;
+      line-height: 1.45;
+    }
+    .asset-review-core code {
+      white-space: nowrap;
+    }
+    .asset-technical {
+      margin-top: 0.7rem;
+      color: var(--color-text-muted);
+    }
+    .asset-technical summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .asset-technical .state-block {
+      margin-top: 0.45rem;
+      line-height: 1.45;
+    }
   </style>
 {% endblock %}
 
@@ -114,61 +160,49 @@
     <h2>Assets</h2>
 
     {% if assets %}
-      <table class="workflow-table">
-        <thead>
-          <tr>
-            <th>Asset</th>
-            <th>Current State</th>
-            <th>After Issue</th>
-            <th>Status</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in assets %}
-            {% set before_holder_display = "Not assigned" if row.before_holder == "null" else row.before_holder %}
-            {% set before_current_location_display = "Not assigned" if row.before_current_location == "null" else row.before_current_location %}
-            {% set after_current_location_display = "Not assigned" if row.after_current_location == "null" else row.after_current_location %}
-            {% set before_home_location_display = "Not assigned" if row.before_home_location == "null" else row.before_home_location %}
-            {% set after_home_location_display = "Not assigned" if row.after_home_location == "null" else row.after_home_location %}
-            <tr>
-              <td><code>{{ row.asset_tag }}</code></td>
+      <div class="asset-review-list">
+        {% for row in assets %}
+          {% set before_holder_display = "Not assigned" if row.before_holder == "null" else row.before_holder %}
+          {% set before_current_location_display = "Not assigned" if row.before_current_location == "null" else row.before_current_location %}
+          {% set after_current_location_display = "Not assigned" if row.after_current_location == "null" else row.after_current_location %}
+          {% set before_home_location_display = "Not assigned" if row.before_home_location == "null" else row.before_home_location %}
+          {% set after_home_location_display = "Not assigned" if row.after_home_location == "null" else row.after_home_location %}
+          <article class="asset-review-card">
+            <div class="asset-review-head">
+              <p class="asset-review-tag"><code>{{ row.asset_tag }}</code></p>
+              {% if row.asset_issues %}
+                <span class="pill bad">blocked</span>
+              {% else %}
+                <span class="pill good">ready</span>
+              {% endif %}
+            </div>
 
-              <td>
-                <div class="state-block">
-                  <strong>Location:</strong> <code>{{ row.before_location_type }}</code><br />
-                  <strong>Current location:</strong> <code>{{ before_current_location_display }}</code><br />
-                  <strong>Issued to:</strong> <code>{{ before_holder_display }}</code><br />
-                  <strong>Home location:</strong> <code>{{ before_home_location_display }}</code><br />
-                  <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code>
-                </div>
-              </td>
+            <div class="asset-review-core">
+              <p><strong>Issue to:</strong> <code>{{ row.after_holder }}</code></p>
+              <p><strong>Current location:</strong> <code>{{ before_current_location_display }}</code></p>
+              <p><strong>Issue result:</strong> <code>{{ row.after_location_type }}</code> at <code>{{ after_current_location_display }}</code></p>
+            </div>
 
-              <td>
-                <div class="state-block">
-                  <strong>Location:</strong> <code>{{ row.after_location_type }}</code><br />
-                  <strong>Current location:</strong> <code>{{ after_current_location_display }}</code><br />
-                  <strong>Issued to:</strong> <code>{{ row.after_holder }}</code><br />
-                  <strong>Home location:</strong> <code>{{ after_home_location_display }}</code><br />
-                  <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code> → <code>{{ row.after_slot_occupancy }}</code>
-                </div>
-              </td>
+            {% if row.asset_issues %}
+              <ul>
+                {% for issue in row.asset_issues %}
+                  <li>{{ issue }}</li>
+                {% endfor %}
+              </ul>
+            {% endif %}
 
-              <td>
-                {% if row.asset_issues %}
-                  <span class="pill bad">blocked</span>
-                  <ul><template>
-                    {% for issue in row.asset_issues %}
-                      <li>{{ issue }}</li>
-                    {% endfor %}
-                  </template></ul>
-                {% else %}
-                  <span class="pill good">ready</span>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+            <details class="asset-technical">
+              <summary>Technical details</summary>
+              <div class="state-block">
+                <strong>Before location:</strong> <code>{{ row.before_location_type }}</code><br />
+                <strong>Before holder:</strong> <code>{{ before_holder_display }}</code><br />
+                <strong>Home location:</strong> <code>{{ before_home_location_display }}</code> → <code>{{ after_home_location_display }}</code><br />
+                <strong>Occupancy:</strong> <code>{{ row.before_slot_occupancy }}</code> → <code>{{ row.after_slot_occupancy }}</code>
+              </div>
+            </details>
+          </article>
+        {% endfor %}
+      </div>
     {% else %}
       <p>No assets queued.</p>
     {% endif %}

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -87,11 +87,12 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert issue_preview.status_code == 200
     assert b"Issue Preview" in issue_preview.data
     assert b"Ready to Issue" in issue_preview.data
-    assert b"Issued to:</strong>" in issue_preview.data
+    assert b"Issue to:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data
     assert b"1 asset queued" in issue_preview.data
-    assert b"Current location:</strong> <code>HQ North / 210</code>" in issue_preview.data
-    assert b"Issued to:</strong> <code>Not assigned</code>" in issue_preview.data
+    assert b"Current location:</strong> HQ North / 210" in issue_preview.data
+    assert b"Issue result:</strong> <code>IN_CUSTODY</code> at <code>HQ North / 210</code>" in issue_preview.data
+    assert b"Technical details" in issue_preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in issue_preview.data
     assert b"I reviewed this batch and want to issue these assets to the selected holder." in issue_preview.data
     assert b'name="confirm_responsibility_ack"' in issue_preview.data

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -190,7 +190,6 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     preview = client_with_temp_db.get("/issue/preview")
     assert preview.status_code == 200
     assert b"Current location:</strong> HQ North / 210" in preview.data
-    assert b"Current location:</strong> <code>HQ North / 210</code>" in preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in preview.data
     assert b"Home location:</strong> <code>Not assigned</code>" not in preview.data
 


### PR DESCRIPTION
## Summary

Simplifies the Issue Preview asset detail section so operators can review the asset, holder, location, and issue result faster.

## Related Issue

Closes #786 

## Changes

- Replaced the dense Issue Preview state table with compact per-asset review cards.
- Kept asset tag, target holder, current location, issue result, and ready/blocked status visible.
- Moved lower-priority technical details into a collapsed section.
- Left Return Preview untouched.
- Updated focused tests for the new Issue Preview presentation.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_issue_23_2_preview_commit_seam.py tests/test_issue_slot_occupancy_consistency.py tests/test_issue_clear_queue.py -q`
- [x] `python3 -m pytest -q`
- [x] Manual smoke: `/issue` loads normally
- [x] Manual smoke: queued asset opens Issue Preview
- [x] Manual smoke: asset tag, holder, current location, issue result, and ready/blocked status are visible
- [x] Manual smoke: technical details are collapsed/de-emphasized
- [x] Confirmed Return Preview was not changed
- [x] Confirmed empty Issue Preview remains blocked
- [x] Confirmed no custody/event/receipt/email/schema/persistence/auth changes

## Notes

Presentation-only cleanup. Queue → preview → commit seam remains intact.