### PR TITLE
Issue 27-118: Add admin empty-slot provisioning and clarify unslotted…

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1625,6 +1625,41 @@ def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict],
     return view, errors
 
 
+def _list_unslotted_storage_assets(conn: sqlite3.Connection) -> list[dict]:
+    asset_columns = get_asset_table_columns(conn)
+    select_fields = [
+        "a.asset_tag AS asset_tag",
+        "a.equipment_type AS equipment_type",
+        "a.created_date AS created_date",
+    ]
+    if "updated_date" in asset_columns:
+        select_fields.append("a.updated_date AS updated_date")
+    else:
+        select_fields.append("NULL AS updated_date")
+
+    rows = conn.execute(
+        f"""
+        SELECT {", ".join(select_fields)}
+        FROM assets a
+        LEFT JOIN slot_occupancy so ON so.asset_id = a.id
+        WHERE UPPER(COALESCE(a.location_type, '')) = 'STORAGE'
+          AND a.home_slot_id IS NULL
+          AND so.asset_id IS NULL
+        ORDER BY COALESCE(NULLIF(a.updated_date, ''), a.created_date, '') DESC, a.asset_tag ASC
+        LIMIT 200;
+        """
+    ).fetchall()
+    return [
+        {
+            "asset_tag": str(row["asset_tag"] or ""),
+            "equipment_type": str(row["equipment_type"] or ""),
+            "created_date": str(row["created_date"] or ""),
+            "updated_date": str(row["updated_date"] or ""),
+        }
+        for row in rows
+    ]
+
+
 def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     asset = _find_asset_for_scan_tag(conn, scan_tag)
     if not asset:
@@ -6459,6 +6494,82 @@ def admin_system():
     )
 
 
+@app.route("/admin/slots/provision", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_slot_provision():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    case_number = ""
+    slot_count = ""
+    if request.method == "POST":
+        case_number = (request.form.get("case_number") or "").strip().upper()
+        slot_count = (request.form.get("slot_count") or "").strip()
+
+        if not case_number:
+            flash("case_number is required.", "error")
+        if not slot_count:
+            flash("slot_count is required.", "error")
+        if not case_number or not slot_count:
+            return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count)
+
+        try:
+            parsed_slot_count = int(slot_count)
+        except ValueError:
+            flash("slot_count must be an integer.", "error")
+            return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count)
+
+        if parsed_slot_count <= 0:
+            flash("slot_count must be greater than 0.", "error")
+            return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count)
+
+        conn = get_connection()
+        try:
+            try:
+                conn.execute("BEGIN;")
+                current_max = conn.execute(
+                    """
+                    SELECT MAX(slot_position) AS max_slot_position
+                    FROM slots
+                    WHERE UPPER(case_name) = UPPER(?);
+                    """,
+                    (case_number,),
+                ).fetchone()
+                start_position = int(current_max["max_slot_position"] or 0) + 1
+                rows = [
+                    (case_number, slot_position, None)
+                    for slot_position in range(start_position, start_position + parsed_slot_count)
+                ]
+                conn.executemany(
+                    """
+                    INSERT INTO slots (case_name, slot_position, current_asset_tag)
+                    VALUES (?, ?, ?);
+                    """,
+                    rows,
+                )
+                conn.commit()
+            except sqlite3.IntegrityError as e:
+                conn.rollback()
+                flash(f"Could not create empty slots: {e}", "error")
+                return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count)
+            except Exception:
+                conn.rollback()
+                raise
+        finally:
+            conn.close()
+
+        end_position = start_position + parsed_slot_count - 1
+        flash(
+            f"Created {parsed_slot_count} empty slots for case {case_number} (slots {start_position}-{end_position}).",
+            "success",
+        )
+        return redirect(url_for("admin_slot_provision"))
+
+    return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count)
+
+
 @app.post("/admin/recovery/acknowledge")
 @require_login
 @require_role("admin")
@@ -8257,17 +8368,19 @@ def admin_assign_slot():
     slot_number = ""
     notes = ""
     asset_view: Optional[dict] = None
+    unslotted_assets: list[dict] = []
 
