### PR TITLE
Issue 27-145: Update AGENTS local settings and navigation rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,11 @@ If a task risks any invariant:
 - commit: Issue X-Y: <plain English>
 - explicit file staging only (no git add .)
 - no scope expansion
+- after an issue branch is merged and the user is back on main, delete the completed local branch:
+  `git branch -D <branch-name>`
+- do not delete active or unmerged branches unless the user confirms merge is complete
+- default to one `git status --short --branch` at the end of branch setup
+- ask for extra status checks only when useful: dirty files, failed branch switch, merge/rebase, pre-commit, or confusion
 
 ---
 
@@ -77,7 +82,29 @@ Rules:
 
 ---
 
-## 6. Testing Discipline
+## 6. Local Settings And Delivery Metadata
+
+- `app_settings` stores local runtime configuration
+- receipt CC may be configured through local app settings
+- local app settings must not become custody truth, receipt truth, event truth, or audit truth
+- schema changes to app settings still require explicit migration approval
+- receipt CC is delivery metadata only
+- receipt CC is not custody truth, receipt truth, event truth, or audit truth
+- receipt CC can be persisted as delivery metadata for sent receipts
+- email delivery failure must not roll back custody or receipt creation
+
+---
+
+## 7. Manual Add Assets Navigation
+
+- manual Add Assets launchers are hidden from normal navigation
+- `/add-assets` remains available by direct URL
+- import/upload paths remain intact
+- do not re-add Manual Add Assets to normal navigation without explicit approval
+
+---
+
+## 8. Testing Discipline
 
 For workflow changes:
 
@@ -96,7 +123,7 @@ Smoke test:
 
 ---
 
-## 7. Output Requirements
+## 9. Output Requirements
 
 For implementation:
 
@@ -109,7 +136,31 @@ For implementation:
 
 ---
 
-## 8. Stop Conditions
+## 10. PR Descriptions
+
+- Codex may provide raw exit-report material
+- final PR descriptions should be prepared/reviewed by Chat from the Codex exit report
+- PR descriptions must use the AssetTrack PR standard
+
+---
+
+## 11. Prompt Estimates
+
+Codex prompts should include:
+
+- token-use estimate only: low, low-medium, medium, or high
+- fix confidence
+- no cost estimates
+
+Rules:
+
+- if token use is high, recommend splitting work into smaller GitHub issues first
+- if fix confidence is below 98.7%, recommend splitting work into smaller GitHub issues first
+- medium prompts may proceed only when scope is tight, invariants are protected, and verification is clear
+
+---
+
+## 12. Stop Conditions
 
 STOP if:
 
@@ -128,7 +179,7 @@ When stopping, report:
 
 ---
 
-## 9. Communication Style (Smart Brevity Constraint)
+## 13. Communication Style (Smart Brevity Constraint)
 
 All communication must follow:
 
@@ -148,7 +199,7 @@ Operators must understand state and next action in seconds under pressure.
 
 ---
 
-## 10. Codex Context Rule
+## 14. Codex Context Rule
 
 Codex source-of-truth hierarchy:
 


### PR DESCRIPTION
## Summary

Closes #843

Updates AGENTS.md with recent AssetTrack workflow, local settings, receipt CC, Add Assets navigation, and project execution rules.

## Changes

- Added local `app_settings` guidance.
- Added receipt CC delivery metadata boundaries.
- Added Manual Add Assets navigation rules.
- Added PR description ownership rule.
- Added prompt estimate guidance for token-use and fix confidence.
- Added post-merge branch cleanup rule.
- Added default git status rule.
- Renumbered later AGENTS.md sections to keep heading order clean.

## Verification

Codex verified:
- Reviewed AGENTS.md diff.
- Confirmed no application code changed.
- Confirmed no test files changed.
- Confirmed no documented docs lint command was available.
- No pytest run needed for docs-only change.

Manual review:
- [ ] Confirm AGENTS.md guidance matches current AssetTrack operating rules.
- [ ] Confirm no rule weakens system invariants.
- [ ] Confirm no app behavior changed.

## Notes

Docs-only change.

`docs/codex/` was reviewed and locally aligned, but it is excluded by `.git/info/exclude`, so this PR intentionally commits AGENTS.md only.

No code, tests, schema, custody, receipt, event, audit, auth, persistence, SMTP, or navigation behavior changed.