### PR TITLE
Issue 27-2: Persist last-used Issue location

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2863,6 +2863,21 @@ def _issue_location_form_from_session() -> dict[str, str]:
     }
 
 
+def _last_issue_location_form_from_session() -> dict[str, str]:
+    return {
+        "building": str(session.get("last_issue_building") or "").strip(),
+        "room": str(session.get("last_issue_room") or "").strip(),
+    }
+
+
+def _remember_last_issue_location(form: dict[str, str]) -> None:
+    building = str(form.get("building") or "").strip()
+    room = str(form.get("room") or "").strip()
+    if building and room:
+        session["last_issue_building"] = building
+        session["last_issue_room"] = room
+
+
 def _ordered_location_names(names: list[str]) -> list[str]:
     normalized_names = {str(name or "").strip() for name in names if str(name or "").strip()}
     return sorted(normalized_names, key=lambda name: (name.casefold(), name))
@@ -2934,6 +2949,24 @@ def _validate_issue_location_form(selected_holder: Optional[dict], form: dict[st
     return normalized_form, errors, context
 
 
+def _issue_location_form_for_holder(selected_holder: Optional[dict]) -> dict[str, str]:
+    current_form = _issue_location_form_from_session()
+    if current_form["building"] or current_form["room"]:
+        return current_form
+
+    last_form = _last_issue_location_form_from_session()
+    if not last_form["building"] and not last_form["room"]:
+        return current_form
+
+    last_normalized, last_errors, _ = _validate_issue_location_form(selected_holder, last_form)
+    if last_errors:
+        return current_form
+
+    session["issue_building"] = last_normalized["building"]
+    session["issue_room"] = last_normalized["room"]
+    return last_normalized
+
+
 def _issue_location_label(form: dict[str, str]) -> str:
     building = str(form.get("building") or "").strip()
     room = str(form.get("room") or "").strip()
@@ -2961,7 +2994,7 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
         holder_label = display_name if not identifier else f"{display_name} ({identifier})"
     issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
         selected_holder,
-        _issue_location_form_from_session(),
+        _issue_location_form_for_holder(selected_holder),
     )
     issue_location_label = _issue_location_label(issue_location_form)
 
@@ -4138,7 +4171,7 @@ def intake():
                 selected_holder = _selected_holder_from_session(require_active=True)
                 issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
                     selected_holder,
-                    _issue_location_form_from_session(),
+                    _issue_location_form_for_holder(selected_holder),
                 )
                 if selected_holder is None:
                     flash("Select a holder before issuing assets.", "error")
@@ -4155,6 +4188,7 @@ def intake():
                     return redirect(url_for("issue"))
                 session["issue_building"] = issue_location_form["building"]
                 session["issue_room"] = issue_location_form["room"]
+                _remember_last_issue_location(issue_location_form)
 
             value = sanitize_scan(scan_text)
             if not value:
@@ -4846,13 +4880,14 @@ def preview_commit():
 
     issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
         holder,
-        _issue_location_form_from_session(),
+        _issue_location_form_for_holder(holder),
     )
     if issue_location_errors:
         if wants_json():
             return {"ok": False, "committed": 0, "error": "; ".join(issue_location_errors)}, 400
         flash("; ".join(issue_location_errors), "error")
         return redirect(url_for("issue"))
+    _remember_last_issue_location(issue_location_form)
 
     asset_tags = _queue_asset_tags()
     user = current_user()
@@ -4915,10 +4950,12 @@ def issue():
 
     issue_location_form, issue_location_errors, issue_location_context = _validate_issue_location_form(
         selected_holder,
-        _issue_location_form_from_session(),
+        _issue_location_form_for_holder(selected_holder),
     )
     session["issue_building"] = issue_location_form["building"]
     session["issue_room"] = issue_location_form["room"]
+    if not issue_location_errors:
+        _remember_last_issue_location(issue_location_form)
     asset_tags = _queue_asset_tags()
     issue_state = _build_issue_preview_state(asset_tags, selected_holder)
     issued_count_raw = (request.args.get("issued") or "").strip()
@@ -4996,6 +5033,7 @@ def issue_location_update():
     if issue_location_errors:
         flash("; ".join(issue_location_errors), "error")
     else:
+        _remember_last_issue_location(issue_location_form)
         flash(f"Current location set to {_issue_location_label(issue_location_form)}.", "success")
 
     return redirect(url_for("issue"))
@@ -5012,10 +5050,12 @@ def issue_preview():
     selected_holder = _selected_holder_from_session(require_active=True)
     issue_location_form, issue_location_errors, issue_location_context = _validate_issue_location_form(
         selected_holder,
-        _issue_location_form_from_session(),
+        _issue_location_form_for_holder(selected_holder),
     )
     session["issue_building"] = issue_location_form["building"]
     session["issue_room"] = issue_location_form["room"]
