### PR TITLE
Issue 27-146: validate receipt SMTP TLS config

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -553,11 +553,22 @@ def _send_email_message(message: EmailMessage) -> None:
     if not smtp_host:
         raise ValueError("Receipt email delivery is not configured.")
 
-    smtp_port = int(str(os.getenv("ASSETTRACK_SMTP_PORT") or "25").strip() or "25")
+    raw_smtp_port = str(os.getenv("ASSETTRACK_SMTP_PORT") or "25").strip() or "25"
+    try:
+        smtp_port = int(raw_smtp_port)
+    except ValueError as exc:
+        raise ValueError("SMTP port must be a number.") from exc
     smtp_username = str(os.getenv("ASSETTRACK_SMTP_USERNAME") or "").strip()
     smtp_password = str(os.getenv("ASSETTRACK_SMTP_PASSWORD") or "")
     smtp_starttls = str(os.getenv("ASSETTRACK_SMTP_STARTTLS") or "").strip().lower() in {"1", "true", "yes", "on"}
     smtp_use_ssl = str(os.getenv("ASSETTRACK_SMTP_USE_SSL") or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    if smtp_starttls and smtp_use_ssl:
+        raise ValueError("SMTP TLS config is invalid: use STARTTLS or implicit SSL, not both.")
+    if smtp_port == 465 and not smtp_use_ssl:
+        raise ValueError("SMTP TLS config is invalid for port 465: set ASSETTRACK_SMTP_USE_SSL=true.")
+    if smtp_port in {587, 2525} and smtp_use_ssl:
+        raise ValueError(f"SMTP TLS config is invalid for port {smtp_port}: use STARTTLS, not implicit SSL.")
 
     smtp_cls = smtplib.SMTP_SSL if smtp_use_ssl else smtplib.SMTP
     with smtp_cls(smtp_host, smtp_port, timeout=10) as smtp:
@@ -6240,9 +6251,10 @@ def receipt_send(receipt_id: int):
         flash(str(exc), "error")
         return redirect(url_for("receipt_detail", receipt_id=receipt_id))
     except Exception as exc:
+        message = f"Receipt email failed after custody was recorded: {exc}"
         if wants_json():
-            return {"ok": False, "error": str(exc)}, 500
-        flash(f"Receipt email failed: {exc}", "error")
+            return {"ok": False, "error": message}, 500
+        flash(message, "error")
         return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
     if wants_json():
@@ -6277,7 +6289,7 @@ def receipt_resend(receipt_id: int):
     try:
         result = _resend_existing_receipt(receipt_id)
     except Exception:
-        message = "Receipt email could not be resent."
+        message = "Receipt email could not be resent. Custody and receipt records were not changed."
         if wants_json():
             return {"ok": False, "error": message}, 500
         flash(message, "error")

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -816,7 +816,10 @@ def test_receipt_send_failure_updates_delivery_state(client_with_temp_db, monkey
     response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
 
     assert response.status_code == 500
-    assert response.json == {"ok": False, "error": "smtp offline"}
+    assert response.json == {
+        "ok": False,
+        "error": "Receipt email failed after custody was recorded: smtp offline",
+    }
 
     conn = db.get_connection()
     try:
@@ -870,7 +873,10 @@ def test_receipt_send_retry_after_failure_uses_existing_send_route(client_with_t
     second = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
 
     assert first.status_code == 500
-    assert first.json == {"ok": False, "error": "smtp offline"}
+    assert first.json == {
+        "ok": False,
+        "error": "Receipt email failed after custody was recorded: smtp offline",
+    }
     assert second.status_code == 200
     assert second.json["ok"] is True
     assert int(second.json["receipt_id"]) == receipt_id
@@ -929,9 +935,15 @@ def test_receipt_send_failed_retry_remains_recoverable_after_repeated_failure(
     second = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
 
     assert first.status_code == 500
-    assert first.json == {"ok": False, "error": "smtp offline"}
+    assert first.json == {
+        "ok": False,
+        "error": "Receipt email failed after custody was recorded: smtp offline",
+    }
     assert second.status_code == 500
-    assert second.json == {"ok": False, "error": "smtp offline"}
+    assert second.json == {
+        "ok": False,
+        "error": "Receipt email failed after custody was recorded: smtp offline",
+    }
     assert send_attempts == [receipt_id, receipt_id]
 
     detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
@@ -1272,7 +1284,10 @@ def test_receipt_resend_failure_is_plain_and_does_not_change_receipt_truth(
     response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
 
     assert response.status_code == 500
-    assert response.json == {"ok": False, "error": "Receipt email could not be resent."}
+    assert response.json == {
+        "ok": False,
+        "error": "Receipt email could not be resent. Custody and receipt records were not changed.",
+    }
 
     conn = db.get_connection()
     try:
@@ -1303,7 +1318,10 @@ def test_admin_resend_does_not_bypass_queued_send_path(
     response = client_with_temp_db.post(f"/receipts/{receipt_id}/resend?json=1")
 
     assert response.status_code == 500
-    assert response.json == {"ok": False, "error": "Receipt email could not be resent."}
+    assert response.json == {
+        "ok": False,
+        "error": "Receipt email could not be resent. Custody and receipt records were not changed.",
+    }
     assert send_calls == []
 
 
@@ -1415,6 +1433,123 @@ def test_send_receipt_email_adds_configured_cc_recipient(
     assert "Recipient email" not in pdf_text
     assert "Delivery issue" not in pdf_text
     assert "Receipt delivery queued. Custody is already recorded." not in pdf_text
+
+
+def test_send_email_message_uses_starttls_without_implicit_ssl(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    class _FakeSMTP:
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            calls.append(("connect", host, port, timeout))
+
+        def __enter__(self) -> "_FakeSMTP":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def starttls(self) -> None:
+            calls.append("starttls")
+
+        def login(self, username: str, password: str) -> None:
+            calls.append(("login", username, password))
+
+        def send_message(self, message: EmailMessage) -> None:
+            calls.append(("send", message["To"]))
+
+    message = EmailMessage()
+    message["To"] = "holder@example.org"
+    message["From"] = "assettrack@example.org"
+    message.set_content("Receipt")
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.setenv("ASSETTRACK_SMTP_PORT", "2525")
+    monkeypatch.setenv("ASSETTRACK_SMTP_STARTTLS", "true")
+    monkeypatch.setenv("ASSETTRACK_SMTP_USE_SSL", "false")
+    monkeypatch.setenv("ASSETTRACK_SMTP_USERNAME", "apikey")
+    monkeypatch.setenv("ASSETTRACK_SMTP_PASSWORD", "secret")
+    monkeypatch.setattr(intake_app.smtplib, "SMTP", _FakeSMTP)
+
+    intake_app._send_email_message(message)
+
+    assert calls == [
+        ("connect", "smtp.example.org", 2525, 10),
+        "starttls",
+        ("login", "apikey", "secret"),
+        ("send", "holder@example.org"),
+    ]
+
+
+def test_send_email_message_uses_implicit_ssl_for_port_465(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[object] = []
+
+    class _FakeSMTPSSL:
+        def __init__(self, host: str, port: int, timeout: int) -> None:
+            calls.append(("ssl-connect", host, port, timeout))
+
+        def __enter__(self) -> "_FakeSMTPSSL":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def send_message(self, message: EmailMessage) -> None:
+            calls.append(("send", message["To"]))
+
+    message = EmailMessage()
+    message["To"] = "holder@example.org"
+    message["From"] = "assettrack@example.org"
+    message.set_content("Receipt")
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.setenv("ASSETTRACK_SMTP_PORT", "465")
+    monkeypatch.setenv("ASSETTRACK_SMTP_STARTTLS", "false")
+    monkeypatch.setenv("ASSETTRACK_SMTP_USE_SSL", "true")
+    monkeypatch.delenv("ASSETTRACK_SMTP_USERNAME", raising=False)
+    monkeypatch.setattr(intake_app.smtplib, "SMTP_SSL", _FakeSMTPSSL)
+
+    intake_app._send_email_message(message)
+
+    assert calls == [
+        ("ssl-connect", "smtp.example.org", 465, 10),
+        ("send", "holder@example.org"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("port", "starttls", "use_ssl", "expected_error"),
+    [
+        ("465", "true", "false", "SMTP TLS config is invalid for port 465"),
+        ("2525", "false", "true", "SMTP TLS config is invalid for port 2525"),
+        ("587", "false", "true", "SMTP TLS config is invalid for port 587"),
+        ("2525", "true", "true", "SMTP TLS config is invalid: use STARTTLS or implicit SSL, not both"),
+    ],
+)
+def test_send_email_message_rejects_tls_mode_mismatch_before_connecting(
+    monkeypatch: pytest.MonkeyPatch,
+    port: str,
+    starttls: str,
+    use_ssl: str,
+    expected_error: str,
+) -> None:
+    class _UnexpectedSMTP:
+        def __init__(self, *_args, **_kwargs) -> None:
+            raise AssertionError("SMTP should not connect with invalid TLS config")
+
+    message = EmailMessage()
+    message["To"] = "holder@example.org"
+    message["From"] = "assettrack@example.org"
+    message.set_content("Receipt")
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.setenv("ASSETTRACK_SMTP_PORT", port)
+    monkeypatch.setenv("ASSETTRACK_SMTP_STARTTLS", starttls)
+    monkeypatch.setenv("ASSETTRACK_SMTP_USE_SSL", use_ssl)
+    monkeypatch.setattr(intake_app.smtplib, "SMTP", _UnexpectedSMTP)
+    monkeypatch.setattr(intake_app.smtplib, "SMTP_SSL", _UnexpectedSMTP)
+
+    with pytest.raises(ValueError, match=expected_error):
+        intake_app._send_email_message(message)
 
 
 def test_receipt_cc_recipients_use_local_setting_before_env_fallback(


### PR DESCRIPTION
## Summary

Closes #844

Diagnosed and hardened the receipt email failure path without changing custody truth, receipt truth, event history, schema, persistence, or role behavior.

The production failure was isolated to SMTP provider/auth behavior. Local testing confirmed the app can reach SendGrid and complete STARTTLS, but SendGrid closes the connection during SMTP login. SendGrid trial expiration is the likely cause.

## Changes

- Added SMTP port/TLS validation before opening the network connection.
- Rejected incompatible STARTTLS and implicit SSL combinations.
- Improved receipt send failure messaging so operators know custody was already recorded.
- Improved resend failure messaging so operators know custody and receipt records were not changed.
- Added focused mocked SMTP tests for STARTTLS, implicit SSL, and invalid TLS/port combinations.

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_receipt_detail.py -q`
- [x] `python3 -m pytest`
- [x] `docker compose up -d --build`
- [x] Incognito login
- [x] Return workflow completed
- [x] Receipt record created
- [x] Receipt resend action visible
- [x] Resend failure did not change custody or receipt truth
- [x] Docker SMTP banner test reached SendGrid
- [x] Docker STARTTLS handshake completed
- [x] SMTP login failure reproduced

## Notes

SMTP delivery is still not restored because the SendGrid account is no longer accepting SMTP authentication. This PR preserves the invariant and improves diagnosis/operator messaging.

A follow-on issue should switch receipt delivery from SendGrid to Brevo or another approved SMTP provider through environment configuration only.