### PR TITLE
Issue 27-161: Trim dashboard action hierarchy

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -26,7 +26,7 @@
 
     .dashboard-primary-grid {
       display: grid;
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      grid-template-columns: repeat(6, minmax(0, 1fr));
       gap: 0.85rem;
       margin-bottom: 1rem;
     }
@@ -64,6 +64,7 @@
       font-weight: 700;
     }
     .dashboard-action-card {
+      grid-column: span 3;
       background: linear-gradient(
         180deg,
         color-mix(in srgb, var(--color-primary-soft) 45%, var(--color-surface-bg)),
@@ -71,12 +72,20 @@
       );
       border-color: color-mix(in srgb, var(--color-primary) 30%, var(--color-surface));
       align-content: space-between;
+      min-height: 8rem;
+    }
+    .dashboard-action-card .dashboard-primary-label {
+      color: var(--color-text);
+      font-size: 1rem;
     }
     .dashboard-action-card .action-secondary {
       width: fit-content;
       min-height: 2.75rem;
       padding: 0.65rem 1rem;
       font-weight: 700;
+    }
+    .dashboard-metric-card {
+      grid-column: span 2;
     }
 
     .dashboard-map-card {
@@ -204,7 +213,11 @@
 
     @media (max-width: 1180px) {
       .dashboard-primary-grid {
-        grid-template-columns: repeat(3, minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+      .dashboard-action-card,
+      .dashboard-metric-card {
+        grid-column: span 1;
       }
     }
     @media (max-width: 760px) {
@@ -220,32 +233,10 @@
   {% set exception_total = overview.attention_count %}
   {% set custody_map = dashboard.snapshots.custody_map %}
   <div class="dashboard-intro">
-    <p class="dashboard-subtitle">Calm operational state first. Use Issue or Return when you are ready to act.</p>
-    <p class="dashboard-note">The custody map below is read-only orientation only. It does not create custody state.</p>
+    <p class="dashboard-note">Custody map is read-only orientation. It does not create custody state.</p>
   </div>
 
   <div class="dashboard-primary-grid" aria-label="Primary dashboard cards">
-    <section class="dashboard-primary-card">
-      <p class="dashboard-primary-label">Assets Out</p>
-      <strong>{{ overview.issued_assets }}</strong>
-      <p class="dashboard-primary-copy">Assets currently in custody.</p>
-      <a class="nav-link dashboard-primary-link" href="{{ url_for('human_report') }}">View Current Custody</a>
-    </section>
-
-    <section class="dashboard-primary-card">
-      <p class="dashboard-primary-label">Assets Remaining</p>
-      <strong>{{ overview.in_storage_assets }}</strong>
-      <p class="dashboard-primary-copy">Assets currently available in storage.</p>
-      <a class="nav-link dashboard-primary-link" href="{{ url_for('dashboard_cases') }}">Review case space</a>
-    </section>
-
-    <section class="dashboard-primary-card">
-      <p class="dashboard-primary-label">Total Assets</p>
-      <strong>{{ overview.total_assets }}</strong>
-      <p class="dashboard-primary-copy">Total assets recorded in the system.</p>
-      <a class="nav-link dashboard-primary-link" href="{{ url_for('asset_search') }}">Search assets</a>
-    </section>
-
     <section class="dashboard-primary-card dashboard-action-card">
       <p class="dashboard-primary-label">Issue Assets</p>
       <a class="action-secondary" href="{{ url_for('issue') }}">Open Issue Workflow</a>
@@ -254,6 +245,24 @@
     <section class="dashboard-primary-card dashboard-action-card">
       <p class="dashboard-primary-label">Return Assets</p>
       <a class="action-secondary" href="{{ url_for('return_queue') }}">Open Return Workflow</a>
+    </section>
+
+    <section class="dashboard-primary-card dashboard-metric-card">
+      <p class="dashboard-primary-label">Assets Out</p>
+      <strong>{{ overview.issued_assets }}</strong>
+      <a class="nav-link dashboard-primary-link" href="{{ url_for('human_report') }}">Current Custody</a>
+    </section>
+
+    <section class="dashboard-primary-card dashboard-metric-card">
+      <p class="dashboard-primary-label">Assets Remaining</p>
+      <strong>{{ overview.in_storage_assets }}</strong>
+      <a class="nav-link dashboard-primary-link" href="{{ url_for('dashboard_cases') }}">Case Status</a>
+    </section>
+
+    <section class="dashboard-primary-card dashboard-metric-card">
+      <p class="dashboard-primary-label">Total Assets</p>
+      <strong>{{ overview.total_assets }}</strong>
+      <a class="nav-link dashboard-primary-link" href="{{ url_for('asset_search') }}">Asset Search</a>
     </section>
   </div>
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -204,6 +204,14 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Return Assets", response.data)
         self.assertIn(b"Open Issue Workflow", response.data)
         self.assertIn(b"Open Return Workflow", response.data)
+        self.assertLess(
+            response.data.index(b"Issue Assets"),
+            response.data.index(b"Current Custody"),
+        )
+        self.assertLess(
+            response.data.index(b"Return Assets"),
+            response.data.index(b"Case Status"),
+        )
         self.assertIn(b"Custody Map", response.data)
         self.assertNotIn(b"Field Operational Custody Map", response.data)
         self.assertIn(b"Thread: CISR", response.data)
@@ -230,9 +238,11 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Issued to", response.data)
         self.assertIn(b"AT-CUST", response.data)
         self.assertIn(b'href="/holders/1"', response.data)
-        self.assertIn(b'href="/report">View Current Custody</a>', response.data)
+        self.assertIn(b'href="/report">Current Custody</a>', response.data)
         self.assertNotIn(b"Open manual holder follow-up", response.data)
         self.assertIn(b'href="/dashboard/cases"', response.data)
+        self.assertIn(b"Case Status", response.data)
+        self.assertIn(b"Asset Search", response.data)
         self.assertIn(b'href="/report"', response.data)
         self.assertNotIn(b"Workflow Shortcuts", response.data)
         self.assertNotIn(b'href="/issue/preview">Issue</a>', response.data)
@@ -249,7 +259,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"No active assets in the custody map.", response.data)
         self.assertIn(b'id="problems-panel"', response.data)
         self.assertNotIn(b'id="problems-panel" open', response.data)
-        self.assertIn(b"Search assets", response.data)
+        self.assertIn(b"Asset Search", response.data)
         self.assertIn(b"No case data available.", response.data)
         self.assertIn(b"No recent activity.", response.data)
         self.assertIn(b"No current problems.", response.data)


### PR DESCRIPTION
## Summary

Closes #866

Trimmed the dashboard action-card hierarchy so Issue Assets and Return Assets are the dominant operator actions.

## Changes

* Reordered dashboard action cards so Issue Assets and Return Assets appear first.
* Kept Current Custody, Case Status, and Asset Search available as secondary actions.
* Removed repeated helper copy from dashboard count cards.
* Shortened the custody-map note.
* Preserved dashboard counts, links, problems panel, recent activity, case status tables, and custody map.
* Added/updated focused dashboard test coverage.

## Verification

* [x] `python3 -m pytest tests/test_dashboard.py tests/test_dashboard_drilldowns.py -q`

  * 35 passed
* [x] `python3 -m compileall assettrack tests`

  * passed
* [x] `docker compose up -d --build`
* [x] Browser smoke: dashboard renders normally.
* [x] Browser smoke: Issue Assets and Return Assets are visually dominant.
* [x] Browser smoke: Current Custody, Case Status, and Asset Search remain available as secondary actions.
* [x] Browser smoke: dashboard counts still render.
* [x] Browser smoke: problems panel and recent activity still render where data exists.
* [x] Browser smoke: custody map remains present and read-only.
* [x] Browser smoke: `/issue` renders the Issue scan page directly.
* [x] Browser smoke: `/return` renders the Return scan page directly.
* [x] Browser smoke: no preview redirect introduced.

## Notes

No routes, permissions, schema, custody logic, dashboard queries, event history, persistence, Issue workflow, Return workflow, preview behavior, receipt behavior, auth behavior, or role behavior were changed.
