### PR TITLE
Issue 27-163: Add movement proof to asset search results

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -73,7 +73,13 @@ from assettrack.settings import (
     save_receipt_cc_addresses,
 )
 from assettrack.audit import ACTIVE_EVENTS_WHERE, record_event
-from assettrack.event_types import ISSUE_EVENT_TYPE, RETURN_EVENT_TYPE
+from assettrack.event_types import (
+    ISSUE_EVENT_TYPE,
+    RETURN_EVENT_TYPE,
+    issue_event_type_values,
+    normalize_event_type,
+    return_event_type_values,
+)
 from assettrack.restore import (
     RestoreError,
     RestoreOperationError,
@@ -1586,10 +1592,64 @@ def _lookup_asset_for_verification(
                 "holder_label": holder_label,
                 "home_case_name": "" if home_slot is None else str(home_slot.get("case_name") or ""),
                 "home_slot_position": None if home_slot is None else int(home_slot["slot_position"]),
+                "movement_proof": _asset_last_movement_proof(conn, str(asset.get("asset_tag") or "")),
             }
         )
 
     return (results, None, lookup_mode)
+
+
+def _asset_last_movement_proof(conn: sqlite3.Connection, asset_tag: str) -> dict[str, object]:
+    event_type_values = tuple(issue_event_type_values() + return_event_type_values())
+    placeholders = ", ".join("?" for _ in event_type_values)
+    active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
+    event_row = conn.execute(
+        f"""
+        SELECT e.id, e.event_type, e.event_date
+        FROM asset_events e
+        WHERE UPPER(e.asset_tag) = UPPER(?)
+          AND UPPER(e.event_type) IN ({placeholders})
+          AND {active_events_where}
+        ORDER BY e.event_date DESC, e.id DESC
+        LIMIT 1;
+        """,
+        (asset_tag, *event_type_values),
+    ).fetchone()
+
+    if event_row is None:
+        return {
+            "event_id": None,
+            "event_type": "",
+            "event_date": "",
+            "event_date_display": "",
+            "receipt_id": None,
+            "receipt_key": "",
+        }
+
+    event_id = int(event_row["id"])
+    receipt_row = conn.execute(
+        """
+        SELECT id, receipt_key
+        FROM receipt_queue
+        WHERE EXISTS (
+            SELECT 1
+            FROM json_each(receipt_queue.source_event_ids_json)
+            WHERE CAST(json_each.value AS INTEGER) = ?
+        )
+        ORDER BY commit_at DESC, id DESC
+        LIMIT 1;
+        """,
+        (event_id,),
+    ).fetchone()
+
+    return {
+        "event_id": event_id,
+        "event_type": normalize_event_type(event_row["event_type"]),
+        "event_date": str(event_row["event_date"] or ""),
+        "event_date_display": _report_event_display_timestamp(event_row["event_date"]),
+        "receipt_id": None if receipt_row is None else int(receipt_row["id"]),
+        "receipt_key": "" if receipt_row is None else str(receipt_row["receipt_key"] or ""),
+    }
 
 
 def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -24,6 +24,14 @@
     }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .results-table code { white-space: nowrap; }
