### PR TITLE
Issue 27-166: Tighten Issue workflow guidance copy

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -77,7 +77,7 @@
 
 {% block content %}
   <nav class="workflow-local-nav" aria-label="Workflow navigation">
-    <a class="nav-link" href="{{ url_for('preview') }}">Back to Batch Preview</a>
+    <a class="nav-link" href="{{ url_for('preview') }}">Back to Issue Review</a>
   </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -197,7 +197,11 @@
 
   <div class="card workflow-card">
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
-    <p class="card-intro">Stage scans in the queue, then review the batch before commit.</p>
+    {% if issue_location_form is defined %}
+      <p class="card-intro">Select who is receiving the asset, set current location, then scan. Staged scans stay in the queue until review.</p>
+    {% else %}
+      <p class="card-intro">Stage scans in the queue, then review the batch before commit.</p>
+    {% endif %}
     {% if message_ns.scan_messages %}
       {% for category, message in message_ns.scan_messages %}
         <div class="flash {{ category|e }}">{{ message }}</div>

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -86,6 +86,8 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     issue_preview = client_with_temp_db.get("/issue/preview")
     assert issue_preview.status_code == 200
     assert b"Issue Preview" in issue_preview.data
+    assert b"Back to Issue Review" in issue_preview.data
+    assert b"Back to Batch Preview" not in issue_preview.data
     assert b"Ready to Issue" in issue_preview.data
     assert b"Issue to:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -104,6 +104,8 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert issue_page.status_code == 200
     assert b"Current Location" in issue_page.data
     assert b"Set where these assets are leaving from before scanning." in issue_page.data
+    assert b"Select who is receiving the asset, set current location, then scan." in issue_page.data
+    assert b"Staged scans stay in the queue until review." in issue_page.data
     assert b"Add to Queue" in issue_page.data
     assert b"Scan or enter asset tag" in issue_page.data
     assert b"Add to queue" in issue_page.data


### PR DESCRIPTION
## Summary

Tightens small Issue workflow copy to reduce operator hesitation.

Closes #883

## Changes

- Changed Issue Preview back-link label from `Back to Batch Preview` to `Back to Issue Review`
- Updated Issue queue intro guidance for ad hoc scans
- Clarified the expected operator order:
  - select receiver
  - set current location
  - scan assets
- Updated focused rendered-copy assertions

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_holder_prerequisite.py tests/test_issue_23_2_preview_commit_seam.py tests/test_issue_location_wiring.py tests/test_issue_case_scan.py tests/test_issue_clear_queue.py -q`
- [x] Focused Issue workflow/template tests passed: 35 passed
- [x] Confirmed copy/UI-only change
- [x] Confirmed no route changes
- [x] Confirmed no workflow order changes
- [x] Confirmed no holder-first, queue, preview, commit, custody, event, receipt, schema, or dependency behavior changed

## Notes

Manual browser verification was not performed. The change is covered through focused template/workflow tests.

Existing unrelated untracked empty files were left untouched.