### PR TITLE
Issue 27-120: Add selectable assign-slot destination controls

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1660,6 +1660,46 @@ def _list_unslotted_storage_assets(conn: sqlite3.Connection) -> list[dict]:
     ]
 
 
+def _assign_slot_location_context(form: Optional[dict[str, str]] = None) -> dict:
+    normalized_form = {
+        "building": str((form or {}).get("building") or "").strip(),
+        "room": str((form or {}).get("room") or "").strip(),
+    }
+    building_names = [str(row.get("name") or "").strip() for row in list_buildings()]
+    building_names = [name for name in building_names if name]
+    return {
+        "form": normalized_form,
+        "building_options": building_names,
+    }
+
+
+def _validate_assign_slot_location_form(form: dict[str, str]) -> tuple[dict[str, str], list[str], dict]:
+    context = _assign_slot_location_context(form)
+    normalized_form = context["form"]
+    errors: list[str] = []
+
+    building = normalized_form["building"]
+    room = normalized_form["room"]
+    building_options = list(context["building_options"])
+    building_name_map = {name.upper(): name for name in building_options}
+
+    if not building:
+        errors.append("Choose a building.")
+    elif building_name_map:
+        matched_name = building_name_map.get(building.upper())
+        if matched_name is None:
+            errors.append("Choose a valid building.")
+        else:
+            normalized_form["building"] = matched_name
+    else:
+        errors.append("No buildings are configured. Add a building in Admin Reference Data first.")
+
+    if not room:
+        errors.append("Enter room or area.")
+
+    return normalized_form, errors, context
+
+
 def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     asset = _find_asset_for_scan_tag(conn, scan_tag)
     if not asset:
@@ -8363,22 +8403,31 @@ def admin_assign_slot():
         return guard_result
 
     asset_tag = ""
-    building_room = ""
-    case_number = ""
-    slot_number = ""
+    building = ""
+    room = ""
+    case_name = ""
+    slot_id = ""
     notes = ""
     asset_view: Optional[dict] = None
     unslotted_assets: list[dict] = []
+    slot_options: list[dict] = []
+    case_options: list[str] = []
+    building_options: list[str] = []
 
     conn = get_connection()
     try:
         unslotted_assets = _list_unslotted_storage_assets(conn)
+        slot_options = _list_slot_options(conn)
+        case_options = _slot_case_options(slot_options)
+        location_context = _assign_slot_location_context()
+        building_options = list(location_context["building_options"])
         if request.method == "POST":
             action = (request.form.get("action") or "lookup").strip().lower()
             asset_tag = (request.form.get("asset_tag") or "").strip()
-            building_room = (request.form.get("building_room") or "").strip()
-            case_number = (request.form.get("case_number") or "").strip().upper()
-            slot_number = (request.form.get("slot_number") or "").strip()
+            building = (request.form.get("building") or "").strip()
+            room = (request.form.get("room") or "").strip()
+            case_name = (request.form.get("case_name") or "").strip().upper()
+            slot_id = (request.form.get("slot_id") or "").strip()
             notes = (request.form.get("notes") or "").strip()
 
             asset_view, blocking_errors = _build_admin_assign_asset_view(conn, asset_tag)
@@ -8394,23 +8443,29 @@ def admin_assign_slot():
             elif action == "assign":
                 if not asset_tag:
                     flash("asset_tag is required.", "error")
-                if not building_room:
-                    flash("building/room is required.", "error")
-                if not case_number:
-                    flash("case_number is required.", "error")
-                if not slot_number:
-                    flash("slot_number is required.", "error")
+                if not building:
+                    flash("building is required.", "error")
+                if not room:
+                    flash("room/area is required.", "error")
+                if not case_name:
+                    flash("case is required.", "error")
+                if not slot_id:
+                    flash("slot is required.", "error")
 
