### PR TITLE
Issue 27-115: Update Codex context memory rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,16 +150,28 @@ Operators must understand state and next action in seconds under pressure.
 
 ## 10. Codex Context Rule
 
-Codex must ONLY rely on:
+Codex source-of-truth hierarchy:
 
-- AGENTS.md
-- docs/codex/PROJECT_MEMORY.md
-- docs/codex/CURRENT_STATE.md
+1. direct task instructions
+2. AGENTS.md
+3. docs/codex/PROJECT_MEMORY.md
+4. docs/codex/CURRENT_STATE.md
+5. repo state
+6. Codex memories (recall only, never authority)
 
 Do NOT:
 
 - infer from other repos
 - reuse patterns without confirmation
+
+Codex memories are non-authoritative recall only.
+Use memories to reduce repeated context setup, never to override:
+
+- direct task instructions
+- AGENTS.md
+- docs/codex/PROJECT_MEMORY.md
+- docs/codex/CURRENT_STATE.md
+- current repo state
 
 If unsure:
 → ASK before acting


### PR DESCRIPTION
## Summary

Updates the Codex context rule so the project authority order is explicit.

## Related Issue

Closes #798

## Changes

- Defines the Codex source-of-truth hierarchy in `AGENTS.md`.
- Clarifies Codex memories are recall only, not authority.
- Keeps project files and current repo state above Codex memory.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] Manual review confirmed only `AGENTS.md` is tracked and changed
- [x] No application behavior changed
- [x] No event, schema, persistence, auth, queue, preview, commit, receipt, route, or dependency changes

## Notes

`docs/codex/PROJECT_MEMORY.md` and `docs/codex/CURRENT_STATE.md` remain local-only because `docs/codex/` is excluded by `.git/info/exclude`.