### PR TITLE
Issue 27-111: Clarify holder vs location operator guidance

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -110,6 +110,7 @@
           <span>ID {{ selected_holder["identifier"] }}</span>
         {% endif %}
       </div>
+      <p class="holder-subtle">Holder is the custody actor. Location and case/slot are context only.</p>
       <div class="workflow-action-row workflow-action-row--quiet">
         <a class="nav-link action-quiet" href="{{ url_for('holders_search') }}">Change holder</a>
       </div>

--- a/docs/operator/workflow-model.md
+++ b/docs/operator/workflow-model.md
@@ -4,6 +4,19 @@ AssetTrack uses one operator workflow seam:
 
 `entry -> prerequisite selection -> scan queue -> preview -> commit`
 
+## Custody Model Terms
+
+- holder = custody actor
+- location = transaction context (where issue/return happened, or where an asset is currently recorded)
+- case/slot = storage logistics
+
+Operator guidance:
+
+- a holder can receive or return assets across multiple locations
+- holder identity does not change when location changes
+- location by itself does not create or transfer custody
+- custody truth comes from committed event history
+
 ## Primary / Global Destinations
 
 These pages begin or anchor work:


### PR DESCRIPTION
## Summary

Clarifies operator guidance for multi-location holder behavior.

## Related Issue

Closes #790 

## Changes

- Added operator documentation explaining:
  - holder = custody actor
  - location = transaction context
  - case/slot = storage logistics
- Added a small Issue Preview helper line near holder review context.
- Reinforced that location does not create, transfer, or redefine custody.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual check: Issue Preview guidance appears near holder context
- [x] Manual check: wording does not imply location is a custody actor
- [x] Manual check: workflow model doc clearly separates holder/location/case-slot
- [x] Confirmed no custody/event/schema/persistence/auth/workflow behavior changes

## Notes

Change Holder access on `/issue` was identified during manual review and tracked separately as Issue 27-113.