### PR TITLE
Issue 27-1: Add admin building name correction

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -66,6 +66,7 @@ from assettrack.reference_data import (
     list_buildings,
     list_organization_building_mappings,
     list_organizations,
+    update_building_name,
 )
 from assettrack.settings import (
     active_receipt_cc_setting,
@@ -7413,6 +7414,12 @@ def admin_reference_data():
             elif action == "create_building":
                 create_building((request.form.get("building_name") or "").strip())
                 flash("Created building.", "success")
+            elif action == "update_building_name":
+                update_building_name(
+                    int((request.form.get("building_id") or "").strip()),
+                    (request.form.get("building_name") or "").strip(),
+                )
+                flash("Updated building name.", "success")
             elif action == "map_organization_building":
                 create_organization_building_mapping(
                     int((request.form.get("organization_id") or "").strip()),

--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -79,6 +79,7 @@
           <tr>
             <th>ID</th>
             <th>Name</th>
+            <th>Correction</th>
           </tr>
         </thead>
         <tbody>
@@ -86,10 +87,19 @@
             <tr>
               <td><code>{{ building.id }}</code></td>
               <td>{{ building.name }}</td>
+              <td>
+                <form method="post" action="{{ url_for('admin_reference_data') }}">
+                  <input type="hidden" name="action" value="update_building_name" />
+                  <input type="hidden" name="building_id" value="{{ building.id }}" />
+                  <label class="sr-only" for="building_name_{{ building.id }}">Correct building name</label>
+                  <input type="text" id="building_name_{{ building.id }}" name="building_name" value="{{ building.name }}" autocomplete="off" />
+                  <button type="submit">Correct name</button>
+                </form>
+              </td>
             </tr>
           {% else %}
             <tr>
-              <td colspan="2">No buildings yet.</td>
+              <td colspan="3">No buildings yet.</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/assettrack/reference_data.py
+++ b/assettrack/reference_data.py
@@ -161,6 +161,58 @@ def create_building(name: str) -> dict:
         conn.close()
 
 
+def update_building_name(building_id: int, name: str) -> dict:
+    normalized_name = _normalize_name(name)
+    now_iso = _utc_now_iso()
+
+    conn = get_connection()
+    try:
+        current = conn.execute(
+            """
+            SELECT id, name, created_at, updated_at
+            FROM buildings
+            WHERE id = ?;
+            """,
+            (int(building_id),),
+        ).fetchone()
+        if current is None:
+            raise ValueError("building not found")
+
+        existing = conn.execute(
+            """
+            SELECT id
+            FROM buildings
+            WHERE UPPER(name) = UPPER(?) AND id != ?
+            LIMIT 1;
+            """,
+            (normalized_name, int(building_id)),
+        ).fetchone()
+        if existing is not None:
+            raise ValueError("building already exists")
+
+        conn.execute(
+            """
+            UPDATE buildings
+            SET name = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (normalized_name, now_iso, int(building_id)),
+        )
+        conn.commit()
+        return dict(
+            conn.execute(
+                """
+                SELECT id, name, created_at, updated_at
+                FROM buildings
+                WHERE id = ?;
+                """,
+                (int(building_id),),
+            ).fetchone()
+        )
+    finally:
+        conn.close()
+
+
 def list_organization_building_mappings() -> list[dict]:
     conn = get_connection()
     try:

--- a/tests/test_admin_reference_data.py
+++ b/tests/test_admin_reference_data.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -90,3 +91,225 @@ class AdminReferenceDataTests(unittest.TestCase):
             (org_row["id"], building_row["id"]),
         ).fetchone()
         self.assertIsNotNone(mapping)
+
+    def test_admin_can_correct_building_name_for_reference_displays(self) -> None:
+        admin_id = create_test_user(username="admin-ref-correct", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+
+        self.conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES ('Operations', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        org_row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = 'Operations';"
+        ).fetchone()
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES ('HQ Nroth', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        building_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'HQ Nroth';"
+        ).fetchone()
+        self.conn.execute(
+            """
+            INSERT INTO organization_buildings (organization_id, building_id, created_at)
+            VALUES (?, ?, '2026-01-01T00:00:00Z');
+            """,
+            (org_row["id"], building_row["id"]),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO holders (
+                holder_type, name, organization, organization_id, identifier, contact_info, created_at, updated_at
+            )
+            VALUES ('PERSON', 'Issue Holder', 'Operations', ?, 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (org_row["id"],),
+        )
+        self.conn.commit()
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "update_building_name",
+                "building_id": str(building_row["id"]),
+                "building_name": "HQ North",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Updated building name.", response.data)
+        self.assertIn(b"HQ North", response.data)
+        self.assertNotIn(b"HQ Nroth", response.data)
+
+        updated_row = self.conn.execute(
+            "SELECT name FROM buildings WHERE id = ?;",
+            (building_row["id"],),
+        ).fetchone()
+        self.assertEqual(updated_row["name"], "HQ North")
+
+        operator_id = create_test_user(username="operator-ref-correct", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+        with self.client.session_transaction() as sess:
+            sess["holder_id"] = 1
+            sess["issue_mode"] = True
+
+        issue_page = self.client.get("/issue")
+
+        self.assertEqual(issue_page.status_code, 200)
+        self.assertIn(b"HQ North", issue_page.data)
+        self.assertNotIn(b"HQ Nroth", issue_page.data)
+
+    def test_operator_cannot_correct_building_name(self) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES ('HQ Nroth', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
+        building_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'HQ Nroth';"
+        ).fetchone()
+
+        operator_id = create_test_user(username="operator-ref-correct-denied", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "update_building_name",
+                "building_id": str(building_row["id"]),
+                "building_name": "HQ North",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        unchanged = self.conn.execute(
+            "SELECT name FROM buildings WHERE id = ?;",
+            (building_row["id"],),
+        ).fetchone()
+        self.assertEqual(unchanged["name"], "HQ Nroth")
+
+    def test_building_name_correction_validates_blank_and_duplicate_names(self) -> None:
+        admin_id = create_test_user(username="admin-ref-correct-validation", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES
+                ('HQ North', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                ('Warehouse West', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
+        warehouse_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'Warehouse West';"
+        ).fetchone()
+
+        blank_response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "update_building_name",
+                "building_id": str(warehouse_row["id"]),
+                "building_name": "   ",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(blank_response.status_code, 200)
+        self.assertIn(b"name is required", blank_response.data)
+
+        duplicate_response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "update_building_name",
+                "building_id": str(warehouse_row["id"]),
+                "building_name": "hq north",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(duplicate_response.status_code, 200)
+        self.assertIn(b"building already exists", duplicate_response.data)
+
+        unchanged = self.conn.execute(
+            "SELECT name FROM buildings WHERE id = ?;",
+            (warehouse_row["id"],),
+        ).fetchone()
+        self.assertEqual(unchanged["name"], "Warehouse West")
+
+    def test_building_name_correction_does_not_rewrite_events_or_receipt_snapshots(self) -> None:
+        admin_id = create_test_user(username="admin-ref-correct-history", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES ('HQ Nroth', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        building_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'HQ Nroth';"
+        ).fetchone()
+        event_payload = {
+            "from_building_room": "Storage/A1",
+            "to_building_room": "HQ Nroth/210",
+        }
+        receipt_snapshot = {
+            "receipt_type": "ISSUE",
+            "location_context": {
+                "building": "HQ Nroth",
+                "room": "210",
+                "building_room": "HQ Nroth/210",
+            },
+        }
+        self.conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES ('AT-100', 'ISSUE', '2026-01-01T00:00:00Z', 'admin', NULL, ?, NULL);
+            """,
+            (json.dumps(event_payload, sort_keys=True),),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO receipt_queue (
+                receipt_key, receipt_type, source_event_ids_json, snapshot_json, commit_at,
+                commit_operator_user_id, holder_id, created_at, updated_at
+            )
+            VALUES (
+                'receipt-history-proof', 'ISSUE', '[1]', ?, '2026-01-01T00:00:00Z',
+                ?, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+            );
+            """,
+            (json.dumps(receipt_snapshot, sort_keys=True), admin_id),
+        )
+        self.conn.commit()
+        event_before = self.conn.execute(
+            "SELECT payload FROM asset_events WHERE asset_tag = 'AT-100';"
+        ).fetchone()["payload"]
+        receipt_before = self.conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE receipt_key = 'receipt-history-proof';"
+        ).fetchone()["snapshot_json"]
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "update_building_name",
+                "building_id": str(building_row["id"]),
+                "building_name": "HQ North",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        event_after = self.conn.execute(
+            "SELECT payload FROM asset_events WHERE asset_tag = 'AT-100';"
+        ).fetchone()["payload"]
+        receipt_after = self.conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE receipt_key = 'receipt-history-proof';"
+        ).fetchone()["snapshot_json"]
+        self.assertEqual(event_after, event_before)
+        self.assertEqual(receipt_after, receipt_before)


### PR DESCRIPTION
## Summary

Adds admin-only building name correction using the existing reference-data surface.

Closes #617

## Changes

- Added admin-only building name correction on `/admin/reference-data`
- Added `update_building_name()` for the existing `buildings` table
- Updates only `buildings.name` and `updated_at`
- Blocks blank building names
- Blocks duplicate names case-insensitively
- Keeps non-admin users blocked by the existing admin role guard
- Adds focused tests for:
  - admin success
  - operator denial
  - blank validation
  - duplicate validation
  - corrected Issue dropdown display
  - unchanged event and receipt history

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_admin_reference_data.py -q`
- [x] Admin reference data tests passed: 6 passed
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_admin_reference_data.py tests/test_admin_slot_provision.py tests/test_issue_location_wiring.py tests/test_basic_auth_guard.py -q`
- [x] Focused admin/location/auth tests passed: 59 passed
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_return_batch.py -q`
- [x] Return batch tests passed: 19 passed
- [x] Combined focused suite passed: 78 passed
- [x] Confirmed no schema or migration changes
- [x] Confirmed no audit history changes
- [x] Confirmed no custody history changes
- [x] Confirmed no asset event changes
- [x] Confirmed no receipt snapshot changes
- [x] Confirmed no Issue, Return, queue, preview, or commit behavior changed

## Notes

Manual browser verification was not performed. The change is covered through focused admin, location, auth, and Return workflow tests.

This correction changes current/future reference-data labels only. It does not rewrite historical `building_room` strings in asset events, receipt snapshots, or asset rows.

Existing unrelated untracked empty files were left untouched.