-                if not asset_tag or not building_room or not case_number or not slot_number:
+                if not asset_tag or not building or not room or not case_name or not slot_id:
                     return render_template(
                         "admin_assign_slot.html",
                         asset_tag=asset_tag,
-                        building_room=building_room,
-                        case_number=case_number,
-                        slot_number=slot_number,
+                        building=building,
+                        room=room,
+                        case_name=case_name,
+                        slot_id=slot_id,
                         notes=notes,
                         asset=asset_view,
                         unslotted_assets=unslotted_assets,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                        building_options=building_options,
                     )
 
                 if blocking_errors:
@@ -8419,27 +8474,68 @@ def admin_assign_slot():
                     return render_template(
                         "admin_assign_slot.html",
                         asset_tag=asset_tag,
-                        building_room=building_room,
-                        case_number=case_number,
-                        slot_number=slot_number,
+                        building=building,
+                        room=room,
+                        case_name=case_name,
+                        slot_id=slot_id,
                         notes=notes,
                         asset=asset_view,
                         unslotted_assets=unslotted_assets,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                        building_options=building_options,
                     )
 
-                try:
-                    slot_position = int(slot_number)
-                except ValueError:
-                    flash("slot_number must be an integer.", "error")
+                normalized_location, location_errors, _ = _validate_assign_slot_location_form(
+                    {"building": building, "room": room}
+                )
+                building = normalized_location["building"]
+                room = normalized_location["room"]
+                if location_errors:
+                    for error in location_errors:
+                        flash(error, "error")
                     return render_template(
                         "admin_assign_slot.html",
                         asset_tag=asset_tag,
-                        building_room=building_room,
-                        case_number=case_number,
-                        slot_number=slot_number,
+                        building=building,
+                        room=room,
+                        case_name=case_name,
+                        slot_id=slot_id,
                         notes=notes,
                         asset=asset_view,
                         unslotted_assets=unslotted_assets,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                        building_options=building_options,
+                    )
+
+                selected_slot, slot_errors = _resolve_slot_selection(
+                    conn,
+                    case_name=case_name,
+                    slot_id_raw=slot_id,
+                )
+                slot_error_map = {
+                    "case and slot must both be selected.": "Select both case and slot.",
+                    "slot selection is invalid.": "Select a valid slot.",
+                    "selected slot does not exist.": "Selected slot does not exist.",
+                    "selected slot does not belong to the selected case.": "Selected slot does not belong to selected case.",
+                }
+                if slot_errors:
+                    for error in slot_errors:
+                        flash(slot_error_map.get(error, error), "error")
+                    return render_template(
+                        "admin_assign_slot.html",
+                        asset_tag=asset_tag,
+                        building=building,
+                        room=room,
+                        case_name=case_name,
+                        slot_id=slot_id,
+                        notes=notes,
+                        asset=asset_view,
+                        unslotted_assets=unslotted_assets,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                        building_options=building_options,
                     )
 
                 try:
@@ -8483,11 +8579,10 @@ def admin_assign_slot():
                         """
                         SELECT id, case_name, slot_position, current_asset_tag
                         FROM slots
-                        WHERE UPPER(case_name) = UPPER(?)
-                          AND slot_position = ?
+                        WHERE id = ?
                         LIMIT 1;
                         """,
-                        (case_number, slot_position),
+                        (int(selected_slot["id"]),),
                     ).fetchone()
                     if not slot:
                         raise ValueError("Selected slot does not exist.")
@@ -8535,7 +8630,7 @@ def admin_assign_slot():
                     update_values.append(slot["id"])
                     if "building_room" in asset_columns:
                         update_clauses.append("building_room = ?")
-                        update_values.append(building_room)
+                        update_values.append(f"{building}/{room}")
                     if "case_number" in asset_columns:
                         update_clauses.append("case_number = ?")
                         update_values.append(str(slot["case_name"]))
@@ -8554,7 +8649,7 @@ def admin_assign_slot():
 
                     payload = {
                         "slot_id": int(slot["id"]),
-                        "building_room": building_room,
+                        "building_room": f"{building}/{room}",
                         "case_number": str(slot["case_name"]),
                         "slot_number": int(slot["slot_position"]),
                     }
