### PR TITLE
Issue 27-123: Import staged switches and routers as custody assets

### DIFF
--- a/assettrack/ingest/committer.py
+++ b/assettrack/ingest/committer.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import sqlite3
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Optional
 
 from assettrack.assets import create_asset, retire_asset, update_asset
 from assettrack.audit import record_event
-from assettrack.db import get_connection
+from assettrack.db import bootstrap_db, get_connection
 
 # Atomic batch commit layer.
 # This module is the ONLY place where batch ingest rows are turned into DB writes.
@@ -30,18 +31,15 @@ class CommitResult:
 
 
 def _get_connection(db_path: Optional[str] = None) -> sqlite3.Connection:
-    """
-    Compatibility shim: if get_connection() supports db_path, pass it.
-    Otherwise fall back to get_connection() with no args.
-    """
     if db_path is None:
         return get_connection()
 
-    try:
-        return get_connection(db_path=db_path)  # type: ignore[arg-type]
-    except TypeError:
-        # Older signature: get_connection() takes no params.
-        return get_connection()
+    path = Path(db_path)
+    bootstrap_db(path)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
 
 
 def commit_batch(validated_rows: list[dict[str, Any]], *, db_path: Optional[str] = None) -> CommitResult:

--- a/assettrack/network_asset_import.py
+++ b/assettrack/network_asset_import.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from assettrack.db import bootstrap_db
+from assettrack.ingest.committer import BatchCommitError, commit_batch
+
+ALLOWED_COLUMNS = {
+    "asset_tag",
+    "barcode",
+    "serial_number",
+    "equipment_type",
+    "manufacturer",
+    "model",
+    "location_building",
+    "case_identifier",
+    "slot_identifier",
+    "notes_comments",
+}
+REJECTED_CMDB_COLUMNS = {
+    "ip_address",
+    "mac_address",
+    "vlan",
+    "switch_port",
+    "topology",
+    "patching",
+    "network_relationships",
+    "running_configuration",
+    "device_configuration",
+}
+ALLOWED_EQUIPMENT_TYPES = {"switch", "router"}
+
+
+@dataclass(frozen=True)
+class NetworkAssetImportRow:
+    row_number: int
+    asset_tag: str
+    serial_number: str
+    equipment_type: str
+    manufacturer: str
+    model: str
+    building: str
+    case_identifier: str
+    slot_identifier: str
+    notes: str
+
+    def to_ingest_row(self, *, actor: str, timestamp: str) -> dict[str, object]:
+        return {
+            "row_number": self.row_number,
+            "data": {
+                "asset_tag": self.asset_tag,
+                "serial_number": self.serial_number,
+                "equipment_type": self.equipment_type,
+                "manufacturer": self.manufacturer,
+                "model": self.model,
+                "building": self.building,
+                "case_number": self.case_identifier,
+                "slot_number": self.slot_identifier,
+                "notes": self.notes,
+                "timestamp": timestamp,
+                "event_type": "SCAN",
+                "operator_id": actor,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class NetworkAssetImportReport:
+    processed: int
+    imported: int
+    errors: tuple[str, ...]
+
+    def summary(self) -> dict[str, int]:
+        return {
+            "processed": self.processed,
+            "imported": self.imported,
+            "errors": len(self.errors),
+        }
+
+
+def _normalize_header(name: str | None) -> str:
+    return str(name or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _normalize_text(value: str | None) -> str:
+    return str(value or "").strip()
+
+
+def _load_rows(csv_path: str | Path, conn: sqlite3.Connection) -> NetworkAssetImportReport | list[NetworkAssetImportRow]:
+    path = Path(csv_path)
+    if not path.exists():
+        return NetworkAssetImportReport(processed=0, imported=0, errors=(f"CSV not found: {path}",))
+
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return NetworkAssetImportReport(processed=0, imported=0, errors=("CSV header row is required.",))
+
+        headers = [_normalize_header(field_name) for field_name in reader.fieldnames]
+        if any(not header for header in headers):
+            return NetworkAssetImportReport(processed=0, imported=0, errors=("CSV headers must not be blank.",))
+        if len(set(headers)) != len(headers):
+            return NetworkAssetImportReport(processed=0, imported=0, errors=("CSV headers must be unique.",))
+
+        rejected = sorted(set(headers) & REJECTED_CMDB_COLUMNS)
+        if rejected:
+            return NetworkAssetImportReport(
+                processed=0,
+                imported=0,
+                errors=(f"Rejected CMDB-like CSV columns: {', '.join(rejected)}",),
+            )
+        unsupported = sorted(set(headers) - ALLOWED_COLUMNS)
+        if unsupported:
+            return NetworkAssetImportReport(
+                processed=0,
+                imported=0,
+                errors=(f"Unsupported CSV columns: {', '.join(unsupported)}",),
+            )
+
+        rows: list[NetworkAssetImportRow] = []
+        errors: list[str] = []
+        seen_asset_tags: dict[str, int] = {}
+        seen_serial_numbers: dict[str, int] = {}
+        processed = 0
+
+        for line_number, raw_row in enumerate(reader, start=2):
+            normalized_row = {_normalize_header(key): value for key, value in raw_row.items() if key is not None}
+            if None in raw_row:
+                errors.append(f"Row {line_number}: malformed CSV row has extra columns.")
+                continue
+            if any(value is None for value in normalized_row.values()):
+                errors.append(f"Row {line_number}: malformed CSV row has missing columns.")
+                continue
+            if all(not _normalize_text(value) for value in normalized_row.values()):
+                continue
+
+            processed += 1
+            asset_tag = _normalize_text(normalized_row.get("asset_tag")).upper()
+            barcode = _normalize_text(normalized_row.get("barcode")).upper()
+            serial_number = _normalize_text(normalized_row.get("serial_number"))
+            equipment_type = _normalize_text(normalized_row.get("equipment_type")).lower()
+            case_identifier = _normalize_text(normalized_row.get("case_identifier")).upper()
+            slot_identifier = _normalize_text(normalized_row.get("slot_identifier"))
+
+            if not asset_tag:
+                asset_tag = barcode
+            if not asset_tag:
+                errors.append(f"Row {line_number}: asset_tag is required; barcode may be used when asset_tag is blank.")
+            if equipment_type not in ALLOWED_EQUIPMENT_TYPES:
+                errors.append(f"Row {line_number}: equipment_type must be switch or router.")
+
+            previous_asset_row = seen_asset_tags.get(asset_tag)
+            if asset_tag and previous_asset_row is not None:
+                errors.append(f"Row {line_number}: duplicate canonical asset_tag matches row {previous_asset_row}: {asset_tag}")
+            elif asset_tag:
+                seen_asset_tags[asset_tag] = line_number
+
+            normalized_serial = serial_number.upper()
+            previous_serial_row = seen_serial_numbers.get(normalized_serial)
+            if normalized_serial and previous_serial_row is not None:
+                errors.append(f"Row {line_number}: duplicate serial_number matches row {previous_serial_row}: {serial_number}")
+            elif normalized_serial:
+                seen_serial_numbers[normalized_serial] = line_number
+
+            if (case_identifier and not slot_identifier) or (slot_identifier and not case_identifier):
+                errors.append(f"Row {line_number}: case_identifier and slot_identifier must both be present for slot assignment.")
+            elif case_identifier and slot_identifier:
+                try:
+                    slot_position = int(slot_identifier)
+                except ValueError:
+                    errors.append(f"Row {line_number}: slot_identifier must be numeric.")
+                else:
+                    slot = conn.execute(
+                        """
+                        SELECT s.id, s.current_asset_tag,
+                               EXISTS(SELECT 1 FROM slot_occupancy so WHERE so.slot_id = s.id) AS occupied
+                        FROM slots s
+                        WHERE UPPER(s.case_name) = UPPER(?)
+                          AND s.slot_position = ?
+                        LIMIT 1;
+                        """,
+                        (case_identifier, slot_position),
+                    ).fetchone()
+                    if slot is None:
+                        errors.append(f"Row {line_number}: case_identifier + slot_identifier does not reference an existing slot.")
+                    elif bool(slot["occupied"]) or _normalize_text(slot["current_asset_tag"]):
+                        errors.append(f"Row {line_number}: selected slot is already occupied.")
+
+            rows.append(
+                NetworkAssetImportRow(
+                    row_number=line_number,
+                    asset_tag=asset_tag,
+                    serial_number=serial_number,
+                    equipment_type=equipment_type,
+                    manufacturer=_normalize_text(normalized_row.get("manufacturer")),
+                    model=_normalize_text(normalized_row.get("model")),
+                    building=_normalize_text(normalized_row.get("location_building")),
+                    case_identifier=case_identifier,
+                    slot_identifier=slot_identifier,
+                    notes=_normalize_text(normalized_row.get("notes_comments")),
+                )
+            )
+
+        for row in rows:
+            existing_asset = conn.execute(
+                "SELECT 1 FROM assets WHERE UPPER(asset_tag) = UPPER(?) LIMIT 1;",
+                (row.asset_tag,),
+            ).fetchone()
+            if row.asset_tag and existing_asset is not None:
+                errors.append(f"Row {row.row_number}: asset_tag already exists: {row.asset_tag}")
+
+            if row.serial_number:
+                existing_serial = conn.execute(
+                    """
+                    SELECT 1
+                    FROM assets
+                    WHERE TRIM(COALESCE(serial_number, '')) <> ''
+                      AND UPPER(serial_number) = UPPER(?)
+                    LIMIT 1;
+                    """,
+                    (row.serial_number,),
+                ).fetchone()
+                if existing_serial is not None:
+                    errors.append(f"Row {row.row_number}: serial_number already exists: {row.serial_number}")
+
+        if errors:
+            return NetworkAssetImportReport(processed=processed, imported=0, errors=tuple(errors))
+        return rows
+
+
+def import_network_assets_csv(
+    csv_path: str | Path,
+    *,
+    db_path: str | Path,
+    actor: str,
+) -> NetworkAssetImportReport:
+    normalized_actor = _normalize_text(actor)
+    if not normalized_actor:
+        return NetworkAssetImportReport(processed=0, imported=0, errors=("actor is required.",))
+
+    path = Path(db_path)
+    bootstrap_db(path)
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA foreign_keys = ON;")
+        parsed = _load_rows(csv_path, conn)
+    finally:
+        conn.close()
+
+    if isinstance(parsed, NetworkAssetImportReport):
+        return parsed
+    if not parsed:
+        return NetworkAssetImportReport(processed=0, imported=0, errors=("CSV contains no import rows.",))
+
+    timestamp = datetime.now(timezone.utc).isoformat()
+    ingest_rows = [row.to_ingest_row(actor=normalized_actor, timestamp=timestamp) for row in parsed]
+    try:
+        result = commit_batch(ingest_rows, db_path=str(path))
+    except BatchCommitError as exc:
+        return NetworkAssetImportReport(processed=len(parsed), imported=0, errors=(f"Import failed: {exc}",))
+    return NetworkAssetImportReport(processed=len(parsed), imported=result.committed_count, errors=())
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="assettrack.network_asset_import")
+    parser.add_argument("csv_path", help="Path to reviewed network switch/router staging CSV")
+    parser.add_argument("--db", required=True, help="Path to SQLite DB")
+    parser.add_argument("--actor", required=True, help="Operator performing the import")
+    args = parser.parse_args(argv)
+
+    report = import_network_assets_csv(args.csv_path, db_path=args.db, actor=args.actor)
+    print(json.dumps(report.summary(), sort_keys=True))
+    if report.errors:
+        for error in report.errors:
+            print(error, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
+++ b/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
@@ -34,8 +34,17 @@ AssetTrack tracks equipment custody and storage. It is not a CMDB or network con
 ## Required Identifiers
 
 - Every row must include `equipment_type`.
-- Every row must include at least one custody-safe identifier: `asset_tag`, `barcode`, or `serial_number`.
-- Rows without a usable identifier must be corrected before import planning continues.
+- `asset_tag` is the canonical custody identifier.
+- When `asset_tag` is blank, `barcode` may be used as `asset_tag`.
+- `serial_number` is useful for reconciliation but is not sufficient by itself.
+- Rows without `asset_tag` or `barcode` must be corrected before import.
+
+## Import Mapping
+
+- `case_identifier` maps to an existing `slots.case_name`.
+- `slot_identifier` maps to an existing numeric `slots.slot_position` in that case.
+- `location_building` maps to `assets.building`.
+- Room remains blank because this staging contract does not include a room column.
 
 ## Duplicate Handling
 

--- a/docs/roadmap/issue-27-123-import-staged-switches-and-routers.md
+++ b/docs/roadmap/issue-27-123-import-staged-switches-and-routers.md
@@ -2,26 +2,27 @@
 
 ## Status
 
-Future planning boundary only. Do not implement import behavior until staged switch/router rows have been reviewed against:
+Implementation is bounded to reviewed switch/router staging rows that comply with:
 
 - `docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv`
 - `docs/fixtures/imports/network/network_switch_router_staging_template_v1.md`
 
 ## Purpose
 
-Plan a later, separately approved path for importing reviewed switch/router custody staging rows.
+Import reviewed switch/router custody staging rows through the existing append-only asset ingest path.
 
-## Required Review Before Implementation
+## Required Review Before Import
 
 - Confirm rows contain custody and storage data only.
-- Confirm each row has `equipment_type` and at least one supported identifier.
+- Confirm each row has `equipment_type` and an `asset_tag` or fallback `barcode`.
 - Resolve duplicate identifiers explicitly.
 - Reject CMDB-like and network configuration columns.
-- Define validation, preview, and commit behavior before runtime work begins.
+- Reject serial-only rows.
+- Map case and numeric slot identifiers to an existing slot when slot assignment is requested.
 
 ## Protected Boundary
 
-Any future implementation must preserve:
+The import must preserve:
 
 - append-only events
 - immutable audit history
@@ -32,9 +33,8 @@ Any future implementation must preserve:
 - role enforcement
 - the `entry -> prerequisite -> queue -> preview -> commit` seam
 
-## Non-Goals For This Planning Doc
+## Non-Goals
 
-- No import implementation
 - No routes
 - No schema or migration changes
 - No event payload or custody behavior changes

--- a/scripts/import_network_assets_csv.py
+++ b/scripts/import_network_assets_csv.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from assettrack.network_asset_import import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_network_asset_import.py
+++ b/tests/test_network_asset_import.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from assettrack.db import bootstrap_db
+from assettrack.network_asset_import import import_network_assets_csv
+
+
+class NetworkAssetImportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "assettrack.db"
+        bootstrap_db(self.db_path)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _connection(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _write_csv(self, content: str) -> Path:
+        path = Path(self.temp_dir.name) / "network.csv"
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def _insert_slot(self, case_name: str, slot_position: int, *, current_asset_tag: str | None = None) -> None:
+        conn = self._connection()
+        try:
+            conn.execute(
+                "INSERT INTO slots (case_name, slot_position, current_asset_tag) VALUES (?, ?, ?);",
+                (case_name, slot_position, current_asset_tag),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _import(self, content: str):
+        return import_network_assets_csv(self._write_csv(content), db_path=self.db_path, actor="admin-import")
+
+    def test_import_creates_switch_with_existing_slot_and_append_only_events(self) -> None:
+        self._insert_slot("CASE-NET", 2)
+        report = self._import(
+            "asset_tag,barcode,serial_number,equipment_type,manufacturer,model,location_building,case_identifier,slot_identifier,notes_comments\n"
+            "SW-100,,SER-100,switch,Cisco,C9300,HQ,CASE-NET,2,Reviewed staging row\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 1, "errors": 0})
+        conn = self._connection()
+        try:
+            asset = conn.execute(
+                """
+                SELECT asset_tag, serial_number, equipment_type, manufacturer, model, building, room, home_slot_id, location_type
+                FROM assets WHERE asset_tag = 'SW-100';
+                """
+            ).fetchone()
+            self.assertIsNotNone(asset)
+            self.assertEqual(asset["building"], "HQ")
+            self.assertIsNone(asset["room"])
+            self.assertEqual(asset["location_type"], "STORAGE")
+            self.assertIsNotNone(asset["home_slot_id"])
+            events = conn.execute(
+                "SELECT event_type FROM asset_events WHERE asset_tag = 'SW-100' ORDER BY id;"
+            ).fetchall()
+            self.assertEqual([row["event_type"] for row in events], ["created", "SLOT_ASSIGN", "SCAN"])
+        finally:
+            conn.close()
+
+    def test_barcode_fills_blank_asset_tag(self) -> None:
+        report = self._import(
+            "asset_tag,barcode,serial_number,equipment_type,manufacturer,model,location_building,case_identifier,slot_identifier,notes_comments\n"
+            ",RTR-200,SER-200,router,Juniper,MX204,HQ,,,\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 1, "errors": 0})
+        conn = self._connection()
+        try:
+            asset = conn.execute("SELECT asset_tag FROM assets WHERE asset_tag = 'RTR-200';").fetchone()
+            self.assertIsNotNone(asset)
+        finally:
+            conn.close()
+
+    def test_serial_only_row_is_rejected(self) -> None:
+        report = self._import(
+            "asset_tag,barcode,serial_number,equipment_type\n"
+            ",,SER-ONLY,switch\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 0, "errors": 1})
+        self.assertIn("asset_tag is required", report.errors[0])
+
+    def test_duplicate_canonical_asset_tag_is_rejected_before_commit(self) -> None:
+        report = self._import(
+            "asset_tag,barcode,serial_number,equipment_type\n"
+            "SW-DUP,,,switch\n"
+            ",SW-DUP,,router\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 2, "imported": 0, "errors": 1})
+        self.assertIn("duplicate canonical asset_tag", report.errors[0])
+
+    def test_existing_serial_number_is_rejected(self) -> None:
+        first = self._import(
+            "asset_tag,barcode,serial_number,equipment_type\n"
+            "SW-FIRST,,SER-DUP,switch\n"
+        )
+        self.assertEqual(first.summary(), {"processed": 1, "imported": 1, "errors": 0})
+
+        second = self._import(
+            "asset_tag,barcode,serial_number,equipment_type\n"
+            "SW-SECOND,,ser-dup,switch\n"
+        )
+        self.assertEqual(second.summary(), {"processed": 1, "imported": 0, "errors": 1})
+        self.assertIn("serial_number already exists", second.errors[0])
+
+    def test_duplicate_serial_number_in_csv_is_rejected_before_commit(self) -> None:
+        report = self._import(
+            "asset_tag,serial_number,equipment_type\n"
+            "SW-SER-1,SER-SAME,switch\n"
+            "SW-SER-2,ser-same,router\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 2, "imported": 0, "errors": 1})
+        self.assertIn("duplicate serial_number", report.errors[0])
+
+    def test_rejected_cmdb_column_blocks_import(self) -> None:
+        report = self._import(
+            "asset_tag,equipment_type,ip_address\n"
+            "SW-IP,switch,192.0.2.10\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 0, "imported": 0, "errors": 1})
+        self.assertEqual(report.errors, ("Rejected CMDB-like CSV columns: ip_address",))
+
+    def test_invalid_case_slot_reference_is_rejected(self) -> None:
+        report = self._import(
+            "asset_tag,equipment_type,case_identifier,slot_identifier\n"
+            "SW-NO-SLOT,switch,CASE-MISSING,1\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 0, "errors": 1})
+        self.assertIn("does not reference an existing slot", report.errors[0])
+
+    def test_non_numeric_slot_identifier_is_rejected(self) -> None:
+        report = self._import(
+            "asset_tag,equipment_type,case_identifier,slot_identifier\n"
+            "SW-BAD-SLOT,switch,CASE-NET,slot-two\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 0, "errors": 1})
+        self.assertIn("slot_identifier must be numeric", report.errors[0])
+
+    def test_occupied_slot_is_rejected(self) -> None:
+        self._insert_slot("CASE-BUSY", 1, current_asset_tag="EXISTING-ASSET")
+        report = self._import(
+            "asset_tag,equipment_type,case_identifier,slot_identifier\n"
+            "SW-BUSY,switch,CASE-BUSY,1\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 0, "errors": 1})
+        self.assertIn("selected slot is already occupied", report.errors[0])
+
+    def test_unsupported_equipment_type_is_rejected(self) -> None:
+        report = self._import(
+            "asset_tag,equipment_type\n"
+            "AP-100,access point\n"
+        )
+
+        self.assertEqual(report.summary(), {"processed": 1, "imported": 0, "errors": 1})
+        self.assertIn("equipment_type must be switch or router", report.errors[0])
+
+    def test_script_entrypoint_runs_end_to_end(self) -> None:
+        csv_path = self._write_csv(
+            "asset_tag,equipment_type\n"
+            "SW-CLI,switch\n"
+        )
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "import_network_assets_csv.py"
+
+        result = subprocess.run(
+            [sys.executable, str(script_path), str(csv_path), "--db", str(self.db_path), "--actor", "admin-import"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), '{"errors": 0, "imported": 1, "processed": 1}')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Added a CSV-only importer for staged switch/router custody assets.

## Related Issue

Closes #814

## Changes

- Added switch/router CSV import support using the existing ingest committer.
- Enforced asset_tag as the canonical custody identifier, with barcode fallback only when asset_tag is blank.
- Rejected serial-only rows, duplicate tags, duplicate serials, unsupported equipment types, invalid slot references, occupied slots, unsupported columns, and CMDB-like fields.
- Mapped location_building to assets.building while keeping room blank.
- Updated staging/import docs to match the approved custody identifier rules.
- Added focused importer tests.

## Verification checklist

- [x] Ran `python3 -m compileall assettrack tests scripts`
- [x] Ran `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_network_asset_import.py -q`
- [x] Confirmed `12 passed`
- [x] Ran `python3 -m pytest`
- [x] Confirmed `401 passed`
- [x] Ran `git diff --check`
- [x] Confirmed no schema, migration, auth, receipt, event semantic, or persistence semantic changes
- [x] Confirmed no CMDB behavior was introduced
- [x] Confirmed no XLSX import was added

## Notes

No browser smoke test required because no admin UI or operator workflow changed. CLI import path is covered end-to-end by tests.