### PR TITLE
Issue 27-151: Show receipt CC metadata on receipt detail

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -3222,7 +3222,18 @@ def _receipt_delivery_snapshot(
     }
 
 
-def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) -> dict[str, Optional[str]]:
+def _receipt_delivery_cc_recipients(snapshot_delivery: dict[str, object]) -> list[str]:
+    raw_cc_recipients = snapshot_delivery.get("cc_recipients")
+    if isinstance(raw_cc_recipients, str):
+        return _normalized_email_addresses(raw_cc_recipients)
+    if isinstance(raw_cc_recipients, list):
+        return _normalized_email_addresses(
+            ",".join(str(recipient or "") for recipient in raw_cc_recipients)
+        )
+    return []
+
+
+def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) -> dict[str, object]:
     snapshot_delivery = snapshot.get("delivery")
     has_snapshot_delivery = isinstance(snapshot_delivery, dict)
     if not has_snapshot_delivery:
@@ -3238,6 +3249,7 @@ def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) ->
             "sent_at": None,
             "last_attempt_at": None,
             "last_error": None,
+            "cc_recipients": [],
         }
 
     if sent_at:
@@ -3247,12 +3259,14 @@ def _receipt_delivery_from_row(row: sqlite3.Row, snapshot: dict[str, object]) ->
     else:
         state = str(snapshot_delivery.get("state") or "pending").strip().lower() or "pending"
 
-    return _receipt_delivery_snapshot(
+    delivery = _receipt_delivery_snapshot(
         state=state,
         sent_at=sent_at,
         last_attempt_at=last_attempt_at,
         last_error=last_error,
     )
+    delivery["cc_recipients"] = _receipt_delivery_cc_recipients(snapshot_delivery)
+    return delivery
 
 
 def _receipt_row_snapshot(row: sqlite3.Row) -> dict[str, object]:

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -326,6 +326,16 @@
             <div class="summary-label">Recipient email</div>
             <div class="summary-copy">{{ receipt.recipient_email or "Not captured" }}</div>
           </div>
+          <div class="summary-value">
+            <div class="summary-label">CC email</div>
+            <div class="summary-copy">
+              {% if receipt.delivery.cc_recipients %}
+                {{ receipt.delivery.cc_recipients|join(", ") }}
+              {% else %}
+                None
+              {% endif %}
+            </div>
+          </div>
           {% if email_timing_value %}
             <div class="summary-value">
               <div class="summary-label">{{ email_timing_label }}</div>

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -440,6 +440,71 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
     assert b"Mar 29, 2026 at 12:05 UTC" in sent_response.data
 
 
+def test_receipt_detail_shows_cc_email_when_delivery_metadata_present(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        row = conn.execute(
+            """
+            SELECT snapshot_json
+            FROM receipt_queue
+            WHERE id = ?;
+            """,
+            (receipt_id,),
+        ).fetchone()
+        assert row is not None
+        snapshot = json.loads(str(row["snapshot_json"]))
+        snapshot["delivery"] = {
+            "state": "sent",
+            "sent_at": "2026-03-29T12:05:00+00:00",
+            "last_attempt_at": "2026-03-29T12:04:00+00:00",
+            "last_error": None,
+            "cc_recipients": ["oversight@example.org"],
+        }
+        conn.execute(
+            """
+            UPDATE receipt_queue
+            SET snapshot_json = ?, sent_at = ?, last_attempt_at = ?, last_error = NULL
+            WHERE id = ?;
+            """,
+            (
+                json.dumps(snapshot, sort_keys=True),
+                "2026-03-29T12:05:00+00:00",
+                "2026-03-29T12:04:00+00:00",
+                receipt_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Recipient email" in response.data
+    assert b"issue@example.org" in response.data
+    assert b"Receipt email status" in response.data
+    assert b">sent<" in response.data
+    assert b"CC email" in response.data
+    assert b"oversight@example.org" in response.data
+
+
+def test_receipt_detail_shows_neutral_cc_state_when_delivery_metadata_missing(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+
+    assert response.status_code == 200
+    assert b"Recipient email" in response.data
+    assert b"issue@example.org" in response.data
+    assert b"Receipt email status" in response.data
+    assert b'data-state="pending"' in response.data
+    assert b">Queued<" in response.data
+    assert b"CC email" in response.data
+    assert b"None" in response.data
+
+
 def test_receipt_detail_hides_delivery_state_for_historical_nonqueued_receipt(client_with_temp_db) -> None:
     receipt_id = _create_issue_receipt(client_with_temp_db)
 


### PR DESCRIPTION
## Summary

Closes #850

Shows receipt CC delivery metadata on the receipt detail page.

This is a presentation-only change. It displays CC metadata when that metadata already exists in the receipt snapshot. Historical receipts or receipts without stored CC metadata show `None`.

## Changes

- Added safe receipt detail handling for optional `delivery.cc_recipients`.
- Added a CC email row near existing receipt recipient/status metadata.
- Displays multiple CC recipients as a comma-separated list.
- Displays `None` when no CC metadata is present.
- Added focused receipt detail test coverage.

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `python3 -m pytest tests/test_receipt_detail.py -q`
- [x] `python3 -m pytest`
- [x] `docker compose up -d --build`
- [x] Opened receipt with CC metadata
- [x] Confirmed primary recipient rendered
- [x] Confirmed CC email rendered
- [x] Opened receipt without CC metadata
- [x] Confirmed CC email shows `None`
- [x] `docker compose down`

## Notes

No send, resend, schema, custody, event, audit, SMTP, settings, navigation, or menu behavior changed.

Follow-on issue needed: persist CC delivery metadata at send time so future production receipts display the CC actually used.