@@ -8633,12 +8728,16 @@ def admin_assign_slot():
                     return render_template(
                         "admin_assign_slot.html",
                         asset_tag=asset_tag,
-                        building_room=building_room,
-                        case_number=case_number,
-                        slot_number=slot_number,
+                        building=building,
+                        room=room,
+                        case_name=case_name,
+                        slot_id=slot_id,
                         notes=notes,
                         asset=asset_view,
                         unslotted_assets=unslotted_assets,
+                        slot_options=slot_options,
+                        case_options=case_options,
+                        building_options=building_options,
                     )
                 except Exception:
                     conn.rollback()
@@ -8657,12 +8756,16 @@ def admin_assign_slot():
     return render_template(
         "admin_assign_slot.html",
         asset_tag=asset_tag,
-        building_room=building_room,
-        case_number=case_number,
-        slot_number=slot_number,
+        building=building,
+        room=room,
+        case_name=case_name,
+        slot_id=slot_id,
         notes=notes,
         asset=asset_view,
         unslotted_assets=unslotted_assets,
+        slot_options=slot_options,
+        case_options=case_options,
+        building_options=building_options,
     )
 
 

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -106,42 +106,54 @@
         <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
 
         <div class="row">
-          <label for="building_room"><strong>building/room</strong> (required)</label><br />
+          <label for="building"><strong>building</strong> (required)</label><br />
+          <select id="building" name="building" required>
+            <option value="">Select building</option>
+            {% for option in building_options %}
+              <option value="{{ option }}" {% if building == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+          </select>
+        </div>
+
+        <div class="row">
+          <label for="room"><strong>room/area</strong> (required)</label><br />
           <input
             type="text"
-            id="building_room"
-            name="building_room"
-            value="{{ building_room or '' }}"
-            placeholder="e.g. BQ26-101"
+            id="room"
+            name="room"
+            value="{{ room or '' }}"
+            placeholder="e.g. 101"
             autocomplete="off"
             required
           />
         </div>
 
         <div class="row">
-          <label for="case_number"><strong>case_number</strong> (required)</label><br />
-          <input
-            type="text"
-            id="case_number"
-            name="case_number"
-            value="{{ case_number or '' }}"
-            placeholder="e.g. CASE-01"
-            autocomplete="off"
-            required
-          />
+          <label for="case_name"><strong>case</strong> (required)</label><br />
+          <select id="case_name" name="case_name" required>
+            <option value="">Select case</option>
+            {% for option in case_options %}
+              <option value="{{ option }}" {% if case_name == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+          </select>
         </div>
 
         <div class="row">
-          <label for="slot_number"><strong>slot_number</strong> (required)</label><br />
-          <input
-            type="text"
-            id="slot_number"
-            name="slot_number"
-            value="{{ slot_number or '' }}"
-            placeholder="e.g. 2"
-            autocomplete="off"
-            required
-          />
+          <label for="slot_id"><strong>slot</strong> (required)</label><br />
+          <select id="slot_id" name="slot_id" required>
+            <option value="">Select slot</option>
+            {% for slot in slot_options %}
+              {% set occupied = slot.occupied_asset_tag %}
+              <option
+                value="{{ slot.id }}"
+                data-case="{{ slot.case_name }}"
+                {% if slot_id == (slot.id|string) %}selected{% endif %}
+                {% if occupied %}disabled{% endif %}
+              >
+                {{ slot.case_name }} / Slot {{ slot.slot_position }}{% if occupied %} - occupied{% endif %}
+              </option>
+            {% endfor %}
+          </select>
         </div>
 
         <div class="row">
@@ -160,4 +172,38 @@
       </form>
     </div>
   {% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+  <script>
+    const assignCaseSelect = document.getElementById("case_name");
+    const assignSlotSelect = document.getElementById("slot_id");
+
+    if (assignCaseSelect && assignSlotSelect) {
+      const assignSlotOptions = Array.from(assignSlotSelect.options);
+
+      function syncAssignSlotOptions() {
+        const selectedCase = assignCaseSelect.value;
+        const selectedSlot = assignSlotSelect.value;
+
+        assignSlotOptions.forEach((option) => {
+          if (!option.value) {
+            option.hidden = false;
+            return;
+          }
+          const matchesCase = !selectedCase || option.dataset.case === selectedCase;
+          const isSelected = option.value === selectedSlot;
+          option.hidden = !matchesCase && !isSelected;
+        });
+
+        const selectedOption = assignSlotSelect.selectedOptions[0];
+        if (selectedOption && selectedOption.value && selectedOption.dataset.case !== selectedCase) {
+          assignSlotSelect.value = "";
+        }
+      }
+
+      assignCaseSelect.addEventListener("change", syncAssignSlotOptions);
+      syncAssignSlotOptions();
+    }
+  </script>
 {% endblock %}

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -23,6 +23,21 @@ def _login_admin(client_with_temp_db) -> None:
     login_session(client_with_temp_db, admin_id)
 
 
+def _create_building(name: str) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES (?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (name,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
 def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
 
@@ -86,6 +101,7 @@ def test_admin_slot_provision_appends_slots_for_existing_case(client_with_temp_d
 
 def test_unslotted_storage_asset_can_be_assigned_after_slot_provision(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
+    _create_building("HQ")
 
     provisioned = client_with_temp_db.post(
         "/admin/slots/provision",
@@ -107,14 +123,24 @@ def test_unslotted_storage_asset_can_be_assigned_after_slot_provision(client_wit
     )
     assert created.status_code == 302
 
+    slot_conn = db.get_connection()
+    try:
+        target_slot = slot_conn.execute(
+            "SELECT id FROM slots WHERE case_name = 'CASE-Q' AND slot_position = 1 LIMIT 1;"
+        ).fetchone()
+    finally:
+        slot_conn.close()
+    assert target_slot is not None
+
     assigned = client_with_temp_db.post(
         "/admin/assign-slot",
         data={
             "action": "assign",
             "asset_tag": "AT-UNSLOT-1",
-            "building_room": "HQ/100",
-            "case_number": "CASE-Q",
-            "slot_number": "1",
+            "building": "HQ",
+            "room": "100",
+            "case_name": "CASE-Q",
+            "slot_id": str(int(target_slot["id"])),
             "notes": "assign after provisioning",
         },
         follow_redirects=True,
@@ -151,6 +177,7 @@ def test_unslotted_storage_asset_can_be_assigned_after_slot_provision(client_wit
 
 def test_assign_slot_page_lists_unslotted_storage_assets(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
+    _create_building("HQ")
     created = client_with_temp_db.post(
         "/admin/assets/new",
         data={
@@ -173,6 +200,7 @@ def test_assign_slot_page_lists_unslotted_storage_assets(client_with_temp_db) ->
 
 def test_assign_slot_page_hides_slotted_assets_from_unslotted_list(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
+    _create_building("HQ")
     conn = db.get_connection()
     conn.execute(
         """
@@ -205,6 +233,7 @@ def test_assign_slot_page_hides_slotted_assets_from_unslotted_list(client_with_t
 
 def test_assign_slot_page_can_select_unslotted_asset_from_list(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
+    _create_building("HQ")
     created = client_with_temp_db.post(
         "/admin/assets/new",
         data={
@@ -226,10 +255,13 @@ def test_assign_slot_page_can_select_unslotted_asset_from_list(client_with_temp_
     assert response.status_code == 200
     assert b"Asset AT-SELECT-1 is eligible for slot assignment." in response.data
     assert b'input type="hidden" name="asset_tag" value="AT-SELECT-1"' in response.data
+    assert b'name="case_name"' in response.data
+    assert b'name="slot_id"' in response.data
 
 
 def test_assign_slot_manual_lookup_still_works(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
+    _create_building("HQ")
     created = client_with_temp_db.post(
         "/admin/assets/new",
         data={
@@ -250,3 +282,132 @@ def test_assign_slot_manual_lookup_still_works(client_with_temp_db) -> None:
     )
     assert response.status_code == 200
     assert b"Asset AT-MANUAL-1 is eligible for slot assignment." in response.data
+
+
+def test_assign_slot_selectors_hide_occupied_slot_options(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (501, 'CASE-SEL', 1, 'AT-BUSY'), (502, 'CASE-SEL', 2, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-SELECTOR-1",
+            "serial_number": "SER-SELECTOR-1",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert response.status_code == 302
+
+    lookup = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-SELECTOR-1"},
+        follow_redirects=True,
+    )
+    assert lookup.status_code == 200
+    assert b"CASE-SEL / Slot 1 - occupied" in lookup.data
+    assert b"CASE-SEL / Slot 2" in lookup.data
+    assert b"disabled" in lookup.data
+
+
+def test_assign_slot_page_shows_known_buildings_as_choices(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ North")
+    _create_building("HQ South")
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-BUILDING-CHOICE",
+            "serial_number": "SER-BUILDING-CHOICE",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ North",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-BUILDING-CHOICE"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'<option value="HQ North"' in response.data
+    assert b'<option value="HQ South"' in response.data
+
+
+def test_assign_slot_rejects_arbitrary_building_without_appending_slot_assign(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (700, 'CASE-BLD', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-BAD-BLD",
+            "serial_number": "SER-BAD-BLD",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    assign_attempt = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "assign",
+            "asset_tag": "AT-BAD-BLD",
+            "building": "booger",
+            "room": "100",
+            "case_name": "CASE-BLD",
+            "slot_id": "700",
+        },
+        follow_redirects=True,
+    )
+    assert assign_attempt.status_code == 200
+    assert b"Choose a valid building." in assign_attempt.data
+
+    verify_conn = db.get_connection()
+    try:
+        asset_row = verify_conn.execute(
+            "SELECT id, home_slot_id FROM assets WHERE asset_tag = 'AT-BAD-BLD' LIMIT 1;"
+        ).fetchone()
+        occupancy = verify_conn.execute(
+            "SELECT 1 FROM slot_occupancy WHERE asset_id = ? LIMIT 1;",
+            (int(asset_row["id"]),),
+        ).fetchone()
+        events = verify_conn.execute(
+            "SELECT event_type FROM asset_events WHERE asset_tag = 'AT-BAD-BLD' ORDER BY id ASC;"
+        ).fetchall()
+    finally:
+        verify_conn.close()
+
+    assert asset_row["home_slot_id"] is None
+    assert occupancy is None
+    assert [str(row["event_type"]) for row in events] == ["ASSET_CREATED"]


### PR DESCRIPTION
## Summary

Adds selectable destination controls to the Assign Slot workflow so admins no longer type case, slot, or building values by memory.

## Related Issue

Closes #806

## Changes

- Replaced typed case and slot fields with selectors.
- Filters slot selection by case and marks occupied slots unavailable.
- Replaced free-text building entry with a validated building selector.
- Keeps room/area as a text field.
- Preserves existing `SLOT_ASSIGN` behavior and canonical assignment checks.
- Blocks invalid building values before assignment writes occur.
- Added tests for selectors, occupied slot behavior, valid assignment, and invalid building rejection.

## Verification checklist

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest -q`
- [x] Manual smoke completed
- [x] Invalid building value cannot be selected
- [x] Valid assignment appends `SLOT_ASSIGN`
- [x] Assignment updates `home_slot_id`
- [x] Assignment updates `slot_occupancy`
- [x] Case detail shows assigned asset
- [x] Occupied slots are not selectable
- [x] No schema changes
- [x] No event semantic changes
- [x] No custody model changes
- [x] No auth boundary changes
- [x] No Issue/Return or queue/preview/commit seam changes

## Notes

Existing event history was not modified. Prior bad smoke-test data remains in the append-only log, as required.