### PR TITLE
Issue 27-135: Clarify direct receipt resend misuse response

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -6348,7 +6348,10 @@ def receipt_resend(receipt_id: int):
 @app.get("/receipts/<int:receipt_id>/resend")
 @require_role("admin")
 def receipt_resend_get(receipt_id: int):
-    flash("Use the receipt detail page button to resend receipt email.", "error")
+    flash(
+        "No receipt email was resent. Use the receipt detail page button to resend receipt email; custody and receipt records were not changed.",
+        "error",
+    )
     return redirect(url_for("receipt_detail", receipt_id=receipt_id))
 
 

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -1329,10 +1329,18 @@ def test_admin_get_receipt_resend_redirects_with_plain_message_without_sending(
 
     monkeypatch.setattr(intake_app, "_send_receipt_email", _fake_send)
 
+    redirect_response = client_with_temp_db.get(f"/receipts/{receipt_id}/resend")
+    assert redirect_response.status_code == 302
+    assert redirect_response.headers["Location"].endswith(f"/receipts/{receipt_id}")
+    assert send_calls == []
+
     response = client_with_temp_db.get(f"/receipts/{receipt_id}/resend", follow_redirects=True)
 
     assert response.status_code == 200
-    assert b"Use the receipt detail page button to resend receipt email." in response.data
+    assert (
+        b"No receipt email was resent. Use the receipt detail page button to resend receipt email; custody and receipt records were not changed."
+        in response.data
+    )
     assert send_calls == []
 
 


### PR DESCRIPTION
## Summary

Improved the direct GET misuse response for the receipt resend route.

The admin-only POST resend behavior is unchanged. Direct GET misuse still redirects safely back to receipt detail, but now clearly states that no receipt email was resent and custody/receipt records were not changed.

## Related Issue

Closes #820

## Changes

- Updated the direct GET `/receipts/<id>/resend` misuse flash message
- Added focused test coverage confirming safe redirect behavior
- Added test coverage confirming the misuse path does not call send logic
- Preserved existing admin-only POST resend behavior

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_receipt_detail.py tests/test_basic_auth_guard.py -q`
- [x] Focused tests passed: 83 passed
- [x] Browser smoke passed
- [x] Confirmed normal resend still works
- [x] Confirmed direct GET misuse shows clearer message
- [x] Confirmed no custody, receipt snapshot, event history, audit history, or PDF behavior changed

## Notes

Class 1 UI / Presentation change.

Receipt delivery remains separate from custody truth.