### PR TITLE
Issue 27-164: Add clearer status cues to asset search

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1582,21 +1582,86 @@ def _lookup_asset_for_verification(
             else:
                 holder_label = _holder_display_name(holder_row)
 
+        location_type = _normalize_location_type(asset.get("location_type"))
+        movement_proof = _asset_last_movement_proof(conn, str(asset.get("asset_tag") or ""))
         results.append(
             {
                 "id": int(asset["id"]),
                 "asset_tag": str(asset.get("asset_tag") or ""),
                 "serial_number": str(asset.get("serial_number") or ""),
-                "location_type": _normalize_location_type(asset.get("location_type")),
+                "location_type": location_type,
                 "state_label": _asset_state_label(asset.get("location_type")),
                 "holder_label": holder_label,
                 "home_case_name": "" if home_slot is None else str(home_slot.get("case_name") or ""),
                 "home_slot_position": None if home_slot is None else int(home_slot["slot_position"]),
-                "movement_proof": _asset_last_movement_proof(conn, str(asset.get("asset_tag") or "")),
+                "movement_proof": movement_proof,
+                "status_cue": _asset_search_status_cue(
+                    location_type=location_type,
+                    holder_label=holder_label,
+                    movement_proof=movement_proof,
+                ),
             }
         )
 
     return (results, None, lookup_mode)
+
+
+def _asset_search_status_cue(*, location_type: str, holder_label: str, movement_proof: dict[str, object]) -> dict[str, str]:
+    normalized_location = _normalize_location_type(location_type)
+    has_holder = bool(str(holder_label or "").strip())
+    has_movement_proof = bool(movement_proof.get("event_id"))
+
+    if _is_terminal_location_type(normalized_location):
+        return {
+            "label": "Unavailable",
+            "detail": "Retired or not in service.",
+            "tone": "terminal",
+        }
+
+    if normalized_location == "IN_CUSTODY":
+        if has_holder:
+            return {
+                "label": "Out with holder",
+                "detail": f"Assigned to {holder_label}.",
+                "tone": "issued",
+            }
+        return {
+            "label": "Problem: holder not recorded",
+            "detail": "Current state says in custody, but no holder is assigned.",
+            "tone": "problem",
+        }
+
+    if normalized_location == "STORAGE":
+        if has_holder:
+            return {
+                "label": "Problem: holder still assigned",
+                "detail": "Current state says stored, but a holder is still assigned.",
+                "tone": "problem",
+            }
+        return {
+            "label": "Stored / returned",
+            "detail": "Current state is storage.",
+            "tone": "stored",
+        }
+
+    if not normalized_location:
+        if has_movement_proof:
+            return {
+                "label": "Unknown current status",
+                "detail": "Movement proof exists, but current state is not recorded.",
+                "tone": "unknown",
+            }
+        return {
+            "label": "No known custody/status proof",
+            "detail": "No current state or movement proof is recorded.",
+            "tone": "unknown",
+        }
+
+    return {
+        "label": _asset_state_label(normalized_location),
+        "detail": f"Current state is {normalized_location}.",
+        "tone": "unknown",
+    }
 
 
 def _asset_last_movement_proof(conn: sqlite3.Connection, asset_tag: str) -> dict[str, object]:

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -32,6 +32,40 @@
     .movement-proof-empty {
       color: var(--color-text-muted);
     }
+    .status-cue {
+      display: grid;
+      gap: 0.3rem;
+      min-width: 12rem;
+    }
+    .status-cue-label {
+      display: inline-flex;
+      width: fit-content;
+      padding: 0.18rem 0.5rem;
+      border-radius: 999px;
+      font-size: 0.88rem;
+      font-weight: 700;
+      background: var(--color-surface-soft);
+    }
+    .status-cue[data-tone="issued"] .status-cue-label {
+      background: var(--color-primary-soft);
+      color: var(--color-primary);
+    }
+    .status-cue[data-tone="stored"] .status-cue-label {
+      background: var(--color-success-soft);
+      color: var(--color-text);
+    }
+    .status-cue[data-tone="problem"],
+    .status-cue[data-tone="terminal"] {
+      color: var(--color-danger);
+    }
+    .status-cue[data-tone="problem"] .status-cue-label,
+    .status-cue[data-tone="terminal"] .status-cue-label {
+      background: color-mix(in srgb, var(--color-danger) 14%, white);
+      color: var(--color-danger);
+    }
+    .status-cue-detail {
+      color: var(--color-text-muted);
+    }
     @media (max-width: 720px) {
       .search-grid {
         grid-template-columns: 1fr;
@@ -109,6 +143,7 @@
         <tbody>
           {% for asset in assets %}
             {% set proof = asset.movement_proof %}
+            {% set status = asset.status_cue %}
             <tr>
               <td>
                 {% if authenticated_role == 'admin' and asset.asset_tag %}
@@ -119,7 +154,13 @@
               </td>
               <td>{{ asset.serial_number or "Not recorded" }}</td>
               <td>
-                <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span>
+                <div class="status-cue" data-tone="{{ status.tone }}">
+                  <span class="status-cue-label">{{ status.label }}</span>
+                  <span class="state-badge{% if asset_is_terminal(asset.location_type) %} terminal{% endif %}">{{ asset_state_label(asset.location_type) }}</span>
+                  {% if status.detail %}
+                    <span class="status-cue-detail">{{ status.detail }}</span>
+                  {% endif %}
+                </div>
               </td>
               <td>{{ asset.holder_label or "Not assigned" }}</td>
               <td>{{ asset.home_case_name or "Not assigned" }}</td>

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -150,6 +150,8 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Alex Holder (Field Ops)", response.data)
         self.assertIn(b"CASE-A", response.data)
         self.assertIn(b"Slot 4", response.data)
+        self.assertIn(b"Problem: holder still assigned", response.data)
+        self.assertIn(b"Current state says stored, but a holder is still assigned.", response.data)
         self.assertIn(b"No movement proof recorded", response.data)
         self.assertNotIn(b'href="/admin/assets/edit?asset_tag=AT-100"', response.data)
 
@@ -177,6 +179,33 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Current holder", response.data)
         self.assertIn(b"Not assigned", response.data)
         self.assertIn(b"Not assigned", response.data)
+        self.assertIn(b"Problem: holder not recorded", response.data)
+        self.assertIn(b"Current state says in custody, but no holder is assigned.", response.data)
+
+    def test_search_shows_stored_status_cue_for_storage_asset(self) -> None:
+        self._insert_asset("AT-STORED-1", serial_number="SER-STORED-1", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=AT-STORED-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Stored / returned", response.data)
+        self.assertIn(b"Current state is storage.", response.data)
+
+    def test_search_shows_out_with_holder_status_cue_for_issued_asset(self) -> None:
+        self._insert_holder(2, "Jamie Holder", "Field Ops")
+        self._insert_asset(
+            "AT-OUT-1",
+            serial_number="SER-OUT-1",
+            location_type="IN_CUSTODY",
+            home_slot_id=None,
+            current_holder_id=2,
+        )
+
+        response = self.client.get("/assets/search?asset_tag=AT-OUT-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Out with holder", response.data)
+        self.assertIn(b"Assigned to Jamie Holder (Field Ops).", response.data)
 
     def test_search_marks_retired_assets_with_clear_terminal_label(self) -> None:
         self._insert_asset("AT-RET-1", serial_number="SER-RET-1", location_type="DISPOSED", home_slot_id=None)
@@ -186,7 +215,19 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"RETIRED \xe2\x80\x94 Not in service", response.data)
         self.assertIn(b"state-badge terminal", response.data)
+        self.assertIn(b"Unavailable", response.data)
+        self.assertIn(b"Retired or not in service.", response.data)
         self.assertNotIn(b"Retired / disposed", response.data)
+
+    def test_search_shows_unknown_status_when_state_and_proof_are_missing(self) -> None:
+        self._insert_asset("AT-UNKNOWN-1", serial_number="SER-UNKNOWN-1", location_type="", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=AT-UNKNOWN-1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"No known custody/status proof", response.data)
+        self.assertIn(b"No current state or movement proof is recorded.", response.data)
+        self.assertIn(b"No movement proof recorded", response.data)
 
     def test_search_shows_latest_movement_event_proof(self) -> None:
         self._insert_asset("AT-PROOF-1", serial_number="SER-PROOF-1", location_type="IN_CUSTODY", home_slot_id=None)


### PR DESCRIPTION
## Summary

Adds clearer read-only status cues to asset search results using existing data only.

Closes #881

## Changes

- Shows operator-facing status cues in asset search results
- Adds cues for:
  - Out with holder
  - Stored / returned
  - Unavailable
  - Problem: holder not recorded
  - Problem: holder still assigned
  - No known custody/status proof
- Preserves movement proof display from Issue 27-163
- Adds focused asset search tests for the new status cue rendering

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_asset_search_ui.py tests/test_basic_auth_guard.py::test_asset_search_requires_login -q`
- [x] Focused asset search/auth tests passed: 19 passed
- [x] Confirmed no schema changes
- [x] Confirmed no route redesign
- [x] Confirmed no custody, event, receipt, Issue, Return, queue, preview, commit, or permission behavior changed

## Notes

Manual browser verification was not performed. The change is covered through focused Flask tests.

The new cues are read-only display logic based on existing `location_type`, holder assignment, and movement proof data.