### PR TITLE
Issue 27-152: Persist receipt CC delivery metadata

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -3210,16 +3210,20 @@ def _receipt_delivery_snapshot(
     sent_at: Optional[str] = None,
     last_attempt_at: Optional[str] = None,
     last_error: Optional[str] = None,
-) -> dict[str, Optional[str]]:
+    cc_recipients: Optional[list[str]] = None,
+) -> dict[str, object]:
     normalized_state = str(state or "").strip().lower()
     if normalized_state not in {"pending", "sent", "failed"}:
         normalized_state = "pending"
-    return {
+    delivery: dict[str, object] = {
         "state": normalized_state,
         "sent_at": sent_at,
         "last_attempt_at": last_attempt_at,
         "last_error": last_error,
     }
+    if cc_recipients is not None:
+        delivery["cc_recipients"] = _normalized_email_addresses(",".join(cc_recipients))
+    return delivery
 
 
 def _receipt_delivery_cc_recipients(snapshot_delivery: dict[str, object]) -> list[str]:
@@ -6033,6 +6037,7 @@ def _update_receipt_delivery_state(
     last_attempt_at: Optional[str],
     sent_at: Optional[str],
     last_error: Optional[str],
+    cc_recipients: Optional[list[str]] = None,
 ) -> None:
     updated_snapshot = dict(snapshot)
     updated_snapshot["delivery"] = _receipt_delivery_snapshot(
@@ -6040,6 +6045,7 @@ def _update_receipt_delivery_state(
         sent_at=sent_at,
         last_attempt_at=last_attempt_at,
         last_error=last_error,
+        cc_recipients=cc_recipients,
     )
     conn.execute(
         """
@@ -6072,6 +6078,7 @@ def _send_queued_receipt(receipt_id: int) -> dict[str, object]:
 
         receipt = _receipt_from_queue_row(row)
         attempt_at = datetime.now(timezone.utc).isoformat()
+        cc_recipients = _receipt_cc_recipients()
 
         try:
             recipients = _send_receipt_email(receipt)
@@ -6097,6 +6104,7 @@ def _send_queued_receipt(receipt_id: int) -> dict[str, object]:
                 last_attempt_at=attempt_at,
                 sent_at=attempt_at,
                 last_error=None,
+                cc_recipients=cc_recipients,
             )
 
         return {
@@ -6121,7 +6129,24 @@ def _resend_existing_receipt(receipt_id: int) -> dict[str, object]:
             raise ValueError("Receipt is not eligible for resend.")
 
         receipt = _receipt_from_queue_row(row)
+        cc_recipients = _receipt_cc_recipients()
         recipients = _send_receipt_email(receipt)
+        delivery = _receipt_delivery_from_row(row, snapshot)
+        delivery_state = str(delivery.get("state") or "sent")
+        last_attempt_at = delivery.get("last_attempt_at")
+        sent_at = delivery.get("sent_at")
+        last_error = delivery.get("last_error")
+        with conn:
+            _update_receipt_delivery_state(
+                conn,
+                receipt_id=int(row["id"]),
+                snapshot=snapshot,
+                state=delivery_state,
+                last_attempt_at=str(last_attempt_at) if last_attempt_at is not None else None,
+                sent_at=str(sent_at) if sent_at is not None else None,
+                last_error=str(last_error) if last_error is not None else None,
+                cc_recipients=cc_recipients,
+            )
         return {
             "receipt_id": int(row["id"]),
             "recipients": recipients,

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -182,6 +182,13 @@ def _receipt_row(receipt_id: int):
     return row
 
 
+def _receipt_snapshot(receipt_id: int) -> dict[str, object]:
+    row = _receipt_row(receipt_id)
+    snapshot = json.loads(str(row["snapshot_json"]))
+    assert isinstance(snapshot, dict)
+    return snapshot
+
+
 def _stored_receipt_display_title(receipt_id: int) -> str:
     row = _receipt_row(receipt_id)
     snapshot = json.loads(str(row["snapshot_json"]))
@@ -850,6 +857,76 @@ def test_receipt_send_success_updates_delivery_state(client_with_temp_db, monkey
     assert row["last_error"] is None
 
 
+def test_receipt_send_with_active_cc_stores_delivery_metadata_and_detail_shows_it(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    captured: dict[str, object] = {}
+
+    def _fake_send(message: EmailMessage) -> None:
+        captured["message"] = message
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "Oversight@example.org")
+    monkeypatch.setattr(intake_app, "_send_email_message", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 200
+    message = captured["message"]
+    assert isinstance(message, EmailMessage)
+    assert message["To"] == "issue@example.org"
+    assert message["Cc"] == "oversight@example.org"
+
+    snapshot = _receipt_snapshot(receipt_id)
+    delivery = snapshot["delivery"]
+    assert isinstance(delivery, dict)
+    assert delivery["state"] == "sent"
+    assert delivery["cc_recipients"] == ["oversight@example.org"]
+
+    detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert detail_response.status_code == 200
+    assert b"Recipient email" in detail_response.data
+    assert b"issue@example.org" in detail_response.data
+    assert b"CC email" in detail_response.data
+    assert b"oversight@example.org" in detail_response.data
+
+
+def test_receipt_send_with_no_cc_stores_empty_delivery_metadata_and_detail_shows_none(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    captured: dict[str, object] = {}
+
+    def _fake_send(message: EmailMessage) -> None:
+        captured["message"] = message
+
+    monkeypatch.setenv("ASSETTRACK_SMTP_HOST", "smtp.example.org")
+    monkeypatch.delenv("ASSETTRACK_RECEIPT_CC_EMAIL", raising=False)
+    monkeypatch.setattr(intake_app, "_send_email_message", _fake_send)
+
+    response = client_with_temp_db.post(f"/receipts/{receipt_id}/send?json=1")
+
+    assert response.status_code == 200
+    message = captured["message"]
+    assert isinstance(message, EmailMessage)
+    assert message["To"] == "issue@example.org"
+    assert message["Cc"] is None
+
+    snapshot = _receipt_snapshot(receipt_id)
+    delivery = snapshot["delivery"]
+    assert isinstance(delivery, dict)
+    assert delivery["state"] == "sent"
+    assert delivery["cc_recipients"] == []
+
+    detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert detail_response.status_code == 200
+    assert b"Recipient email" in detail_response.data
+    assert b"issue@example.org" in detail_response.data
+    assert b"CC email" in detail_response.data
+    assert b"None" in detail_response.data
+
+
 def test_receipt_send_failure_updates_delivery_state(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
     _insert_holder(
         1,
@@ -872,6 +949,12 @@ def test_receipt_send_failure_updates_delivery_state(client_with_temp_db, monkey
     )
     assert commit.status_code == 302
     receipt_id = _latest_receipt_id()
+    conn = db.get_connection()
+    try:
+        event_count_before = conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()
+    finally:
+        conn.close()
+    assert event_count_before is not None
 
     def _fake_send(_receipt: dict[str, object]) -> list[str]:
         raise RuntimeError("smtp offline")
@@ -889,16 +972,22 @@ def test_receipt_send_failure_updates_delivery_state(client_with_temp_db, monkey
     conn = db.get_connection()
     try:
         row = conn.execute(
-            "SELECT sent_at, last_attempt_at, last_error FROM receipt_queue WHERE id = ?;",
+            "SELECT sent_at, last_attempt_at, last_error, snapshot_json FROM receipt_queue WHERE id = ?;",
             (receipt_id,),
         ).fetchone()
+        event_count_after = conn.execute("SELECT COUNT(*) AS c FROM asset_events;").fetchone()
     finally:
         conn.close()
 
     assert row is not None
+    assert event_count_after is not None
     assert row["sent_at"] is None
     assert row["last_attempt_at"] is not None
     assert row["last_error"] == "smtp offline"
+    assert int(event_count_after["c"]) == int(event_count_before["c"])
+    snapshot = json.loads(str(row["snapshot_json"]))
+    assert snapshot["recipient_email"] == "issue@example.org"
+    assert "cc_recipients" not in snapshot["delivery"]
 
 
 def test_receipt_send_retry_after_failure_uses_existing_send_route(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1145,6 +1234,7 @@ def test_admin_can_resend_existing_receipt_without_changing_receipt_or_event_tru
             """,
             (json.dumps(snapshot, sort_keys=True), "2026-04-01T12:00:00+00:00", "2026-04-01T12:00:00+00:00", receipt_id),
         )
+        write_receipt_cc_setting(conn, "resend-oversight@example.org")
         conn.commit()
         receipt_before = conn.execute(
             "SELECT snapshot_json, sent_at, last_attempt_at, last_error FROM receipt_queue WHERE id = ?;",
@@ -1155,6 +1245,9 @@ def test_admin_can_resend_existing_receipt_without_changing_receipt_or_event_tru
         conn.close()
     assert receipt_before is not None
     assert event_count_before is not None
+    snapshot_before = json.loads(str(receipt_before["snapshot_json"]))
+    receipt_facts_before = dict(snapshot_before)
+    receipt_facts_before.pop("delivery", None)
 
     sent_receipts: list[int] = []
 
@@ -1186,8 +1279,20 @@ def test_admin_can_resend_existing_receipt_without_changing_receipt_or_event_tru
 
     assert receipt_after is not None
     assert event_count_after is not None
-    assert dict(receipt_after) == dict(receipt_before)
+    snapshot_after = json.loads(str(receipt_after["snapshot_json"]))
+    receipt_facts_after = dict(snapshot_after)
+    receipt_facts_after.pop("delivery", None)
+    assert receipt_facts_after == receipt_facts_before
+    assert receipt_after["sent_at"] == receipt_before["sent_at"]
+    assert receipt_after["last_attempt_at"] == receipt_before["last_attempt_at"]
+    assert receipt_after["last_error"] == receipt_before["last_error"]
+    assert snapshot_after["delivery"]["cc_recipients"] == ["resend-oversight@example.org"]
     assert int(event_count_after["c"]) == int(event_count_before["c"])
+
+    detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
+    assert detail_response.status_code == 200
+    assert b"CC email" in detail_response.data
+    assert b"resend-oversight@example.org" in detail_response.data
 
 
 def test_operator_cannot_trigger_receipt_resend(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Closes #851

Persists receipt CC delivery metadata when receipt emails are successfully sent.

This completes the CC visibility lane started in Issue 27-151. The receipt detail page can now show the CC address actually used on future successful sends and resends.

## Changes

- Persist resolved CC recipients into `snapshot.delivery.cc_recipients` after successful receipt send.
- Refresh CC delivery metadata after successful receipt resend.
- Store an empty CC list when no CC is configured.
- Avoid storing CC metadata when email delivery fails.
- Added focused receipt delivery metadata tests.

## Verification

Codex verified:
- `python3 -m compileall assettrack tests`
- `python3 -m pytest tests/test_receipt_detail.py -q`
- `python3 -m pytest`

Manual smoke:
- [x] `docker compose up -d --build`
- [x] Incognito login
- [x] Opened receipt detail
- [x] Resent receipt email with active CC
- [x] Confirmed primary email arrived
- [x] Confirmed email header included CC
- [x] Refreshed receipt detail
- [x] Confirmed CC email displayed on receipt detail
- [x] `docker compose down`

## Notes

CC remains delivery metadata only.

No schema, custody, receipt truth, event history, audit behavior, SMTP configuration, settings UI, navigation, or menu behavior changed.