### PR TITLE
Issue 27-157: Group admin tools links

### DIFF
--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -14,7 +14,15 @@
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 0.75rem;
-      margin: 0.5rem 0 1rem;
+      margin: 0.5rem 0 0.9rem;
+    }
+    .admin-tool-section {
+      margin-top: 1rem;
+    }
+    .admin-tool-section h3 {
+      margin: 0 0 0.35rem 0;
+      color: var(--color-text);
+      font-size: 1rem;
     }
     .admin-tool-link {
       display: block;
@@ -134,19 +142,44 @@
 
   <div class="card admin-control-panel">
     <h2>Admin Tools</h2>
-    <p class="card-intro">Use these tools for administrative maintenance and operational follow-up without changing workflow order.</p>
-    <nav class="admin-tool-grid" aria-label="Admin tool navigation">
-      <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">Create empty slots</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Manage Users</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_receipt_cc_settings') }}">Receipt CC Settings</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_human_report') }}">Open Operational Report</a>
-      <a class="admin-tool-link" href="{{ url_for('admin_db_restore') }}">Restore Database Backup</a>
-    </nav>
-    <div class="workflow-action-row admin-secondary-actions" aria-label="Admin tool actions">
-      <a class="action-secondary" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
+    <div class="admin-tool-section">
+      <h3>Access</h3>
+      <nav class="admin-tool-grid" aria-label="Access admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Manage Users</a>
+      </nav>
+    </div>
+    <div class="admin-tool-section">
+      <h3>Setup Data</h3>
+      <nav class="admin-tool-grid" aria-label="Setup data admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a>
+      </nav>
+    </div>
+    <div class="admin-tool-section">
+      <h3>Storage</h3>
+      <nav class="admin-tool-grid" aria-label="Storage admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">Create empty slots</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
+      </nav>
+    </div>
+    <div class="admin-tool-section">
+      <h3>Delivery</h3>
+      <nav class="admin-tool-grid" aria-label="Delivery admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_receipt_cc_settings') }}">Receipt CC Settings</a>
+      </nav>
+    </div>
+    <div class="admin-tool-section">
+      <h3>Reports/Backup</h3>
+      <nav class="admin-tool-grid" aria-label="Reports and backup admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_human_report') }}">Open Operational Report</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
+      </nav>
+    </div>
+    <div class="admin-tool-section">
+      <h3>Recovery</h3>
+      <nav class="admin-tool-grid" aria-label="Recovery admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_db_restore') }}">Restore Database Backup</a>
+      </nav>
     </div>
   </div>
 

--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -59,8 +59,8 @@
                     <span class="top-nav-admin-arrow" aria-hidden="true">▼</span>
                   </summary>
                   <nav class="top-nav-admin-panel" aria-label="Admin destinations">
-                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/users') %} active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/system') %} active{% endif %}" href="{{ url_for('admin_system') }}">Admin Tools</a>
+                    <a class="top-nav-admin-link{% if request.path.startswith('/admin/users') %} active{% endif %}" href="{{ url_for('admin_users') }}">Users</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/reference-data') %} active{% endif %}" href="{{ url_for('admin_reference_data') }}">Reference Data</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/holders/import') %} active{% endif %}" href="{{ url_for('admin_holder_import') }}">Import Holders</a>
                     <a class="top-nav-admin-link{% if request.path.startswith('/admin/report') %} active{% endif %}" href="{{ url_for('admin_human_report') }}">Operational Report</a>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -115,6 +115,12 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b'id="asset-count">1<' in response.data
     assert b"assettrack.db" in response.data
     assert b"Add Assets" not in response.data
+    assert b"Access" in response.data
+    assert b"Setup Data" in response.data
+    assert b"Storage" in response.data
+    assert b"Delivery" in response.data
+    assert b"Reports/Backup" in response.data
+    assert b"Recovery" in response.data
     assert b"Manage Users" in response.data
     assert b"Create empty slots" in response.data
     assert b"Assign unslotted asset" in response.data

--- a/tests/test_issue_23_3_admin_system_nav.py
+++ b/tests/test_issue_23_3_admin_system_nav.py
@@ -27,6 +27,7 @@ def test_admin_navigation_exposes_system_health_link(client_with_temp_db) -> Non
     assert response.status_code == 200
     assert b'href="/admin/system"' in response.data
     assert b">Admin Tools<" in response.data
+    assert response.data.index(b">Admin Tools<") < response.data.index(b">Users<")
 
 
 def test_operator_navigation_hides_system_health_link(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary

Closes #861

Put Admin Tools first in the Admin dropdown and grouped the Admin Tools page into clearer operational sections.

## Changes

* Moved Admin Tools to the first item in the Admin dropdown.
* Grouped Admin Tools page links under:

  * Access
  * Setup Data
  * Storage
  * Delivery
  * Reports/Backup
  * Recovery
* Kept Restore Database Backup under Recovery.
* Kept Recovery State visible below the grouped tools.
* Added/updated focused tests for admin nav order and grouped admin links.

## Verification

* [x] `python3 -m pytest tests/test_admin_system_health.py tests/test_issue_23_3_admin_system_nav.py tests/test_basic_auth_guard.py -q`

  * 53 passed
* [x] `python3 -m compileall assettrack tests`

  * passed
* [x] `python3 -m pytest tests/test_admin_db_restore.py -q`

  * 12 passed
* [x] `docker compose up -d --build`

  * container healthy
* [x] Browser smoke: Admin dropdown shows Admin Tools first.
* [x] Browser smoke: Admin Tools page shows grouped sections.
* [x] Browser smoke: Restore Database Backup appears under Recovery.
* [x] Browser smoke: Recovery State remains visible and works normally.
* [x] Browser smoke: logged-out direct access to `/admin/system` is not allowed.

## Notes

No routes, permissions, schema, custody logic, event history, persistence, Issue workflow, Return workflow, restore behavior, backup behavior, receipt behavior, user behavior, import behavior, or reference-data behavior were changed.

Follow-up candidate: review Admin Tools typography, spacing, and whether grouped sections should become collapsible.
