### PR TITLE
Issue 27-142: Trim dashboard action-card helper copy

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -248,13 +248,11 @@
 
     <section class="dashboard-primary-card dashboard-action-card">
       <p class="dashboard-primary-label">Issue Assets</p>
-      <p class="dashboard-primary-copy">Start the issue workflow for assets leaving storage.</p>
       <a class="action-secondary" href="{{ url_for('issue') }}">Open Issue Workflow</a>
     </section>
 
     <section class="dashboard-primary-card dashboard-action-card">
       <p class="dashboard-primary-label">Return Assets</p>
-      <p class="dashboard-primary-copy">Start the return workflow for assets coming back in.</p>
       <a class="action-secondary" href="{{ url_for('return_queue') }}">Open Return Workflow</a>
     </section>
   </div>


### PR DESCRIPTION
## Summary

Trims excess dashboard action-card helper copy.

## Related Issue

Closes #834

## Changes

* Removed the Issue action-card helper sentence.
* Removed the Return action-card helper sentence.
* Kept dashboard action labels and routes unchanged.
* Preserved custody-map warning text, headings, status cards, workflow links, and protected wording.

## Verification checklist

* [x] `python3 -m pytest tests/test_dashboard.py tests/test_dashboard_drilldowns.py -q`
* [x] `python3 -m compileall assettrack tests scripts`
* [x] `python3 -m pytest`
* [x] `git diff --check`
* [x] `docker compose up -d --build`
* [x] Docker HTTP smoke
* [x] Confirmed login
* [x] Confirmed dashboard action cards remain clear
* [x] Confirmed Issue action follows holder prerequisite
* [x] Confirmed Return link works

## Notes

No runtime behavior, schema, persistence, custody truth, receipt truth, audit history, event history, auth behavior, validation behavior, routes, buttons, or workflow behavior changed.
