### PR TITLE
Issue 27-147: Simplify receipt CC settings page

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -6665,7 +6665,12 @@ def _receipt_cc_settings_context(form_value: str | None = None, error_message: s
 
     active_value = active_receipt_cc_setting()
     active_addresses = _normalized_email_addresses(active_value)
-    source_label = "Local setting" if local_value is not None else "Environment fallback"
+    if local_value is not None:
+        source_label = "Local app setting"
+    elif active_addresses:
+        source_label = "Environment fallback"
+    else:
+        source_label = "No CC configured"
     textarea_value = form_value if form_value is not None else (local_value or "")
     return {
         "active_addresses": active_addresses,

--- a/assettrack/intake/templates/admin_receipt_cc.html
+++ b/assettrack/intake/templates/admin_receipt_cc.html
@@ -6,6 +6,20 @@
 
 {% block extra_head %}
   <style>
+    .receipt-cc-status {
+      display: grid;
+      gap: 0.75rem;
+      margin: 0.85rem 0;
+    }
+    .receipt-cc-status-row {
+      margin: 0;
+    }
+    .receipt-cc-label {
+      color: var(--color-text-muted);
+      display: block;
+      font-size: 0.85rem;
+      margin-bottom: 0.2rem;
+    }
     .receipt-cc-textarea {
       box-sizing: border-box;
       min-height: 9rem;
@@ -15,6 +29,9 @@
     }
     .receipt-cc-list {
       margin: 0.5rem 0 0 1.25rem;
+    }
+    .receipt-cc-empty {
+      margin: 0.5rem 0 0 0;
     }
   </style>
 {% endblock %}
@@ -37,24 +54,33 @@
   {% endif %}
 
   <div class="card">
-    <h2>Active Receipt CC</h2>
-    <p><strong>Source:</strong> {{ active_source }}</p>
-    {% if active_addresses %}
-      <ul class="receipt-cc-list">
-        {% for address in active_addresses %}
-          <li>{{ address }}</li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p>No active CC addresses.</p>
-    {% endif %}
+    <h2>Receipt CC now</h2>
+    <div class="receipt-cc-status" aria-label="Active receipt CC status">
+      <p class="receipt-cc-status-row">
+        <span class="receipt-cc-label">Source</span>
+        <strong>{{ active_source }}</strong>
+      </p>
+      <div class="receipt-cc-status-row">
+        <span class="receipt-cc-label">Copied on receipt emails</span>
+        {% if active_addresses %}
+          <ul class="receipt-cc-list">
+            {% for address in active_addresses %}
+              <li>{{ address }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <p class="receipt-cc-empty"><strong>No active CC addresses.</strong></p>
+        {% endif %}
+      </div>
+    </div>
   </div>
 
   <div class="card">
-    <h2>Saved Local CC</h2>
+    <h2>Change or clear</h2>
+    <p class="card-intro">Save one address per line, or leave blank and save to clear the local setting.</p>
     <form method="post" action="{{ url_for('admin_receipt_cc_settings') }}">
       <div class="row">
-        <label for="cc_addresses"><strong>CC addresses</strong></label><br />
+        <label for="cc_addresses"><strong>Local CC setting</strong></label><br />
         <textarea
           class="receipt-cc-textarea"
           id="cc_addresses"
@@ -62,8 +88,10 @@
           spellcheck="false"
         >{{ textarea_value }}</textarea>
       </div>
-      <button type="submit">Save Receipt CC</button>
+      <div class="actions">
+        <button type="submit">Save CC</button>
+      </div>
     </form>
-    <p class="muted">Leave blank and save to clear the local CC list. Environment fallback applies when configured.</p>
+    <p class="muted">Clearing the local setting restores the environment fallback when it exists.</p>
   </div>
 {% endblock %}

--- a/tests/test_admin_receipt_cc_settings.py
+++ b/tests/test_admin_receipt_cc_settings.py
@@ -6,7 +6,7 @@ import pytest
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from assettrack.settings import active_receipt_cc_setting, read_receipt_cc_setting
+from assettrack.settings import active_receipt_cc_setting, read_receipt_cc_setting, write_receipt_cc_setting
 from tests.auth_test_utils import create_test_user, login_session
 
 
@@ -18,7 +18,9 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return intake_app.app.test_client()
 
 
-def test_admin_can_view_receipt_cc_settings(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_admin_can_view_env_fallback_receipt_cc_settings(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "env@example.org")
     admin_id = create_test_user(username="receipt-cc-admin-view", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
@@ -29,6 +31,44 @@ def test_admin_can_view_receipt_cc_settings(client_with_temp_db, monkeypatch: py
     assert b"Admin: Receipt CC Settings" in response.data
     assert b"Environment fallback" in response.data
     assert b"env@example.org" in response.data
+    assert b"Copied on receipt emails" in response.data
+
+
+def test_admin_can_view_local_receipt_cc_as_active_source(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ASSETTRACK_RECEIPT_CC_EMAIL", "env@example.org")
+    admin_id = create_test_user(username="receipt-cc-admin-local-view", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    conn = db.get_connection()
+    try:
+        with conn:
+            write_receipt_cc_setting(conn, "local@example.org\naudit@example.org")
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/admin/receipt-cc")
+
+    assert response.status_code == 200
+    assert b"Receipt CC now" in response.data
+    assert b"Local app setting" in response.data
+    assert b"local@example.org" in response.data
+    assert b"audit@example.org" in response.data
+
+
+def test_admin_can_view_neutral_state_when_no_receipt_cc_exists(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ASSETTRACK_RECEIPT_CC_EMAIL", raising=False)
+    admin_id = create_test_user(username="receipt-cc-admin-none-view", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/receipt-cc")
+
+    assert response.status_code == 200
+    assert b"No CC configured" in response.data
+    assert b"No active CC addresses." in response.data
+    assert b"Change or clear" in response.data
 
 
 def test_operator_cannot_access_or_modify_receipt_cc_settings(client_with_temp_db) -> None:
@@ -55,9 +95,10 @@ def test_admin_can_save_valid_receipt_cc_list_and_deduplicate(client_with_temp_d
 
     assert response.status_code == 200
     assert b"Receipt CC saved: ops@example.org, audit@example.org." in response.data
-    assert b"Local setting" in response.data
+    assert b"Local app setting" in response.data
     assert response.data.count(b"ops@example.org") >= 1
     assert b"audit@example.org" in response.data
+    assert b"Save CC" in response.data
 
     conn = db.get_connection()
     try:


### PR DESCRIPTION
## Summary

Closes #845

Simplifies the receipt CC settings page so admins can quickly see the active CC value, where it comes from, and how to change or clear it.

## Changes

- Reworked `/admin/receipt-cc` presentation.
- Shows active CC recipients clearly.
- Shows source as local app setting, environment fallback, or no CC configured.
- Keeps existing save and clear behavior unchanged.
- Renamed the submit button to `Save CC`.
- Added focused tests for local, env fallback, none, and save/clear behavior.

## Verification

Codex verified:
- `python3 -m pytest tests/test_admin_receipt_cc_settings.py -q`
- `python3 -m compileall assettrack tests`
- `python3 -m pytest tests/test_receipt_detail.py -q`
- `python3 -m pytest`

Manual smoke:
- [x] `docker compose up -d --build`
- [x] Incognito admin login
- [x] Opened `/admin/receipt-cc`
- [x] Confirmed active CC value is obvious
- [x] Confirmed source is obvious
- [x] Saved local CC
- [x] Confirmed source changed to local app setting
- [x] Changed button label to `Save CC`
- [x] Cleared local CC
- [x] Confirmed source returned to environment fallback
- [x] `docker compose down`

## Notes

No schema, receipt send/resend, custody, event, audit, auth, navigation, SMTP, or CC resolution behavior changed.

Receipt CC remains delivery metadata only.