### PR TITLE
Issue 27-27: Add admin-triggered receipt resend

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -6078,6 +6078,28 @@ def _send_queued_receipt(receipt_id: int) -> dict[str, object]:
         conn.close()
 
 
+def _resend_existing_receipt(receipt_id: int) -> dict[str, object]:
+    conn = get_connection()
+    try:
+        row = _receipt_queue_row_by_id(conn, receipt_id)
+        if row is None:
+            raise ValueError("Receipt not found.")
+
+        snapshot = _receipt_row_snapshot(row)
+        delivery = _receipt_delivery_from_row(row, snapshot)
+        if str(delivery.get("state") or "").strip().lower() != "sent":
+            raise ValueError("Receipt is not eligible for resend.")
+
+        receipt = _receipt_from_queue_row(row)
+        recipients = _send_receipt_email(receipt)
+        return {
+            "receipt_id": int(row["id"]),
+            "recipients": recipients,
+        }
+    finally:
+        conn.close()
+
+
 @app.get("/receipts")
 @require_login
 def receipts_list():
@@ -6227,6 +6249,43 @@ def receipt_send(receipt_id: int):
         }
 
     flash(f"Receipt email sent to {', '.join(result['recipients'])}.", "success")
+    return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+
+
+@app.post("/receipts/<int:receipt_id>/resend")
+@require_role("admin")
+def receipt_resend(receipt_id: int):
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        if wants_json():
+            return {"ok": False, "error": "Locked"}, 401
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    if recovery_mode_is_active(_resolved_runtime_db_path()):
+        message = _recovery_mode_send_block_message()
+        if wants_json():
+            return {"ok": False, "error": message}, 409
+        flash(message, "error")
+        return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+
+    try:
+        result = _resend_existing_receipt(receipt_id)
+    except Exception:
+        message = "Receipt email could not be resent."
+        if wants_json():
+            return {"ok": False, "error": message}, 500
+        flash(message, "error")
+        return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+
+    if wants_json():
+        return {
+            "ok": True,
+            "receipt_id": result["receipt_id"],
+            "recipients": result["recipients"],
+        }
+
+    flash(f"Receipt email resent to {', '.join(result['recipients'])}.", "success")
     return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
 

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -246,6 +246,15 @@
         </form>
       {% endif %}
     {% endif %}