+    .movement-proof {
+      display: grid;
+      gap: 0.25rem;
+      min-width: 12rem;
+    }
+    .movement-proof-empty {
+      color: var(--color-text-muted);
+    }
     @media (max-width: 720px) {
       .search-grid {
         grid-template-columns: 1fr;
@@ -95,10 +103,12 @@
             <th>Current holder</th>
             <th>Home case</th>
             <th>Home slot</th>
+            <th>Last proof</th>
           </tr>
         </thead>
         <tbody>
           {% for asset in assets %}
+            {% set proof = asset.movement_proof %}
             <tr>
               <td>
                 {% if authenticated_role == 'admin' and asset.asset_tag %}
@@ -118,6 +128,30 @@
                   Slot {{ asset.home_slot_position }}
                 {% else %}
                   Not assigned
+                {% endif %}
+              </td>
+              <td>
+                {% if proof and proof.event_id %}
+                  <div class="movement-proof">
+                    <div>
+                      <strong>{{ proof.event_type }}</strong>
+                      {% if proof.event_date_display %}
+                        <span>{{ proof.event_date_display }}</span>
+                      {% endif %}
+                    </div>
+                    <div><code>Event #{{ proof.event_id }}</code></div>
+                    {% if proof.receipt_id %}
+                      <div>
+                        <a class="nav-link" href="{{ url_for('receipt_detail', receipt_id=proof.receipt_id) }}">
+                          Receipt {{ proof.receipt_key or proof.receipt_id }}
+                        </a>
+                      </div>
+                    {% else %}
+                      <div class="movement-proof-empty">No receipt linked</div>
+                    {% endif %}
+                  </div>
+                {% else %}
+                  <span class="movement-proof-empty">No movement proof recorded</span>
                 {% endif %}
               </td>
             </tr>

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -30,6 +31,56 @@ class AssetSearchUiTests(unittest.TestCase):
             VALUES (?, 'PERSON', ?, ?, NULL, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
             """,
             (holder_id, name, organization),
+        )
+        self.conn.commit()
+
+    def _insert_event(
+        self,
+        asset_tag: str,
+        *,
+        event_type: str,
+        event_date: str,
+        supersedes_event_id: int | None = None,
+        correction_reason: str | None = None,
+    ) -> int:
+        cursor = self.conn.execute(
+            """
+            INSERT INTO asset_events (
+                asset_tag,
+                event_type,
+                event_date,
+                actor,
+                notes,
+                payload,
+                holder_id,
+                supersedes_event_id,
+                correction_reason
+            )
+            VALUES (?, ?, ?, 'system', NULL, '{}', NULL, ?, ?);
+            """,
+            (asset_tag, event_type, event_date, supersedes_event_id, correction_reason),
+        )
+        self.conn.commit()
+        return int(cursor.lastrowid)
+
+    def _insert_receipt(self, receipt_id: int, receipt_key: str, source_event_ids: list[int]) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO receipt_queue (
+                id,
+                receipt_key,
+                receipt_type,
+                source_event_ids_json,
+                snapshot_json,
+                commit_at,
+                commit_operator_user_id,
+                holder_id,
+                created_at,
+                updated_at
+            )
+            VALUES (?, ?, 'ISSUE', ?, '{}', '2026-04-03T09:20:00+00:00', 1, NULL, '2026-04-03T09:20:00+00:00', '2026-04-03T09:20:00+00:00');
+            """,
+            (receipt_id, receipt_key, json.dumps(source_event_ids)),
         )
         self.conn.commit()
 
@@ -99,6 +150,7 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Alex Holder (Field Ops)", response.data)
         self.assertIn(b"CASE-A", response.data)
         self.assertIn(b"Slot 4", response.data)
+        self.assertIn(b"No movement proof recorded", response.data)
         self.assertNotIn(b'href="/admin/assets/edit?asset_tag=AT-100"', response.data)
 
     def test_admin_search_links_asset_tag_to_admin_edit_asset(self) -> None:
@@ -135,6 +187,73 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"RETIRED \xe2\x80\x94 Not in service", response.data)
         self.assertIn(b"state-badge terminal", response.data)
         self.assertNotIn(b"Retired / disposed", response.data)
+
+    def test_search_shows_latest_movement_event_proof(self) -> None:
+        self._insert_asset("AT-PROOF-1", serial_number="SER-PROOF-1", location_type="IN_CUSTODY", home_slot_id=None)
+        old_event_id = self._insert_event(
+            "AT-PROOF-1",
+            event_type="ISSUE",
+            event_date="2026-04-01T08:00:00+00:00",
+        )
+        latest_event_id = self._insert_event(
+            "AT-PROOF-1",
+            event_type="RETURN",
+            event_date="2026-04-03T09:18:00+00:00",
+        )
+
+        response = self.client.get("/assets/search?asset_tag=AT-PROOF-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Last proof", response.data)
+        self.assertIn(b"<strong>RETURN</strong>", response.data)
+        self.assertIn(b"Apr 3, 2026 9:18 AM", response.data)
+        self.assertIn(f"Event #{latest_event_id}".encode("utf-8"), response.data)
+        self.assertNotIn(f"Event #{old_event_id}".encode("utf-8"), response.data)
+        self.assertIn(b"No receipt linked", response.data)
+
+    def test_search_shows_receipt_link_for_movement_proof(self) -> None:
+        self._insert_asset("AT-RECEIPT-1", serial_number="SER-RECEIPT-1", location_type="IN_CUSTODY", home_slot_id=None)
+        event_id = self._insert_event(
+            "AT-RECEIPT-1",
+            event_type="ISSUE",
+            event_date="2026-04-03T09:18:00+00:00",
+        )
+        self._insert_receipt(42, "ISSUE:42", [event_id])
+
+        response = self.client.get("/assets/search?asset_tag=AT-RECEIPT-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"<strong>ISSUE</strong>", response.data)
+        self.assertIn(f"Event #{event_id}".encode("utf-8"), response.data)
+        self.assertIn(b'href="/receipts/42"', response.data)
+        self.assertIn(b"Receipt ISSUE:42", response.data)
+
+    def test_search_ignores_superseded_movement_events(self) -> None:
+        self._insert_asset("AT-CORRECTED-1", serial_number="SER-CORRECTED-1", location_type="IN_CUSTODY", home_slot_id=None)
+        active_event_id = self._insert_event(
+            "AT-CORRECTED-1",
+            event_type="ISSUE",
+            event_date="2026-04-01T08:00:00+00:00",
+        )
+        superseded_event_id = self._insert_event(
+            "AT-CORRECTED-1",
+            event_type="RETURN",
+            event_date="2026-04-05T08:00:00+00:00",
+        )
+        correction_event_id = self._insert_event(
+            "AT-CORRECTED-1",
+            event_type="ASSET_UPDATED",
+            event_date="2026-04-06T08:00:00+00:00",
+            supersedes_event_id=superseded_event_id,
+            correction_reason="Incorrect return event.",
+        )
+
+        response = self.client.get("/assets/search?asset_tag=AT-CORRECTED-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f"Event #{active_event_id}".encode("utf-8"), response.data)
+        self.assertNotIn(f"Event #{superseded_event_id}".encode("utf-8"), response.data)
+        self.assertNotIn(f"Event #{correction_event_id}".encode("utf-8"), response.data)
 
     def test_partial_asset_tag_search_returns_matching_assets(self) -> None:
         self._insert_holder(1, "Alex Holder", "Field Ops")


### PR DESCRIPTION
## Summary

Adds read-only last movement proof to asset search results.

Closes #880

## Changes

- Shows the latest active ISSUE/RETURN movement event in asset search results
- Shows movement event date and event ID
- Shows a receipt detail link when `receipt_queue.source_event_ids_json` proves the movement
- Shows `No movement proof recorded` when no movement proof exists
- Adds focused asset search tests for movement proof rendering, receipt link rendering, and no-proof empty state

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_asset_search_ui.py tests/test_basic_auth_guard.py::test_asset_search_requires_login -q`
- [x] Asset search focused tests passed: 16 passed
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_receipt_detail.py -q`
- [x] Receipt detail tests passed: 49 passed
- [x] Confirmed no schema changes
- [x] Confirmed no route redesign
- [x] Confirmed no custody, event, receipt, Issue, Return, queue, preview, commit, or permission behavior changed

## Notes

Manual browser verification was not performed. The change is covered through focused Flask tests.