### PR TITLE
Issue 27-159: Simplify holder search navigation

### DIFF
--- a/assettrack/intake/templates/holders_search.html
+++ b/assettrack/intake/templates/holders_search.html
@@ -92,7 +92,13 @@
 {% endblock %}
 
 {% block content %}
-  <p><a href="{{ url_for('preview') }}">← Back to preview</a> | <a href="{{ url_for('issue') }}">Issue Assets</a></p>
+  <nav class="workflow-local-nav" aria-label="Holder search navigation">
+    {% if return_to == url_for('issue') %}
+      <a class="nav-link" href="{{ return_to }}">Back to Issue</a>
+    {% elif return_to %}
+      <a class="nav-link" href="{{ return_to }}">Back to workflow</a>
+    {% endif %}
+  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -92,6 +92,9 @@ def test_holders_issue_selection_page_uses_issue_specific_action_label(client_wi
     response = client_with_temp_db.get("/holders?return_to=/issue")
 
     assert response.status_code == 200
+    assert b"Back to Issue" in response.data
+    assert b"Back to preview" not in response.data
+    assert b"Issue Assets" not in response.data
     assert b"Select for Issue" in response.data
     assert b'class="holder-select-button"' in response.data
     assert b'href="/holders/1?return_to=/issue"' in response.data


### PR DESCRIPTION
## Summary

Closes #864

Simplified the holder search local navigation so the Issue holder-selection path no longer uses preview-centered wording.

## Changes

* Replaced the legacy `Back to preview | Issue Assets` local nav with a workflow-local nav row.
* Added `Back to Issue` when holder search is reached from `/holders?return_to=/issue`.
* Added neutral `Back to workflow` wording for other safe return paths.
* Preserved inactive-holder assignment filtering messaging.
* Added focused test coverage to prevent preview-centered wording from returning on the Issue holder-selection path.

## Verification

* [x] `python3 -m pytest tests/test_issue_holder_prerequisite.py tests/test_holder_creation_viability.py tests/test_holders.py -q`

  * 61 passed
* [x] `python3 -m compileall assettrack tests`

  * passed
* [x] `docker compose up -d --build`
* [x] Browser smoke: `/holders?return_to=/issue` shows `Back to Issue`.
* [x] Browser smoke: old `Back to preview | Issue Assets` wording is gone.
* [x] Browser smoke: inactive-holder filtering message remains visible.
* [x] Browser smoke: selecting a holder returns safely to `/issue`.

## Notes

No routes, permissions, schema, custody logic, event history, persistence, Issue workflow, Return workflow, preview behavior, holder create/edit/deactivate behavior, or selected-holder behavior were changed.

Follow-up candidate: review whether the inactive-holder filtering message should be visually quieter or moved closer to the holder directory heading.
