### PR TITLE
Issue 27-107: Add manual holder follow-up email action

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -581,6 +581,48 @@ def _send_demo_receipt_email(recipient_email: str) -> str:
     return recipient_email
 
 
+def _send_holder_followup_email(*, holder: dict, note: str, actor_username: str) -> str:
+    recipient_email = str(holder.get("email") or "").strip().lower()
+    if not recipient_email:
+        raise ValueError("Holder follow-up email requires a holder email address.")
+
+    smtp_host = str(os.getenv("ASSETTRACK_SMTP_HOST") or "").strip()
+    if not smtp_host:
+        raise ValueError("Follow-up email delivery is not configured.")
+
+    holder_name = _holder_display_name(holder) or "Holder"
+    organization = str(holder.get("organization") or "").strip()
+    identifier = str(holder.get("identifier") or "").strip()
+
+    subject = f"AssetTrack Holder Follow-Up: {holder_name}"
+    lines = [
+        f"Holder follow-up for: {holder_name}",
+    ]
+    if organization:
+        lines.append(f"Organization: {organization}")
+    if identifier:
+        lines.append(f"Identifier: {identifier}")
+    lines.extend(
+        [
+            "",
+            "This is a manual follow-up reminder from an operator.",
+            "It does not record, prove, or change custody.",
+        ]
+    )
+    if note:
+        lines.extend(["", "Operator note:", note])
+    lines.extend(["", f"Sent by: {actor_username}"])
+
+    from_address = str(os.getenv("ASSETTRACK_RECEIPT_FROM_EMAIL") or "assettrack@local").strip() or "assettrack@local"
+    message = EmailMessage()
+    message["Subject"] = subject
+    message["From"] = from_address
+    message["To"] = recipient_email
+    message.set_content("\n".join(lines))
+    _send_email_message(message)
+    return recipient_email
+
+
 def _queue_contains_asset_tag(asset_tag: str) -> bool:
     normalized = sanitize_scan(asset_tag or "")
     if not normalized:
@@ -5096,6 +5138,48 @@ def holder_detail(holder_id: int):
         asset_count=len(assigned_assets),
         return_to=return_to,
     )
+
+
+@app.post("/holders/<int:holder_id>/follow-up-email")
+@require_login
+def holder_followup_email_send(holder_id: int):
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    user = current_user()
+    if user is None:
+        return {"ok": False, "error": "Forbidden"}, 403
+    role = str(user.get("role") or "").strip().lower()
+    if role not in {"admin", "operator"}:
+        return {"ok": False, "error": "Forbidden"}, 403
+
+    holder = get_holder(holder_id)
+    if holder is None:
+        abort(404)
+
+    return_to = _safe_local_return_to(request.form.get("return_to") or "") or ""
+    note = (request.form.get("followup_note") or "").strip()
+    if len(note) > 2000:
+        flash("Follow-up note must be 2000 characters or fewer.", "error")
+        return redirect(url_for("holder_detail", holder_id=holder_id, return_to=return_to))
+
+    try:
+        sent_to = _send_holder_followup_email(
+            holder=holder,
+            note=note,
+            actor_username=str(user.get("username") or "unknown"),
+        )
+    except ValueError as exc:
+        flash(str(exc), "error")
+        return redirect(url_for("holder_detail", holder_id=holder_id, return_to=return_to))
+    except Exception as exc:
+        flash(f"Holder follow-up email failed: {exc}", "error")
+        return redirect(url_for("holder_detail", holder_id=holder_id, return_to=return_to))
+
+    flash(f"Holder follow-up email sent to {sent_to}.", "success")
+    return redirect(url_for("holder_detail", holder_id=holder_id, return_to=return_to))
 
 
 @app.get("/receipts/<int:receipt_id>")

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -121,6 +121,24 @@
       background: #fde9e7;
       color: #8a2d2d;
     }
+    .holder-followup-form {
+      margin-top: 0.85rem;
+      padding: 0.85rem 1rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 10px;
+      background: var(--color-surface-bg);
+    }
+    .holder-followup-form p {
+      margin: 0 0 0.55rem;
+    }
+    .holder-followup-form textarea {
+      width: 100%;
+      max-width: 640px;
+      min-height: 88px;
+      box-sizing: border-box;
+      padding: 0.6rem;
+      font-size: 0.95rem;
+    }
   </style>
 {% endblock %}
 
@@ -214,6 +232,23 @@
       </div>
     </div>
   </section>
+
+  {% if holder.email %}
+    <section class="card holder-details-card">
+      <h2>Send this Holder a Follow-Up Email</h2>
+      <form method="post" action="{{ url_for('holder_followup_email_send', holder_id=holder.id) }}" class="holder-followup-form">
+        {% if return_to and return_to != url_for('human_report') %}
+          <input type="hidden" name="return_to" value="{{ return_to }}" />
+        {% endif %}
+        <p class="muted">Follow-up emails are manual reminders. They do not record or change custody.</p>
+        <label for="followup_note"><strong>Operator note</strong> (optional)</label><br />
+        <textarea id="followup_note" name="followup_note" maxlength="2000" placeholder="Add optional reminder details for this holder."></textarea>
+        <div class="workflow-action-row" style="margin-top: 0.65rem;">
+          <button type="submit">Send Follow-Up Email</button>
+        </div>
+      </form>
+    </section>
+  {% endif %}
 
   <section class="card holder-assets-card">
     <h2>Assets In Custody ({{ asset_count }})</h2>

