### PR TITLE
Issue 27-122: Add switch and router staging planning artifacts

### DIFF
--- a/docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv
+++ b/docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv
@@ -1,0 +1,1 @@
+asset_tag,barcode,serial_number,equipment_type,manufacturer,model,location_building,case_identifier,slot_identifier,notes_comments

--- a/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
+++ b/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
@@ -1,0 +1,64 @@
+# Network Switch/Router Staging Template v1
+
+## Purpose
+
+Use `network_switch_router_staging_template_v1.csv` to prepare switch and router custody records for operator review.
+
+This template is a planning and staging artifact only. It does not upload data, create assets, append events, or implement import behavior.
+
+AssetTrack tracks equipment custody and storage. It is not a CMDB or network configuration system.
+
+## Allowed Rows
+
+- One physical switch or router per row.
+- `equipment_type` must be `switch` or `router`.
+- Use custody and storage details only.
+- Leave a field blank when the value is unknown.
+- Do not add columns without a separate review of the staging contract.
+
+## Fields
+
+| Field | Use |
+| --- | --- |
+| `asset_tag` | AssetTrack asset tag, when assigned. |
+| `barcode` | Scannable custody barcode, when available. |
+| `serial_number` | Manufacturer serial number, when available. |
+| `equipment_type` | Required. Use `switch` or `router`. |
+| `manufacturer` | Equipment manufacturer. |
+| `model` | Equipment model. |
+| `location_building` | Current storage location or building. |
+| `case_identifier` | Storage case identifier, when applicable. |
+| `slot_identifier` | Storage slot identifier, when applicable. |
+| `notes_comments` | Short custody or storage note. Do not enter configuration data. |
+
+## Required Identifiers
+
+- Every row must include `equipment_type`.
+- Every row must include at least one custody-safe identifier: `asset_tag`, `barcode`, or `serial_number`.
+- Rows without a usable identifier must be corrected before import planning continues.
+
+## Duplicate Handling
+
+- Treat repeated `asset_tag`, `barcode`, or `serial_number` values as review items.
+- Do not silently merge, overwrite, or discard duplicate rows.
+- Resolve duplicates during staging review before any future import attempt.
+
+## Rejected Fields
+
+Do not add or record CMDB-like or network configuration fields, including:
+
+- IP address
+- MAC address
+- VLAN
+- switch port
+- topology
+- patching
+- network relationships
+- running configuration
+- device configuration
+
+## Review Before Import
+
+Operators must review staged rows against this CSV and Markdown contract before any future import work proceeds.
+
+Import behavior is intentionally out of scope. A later issue must define validation, preview, duplicate resolution, event behavior, and commit boundaries before runtime implementation begins.

--- a/docs/roadmap/issue-27-122-stage-switches-and-routers.md
+++ b/docs/roadmap/issue-27-122-stage-switches-and-routers.md
@@ -1,0 +1,39 @@
+# Issue 27-122 Stage Switches and Routers
+
+## Purpose
+
+Add repo-tracked planning artifacts for future switch/router custody staging.
+
+This issue defines the staging contract before any import behavior is implemented.
+
+## Artifacts
+
+- `docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv`
+- `docs/fixtures/imports/network/network_switch_router_staging_template_v1.md`
+- `docs/roadmap/issue-27-123-import-staged-switches-and-routers.md`
+
+## Boundary
+
+AssetTrack tracks equipment custody and storage. It must not become a CMDB or network configuration system.
+
+The staging template allows custody-safe identifiers, equipment description, storage location, case/slot placement, and short notes. It excludes IP addresses, MAC addresses, VLANs, switch ports, topology, patching, network relationships, running configuration, and device configuration.
+
+## Why It Matters
+
+Operators need a reviewable, diff-friendly CSV contract before switch/router rows are considered for import. Defining that contract first keeps later implementation bounded to custody and storage.
+
+## Non-Goals
+
+- No import code
+- No routes
+- No model, schema, or migration changes
+- No event or custody logic changes
+- No auth or role changes
+- No persistence changes
+- No XLSX tracking
+
+## Completion Check
+
+- The CSV template is tracked and human-readable.
+- The Markdown spec defines allowed rows, identifiers, duplicate review, rejected CMDB-like fields, and review-before-import expectations.
+- Future import planning is separated into Issue 27-123.

--- a/docs/roadmap/issue-27-123-import-staged-switches-and-routers.md
+++ b/docs/roadmap/issue-27-123-import-staged-switches-and-routers.md
@@ -1,0 +1,46 @@
+# Issue 27-123 Import Staged Switches and Routers
+
+## Status
+
+Future planning boundary only. Do not implement import behavior until staged switch/router rows have been reviewed against:
+
+- `docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv`
+- `docs/fixtures/imports/network/network_switch_router_staging_template_v1.md`
+
+## Purpose
+
+Plan a later, separately approved path for importing reviewed switch/router custody staging rows.
+
+## Required Review Before Implementation
+
+- Confirm rows contain custody and storage data only.
+- Confirm each row has `equipment_type` and at least one supported identifier.
+- Resolve duplicate identifiers explicitly.
+- Reject CMDB-like and network configuration columns.
+- Define validation, preview, and commit behavior before runtime work begins.
+
+## Protected Boundary
+
+Any future implementation must preserve:
+
+- append-only events
+- immutable audit history
+- state derived from event history
+- custody reconciliation with the event log
+- offline-first operation
+- local SQLite persistence
+- role enforcement
+- the `entry -> prerequisite -> queue -> preview -> commit` seam
+
+## Non-Goals For This Planning Doc
+
+- No import implementation
+- No routes
+- No schema or migration changes
+- No event payload or custody behavior changes
+- No auth, role, or persistence changes
+- No CMDB or network configuration behavior
+
+## Stop Conditions
+
+Stop and open a separately approved plan if implementation requires schema changes, migration work, event semantic changes, persistence changes, role changes, or CMDB-like data.


### PR DESCRIPTION
## Summary

Added switch/router staging planning artifacts for future import work.

## Related Issue

Closes #810

## Changes

- Added the switch/router CSV staging template.
- Added the Markdown spec for allowed and rejected staging fields.
- Added the 27-122 roadmap doc for staging artifacts.
- Added the 27-123 roadmap doc to preserve the future import boundary.
- Explicitly excluded CMDB/network configuration fields from the staging contract.

## Verification checklist

- [x] Ran `python3 -m compileall assettrack tests`
- [x] Ran `git diff --cached --check`
- [x] Confirmed only four intended docs/fixture files are staged
- [x] Confirmed no XLSX was force-added
- [x] Confirmed no app, schema, auth, event, persistence, or runtime files changed

## Notes

CSV was intentionally force-added because repo-wide CSV ignore applies. No `.gitignore` change was made.