### PR TITLE
Issue 27-6: Normalize location dropdown ordering

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1806,8 +1806,7 @@ def _assign_slot_location_context(form: Optional[dict[str, str]] = None) -> dict
         "building": str((form or {}).get("building") or "").strip(),
         "room": str((form or {}).get("room") or "").strip(),
     }
-    building_names = [str(row.get("name") or "").strip() for row in list_buildings()]
-    building_names = [name for name in building_names if name]
+    building_names = _ordered_location_names([str(row.get("name") or "") for row in list_buildings()])
     return {
         "form": normalized_form,
         "building_options": building_names,
@@ -2864,13 +2863,17 @@ def _issue_location_form_from_session() -> dict[str, str]:
     }
 
 
+def _ordered_location_names(names: list[str]) -> list[str]:
+    normalized_names = {str(name or "").strip() for name in names if str(name or "").strip()}
+    return sorted(normalized_names, key=lambda name: (name.casefold(), name))
+
+
 def _issue_location_context(selected_holder: Optional[dict], form: Optional[dict[str, str]] = None) -> dict:
     normalized_form = {
         "building": str((form or {}).get("building") or "").strip(),
         "room": str((form or {}).get("room") or "").strip(),
     }
-    all_building_names = [str(row.get("name") or "").strip() for row in list_buildings()]
-    all_building_names = [name for name in all_building_names if name]
+    all_building_names = _ordered_location_names([str(row.get("name") or "") for row in list_buildings()])
     allowed_building_names = list(all_building_names)
     constrained_by_org = False
 
@@ -2886,7 +2889,7 @@ def _issue_location_context(selected_holder: Optional[dict], form: Optional[dict
             for mapping in list_organization_building_mappings()
             if int(mapping["organization_id"]) == normalized_holder_org_id
         ]
-        mapped_buildings = [name for name in mapped_buildings if name]
+        mapped_buildings = _ordered_location_names(mapped_buildings)
         if mapped_buildings:
             constrained_by_org = True
             allowed_building_names = mapped_buildings

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -132,6 +132,46 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert b"Scan not added. Choose the current building." in scan_response.data
 
 
+def test_issue_location_dropdown_orders_allowed_buildings_alphabetically(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        organization_row = conn.execute(
+            "SELECT id FROM organizations WHERE name = 'Operations' LIMIT 1;"
+        ).fetchone()
+        assert organization_row is not None
+        organization_id = int(organization_row["id"])
+        for name in ["Zulu Yard", "Alpha Annex", "bravo Depot"]:
+            conn.execute(
+                """
+                INSERT INTO buildings (name, created_at, updated_at)
+                VALUES (?, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                """,
+                (name,),
+            )
+            building_id = int(conn.execute("SELECT last_insert_rowid() AS id;").fetchone()["id"])
+            conn.execute(
+                """
+                INSERT INTO organization_buildings (organization_id, building_id, created_at)
+                VALUES (?, ?, '2026-01-01T00:00:00Z');
+                """,
+                (organization_id, building_id),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/issue")
+
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+    assert html.index('value="Alpha Annex"') < html.index('value="bravo Depot"')
+    assert html.index('value="bravo Depot"') < html.index('value="HQ North"')
+    assert html.index('value="HQ North"') < html.index('value="Zulu Yard"')
+    assert "Warehouse West" not in html
+
+
 def test_issue_commit_rejects_building_outside_selected_holder_org(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db)
 


### PR DESCRIPTION
## Summary

Normalizes location dropdown ordering for predictable operator selection.

Closes #622

## Changes

- Added `_ordered_location_names()` to normalize location option display
- Trims blank location names
- Removes duplicate location names
- Sorts location names case-insensitively
- Applies ordering to Issue current-location building options
- Applies ordering to Admin slot-assignment building options
- Adds focused rendered-dropdown coverage for organization-constrained Issue building options

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_location_wiring.py tests/test_issue_holder_prerequisite.py tests/test_return_batch.py -q`
- [x] Focused Issue/Return tests passed: 37 passed
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_admin_slot_provision.py -q`
- [x] Admin slot provisioning tests passed: 10 passed
- [x] Confirmed `tests/test_return_workflow.py` does not exist, so `tests/test_return_batch.py` was used as closest Return coverage
- [x] Confirmed no schema, route, custody, event, receipt, queue, preview, or commit behavior changed

## Notes

Manual browser verification was not performed. The change is covered through focused Flask/template tests.

Existing unrelated untracked empty files were left untouched.