### PR TITLE
Issue 27-144: Add local receipt settings persistence

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -5,7 +5,15 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-REQUIRED_TABLES = {"assets", "holders", "organizations", "buildings", "organization_buildings", "receipt_queue"}
+REQUIRED_TABLES = {
+    "app_settings",
+    "assets",
+    "holders",
+    "organizations",
+    "buildings",
+    "organization_buildings",
+    "receipt_queue",
+}
 EVENT_TABLE_ALIASES = ("events", "asset_events")
 DEFAULT_AD_HOC_ORGANIZATION = "Ad Hoc"
 
@@ -456,6 +464,18 @@ def _create_schema(conn: sqlite3.Connection):
             sent_at TEXT NULL,
             last_attempt_at TEXT NULL,
             last_error TEXT NULL
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS app_settings (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            CHECK(key IN ('receipt_cc_addresses'))
         );
         """
     )

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -67,6 +67,7 @@ from assettrack.reference_data import (
     list_organization_building_mappings,
     list_organizations,
 )
+from assettrack.settings import active_receipt_cc_setting
 from assettrack.audit import ACTIVE_EVENTS_WHERE, record_event
 from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
 from assettrack.restore import (
@@ -5636,7 +5637,7 @@ def _receipt_email_recipients(receipt: dict[str, object]) -> list[str]:
 
 
 def _receipt_cc_recipients() -> list[str]:
-    configured_cc = str(os.getenv("ASSETTRACK_RECEIPT_CC_EMAIL") or "").strip().lower()
+    configured_cc = active_receipt_cc_setting().lower()
     return _normalized_email_addresses(configured_cc)
 
 

--- a/assettrack/settings.py
+++ b/assettrack/settings.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+import sqlite3
+from datetime import datetime, timezone
+
+from assettrack.db import get_connection
+
+RECEIPT_CC_SETTING_KEY = "receipt_cc_addresses"
+ALLOWED_SETTING_KEYS = {RECEIPT_CC_SETTING_KEY}
+
+
+def _validate_key(key: str) -> str:
+    normalized = str(key or "").strip()
+    if normalized not in ALLOWED_SETTING_KEYS:
+        raise ValueError("Unsupported app setting key.")
+    return normalized
+
+
+def read_setting(conn: sqlite3.Connection, key: str) -> str | None:
+    setting_key = _validate_key(key)
+    row = conn.execute(
+        """
+        SELECT value
+        FROM app_settings
+        WHERE key = ?;
+        """,
+        (setting_key,),
+    ).fetchone()
+    if row is None:
+        return None
+    return str(row["value"] if isinstance(row, sqlite3.Row) else row[0])
+
+
+def write_setting(conn: sqlite3.Connection, key: str, value: str) -> str:
+    setting_key = _validate_key(key)
+    normalized_value = str(value or "").strip()
+    now_iso = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT INTO app_settings (key, value, created_at, updated_at)
+        VALUES (?, ?, ?, ?)
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at;
+        """,
+        (setting_key, normalized_value, now_iso, now_iso),
+    )
+    return normalized_value
+
+
+def clear_setting(conn: sqlite3.Connection, key: str) -> None:
+    setting_key = _validate_key(key)
+    conn.execute(
+        """
+        DELETE FROM app_settings
+        WHERE key = ?;
+        """,
+        (setting_key,),
+    )
+
+
+def read_receipt_cc_setting(conn: sqlite3.Connection) -> str | None:
+    return read_setting(conn, RECEIPT_CC_SETTING_KEY)
+
+
+def write_receipt_cc_setting(conn: sqlite3.Connection, value: str) -> str:
+    normalized_value = str(value or "").strip()
+    if not normalized_value:
+        clear_receipt_cc_setting(conn)
+        return ""
+    return write_setting(conn, RECEIPT_CC_SETTING_KEY, normalized_value)
+
+
+def clear_receipt_cc_setting(conn: sqlite3.Connection) -> None:
+    clear_setting(conn, RECEIPT_CC_SETTING_KEY)
+
+
+def active_receipt_cc_setting() -> str:
+    conn = get_connection()
+    try:
+        configured = read_receipt_cc_setting(conn)
+    finally:
+        conn.close()
+
+    if configured is not None:
+        return configured
+    return str(os.getenv("ASSETTRACK_RECEIPT_CC_EMAIL") or "").strip()

