### PR TITLE
Issue 27-139: Add admin-managed receipt CC settings

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -67,7 +67,11 @@ from assettrack.reference_data import (
     list_organization_building_mappings,
     list_organizations,
 )
-from assettrack.settings import active_receipt_cc_setting
+from assettrack.settings import (
+    active_receipt_cc_setting,
+    read_receipt_cc_setting,
+    save_receipt_cc_addresses,
+)
 from assettrack.audit import ACTIVE_EVENTS_WHERE, record_event
 from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
 from assettrack.restore import (
@@ -5646,7 +5650,7 @@ def _normalized_email_addresses(raw_addresses: str) -> list[str]:
         return []
 
     recipients: list[str] = []
-    for _, email_address in getaddresses([raw_addresses]):
+    for _, email_address in getaddresses([raw_addresses.replace("\n", ",")]):
         normalized = str(email_address or "").strip().lower()
         if normalized and normalized not in recipients:
             recipients.append(normalized)
@@ -6599,6 +6603,57 @@ def admin_system():
         schema_warning=schema_warning,
         restore_history=restore_history,
     )
+
+
+def _receipt_cc_settings_context(form_value: str | None = None, error_message: str = "") -> dict[str, object]:
+    conn = get_connection()
+    try:
+        local_value = read_receipt_cc_setting(conn)
+    finally:
+        conn.close()
+
+    active_value = active_receipt_cc_setting()
+    active_addresses = _normalized_email_addresses(active_value)
+    source_label = "Local setting" if local_value is not None else "Environment fallback"
+    textarea_value = form_value if form_value is not None else (local_value or "")
+    return {
+        "active_addresses": active_addresses,
+        "active_source": source_label,
+        "error_message": error_message,
+        "has_local_setting": local_value is not None,
+        "textarea_value": textarea_value,
+    }
+
+
+@app.route("/admin/receipt-cc", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_receipt_cc_settings():
+    if request.method == "POST":
+        raw_addresses = request.form.get("cc_addresses") or ""
+        try:
+            conn = get_connection()
+            try:
+                with conn:
+                    saved_addresses = save_receipt_cc_addresses(conn, raw_addresses)
+            finally:
+                conn.close()
+        except ValueError as exc:
+            return (
+                render_template(
+                    "admin_receipt_cc.html",
+                    **_receipt_cc_settings_context(form_value=raw_addresses, error_message=str(exc)),
+                ),
+                400,
+            )
+
+        if saved_addresses:
+            flash(f"Receipt CC saved: {', '.join(saved_addresses)}.", "success")
+        else:
+            flash("Local receipt CC cleared. Environment fallback applies when configured.", "success")
+        return redirect(url_for("admin_receipt_cc_settings"))
+
+    return render_template("admin_receipt_cc.html", **_receipt_cc_settings_context())
 
 
 @app.route("/admin/slots/provision", methods=["GET", "POST"])

--- a/assettrack/intake/templates/admin_receipt_cc.html
+++ b/assettrack/intake/templates/admin_receipt_cc.html
@@ -1,0 +1,69 @@
+<!-- file: assettrack/intake/templates/admin_receipt_cc.html -->
+{% extends "base.html" %}
+
+{% block title %}Receipt CC Settings{% endblock %}
+{% block page_heading %}Admin: Receipt CC Settings{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .receipt-cc-textarea {
+      box-sizing: border-box;
+      min-height: 9rem;
+      width: min(100%, 42rem);
+      padding: 0.65rem;
+      font: inherit;
+    }
+    .receipt-cc-list {
+      margin: 0.5rem 0 0 1.25rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="workflow-local-nav" aria-label="Receipt CC settings navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Active Receipt CC</h2>
+    <p><strong>Source:</strong> {{ active_source }}</p>
+    {% if active_addresses %}
+      <ul class="receipt-cc-list">
+        {% for address in active_addresses %}
+          <li>{{ address }}</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <p>No active CC addresses.</p>
+    {% endif %}
+  </div>
+
+  <div class="card">
+    <h2>Saved Local CC</h2>
+    <form method="post" action="{{ url_for('admin_receipt_cc_settings') }}">
+      <div class="row">
+        <label for="cc_addresses"><strong>CC addresses</strong></label><br />
+        <textarea
+          class="receipt-cc-textarea"
+          id="cc_addresses"
+          name="cc_addresses"
+          spellcheck="false"
+        >{{ textarea_value }}</textarea>
+      </div>
+      <button type="submit">Save Receipt CC</button>
+    </form>
+    <p class="muted">Leave blank and save to clear the local CC list. Environment fallback applies when configured.</p>
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -140,6 +140,7 @@
       <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
       <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Manage Users</a>
       <a class="admin-tool-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a>
+      <a class="admin-tool-link" href="{{ url_for('admin_receipt_cc_settings') }}">Receipt CC Settings</a>
       <a class="admin-tool-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a>
       <a class="admin-tool-link" href="{{ url_for('admin_human_report') }}">Open Operational Report</a>
       <a class="admin-tool-link" href="{{ url_for('admin_db_restore') }}">Restore Database Backup</a>

--- a/assettrack/settings.py
+++ b/assettrack/settings.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 from datetime import datetime, timezone
+from email.utils import getaddresses
 
 from assettrack.db import get_connection
 
@@ -74,6 +75,50 @@ def write_receipt_cc_setting(conn: sqlite3.Connection, value: str) -> str:
 
 def clear_receipt_cc_setting(conn: sqlite3.Connection) -> None:
     clear_setting(conn, RECEIPT_CC_SETTING_KEY)
+
+
+def normalize_receipt_cc_addresses(raw_addresses: str) -> list[str]:
+    raw_value = str(raw_addresses or "").strip()
+    if not raw_value:
+        return []
+
+    normalized: list[str] = []
+    invalid: list[str] = []
+    for _, email_address in getaddresses([raw_value.replace("\n", ",")]):
+        candidate = str(email_address or "").strip().lower()
+        if not _is_valid_email_address(candidate):
+            invalid.append(candidate or "blank entry")
+            continue
+        if candidate not in normalized:
+            normalized.append(candidate)
+
+    if invalid or not normalized:
+        invalid_display = ", ".join(invalid) if invalid else raw_value
+        raise ValueError(f"Invalid receipt CC address: {invalid_display}")
+
+    return normalized
+
+
+def save_receipt_cc_addresses(conn: sqlite3.Connection, raw_addresses: str) -> list[str]:
+    addresses = normalize_receipt_cc_addresses(raw_addresses)
+    if not addresses:
+        clear_receipt_cc_setting(conn)
+        return []
+    write_receipt_cc_setting(conn, "\n".join(addresses))
+    return addresses
+
+
+def _is_valid_email_address(value: str) -> bool:
+    if not value or any(char.isspace() for char in value):
+        return False
+    if value.count("@") != 1:
+        return False
+    local_part, domain = value.split("@", 1)
+    if not local_part or not domain or "." not in domain:
+        return False
+    if domain.startswith(".") or domain.endswith("."):
+        return False
+    return True
 
 
 def active_receipt_cc_setting() -> str:

--- a/tests/test_admin_receipt_cc_settings.py
+++ b/tests/test_admin_receipt_cc_settings.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.settings import active_receipt_cc_setting, read_receipt_cc_setting
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    intake_app.SCAN_QUEUE.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def test_admin_can_view_receipt_cc_settings(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "env@example.org")
+    admin_id = create_test_user(username="receipt-cc-admin-view", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/receipt-cc")
+
+    assert response.status_code == 200
+    assert b"Admin: Receipt CC Settings" in response.data
+    assert b"Environment fallback" in response.data
+    assert b"env@example.org" in response.data
+
+
+def test_operator_cannot_access_or_modify_receipt_cc_settings(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="receipt-cc-operator", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    get_response = client_with_temp_db.get("/admin/receipt-cc")
+    post_response = client_with_temp_db.post("/admin/receipt-cc", data={"cc_addresses": "ops@example.org"})
+
+    assert get_response.status_code == 403
+    assert post_response.status_code == 403
+    assert active_receipt_cc_setting() == ""
+
+
+def test_admin_can_save_valid_receipt_cc_list_and_deduplicate(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="receipt-cc-admin-save", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.post(
+        "/admin/receipt-cc",
+        data={"cc_addresses": " Ops@example.org\nops@example.org, Audit@example.org "},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Receipt CC saved: ops@example.org, audit@example.org." in response.data
+    assert b"Local setting" in response.data
+    assert response.data.count(b"ops@example.org") >= 1
+    assert b"audit@example.org" in response.data
+
+    conn = db.get_connection()
+    try:
+        assert read_receipt_cc_setting(conn) == "ops@example.org\naudit@example.org"
+    finally:
+        conn.close()
+
+
+def test_admin_invalid_receipt_cc_is_rejected_without_changing_saved_value(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="receipt-cc-admin-invalid", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    valid_response = client_with_temp_db.post(
+        "/admin/receipt-cc",
+        data={"cc_addresses": "saved@example.org"},
+        follow_redirects=True,
+    )
+    assert valid_response.status_code == 200
+
+    invalid_response = client_with_temp_db.post(
+        "/admin/receipt-cc",
+        data={"cc_addresses": "not-an-email"},
+    )
+
+    assert invalid_response.status_code == 400
+    assert b"Invalid receipt CC address: not-an-email" in invalid_response.data
+    conn = db.get_connection()
+    try:
+        assert read_receipt_cc_setting(conn) == "saved@example.org"
+    finally:
+        conn.close()
+
+
+def test_admin_blank_save_clears_local_receipt_cc_and_restores_env_fallback(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "fallback@example.org")
+    admin_id = create_test_user(username="receipt-cc-admin-clear", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    save_response = client_with_temp_db.post(
+        "/admin/receipt-cc",
+        data={"cc_addresses": "local@example.org"},
+        follow_redirects=True,
+    )
+    assert save_response.status_code == 200
+    assert active_receipt_cc_setting() == "local@example.org"
+
+    clear_response = client_with_temp_db.post(
+        "/admin/receipt-cc",
+        data={"cc_addresses": "  "},
+        follow_redirects=True,
+    )
+
+    assert clear_response.status_code == 200
+    assert b"Local receipt CC cleared. Environment fallback applies when configured." in clear_response.data
+    assert b"Environment fallback" in clear_response.data
+    assert b"fallback@example.org" in clear_response.data
+    assert active_receipt_cc_setting() == "fallback@example.org"

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -118,6 +118,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Manage Users" in response.data
     assert b"Create empty slots" in response.data
     assert b"Assign unslotted asset" in response.data
+    assert b"Receipt CC Settings" in response.data
     assert b"Import Holders from CSV" in response.data
     assert b"Open Operational Report" in response.data
     assert b"Restore Database Backup" in response.data

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -1176,7 +1176,7 @@ def test_operator_get_receipt_resend_remains_forbidden(
     assert send_calls == []
 
 
-def test_receipt_resend_uses_configured_cc_and_existing_email_content(
+def test_receipt_resend_uses_local_cc_and_existing_email_content(
     client_with_temp_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     receipt_id = _create_issue_receipt(client_with_temp_db)
@@ -1201,6 +1201,7 @@ def test_receipt_resend_uses_configured_cc_and_existing_email_content(
             """,
             (json.dumps(snapshot, sort_keys=True), "2026-04-01T12:00:00+00:00", "2026-04-01T12:00:00+00:00", receipt_id),
         )
+        write_receipt_cc_setting(conn, "local-oversight@example.org")
         conn.commit()
     finally:
         conn.close()
@@ -1210,7 +1211,7 @@ def test_receipt_resend_uses_configured_cc_and_existing_email_content(
         captured["message"] = message
 
     monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
-    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "oversight@example.org")
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "env-oversight@example.org")
     monkeypatch.setattr(intake_app, "_send_email_message", _fake_send)
 
     response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
@@ -1219,7 +1220,7 @@ def test_receipt_resend_uses_configured_cc_and_existing_email_content(
     message = captured["message"]
     assert isinstance(message, EmailMessage)
     assert message["To"] == "issue@example.org"
-    assert message["Cc"] == "oversight@example.org"
+    assert message["Cc"] == "local-oversight@example.org"
     assert "Receipt key:" in message.get_body(preferencelist=("plain",)).get_content()
     attachments = list(message.iter_attachments())
     assert len(attachments) == 1
@@ -1423,13 +1424,13 @@ def test_receipt_cc_recipients_use_local_setting_before_env_fallback(
     conn = db.get_connection()
     try:
         with conn:
-            write_receipt_cc_setting(conn, "Local@example.org")
+            write_receipt_cc_setting(conn, "Local@example.org\nAudit@example.org")
     finally:
         conn.close()
 
     monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "env@example.org")
 
-    assert intake_app._receipt_cc_recipients() == ["local@example.org"]
+    assert intake_app._receipt_cc_recipients() == ["local@example.org", "audit@example.org"]
 
 
 def test_send_receipt_email_omits_cc_when_config_is_blank(


### PR DESCRIPTION
## Summary

Adds admin-managed receipt CC settings using the approved local settings path.

## Related Issue

Closes #828

## Changes

* Added admin-only `/admin/receipt-cc` settings page.
* Added Receipt CC Settings launcher under Admin Tools.
* Added textarea save/clear flow for receipt CC addresses.
* Added validation, normalization, deduplication, and newline/comma parsing.
* Updated receipt CC parsing so saved newline-separated settings apply to receipt send and resend.

## Verification checklist

* [x] `python3 -m compileall assettrack tests scripts`
* [x] `python3 -m pytest tests/test_admin_receipt_cc_settings.py tests/test_app_settings.py tests/test_admin_system_health.py tests/test_receipt_detail.py -q`
* [x] `python3 -m pytest`
* [x] `git diff --check`
* [x] `docker compose up -d --build`
* [x] Admin login
* [x] Opened receipt CC settings page
* [x] Saved multiple CC addresses and confirmed active display
* [x] Confirmed receipt email metadata applied saved CC
* [x] Cleared CC addresses
* [x] Confirmed environment fallback behavior
* [x] Confirmed no active CC omits `Cc`
* [x] Confirmed operator access is blocked
* [x] Confirmed app remains usable after simulated email failure
* [x] Confirmed custody/event/receipt counts stayed unchanged
* [x] `docker compose down`

## Notes

No custody truth, receipt truth, event history, audit history, receipt snapshots, schema, or broad persistence semantics changed.

This only reads and writes receipt CC delivery metadata through the approved local `app_settings` helper.
