### PR TITLE
Issue 27-116: Simplify add-assets equipment type UI

### DIFF
--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -143,7 +143,8 @@
     {% else %}
       <form id="intake-form" class="row" method="post" action="{{ url_for('intake') }}">
         <div class="row">
-          <label for="equipment_type"><strong>Equipment type</strong></label><br />
+          <label for="equipment_type"><strong>Asset type</strong> (default: Laptop)</label><br />
+          <p class="muted" style="margin: 0.2rem 0 0.45rem 0;">Applies to assets created from this queued batch.</p>
           <select id="equipment_type" name="equipment_type" data-timeout-lock-target>
             {% for option in equipment_type_options %}
               <option value="{{ option.value }}" {% if (equipment_type or 'laptop') == option.value %}selected{% endif %}>


### PR DESCRIPTION
## Summary

Simplifies the Add Assets equipment type wording without changing behavior.

## Related Issue

Closes #800

## Changes

- Renamed the Add Assets equipment type label to `Asset type (default: Laptop)`.
- Added one short helper line explaining that the selected type applies to assets created from the queued batch.
- Preserved selector behavior, options, defaults, validation, and stored values.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual smoke completed
- [x] No schema, route, event, custody, queue, preview, commit, receipt, auth, persistence, import, or dependency behavior changed

## Notes

This is a Class 1 UI presentation change only.

Follow-on need identified during smoke: operators need a safe way to add empty slot capacity or stage unslotted assets into an issue/intake pool before slot assignment. That should be tracked separately because it may affect workflow and data model behavior.