### PR TITLE
Issue 27-112: Restore operator access path to holders

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -49,6 +49,7 @@
               <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
               <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
               <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
+              <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
               <a class="chip {% if request.path.startswith('/report') or request.path.startswith('/receipts') or request.path.startswith('/assets/search') or request.path.startswith('/dashboard/holders') or request.path.startswith('/dashboard/cases') %}active{% endif %}" href="{{ url_for('human_report') }}">Reports</a>
               {% if authenticated_role == 'admin' %}
                 {% set admin_menu_active = request.path.startswith('/admin') or request.path.startswith('/add-assets') %}

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -590,6 +590,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Preview</a>" not in dashboard_response.data
     assert b">Issue</a>" in dashboard_response.data
     assert b">Return</a>" in dashboard_response.data
+    assert b">Holders</a>" in dashboard_response.data
     assert b">Receipts</a>" not in dashboard_response.data
     assert b">Add Assets</a>" not in dashboard_response.data
     assert b">Users</a>" not in dashboard_response.data
@@ -606,6 +607,7 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
     dashboard_response = client_with_temp_db.get("/dashboard")
 
     assert dashboard_response.status_code == 200
+    assert b">Holders</a>" in dashboard_response.data
     assert b">Receipts</a>" not in dashboard_response.data
     assert b">Add Assets</a>" in dashboard_response.data
     assert b">Users</a>" in dashboard_response.data


### PR DESCRIPTION
## Summary

Restores a clear navigation path to holder records.

## Related Issue

Closes #791 

## Changes

- Added a Holders link to the primary navigation.
- Reused the existing `/holders` route and nav styling.
- Updated auth/nav tests for the restored holder access path.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual smoke: Holders appears in primary nav
- [x] Manual smoke: `/holders` opens
- [x] Manual smoke: holder detail opens
- [x] Manual smoke: Manual Holder Follow-Up Email appears near the top of holder detail
- [x] Manual smoke: Issue page still loads
- [x] Manual smoke: Return page still loads
- [x] Confirmed no custody/event/schema/persistence/auth/workflow behavior changes

## Notes

A Change Holder action beside the Issue holder block was requested during smoke testing and is tracked separately as Issue 27-113.