### PR TITLE
Issue 27-114: Simplify issue current-location guidance

### DIFF
--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -172,7 +172,7 @@
             {% if issue_location_ready %}
               <code class="issue-location-status-value">{{ issue_location_label }}</code>
             {% else %}
-              <span class="issue-location-status-value">Required before issue scans.</span>
+              <span class="issue-location-status-value">Set where these assets are leaving from before scanning.</span>
             {% endif %}
           </div>
           {% if message_ns.location_messages %}

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -103,7 +103,7 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
 
     assert issue_page.status_code == 200
     assert b"Current Location" in issue_page.data
-    assert b"Required before issue scans." in issue_page.data
+    assert b"Set where these assets are leaving from before scanning." in issue_page.data
     assert b"Add to Queue" in issue_page.data
     assert b"Scan or enter asset tag" in issue_page.data
     assert b"Add to queue" in issue_page.data


### PR DESCRIPTION
## Summary

Simplifies the Issue Current Location prerequisite copy so operators get one clear instruction before scanning.

## Related Issue

Closes #796 

## Changes

- Replaced the longer prerequisite copy with one short instruction.
- Kept Current Location heading, inputs, validation, and workflow behavior unchanged.
- Updated the related location wiring test.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [ ] Manual smoke completed
- [x] No event, custody, queue, preview, commit, receipt, auth, persistence, schema, route, or redirect behavior changed

## Notes

Manual smoke should confirm the `/issue` Current Location card reads clearly and the queue → preview flow still works.