-    if request.method == "POST":
-        action = (request.form.get("action") or "lookup").strip().lower()
-        asset_tag = (request.form.get("asset_tag") or "").strip()
-        building_room = (request.form.get("building_room") or "").strip()
-        case_number = (request.form.get("case_number") or "").strip().upper()
-        slot_number = (request.form.get("slot_number") or "").strip()
-        notes = (request.form.get("notes") or "").strip()
+    conn = get_connection()
+    try:
+        unslotted_assets = _list_unslotted_storage_assets(conn)
+        if request.method == "POST":
+            action = (request.form.get("action") or "lookup").strip().lower()
+            asset_tag = (request.form.get("asset_tag") or "").strip()
+            building_room = (request.form.get("building_room") or "").strip()
+            case_number = (request.form.get("case_number") or "").strip().upper()
+            slot_number = (request.form.get("slot_number") or "").strip()
+            notes = (request.form.get("notes") or "").strip()
 
-        conn = get_connection()
-        try:
             asset_view, blocking_errors = _build_admin_assign_asset_view(conn, asset_tag)
 
             if action == "lookup":
@@ -8297,6 +8410,7 @@ def admin_assign_slot():
                         slot_number=slot_number,
                         notes=notes,
                         asset=asset_view,
+                        unslotted_assets=unslotted_assets,
                     )
 
                 if blocking_errors:
@@ -8310,6 +8424,7 @@ def admin_assign_slot():
                         slot_number=slot_number,
                         notes=notes,
                         asset=asset_view,
+                        unslotted_assets=unslotted_assets,
                     )
 
                 try:
@@ -8324,6 +8439,7 @@ def admin_assign_slot():
                         slot_number=slot_number,
                         notes=notes,
                         asset=asset_view,
+                        unslotted_assets=unslotted_assets,
                     )
 
                 try:
@@ -8413,18 +8529,19 @@ def admin_assign_slot():
                     asset_columns = get_asset_table_columns(conn)
                     update_clauses: list[str] = []
                     update_values: list[object] = []
-                    if "home_slot_id" in asset_columns:
-                        update_clauses.append("home_slot_id = ?")
-                        update_values.append(slot["id"])
+                    if "home_slot_id" not in asset_columns:
+                        raise ValueError("Assets table missing required column: home_slot_id.")
+                    update_clauses.append("home_slot_id = ?")
+                    update_values.append(slot["id"])
                     if "building_room" in asset_columns:
                         update_clauses.append("building_room = ?")
                         update_values.append(building_room)
                     if "case_number" in asset_columns:
                         update_clauses.append("case_number = ?")
-                        update_values.append(case_number)
+                        update_values.append(str(slot["case_name"]))
                     if "slot_number" in asset_columns:
                         update_clauses.append("slot_number = ?")
-                        update_values.append(str(slot_position))
+                        update_values.append(str(slot["slot_position"]))
                     if "updated_date" in asset_columns:
                         update_clauses.append("updated_date = ?")
                         update_values.append(now_iso)
@@ -8465,11 +8582,54 @@ def admin_assign_slot():
                         ),
                     )
 
+                    canonical_asset = conn.execute(
+                        """
+                        SELECT home_slot_id, case_number, slot_number
+                        FROM assets
+                        WHERE id = ?
+                        LIMIT 1;
+                        """,
+                        (asset_row["id"],),
+                    ).fetchone()
+                    if canonical_asset is None:
+                        raise ValueError("Asset disappeared during assignment.")
+                    if canonical_asset["home_slot_id"] is None or int(canonical_asset["home_slot_id"]) != int(slot["id"]):
+                        raise ValueError("Slot assignment failed to persist home_slot_id.")
+                    occupancy_link = conn.execute(
+                        """
+                        SELECT 1
+                        FROM slot_occupancy
+                        WHERE slot_id = ? AND asset_id = ?
+                        LIMIT 1;
+                        """,
+                        (slot["id"], asset_row["id"]),
+                    ).fetchone()
+                    if occupancy_link is None:
+                        raise ValueError("Slot assignment failed to persist slot_occupancy link.")
+                    event_link = conn.execute(
+                        """
+                        SELECT 1
+                        FROM asset_events
+                        WHERE asset_tag = ?
+                          AND event_type = 'SLOT_ASSIGN'
+                          AND event_date = ?
+                        LIMIT 1;
+                        """,
+                        (str(asset_row["asset_tag"]), now_iso),
+                    ).fetchone()
+                    if event_link is None:
+                        raise ValueError("Slot assignment failed to append SLOT_ASSIGN event.")
+                    if "case_number" in asset_columns and str(canonical_asset["case_number"] or "") != str(slot["case_name"]):
+                        raise ValueError("Slot assignment failed to persist canonical case_number.")
+                    if "slot_number" in asset_columns and str(canonical_asset["slot_number"] or "") != str(slot["slot_position"]):
+                        raise ValueError("Slot assignment failed to persist canonical slot_number.")
+
                     conn.commit()
                 except ValueError as e:
                     conn.rollback()
                     flash(str(e), "error")
                     asset_view, _ = _build_admin_assign_asset_view(conn, asset_tag)