+    {% if authenticated_role == "admin" and receipt.delivery.state == "sent" %}
+      {% if recovery_mode.active %}
+        <span class="pill bad">Recovery mode blocks resend receipt email</span>
+      {% else %}
+        <form method="post" action="{{ url_for('receipt_resend', receipt_id=receipt.id) }}">
+          <button type="submit">Resend receipt email</button>
+        </form>
+      {% endif %}
+    {% endif %}
   </nav>
 
   <section class="card">

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -1041,6 +1041,264 @@ def test_receipt_send_fails_clearly_when_snapshot_email_is_missing(client_with_t
     assert response.json == {"ok": False, "error": "Receipt has no stored email recipient."}
 
 
+def test_admin_can_resend_existing_receipt_without_changing_receipt_or_event_truth(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    admin_id = create_test_user(username="receipt-resend-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "sent",
+            "sent_at": "2026-04-01T12:00:00+00:00",
+            "last_attempt_at": "2026-04-01T12:00:00+00:00",
+            "last_error": None,
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = ?, last_attempt_at = ?, last_error = NULL
+            WHERE id = ?;
+            """,
+            (json.dumps(snapshot, sort_keys=True), "2026-04-01T12:00:00+00:00", "2026-04-01T12:00:00+00:00", receipt_id),
+        )
+        conn.commit()
+        receipt_before = conn.execute(
+            "SELECT snapshot_json, sent_at, last_attempt_at, last_error FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+        event_count_before = conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()
+    finally:
+        conn.close()
+    assert receipt_before is not None
+    assert event_count_before is not None
+
+    sent_receipts: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        sent_receipts.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
+
+    assert response.status_code == 200
+    assert response.json == {
+        "ok": True,
+        "receipt_id": receipt_id,
+        "recipients": ["issue@example.org"],
+    }
+    assert sent_receipts == [receipt_id]
+
+    conn = db.get_connection()
+    try:
+        receipt_after = conn.execute(
+            "SELECT snapshot_json, sent_at, last_attempt_at, last_error FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+        event_count_after = conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()
+    finally:
+        conn.close()
+
+    assert receipt_after is not None
+    assert event_count_after is not None
+    assert dict(receipt_after) == dict(receipt_before)
+    assert int(event_count_after["c"]) == int(event_count_before["c"])
+
+
+def test_operator_cannot_trigger_receipt_resend(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(
+        f"/receipts/{receipt_id}/resend",
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 403
+    assert response.json == {"ok": False, "error": "Forbidden"}
+    assert send_calls == []
+
+
+def test_receipt_resend_uses_configured_cc_and_existing_email_content(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    admin_id = create_test_user(username="receipt-resend-cc-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "sent",
+            "sent_at": "2026-04-01T12:00:00+00:00",
+            "last_attempt_at": "2026-04-01T12:00:00+00:00",
+            "last_error": None,
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = ?, last_attempt_at = ?, last_error = NULL
+            WHERE id = ?;
+            """,
+            (json.dumps(snapshot, sort_keys=True), "2026-04-01T12:00:00+00:00", "2026-04-01T12:00:00+00:00", receipt_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    captured: dict[str, object] = {}
+
+    def _fake_send(message: EmailMessage) -> None:
+        captured["message"] = message
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "oversight@example.org")
+    monkeypatch.setattr(intake_app, "_send_email_message", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
+
+    assert response.status_code == 200
+    message = captured["message"]
+    assert isinstance(message, EmailMessage)
+    assert message["To"] == "issue@example.org"
+    assert message["Cc"] == "oversight@example.org"
+    assert "Receipt key:" in message.get_body(preferencelist=("plain",)).get_content()
+    attachments = list(message.iter_attachments())
+    assert len(attachments) == 1
+    pdf_text = _extract_pdf_text(attachments[0].get_payload(decode=True))
+    assert "ISSUE-100" in pdf_text
+    assert "Audit Details" not in pdf_text
+
+
+def test_receipt_resend_failure_is_plain_and_does_not_change_receipt_truth(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    admin_id = create_test_user(username="receipt-resend-fail-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "sent",
+            "sent_at": "2026-04-01T12:00:00+00:00",
+            "last_attempt_at": "2026-04-01T12:00:00+00:00",
+            "last_error": None,
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = ?, last_attempt_at = ?, last_error = NULL
+            WHERE id = ?;
+            """,
+            (json.dumps(snapshot, sort_keys=True), "2026-04-01T12:00:00+00:00", "2026-04-01T12:00:00+00:00", receipt_id),
+        )
+        conn.commit()
+        snapshot_before = conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert snapshot_before is not None
+
+    def _fake_send(_receipt: dict[str, object]) -> list[str]:
+        raise RuntimeError("smtp.internal.example refused credentials")
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
+
+    assert response.status_code == 500
+    assert response.json == {"ok": False, "error": "Receipt email could not be resent."}
+
+    conn = db.get_connection()
+    try:
+        snapshot_after = conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE id = ?;",
+            (receipt_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert snapshot_after is not None
+    assert snapshot_after["snapshot_json"] == snapshot_before["snapshot_json"]
+
+
+def test_admin_resend_does_not_bypass_queued_send_path(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    admin_id = create_test_user(username="receipt-resend-queued-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
+
+    assert response.status_code == 500
+    assert response.json == {"ok": False, "error": "Receipt email could not be resent."}
+    assert send_calls == []
+
+
+def test_receipt_detail_shows_resend_action_only_to_admin_after_send(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT snapshot_json FROM receipt_queue WHERE id = ?;", (receipt_id,)).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "sent",
+            "sent_at": "2026-04-01T12:00:00+00:00",
+            "last_attempt_at": "2026-04-01T12:00:00+00:00",
+            "last_error": None,
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = ?, last_attempt_at = ?, last_error = NULL
+            WHERE id = ?;
+            """,
+            (json.dumps(snapshot, sort_keys=True), "2026-04-01T12:00:00+00:00", "2026-04-01T12:00:00+00:00", receipt_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    operator_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert operator_response.status_code == 200
+    assert b"Resend receipt email" not in operator_response.data
+
+    admin_id = create_test_user(username="receipt-resend-view-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    admin_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert admin_response.status_code == 200
+    assert f'action="/receipts/{receipt_id}/resend"'.encode("utf-8") in admin_response.data
+    assert b"Resend receipt email" in admin_response.data
+
+
 def test_send_receipt_email_adds_configured_cc_recipient(monkeypatch: pytest.MonkeyPatch) -> None:
     receipt = {
         "id": 7,

--- a/tests/test_recovery_mode.py
+++ b/tests/test_recovery_mode.py
@@ -187,6 +187,32 @@ def test_receipt_send_is_blocked_during_recovery_mode(client_with_temp_db, monke
     assert send_calls == []
 
 
+def test_admin_receipt_resend_is_blocked_during_recovery_mode(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    admin_id = create_test_user(username="admin-resend-block", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    _write_recovery_state(db.DB_PATH)
+
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
+
+    assert response.status_code == 409
+    assert response.json == {
+        "ok": False,
+        "error": "Receipt resend is blocked during recovery mode. Admin acknowledgment is required before email delivery resumes.",
+    }
+    assert send_calls == []
+
+
 def test_admin_banner_is_visible_only_to_admins_during_recovery_mode(client_with_temp_db) -> None:
     _write_recovery_state(db.DB_PATH, source_filename="restore-banner.db")
 


### PR DESCRIPTION
## Summary

Added an admin-only action to resend already-delivered receipt emails.

## Related Issue

Closes #643

## Changes

- Added `POST /receipts/<receipt_id>/resend`.
- Added an admin-only resend button on delivered receipt detail pages.
- Reused the existing stored receipt snapshot and email/PDF sender.
- Preserved configured receipt CC behavior.
- Blocked resend in recovery mode.
- Prevented pending/failed receipts from bypassing the existing send/retry path.
- Added tests for admin success, operator rejection, failure handling, CC preservation, recovery mode blocking, and no receipt/event mutation.

## Verification checklist

- [x] Ran `python3 -m compileall assettrack tests scripts`
- [x] Ran focused receipt and recovery tests
- [x] Confirmed `40 passed`
- [x] Ran `python3 -m pytest`
- [x] Confirmed `408 passed`
- [x] Ran `git diff --check`
- [x] Smoke tested admin resend from delivered receipt detail
- [x] Confirmed success message appears
- [x] Confirmed receipt content did not change
- [x] Confirmed operator does not get resend access
- [x] Confirmed no custody events, audit events, schema, migration, auth model, or persistence semantics changed

## Notes

Browser direct access to `/receipts/<receipt_id>/resend` returns 405 because the route is intentionally POST-only.