### PR TITLE
Issue 27-138: Hide manual Add Assets launchers

### DIFF
--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -136,7 +136,6 @@
     <h2>Admin Tools</h2>
     <p class="card-intro">Use these tools for administrative maintenance and operational follow-up without changing workflow order.</p>
     <nav class="admin-tool-grid" aria-label="Admin tool navigation">
-      <a class="admin-tool-link admin-tool-link--primary" href="{{ url_for('add_assets') }}">Add Assets</a>
       <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">Create empty slots</a>
       <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
       <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Manage Users</a>

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -59,7 +59,6 @@
                     <span class="top-nav-admin-arrow" aria-hidden="true">▼</span>
                   </summary>
                   <nav class="top-nav-admin-panel" aria-label="Admin destinations">
-                    <a class="top-nav-admin-link{% if request.path.startswith('/add-assets') %} active{% endif %}" href="{{ url_for('add_assets') }}">Add Assets</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/users') %} active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/system') %} active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/reference-data') %} active{% endif %}" href="{{ url_for('admin_reference_data') }}">Reference Data</a>

--- a/docs/release/user-manual.md
+++ b/docs/release/user-manual.md
@@ -118,9 +118,9 @@ The main navigation uses these labels:
 - `Return`
 - `Preview`
 - `Users`
-- `Add Assets`
+- `Admin Tools`
 
-If you do not see `Users` or `Add Assets`, your account may not have admin access.
+If you do not see `Users` or `Admin Tools`, your account may not have admin access.
 
 ## Issue workflow
 
@@ -230,11 +230,11 @@ Expected result:
 
 ## How to add assets
 
-This is an admin workflow.
+This is an admin workflow. The named manual `Add Assets` launcher is not shown in normal navigation. Use the approved import workflow or a scoped admin asset-creation path when your local procedure calls for it.
 
-### Step 1. Open the add asset page
+### Step 1. Open the approved asset-creation path
 
-1. Select `Add Assets`.
+1. Use the import workflow or the scoped admin create form provided by your local process.
 
 ### Step 2. Enter the required asset details
 

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -114,6 +114,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b'id="holder-count">1<' in response.data
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
+    assert b"Add Assets" not in response.data
     assert b"Manage Users" in response.data
     assert b"Create empty slots" in response.data
     assert b"Assign unslotted asset" in response.data

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -618,7 +618,7 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
     assert dashboard_response.status_code == 200
     assert b">Holders</a>" in dashboard_response.data
     assert b">Receipts</a>" not in dashboard_response.data
-    assert b">Add Assets</a>" in dashboard_response.data
+    assert b">Add Assets</a>" not in dashboard_response.data
     assert b">Users</a>" in dashboard_response.data
     assert b">Admin Tools</a>" in dashboard_response.data
 


### PR DESCRIPTION
## Summary

Hides the manual Add Assets launchers while preserving direct routes and import paths.

## Related Issue

Closes #827

## Changes

* Removed the visible Add Assets launcher from the admin dropdown.
* Removed the visible Add Assets launcher from Admin Tools.
* Updated user manual wording so operators are no longer directed to the hidden launcher.
* Updated focused navigation assertions to expect the launcher to be hidden.

## Verification checklist

* [x] `python3 -m compileall assettrack tests scripts`
* [x] `python3 -m pytest tests/test_basic_auth_guard.py tests/test_admin_system_health.py tests/test_admin_add_asset_ui.py tests/test_network_asset_import.py -q`
* [x] `python3 -m pytest`
* [x] `git diff --check`
* [x] Docker smoke
* [x] Confirmed admin login works
* [x] Confirmed dashboard/admin navigation no longer shows Add Assets
* [x] Confirmed Admin Tools no longer shows Add Assets
* [x] Confirmed holder import remains reachable
* [x] Confirmed database restore upload remains reachable
* [x] Confirmed direct `/add-assets` still loads
* [x] Confirmed asset search works
* [x] Confirmed Issue workflow finds an existing storage asset
* [x] Confirmed Return workflow finds an existing custody asset
* [x] Confirmed asset/event/receipt counts were unchanged before and after smoke

## Notes

This is the hide-first path from the Issue 27-136 recon.

Direct `/add-assets` remains reachable by URL by design.

No custody truth, receipt truth, event history, audit history, schema, SQLite persistence semantics, import behavior, Issue workflow behavior, Return workflow behavior, or auth enforcement semantics changed.