+                    unslotted_assets = _list_unslotted_storage_assets(conn)
                     return render_template(
                         "admin_assign_slot.html",
                         asset_tag=asset_tag,
@@ -8478,6 +8638,7 @@ def admin_assign_slot():
                         slot_number=slot_number,
                         notes=notes,
                         asset=asset_view,
+                        unslotted_assets=unslotted_assets,
                     )
                 except Exception:
                     conn.rollback()
@@ -8490,8 +8651,8 @@ def admin_assign_slot():
                 return redirect(url_for("admin_assign_slot"))
             else:
                 flash("Unknown action.", "error")
-        finally:
-            conn.close()
+    finally:
+        conn.close()
 
     return render_template(
         "admin_assign_slot.html",
@@ -8501,6 +8662,7 @@ def admin_assign_slot():
         slot_number=slot_number,
         notes=notes,
         asset=asset_view,
+        unslotted_assets=unslotted_assets,
     )
 
 

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -19,8 +19,46 @@
   {% endwith %}
 
   <div class="card">
-    <h2>1) Scan or Enter Asset Tag</h2>
-    <p class="card-intro">Scanner-first flow: scan into `asset_tag` and load the asset before assigning a home slot.</p>
+    <h2>1) Unslotted Assets</h2>
+    <p class="card-intro">Select an existing unslotted STORAGE asset to start assignment.</p>
+    {% if unslotted_assets %}
+      <table>
+        <thead>
+          <tr>
+            <th>Asset tag</th>
+            <th>Equipment type</th>
+            <th>Updated</th>
+            <th>Created</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in unslotted_assets %}
+            <tr>
+              <td><code>{{ row.asset_tag }}</code></td>
+              <td>{{ row.equipment_type or "Unknown" }}</td>
+              <td>{{ row.updated_date or "N/A" }}</td>
+              <td>{{ row.created_date or "N/A" }}</td>
+              <td>
+                <form method="post" action="{{ url_for('admin_assign_slot') }}">
+                  <input type="hidden" name="action" value="lookup" />
+                  <input type="hidden" name="asset_tag" value="{{ row.asset_tag }}" />
+                  <button type="submit">Assign</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="muted">No unslotted assets found.</p>
+    {% endif %}
+  </div>
+
+  <div class="card">
+    <h2>2) Scan or enter asset tag</h2>
+    <p class="card-intro">Use this fallback when the asset is not selected from the unslotted list.</p>
+    <p class="muted"><a href="{{ url_for('admin_slot_provision') }}">Create empty slots</a> first if needed.</p>
     <form method="post" action="{{ url_for('admin_assign_slot') }}">
       <input type="hidden" name="action" value="lookup" />
       <div class="row">
@@ -41,7 +79,7 @@
 
   {% if asset %}
     <div class="card">
-      <h2>2) Asset Details</h2>
+      <h2>3) Asset Details</h2>
       <div class="admin-maintenance-grid">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
         <div><strong>manufacturer:</strong> {{ asset.manufacturer or "" }}</div>
@@ -62,7 +100,7 @@
     </div>
 
     <div class="card">
-      <h2>3) Assign Slot</h2>
+      <h2>4) Assign Slot</h2>
       <form method="post" action="{{ url_for('admin_assign_slot') }}">
         <input type="hidden" name="action" value="assign" />
         <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -104,6 +104,7 @@
             {% endfor %}
           </select>
           <p class="muted">Choose both Case and Slot to assign a home location, or leave both blank.</p>
+          <p class="muted">If left unassigned, use <a href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a> later.</p>
         </div>
       </div>
 