+    if not issue_location_errors:
+        _remember_last_issue_location(issue_location_form)
     asset_tags = _queue_asset_tags()
     if not asset_tags:
         flash("Queue is empty. Scan assets before opening Issue Preview.", "error")
@@ -5098,13 +5138,14 @@ def issue_commit():
 
     issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
         holder,
-        _issue_location_form_from_session(),
+        _issue_location_form_for_holder(holder),
     )
     if issue_location_errors:
         if wants_json():
             return {"ok": False, "committed": 0, "error": "; ".join(issue_location_errors)}, 400
         flash("; ".join(issue_location_errors), "error")
         return redirect(url_for("issue"))
+    _remember_last_issue_location(issue_location_form)
 
     asset_tags = _queue_asset_tags()
     if not asset_tags:

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -204,6 +204,68 @@ def test_issue_commit_rejects_building_outside_selected_holder_org(client_with_t
     assert str(asset_row["building_room"]) == "Storage/A1"
 
 
+def test_issue_reuses_last_valid_current_location_when_active_location_is_empty(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["last_issue_building"] = "HQ North"
+        sess["last_issue_room"] = "210"
+        sess.pop("issue_building", None)
+        sess.pop("issue_room", None)
+
+    issue_page = client_with_temp_db.get("/issue")
+
+    assert issue_page.status_code == 200
+    assert b'value="HQ North" selected' in issue_page.data
+    assert b'id="issue-room" type="text" name="room" value="210"' in issue_page.data
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["issue_building"] == "HQ North"
+        assert sess["issue_room"] == "210"
+
+    scan_redirect = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=False,
+    )
+
+    assert scan_redirect.status_code == 302
+    assert (scan_redirect.headers.get("Location") or "").endswith("/issue#queue-actions")
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
+
+
+def test_issue_does_not_reuse_last_current_location_blocked_for_selected_holder(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["last_issue_building"] = "Warehouse West"
+        sess["last_issue_room"] = "201"
+        sess.pop("issue_building", None)
+        sess.pop("issue_room", None)
+
+    issue_page = client_with_temp_db.get("/issue")
+
+    assert issue_page.status_code == 200
+    assert b'value="Warehouse West" selected' not in issue_page.data
+    assert b'id="issue-room" type="text" name="room" value=""' in issue_page.data
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["issue_building"] == ""
+        assert sess["issue_room"] == ""
+        assert sess["last_issue_building"] == "Warehouse West"
+        assert sess["last_issue_room"] == "201"
+
+    scan_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert scan_response.status_code == 200
+    assert len(intake_app.SCAN_QUEUE) == 0
+    assert b"Scan not added. Choose the current building." in scan_response.data
+
+
 def test_issue_commit_updates_current_location_and_preserves_home_location_context(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db)
 
@@ -215,6 +277,9 @@ def test_issue_commit_updates_current_location_and_preserves_home_location_conte
     assert location_response.status_code == 200
     assert b"Current location set to HQ North / 210." in location_response.data
     assert b"flash success" in location_response.data
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_issue_building"] == "HQ North"
+        assert sess["last_issue_room"] == "210"
 
     scan_redirect = client_with_temp_db.post(
         "/",


### PR DESCRIPTION
## Summary

Persists the last valid Issue current location using session/workflow state only.

Closes #618

## Changes

- Added session-only last valid Issue current location state
- Stores `last_issue_building` and `last_issue_room` in the existing Flask session
- Reuses the last location only when the active Issue location is empty
- Keeps existing holder/building validation in the reuse path
- Remembers valid Issue locations after:
  - successful save
  - scan validation
  - preview validation
  - commit validation
- Adds focused tests for:
  - valid last-location reuse
  - invalid holder-constrained fallback
  - remembering a saved location

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_location_wiring.py -q`
- [x] Focused Issue location tests passed: 9 passed
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_issue_location_wiring.py tests/test_issue_holder_prerequisite.py tests/test_return_batch.py tests/test_issue_case_scan.py tests/test_issue_clear_queue.py -q`
- [x] Focused Issue/Return workflow tests passed: 53 passed
- [x] Confirmed session/workflow-state only
- [x] Confirmed no database persistence
- [x] Confirmed no schema or migration changes
- [x] Confirmed no custody, event, receipt, holder, queue, preview, commit, permission, or route redesign behavior changed

## Notes

Manual browser verification was not performed. The change is covered through focused Flask workflow tests.

Return workflow was not changed because current Return behavior derives destination from asset home slots and does not have a separate Return current-location selector to persist.

Existing unrelated untracked empty files were left untouched.