### PR TITLE
Issue 27-113: Add Change Holder action to Issue header

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4707,6 +4707,7 @@ def issue():
         workflow_banner_title="Issue",
         workflow_banner_queued_count=len(asset_tags),
         workflow_banner_outcome=workflow_banner_outcome,
+        workflow_banner_change_holder_href=url_for("holders_search", return_to=url_for("issue")),
         return_to=url_for("issue"),
         preview_url=url_for("issue_preview"),
         preview_label="Review Before Issue",

--- a/assettrack/intake/static/css/base.css
+++ b/assettrack/intake/static/css/base.css
@@ -79,6 +79,35 @@
   line-height: 1.55;
 }
 
+.workflow-banner-main {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem 1rem;
+}
+
+.workflow-banner-main .workflow-summary {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.workflow-banner-action {
+  flex: 0 0 auto;
+}
+
+.workflow-banner-action-mobile {
+  display: none;
+}
+
+@media (max-width: 760px) {
+  .workflow-banner-main .workflow-banner-action {
+    display: none;
+  }
+  .workflow-banner-action-mobile {
+    display: flex;
+  }
+}
+
 .workflow-table td strong {
   color: var(--color-primary);
 }

--- a/assettrack/intake/templates/_workflow_context_banner.html
+++ b/assettrack/intake/templates/_workflow_context_banner.html
@@ -1,26 +1,38 @@
 <!-- file: assettrack/intake/templates/_workflow_context_banner.html -->
 <div class="card workflow-banner">
   <h2>{{ workflow_banner_title }}</h2>
-  <p class="workflow-summary" style="margin: 0;">
-    {% if selected_holder %}
-      <strong>{{ holder_display_name(selected_holder) }}</strong>
-      {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
-        ({{ selected_holder["organization"] }})
+  <div class="workflow-banner-main">
+    <p class="workflow-summary" style="margin: 0;">
+      {% if selected_holder %}
+        <strong>{{ holder_display_name(selected_holder) }}</strong>
+        {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+          ({{ selected_holder["organization"] }})
+        {% endif %}
+        {% if workflow_banner_destination or workflow_banner_outcome or workflow_banner_queued_count is not none %}
+          &nbsp;|&nbsp;
+        {% endif %}
       {% endif %}
-      {% if workflow_banner_destination or workflow_banner_outcome or workflow_banner_queued_count is not none %}
-        &nbsp;|&nbsp;
+      {% if workflow_banner_destination %}
+        Home location: {{ workflow_banner_destination }}
+        {% if workflow_banner_outcome or workflow_banner_queued_count is not none %}
+          &nbsp;|&nbsp;
+        {% endif %}
       {% endif %}
-    {% endif %}
-    {% if workflow_banner_destination %}
-      Home location: {{ workflow_banner_destination }}
-      {% if workflow_banner_outcome or workflow_banner_queued_count is not none %}
-        &nbsp;|&nbsp;
+      {% if workflow_banner_outcome %}
+        {{ workflow_banner_outcome }}
+      {% elif workflow_banner_queued_count is not none %}
+        {{ workflow_banner_queued_count }} asset{% if workflow_banner_queued_count != 1 %}s{% endif %} queued
       {% endif %}
+    </p>
+    {% if workflow_banner_change_holder_href %}
+      <div class="workflow-banner-action">
+        <a class="action-secondary" href="{{ workflow_banner_change_holder_href }}">Change Holder</a>
+      </div>
     {% endif %}
-    {% if workflow_banner_outcome %}
-      {{ workflow_banner_outcome }}
-    {% elif workflow_banner_queued_count is not none %}
-      {{ workflow_banner_queued_count }} asset{% if workflow_banner_queued_count != 1 %}s{% endif %} queued
-    {% endif %}
-  </p>
+  </div>
+  {% if workflow_banner_change_holder_href %}
+    <div class="workflow-action-row workflow-action-row--quiet workflow-banner-action-mobile">
+      <a class="action-secondary" href="{{ workflow_banner_change_holder_href }}">Change Holder</a>
+    </div>
+  {% endif %}
 </div>

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -176,6 +176,8 @@ def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> Non
     assert b"Issue" in response.data
     assert b"Issue Holder" in response.data
     assert b"Issue Org" in response.data
+    assert b"Change Holder" in response.data
+    assert b'href="/holders?return_to=/issue"' in response.data
     assert b"0 assets queued" in response.data
 
 


### PR DESCRIPTION
## Summary

Adds a clearer Change Holder action beside the selected holder on the Issue screen.

## Related Issue

Closes #792 

## Changes

- Added Change Holder to the Issue workflow banner near the selected holder.
- Right-aligned the action in the same holder context row.
- Preserved the existing holder selection flow with `return_to=/issue`.
- Scoped banner rendering so Return is unaffected.
- Added focused test coverage for the Issue holder action.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_issue_holder_prerequisite.py -q`
- [x] `python3 -m pytest -q`
- [x] Manual smoke: `/issue` shows selected holder on the left and Change Holder on the right
- [x] Manual smoke: Change Holder opens holder selection and returns to `/issue`
- [x] Manual smoke: selected holder updates correctly
- [x] Manual smoke: `/return` still loads normally
- [x] Confirmed no custody/event/schema/persistence/auth/receipt/email changes
- [x] Confirmed queue → preview → commit seam unchanged

## Notes

Presentation/navigation cleanup only. The action stays tied to the existing holder selection flow.