--- a/tests/test_holder_followup_email.py
+++ b/tests/test_holder_followup_email.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from email.message import EmailMessage
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO holders (id, holder_type, name, organization, identifier, email, contact_info, created_at, updated_at)
+        VALUES (1, 'PERSON', 'Followup Holder', 'Ops', 'FH-1', 'holder.followup@example.org', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _counts() -> tuple[int, int]:
+    conn = db.get_connection()
+    try:
+        events = conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()
+        receipts = conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+    finally:
+        conn.close()
+    return int(events["c"]), int(receipts["c"])
+
+
+def test_holder_detail_shows_manual_followup_action_and_language(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-followup-ui", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.get("/holders/1")
+
+    assert response.status_code == 200
+    assert b"Send this Holder a Follow-Up Email" in response.data
+    assert b"Follow-up emails are manual reminders. They do not record or change custody." in response.data
+    assert b'action="/holders/1/follow-up-email"' in response.data
+    assert b"Send Follow-Up Email" in response.data
+    assert b"Send Receipt Email" not in response.data
+
+
+@pytest.mark.parametrize("role", ["operator", "admin"])
+def test_followup_send_allowed_for_operator_and_admin_and_does_not_mutate_custody_or_receipts(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+    role: str,
+) -> None:
+    user_id = create_test_user(username=f"{role}-followup-send", password="pass", role=role)
+    login_session(client_with_temp_db, user_id)
+
+    sent_messages: list[EmailMessage] = []
+
+    def _fake_send(message: EmailMessage) -> None:
+        sent_messages.append(message)
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.setattr(intake_app, "_send_email_message", _fake_send)
+
+    before_events, before_receipts = _counts()
+
+    response = client_with_temp_db.post(
+        "/holders/1/follow-up-email",
+        data={"followup_note": "Please confirm return timeline.", "return_to": "/holders"},
+        follow_redirects=True,
+    )
+
+    after_events, after_receipts = _counts()
+
+    assert response.status_code == 200
+    assert b"Holder follow-up email sent to holder.followup@example.org." in response.data
+    assert b"receipt sent" not in response.data.lower()
+    assert before_events == after_events
+    assert before_receipts == after_receipts
+    assert len(sent_messages) == 1
+    message = sent_messages[0]
+    assert "Holder Follow-Up" in str(message["Subject"] or "")
+    assert str(message["To"] or "") == "holder.followup@example.org"
+    body = message.get_content()
+    assert "manual follow-up reminder" in body
+    assert "does not record, prove, or change custody" in body
+    assert "Please confirm return timeline." in body
+
+
+def test_followup_send_requires_login(client_with_temp_db) -> None:
+    response = client_with_temp_db.post(
+        "/holders/1/follow-up-email",
+        data={"followup_note": "test"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 403
+
+
+def test_followup_send_fails_safely_when_email_not_configured_and_does_not_mutate_custody_or_receipts(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator_id = create_test_user(username="operator-followup-fail", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    monkeypatch.delenv("ASSETTRACK_SMTP_HOST", raising=False)
+
+    before_events, before_receipts = _counts()
+
+    response = client_with_temp_db.post(
+        "/holders/1/follow-up-email",
+        data={"followup_note": "Need acknowledgment.", "return_to": "/holders"},
+        follow_redirects=True,
+    )
+
+    after_events, after_receipts = _counts()
+
+    assert response.status_code == 200
+    assert b"Follow-up email delivery is not configured." in response.data
+    assert before_events == after_events
+    assert before_receipts == after_receipts


### PR DESCRIPTION
## Summary

Adds a manual Holder Follow-Up Email action on holder detail pages.

## Related Issue

Closes #782 

## Changes

- Added a manual follow-up email action on Holder Detail.
- Placed the action near the top of the holder page before long asset lists.
- Added clear boundary language that follow-up emails are manual reminders and do not record or change custody.
- Sends follow-up emails through the existing SMTP path when configured.
- Fails safely with operator-visible messages when holder email or SMTP config is missing.
- Added focused tests for permissions, safe failure, email behavior, and custody/receipt invariants.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual smoke: holder detail page shows Manual Holder Follow-Up Email near the top
- [x] Manual smoke: action is clearly separated from receipt language
- [x] Manual smoke: safe success/failure path works
- [x] Confirmed no custody state changes
- [x] Confirmed no `asset_events` writes added
- [x] Confirmed no `receipt_queue` mutations added
- [x] Confirmed no queue/preview/commit changes
- [x] Confirmed no schema/persistence/dependency changes

## Notes

Follow-up email remains manual operator coordination only. Receipts remain the custody proof.