--- a/tests/test_app_settings.py
+++ b/tests/test_app_settings.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.settings import (
+    active_receipt_cc_setting,
+    clear_receipt_cc_setting,
+    read_receipt_cc_setting,
+    write_receipt_cc_setting,
+    write_setting,
+)
+
+
+def test_receipt_cc_setting_persists_across_sqlite_connections(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        with conn:
+            saved = write_receipt_cc_setting(conn, "  Ops@example.org\nAudit@example.org  ")
+    finally:
+        conn.close()
+
+    assert saved == "Ops@example.org\nAudit@example.org"
+
+    reopened = sqlite3.connect(db_path)
+    reopened.row_factory = sqlite3.Row
+    try:
+        assert read_receipt_cc_setting(reopened) == "Ops@example.org\nAudit@example.org"
+    finally:
+        reopened.close()
+
+
+def test_clear_receipt_cc_setting_removes_local_value_and_restores_env_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "fallback@example.org")
+
+    conn = db.get_connection()
+    try:
+        with conn:
+            write_receipt_cc_setting(conn, "local@example.org")
+        assert active_receipt_cc_setting() == "local@example.org"
+
+        with conn:
+            clear_receipt_cc_setting(conn)
+    finally:
+        conn.close()
+
+    assert active_receipt_cc_setting() == "fallback@example.org"
+
+
+def test_blank_receipt_cc_setting_clears_local_value(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    monkeypatch.delenv("ASSETTRACK_RECEIPT_CC_EMAIL", raising=False)
+
+    conn = db.get_connection()
+    try:
+        with conn:
+            write_receipt_cc_setting(conn, "local@example.org")
+        assert active_receipt_cc_setting() == "local@example.org"
+
+        with conn:
+            saved = write_receipt_cc_setting(conn, "   ")
+        assert saved == ""
+    finally:
+        conn.close()
+
+    assert active_receipt_cc_setting() == ""
+
+
+def test_settings_reject_unsupported_keys(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db.initialize_schema(db_path)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        with pytest.raises(ValueError, match="Unsupported app setting key"):
+            write_setting(conn, "broad_notification_setting", "enabled")
+    finally:
+        conn.close()

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -179,6 +179,116 @@ def test_get_connection_bootstraps_missing_db(monkeypatch: pytest.MonkeyPatch, t
     assert "assets" in tables
     assert "asset_events" in tables
     assert "receipt_queue" in tables
+    assert "app_settings" in tables
+
+
+def test_bootstrap_db_adds_app_settings_table_to_existing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE holders (
+                id INTEGER PRIMARY KEY,
+                holder_type TEXT NOT NULL,
+                name TEXT NOT NULL,
+                organization TEXT NULL,
+                organization_id INTEGER NULL,
+                is_active INTEGER NOT NULL DEFAULT 1,
+                identifier TEXT NULL,
+                email TEXT NULL,
+                contact_info TEXT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE organizations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE buildings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE organization_buildings (
+                organization_id INTEGER NOT NULL,
+                building_id INTEGER NOT NULL,
+                created_at TEXT NOT NULL,
+                PRIMARY KEY (organization_id, building_id)
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT,
+                holder_id INTEGER NULL,
+                supersedes_event_id INTEGER NULL,
+                correction_reason TEXT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE receipt_queue (
+                id INTEGER PRIMARY KEY,
+                receipt_key TEXT NOT NULL UNIQUE,
+                receipt_type TEXT NOT NULL,
+                source_event_ids_json TEXT NOT NULL,
+                snapshot_json TEXT NOT NULL,
+                commit_at TEXT NOT NULL,
+                commit_operator_user_id INTEGER NOT NULL,
+                holder_id INTEGER NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    initialized = db.bootstrap_db(db_path)
+
+    assert initialized is False
+    verify_conn = sqlite3.connect(db_path)
+    try:
+        tables = {row[0] for row in verify_conn.execute("SELECT name FROM sqlite_master WHERE type = 'table';")}
+        columns = {row[1] for row in verify_conn.execute("PRAGMA table_info(app_settings);")}
+    finally:
+        verify_conn.close()
+
+    assert "app_settings" in tables
+    assert {"key", "value", "created_at", "updated_at"} <= columns
 
 
 def test_get_connection_applies_holder_is_active_migration_to_existing_db(
@@ -303,6 +413,7 @@ def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> N
     assert "organizations" in tables
     assert "buildings" in tables
     assert "organization_buildings" in tables
+    assert "app_settings" in tables
 
 
 def test_initialize_schema_creates_default_ad_hoc_organization(tmp_path: Path) -> None:

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -10,6 +10,7 @@ from pypdf import PdfReader
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
+from assettrack.settings import write_receipt_cc_setting
 from tests.auth_test_utils import create_test_user, login_session
 
 
@@ -1342,7 +1343,10 @@ def test_receipt_detail_shows_resend_action_only_to_admin_after_send(client_with
     assert b"Resend receipt email" in admin_response.data
 
 
-def test_send_receipt_email_adds_configured_cc_recipient(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_send_receipt_email_adds_configured_cc_recipient(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
     receipt = {
         "id": 7,
         "receipt_key": "R-7",
@@ -1412,7 +1416,26 @@ def test_send_receipt_email_adds_configured_cc_recipient(monkeypatch: pytest.Mon
     assert "Receipt delivery queued. Custody is already recorded." not in pdf_text
 
 
-def test_send_receipt_email_omits_cc_when_config_is_blank(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_receipt_cc_recipients_use_local_setting_before_env_fallback(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    try:
+        with conn:
+            write_receipt_cc_setting(conn, "Local@example.org")
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "env@example.org")
+
+    assert intake_app._receipt_cc_recipients() == ["local@example.org"]
+
+
+def test_send_receipt_email_omits_cc_when_config_is_blank(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
     receipt = {
         "id": 8,
         "receipt_key": "R-8",


### PR DESCRIPTION
## Summary

Adds narrow local SQLite settings persistence for receipt configuration.

## Related Issue

Closes #840

## Changes

* Added a local `app_settings` table through the existing schema/bootstrap path.
* Added constrained settings helpers for `receipt_cc_addresses` only.
* Updated receipt CC lookup to use the local setting first, then fall back to `ASSETTRACK_RECEIPT_CC_EMAIL`.
* Added tests for schema bootstrap, existing DB migration, helper read/write/clear behavior, fallback behavior, local override behavior, and blank CC behavior.

## Verification checklist

* [x] `python3 -m compileall assettrack tests scripts`
* [x] `python3 -m pytest tests/test_app_settings.py tests/test_db_init_startup.py tests/test_receipt_detail.py -q`
* [x] `python3 -m pytest tests/test_admin_db_restore.py tests/test_app_settings.py tests/test_db_init_startup.py tests/test_receipt_detail.py -q`
* [x] `python3 -m pytest`
* [x] `git diff --check`
* [x] Saved local receipt CC setting and confirmed it persisted after SQLite reconnect
* [x] Cleared local setting and confirmed environment fallback behavior
* [x] Confirmed blank fallback does not force a `Cc` header
* [x] `docker compose up -d --build`
* [x] Confirmed container started healthy
* [x] Confirmed Docker SQLite DB has `app_settings`
* [x] Confirmed `/dashboard`, `/issue`, `/return`, and `/receipts` load successfully
* [x] Confirmed setting persisted after container restart
* [x] `docker compose down`

## Notes

No admin UI was added in this issue. Issue 27-139 can now build on the local settings helpers.

No custody truth, receipt truth, event history, audit history, receipt snapshots, receipt PDFs, or offline-first operation changed.