--- a/assettrack/intake/templates/admin_slot_provision.html
+++ b/assettrack/intake/templates/admin_slot_provision.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Slot Capacity{% endblock %}
+{% block page_heading %}Admin: Create Empty Slots{% endblock %}
+{% block page_class %} admin-maintenance-standard-fields{% endblock %}
+
+{% block content %}
+  <nav class="workflow-local-nav" aria-label="Admin slot provisioning navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+    <a class="action-secondary" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
+  </nav>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card">
+    <h2>Create empty slots</h2>
+    <p class="card-intro">Adds new empty capacity for a case by appending slot numbers. Existing slots are unchanged.</p>
+    <form method="post" action="{{ url_for('admin_slot_provision') }}">
+      <div class="admin-maintenance-grid">
+        <div class="row">
+          <label for="case_number"><strong>case_number</strong> (required)</label><br />
+          <input type="text" id="case_number" name="case_number" value="{{ case_number or '' }}" autocomplete="off" required />
+        </div>
+        <div class="row">
+          <label for="slot_count"><strong>slot_count</strong> (required)</label><br />
+          <input type="text" id="slot_count" name="slot_count" value="{{ slot_count or '' }}" autocomplete="off" required />
+        </div>
+      </div>
+      <button type="submit">Create empty slots</button>
+    </form>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -137,6 +137,8 @@
     <p class="card-intro">Use these tools for administrative maintenance and operational follow-up without changing workflow order.</p>
     <nav class="admin-tool-grid" aria-label="Admin tool navigation">
       <a class="admin-tool-link admin-tool-link--primary" href="{{ url_for('add_assets') }}">Add Assets</a>
