### PR TITLE
Issue 27-149A: Delete low-value helper paragraphs

### DIFF
--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -57,7 +57,6 @@
 
   <div class="card">
     <h2>Unslotted Assets</h2>
-    <p class="card-intro">Select an unslotted asset.</p>
     {% if unslotted_assets %}
       <table class="assign-slot-table">
         <thead>

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -70,7 +70,6 @@
 
   <div class="card">
     <h2>Create User</h2>
-    <p class="card-intro">Create accounts here, then manage account state and password resets from the user list below.</p>
     <form method="post" action="{{ url_for('admin_users_create') }}">
       <div class="row">
         <label for="username"><strong>Username</strong></label><br />

--- a/assettrack/intake/templates/holder_detail.html
+++ b/assettrack/intake/templates/holder_detail.html
@@ -210,15 +210,6 @@
     <div class="summary-card">
       <span class="summary-label">Assets currently assigned</span>
       <div class="summary-value">{{ asset_count }}</div>
-      <div class="summary-note">
-        {% if asset_count == 0 %}
-          No assets need action from this holder right now.
-        {% elif asset_count == 1 %}
-          Review the assigned asset below.
-        {% else %}
-          Review the assigned assets below.
-        {% endif %}
-      </div>
     </div>
     <div class="summary-card">
       <span class="summary-label">Holder record</span>
@@ -252,9 +243,6 @@
 
   <section class="card holder-assets-card">
     <h2>Assets In Custody ({{ asset_count }})</h2>
-    <p class="holder-assets-intro">
-      Use this list to review what the holder has before selecting the next workflow action.
-    </p>
     <table>
       <thead>
         <tr>

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -450,7 +450,6 @@
 
   <section class="card">
     <h2>Assets ({{ receipt.assets|length }})</h2>
-    <p class="receipt-assets-lead">Review this only if something looks wrong. Each row shows the asset, movement, holder context, and home slot.</p>
     <table>
       <thead>
         <tr>


### PR DESCRIPTION
## Summary

Deleted the five scoped low-value helper paragraphs identified by Issue 27-149.

This is a Class 1 UI / Presentation change only. The removed text repeated nearby headings, counts, tables, forms, or action buttons.

## Related Issue

Closes #875 

## Changes

- Removed repeated helper copy from holder detail
- Removed repeated helper copy from receipt detail
- Removed repeated helper copy from admin users
- Removed repeated helper copy from admin slot assignment
- Left headings, labels, buttons, tables, forms, workflow copy, receipt status text, recovery text, and safety warnings unchanged

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] Focused pytest run passed: 35 passed
- [x] Confirmed holder detail still shows assigned asset count and Assets In Custody table
- [x] Confirmed receipt detail still shows stored receipt snapshot and asset rows/status text
- [x] Confirmed Admin Users still supports create user and user management actions
- [x] Confirmed admin slot assignment still shows Unslotted Assets and Assign actions
- [x] Confirmed no workflow entry, preview, commit, receipt status, recovery, or custody-truth safety text changed

## Notes

No behavior changes were made.

Inert CSS selectors were left in place to avoid opportunistic cleanup outside the issue scope.