### PR TITLE
Issue 27-135: Improve direct resend route misuse response

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -6289,6 +6289,13 @@ def receipt_resend(receipt_id: int):
     return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
 
+@app.get("/receipts/<int:receipt_id>/resend")
+@require_role("admin")
+def receipt_resend_get(receipt_id: int):
+    flash("Use the receipt detail page button to resend receipt email.", "error")
+    return redirect(url_for("receipt_detail", receipt_id=receipt_id))
+
+
 @app.get("/receipts/<int:receipt_id>/pdf")
 @require_login
 def receipt_pdf(receipt_id: int):

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -196,6 +196,14 @@
 {% endblock %}
 
 {% block content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
   {% set operator = receipt.commit_operator %}
   {% set holder = receipt.holder_snapshot %}
   {% set organization = receipt.organization_snapshot %}

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -1132,6 +1132,49 @@ def test_operator_cannot_trigger_receipt_resend(client_with_temp_db, monkeypatch
     assert send_calls == []
 
 
+def test_admin_get_receipt_resend_redirects_with_plain_message_without_sending(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    admin_id = create_test_user(username="receipt-resend-get-admin", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}/resend", follow_redirects=True)
+
+    assert response.status_code == 200
+    assert b"Use the receipt detail page button to resend receipt email." in response.data
+    assert send_calls == []
+
+
+def test_operator_get_receipt_resend_remains_forbidden(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    send_calls: list[int] = []
+
+    def _fake_send(receipt: dict[str, object]) -> list[str]:
+        send_calls.append(int(receipt["id"]))
+        return ["issue@example.org"]
+
+    monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
+
+    response = client_with_temp_db.get(
+        f"/receipts/{receipt_id}/resend",
+        headers={"Accept": "application/json"},
+    )
+
+    assert response.status_code == 403
+    assert response.json == {"ok": False, "error": "Forbidden"}
+    assert send_calls == []
+
+
 def test_receipt_resend_uses_configured_cc_and_existing_email_content(
     client_with_temp_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Improved the direct resend URL misuse response.

## Related Issue

Closes #27-135

## Changes

- Added admin-only `GET /receipts/<receipt_id>/resend`.
- Redirects GET misuse back to the receipt detail page with a clear guidance message.
- Added receipt-detail flash rendering using the existing template pattern.
- Kept POST resend behavior unchanged.
- Confirmed GET does not send email.

## Verification checklist

- [x] Ran `python3 -m compileall assettrack tests scripts`
- [x] Ran `python3 -m pytest tests/test_receipt_detail.py -q`
- [x] Confirmed `38 passed`
- [x] Ran `python3 -m pytest`
- [x] Confirmed `410 passed`
- [x] Ran `git diff --check`
- [x] Smoke tested admin direct GET misuse
- [x] Confirmed redirect and guidance message
- [x] Smoke tested POST resend still works
- [x] Confirmed receipt content did not change
- [x] Confirmed no receipt, custody, event, audit, schema, or persistence behavior changed

## Notes

GET access remains delivery-safe. Only POST from the receipt detail action sends the receipt email.