+      <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">Create empty slots</a>
+      <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
       <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Manage Users</a>
       <a class="admin-tool-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a>
       <a class="admin-tool-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a>

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_admin(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-slots", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+
+def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"case_number": "CASE-P", "slot_count": "3"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Created 3 empty slots for case CASE-P (slots 1-3)." in response.data
+
+    conn = db.get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT case_name, slot_position, current_asset_tag
+            FROM slots
+            WHERE case_name = 'CASE-P'
+            ORDER BY slot_position ASC;
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert [(row["case_name"], row["slot_position"], row["current_asset_tag"]) for row in rows] == [
+        ("CASE-P", 1, None),
+        ("CASE-P", 2, None),
+        ("CASE-P", 3, None),
+    ]
+
+
+def test_admin_slot_provision_appends_slots_for_existing_case(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (10, 'CASE-P', 1, NULL), (11, 'CASE-P', 2, NULL);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"case_number": "CASE-P", "slot_count": "2"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Created 2 empty slots for case CASE-P (slots 3-4)." in response.data
+
+    verify_conn = db.get_connection()
+    try:
+        rows = verify_conn.execute(
+            "SELECT slot_position FROM slots WHERE case_name = 'CASE-P' ORDER BY slot_position ASC;"
+        ).fetchall()
+    finally:
+        verify_conn.close()
+    assert [int(row["slot_position"]) for row in rows] == [1, 2, 3, 4]
+
+
+def test_unslotted_storage_asset_can_be_assigned_after_slot_provision(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    provisioned = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"case_number": "CASE-Q", "slot_count": "1"},
+        follow_redirects=True,
+    )
+    assert provisioned.status_code == 200
+
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-UNSLOT-1",
+            "serial_number": "SER-UNSLOT-1",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    assigned = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "assign",
+            "asset_tag": "AT-UNSLOT-1",
+            "building_room": "HQ/100",
+            "case_number": "CASE-Q",
+            "slot_number": "1",
+            "notes": "assign after provisioning",
+        },
+        follow_redirects=True,
+    )
+    assert assigned.status_code == 200
+    assert b"Assigned asset AT-UNSLOT-1 to CASE-Q slot 1." in assigned.data
+
+    case_detail = client_with_temp_db.get("/dashboard/cases/CASE-Q")
+    assert case_detail.status_code == 200
+    assert b"AT-UNSLOT-1" in case_detail.data
+
+    conn = db.get_connection()
+    try:
+        asset_row = conn.execute(
+            "SELECT id, location_type, home_slot_id, current_holder_id FROM assets WHERE asset_tag = 'AT-UNSLOT-1';"
+        ).fetchone()
+        occupancy_row = conn.execute(
+            "SELECT slot_id FROM slot_occupancy WHERE asset_id = ?;",
+            (int(asset_row["id"]),),
+        ).fetchone()
+        slot_row = conn.execute("SELECT current_asset_tag FROM slots WHERE case_name = 'CASE-Q' AND slot_position = 1;").fetchone()
+        events = conn.execute(
+            "SELECT event_type FROM asset_events WHERE asset_tag = 'AT-UNSLOT-1' ORDER BY id ASC;"
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert asset_row["location_type"] == "STORAGE"
+    assert asset_row["current_holder_id"] is None
+    assert int(asset_row["home_slot_id"]) == int(occupancy_row["slot_id"])
+    assert slot_row["current_asset_tag"] == "AT-UNSLOT-1"
+    assert [str(row["event_type"]) for row in events] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+
+
+def test_assign_slot_page_lists_unslotted_storage_assets(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-LIST-1",
+            "serial_number": "SER-LIST-1",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.get("/admin/assign-slot")
+    assert response.status_code == 200
+    assert b"Unslotted Assets" in response.data
+    assert b"AT-LIST-1" in response.data
+    assert b"Assign" in response.data
+
+
+def test_assign_slot_page_hides_slotted_assets_from_unslotted_list(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (99, 'CASE-Z', 1, NULL);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-SLOTTED-1",
+            "serial_number": "SER-SLOTTED-1",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+            "case_name": "CASE-Z",
+            "slot_id": "99",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.get("/admin/assign-slot")
+    assert response.status_code == 200
+    assert b"<code>AT-SLOTTED-1</code>" not in response.data
+
+
+def test_assign_slot_page_can_select_unslotted_asset_from_list(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-SELECT-1",
+            "serial_number": "SER-SELECT-1",
+            "manufacturer": "Dell",
+            "equipment_type": "monitor",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-SELECT-1"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Asset AT-SELECT-1 is eligible for slot assignment." in response.data
+    assert b'input type="hidden" name="asset_tag" value="AT-SELECT-1"' in response.data
+
+
+def test_assign_slot_manual_lookup_still_works(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-MANUAL-1",
+            "serial_number": "SER-MANUAL-1",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-MANUAL-1"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Asset AT-MANUAL-1 is eligible for slot assignment." in response.data

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -115,6 +115,8 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
     assert b"Manage Users" in response.data
+    assert b"Create empty slots" in response.data
+    assert b"Assign unslotted asset" in response.data
     assert b"Import Holders from CSV" in response.data
     assert b"Open Operational Report" in response.data
     assert b"Restore Database Backup" in response.data

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -562,6 +562,13 @@ def test_operator_denied_admin_endpoint(client_with_temp_db) -> None:
 
     reference_data_response = client_with_temp_db.get("/admin/reference-data")
     assert reference_data_response.status_code == 403
+    slot_provision_response = client_with_temp_db.get("/admin/slots/provision")
+    assert slot_provision_response.status_code == 403
+    slot_provision_post_response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"case_number": "CASE-X", "slot_count": "2"},
+    )
+    assert slot_provision_post_response.status_code == 403
 
 def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     create_user("admin", "admin-pass", "admin", True)
@@ -574,6 +581,8 @@ def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     assert retire_response.status_code == 200
     reference_data_response = client_with_temp_db.get("/admin/reference-data")
     assert reference_data_response.status_code == 200
+    slot_provision_response = client_with_temp_db.get("/admin/slots/provision")
+    assert slot_provision_response.status_code == 200
 
 
 def test_asset_search_requires_login(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary

Adds admin slot-capacity provisioning and a clearer unslotted asset assignment path.

## Related Issue

Closes #803

## Changes

- Added admin-only empty slot provisioning.
- Added an unslotted assets list to the assign-slot workflow.
- Preserved manual asset tag lookup as a fallback.
- Hardened unslotted-to-slot assignment so canonical state must persist before success.
- Clarified Add Asset and Assign Slot wording around unslotted assets.
- Added tests for route protection, slot provisioning, unslotted selection, and canonical assignment.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual smoke completed
- [x] Admin can create empty slots
- [x] Admin can select an unslotted asset
- [x] Assignment updates `home_slot_id`
- [x] Assignment updates `slot_occupancy`
- [x] Assignment appends `SLOT_ASSIGN`
- [x] Case detail shows assigned asset
- [x] Issue flow still works
- [x] Receipt preserves home slot
- [x] No schema changes
- [x] No event semantic changes
- [x] No custody model changes
- [x] No auth boundary changes
- [x] No Issue/Return seam redesign

## Notes

Follow-on UI improvement identified: the assign-slot destination should use selectable case/slot controls instead of requiring typed case and slot values.