### PR TITLE
Issue 27-4: Improve Issue holder visibility

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -212,6 +212,17 @@
   <div class="card workflow-card">
     <h2>Commit</h2>
     <p class="card-intro">Commit only after the holder, current location, and queued assets are fully reviewed.</p>
+    {% if selected_holder %}
+      <p class="holder-summary">
+        <strong>Commit target holder:</strong> {{ holder_display_name(selected_holder) }}
+        {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+          ({{ selected_holder["organization"] }})
+        {% endif %}
+        {% if selected_holder["identifier"] %}
+          | ID {{ selected_holder["identifier"] }}
+        {% endif %}
+      </p>
+    {% endif %}
     <div class="workflow-action-stack">
       <form method="post" action="{{ url_for('issue_commit') }}">
         <label style="display:block; margin-bottom: 10px;">

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -199,6 +199,18 @@
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
     {% if issue_location_form is defined %}
       <p class="card-intro">Select who is receiving the asset, set current location, then scan. Staged scans stay in the queue until review.</p>
+      {% if selected_holder %}
+        <div class="workflow-summary workflow-summary--prereq">
+          <strong>Receiving holder</strong>
+          <span>{{ holder_display_name(selected_holder) }}</span>
+          {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+            <span>{{ selected_holder["organization"] }}</span>
+          {% endif %}
+          {% if selected_holder["identifier"] %}
+            <span>ID {{ selected_holder["identifier"] }}</span>
+          {% endif %}
+        </div>
+      {% endif %}
     {% else %}
       <p class="card-intro">Stage scans in the queue, then review the batch before commit.</p>
     {% endif %}

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -93,6 +93,8 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Issue Holder" in issue_preview.data
     assert b"1 asset queued" in issue_preview.data
     assert b"Current location:</strong> HQ North / 210" in issue_preview.data
+    assert b"Commit target holder:</strong> Issue Holder" in issue_preview.data
+    assert b"| ID IH-1" in issue_preview.data
     assert b"Issue result:</strong> <code>IN_CUSTODY</code> at <code>HQ North / 210</code>" in issue_preview.data
     assert b"Technical details" in issue_preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in issue_preview.data

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -179,6 +179,8 @@ def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> Non
     assert b"Issue" in response.data
     assert b"Issue Holder" in response.data
     assert b"Issue Org" in response.data
+    assert b"Receiving holder" in response.data
+    assert b"ID IH-1" in response.data
     assert b"Change Holder" in response.data
     assert b'href="/holders?return_to=/issue"' in response.data
     assert b"0 assets queued" in response.data


### PR DESCRIPTION
## Summary

Improves selected holder visibility during the Issue assignment workflow.

Closes #620

## Changes

- Added a visible `Receiving holder` summary on the Issue queue scan card
- Added a `Commit target holder` line on Issue Preview before commit controls
- Updated focused rendered-template assertions for both surfaces
- Uses existing `selected_holder` template data only

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_holder_prerequisite.py tests/test_issue_23_2_preview_commit_seam.py tests/test_issue_location_wiring.py tests/test_issue_case_scan.py tests/test_issue_clear_queue.py -q`
- [x] Focused Issue workflow/template tests passed: 36 passed
- [x] Confirmed UI/presentation-only change
- [x] Confirmed no schema changes
- [x] Confirmed no route changes
- [x] Confirmed no workflow order changes
- [x] Confirmed no holder/location selection, queue, preview, commit, custody, event, receipt, persistence, or auth behavior changed

## Notes

Manual browser verification was not performed. Focused Flask rendering tests verify holder visibility on the Issue queue and Issue Preview.

Existing unrelated untracked empty files were left untouched.