### PR TITLE
Issue 27-167: Lock organization creation to admin role

### DIFF
--- a/tests/test_admin_reference_data.py
+++ b/tests/test_admin_reference_data.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import tempfile
 import unittest
+from io import BytesIO
 from pathlib import Path
 
 import assettrack.db as db
@@ -30,6 +31,57 @@ class AdminReferenceDataTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 403)
 
+    def test_operator_direct_post_cannot_create_organization(self) -> None:
+        operator_id = create_test_user(username="operator-ref-post", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={"action": "create_organization", "organization_name": "Denied Operations"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = ?;",
+            ("Denied Operations",),
+        ).fetchone()
+        self.assertIsNone(row)
+
+    def test_unauthenticated_direct_post_cannot_create_organization(self) -> None:
+        response = self.client.post(
+            "/admin/reference-data",
+            data={"action": "create_organization", "organization_name": "Anonymous Operations"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = ?;",
+            ("Anonymous Operations",),
+        ).fetchone()
+        self.assertIsNone(row)
+
+    def test_operator_cannot_create_organization_through_holder_import(self) -> None:
+        operator_id = create_test_user(username="operator-import-ref", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.post(
+            "/admin/holders/import",
+            data={
+                "csv_file": (
+                    BytesIO(b"organization,name,email\nDenied Import Org,Jane Doe,jane@example.org\n"),
+                    "holders.csv",
+                )
+            },
+            content_type="multipart/form-data",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = ?;",
+            ("Denied Import Org",),
+        ).fetchone()
+        self.assertIsNone(row)
+
     def test_admin_can_create_organization_building_and_mapping(self) -> None:
         admin_id = create_test_user(username="admin-ref", password="admin-pass", role="admin")
         login_session(self.client, admin_id)
@@ -39,6 +91,9 @@ class AdminReferenceDataTests(unittest.TestCase):
         self.assertIn(b"Organizations", response.data)
         self.assertIn(b"Buildings", response.data)
         self.assertIn(b"box-sizing: border-box;", response.data)
+        self.assertIn(b'name="action" value="create_organization"', response.data)
+        self.assertIn(b"name=\"organization_name\"", response.data)
+        self.assertIn(b"Create organization", response.data)
 
         create_org = self.client.post(
             "/admin/reference-data",

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -49,6 +49,19 @@ class HolderCreationViabilityTests(unittest.TestCase):
         self.assertIn(b"novalidate", response.data)
         self.assertNotIn(b'name="organization_id" required', response.data)
 
+    def test_operator_holder_form_selects_existing_organizations_without_creation_controls(self) -> None:
+        org_id = self._create_org("Existing Ops")
+
+        response = self.client.get("/holders/new")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f'value="{org_id}"'.encode("utf-8"), response.data)
+        self.assertIn(b"Existing Ops", response.data)
+        self.assertIn(b"Select organization", response.data)
+        self.assertNotIn(b'name="action" value="create_organization"', response.data)
+        self.assertNotIn(b"name=\"organization_name\"", response.data)
+        self.assertNotIn(b"Create organization", response.data)
+
     def test_get_holders_list_route_exists(self) -> None:
         response = self.client.get("/holders/list")
         self.assertEqual(response.status_code, 302)


### PR DESCRIPTION
## Summary

Locks the existing admin-only organization creation boundary with focused security regression coverage.

Closes #892

## Changes

- Added operator direct POST denial coverage for organization creation
- Added unauthenticated direct POST denial coverage
- Verifies denied requests create no organization record
- Added holder import misuse coverage because holder import can create missing organizations
- Added admin organization creation-control visibility assertions
- Added operator holder-form coverage confirming:
  - existing organizations remain selectable
  - organization creation controls are unavailable
- Confirmed building creation remains separate and unchanged

## Creation Paths Reviewed

- `/admin/reference-data` GET/POST
- `action=create_organization`
- `assettrack/reference_data.py:create_organization()`
- `/admin/holders/import`
- holder new/edit forms
- organization-building mapping
- separate building creation action

Production organization creation routes were already protected by login and admin-role enforcement. This PR adds regression coverage rather than redundant runtime logic.

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_admin_reference_data.py tests/test_basic_auth_guard.py -q`
- [x] Admin reference-data/auth tests passed: 43 passed
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_holder_creation_viability.py tests/test_holder_import.py tests/test_admin_system_health.py -q`
- [x] Holder/import/admin tests passed: 58 passed
- [x] Docker image rebuilt and app reported healthy
- [x] Admin organization creation succeeded
- [x] Operator creation controls were unavailable
- [x] Operator direct POST returned 403 and created no organization
- [x] Anonymous direct POST returned 403 and created no organization
- [x] Existing organization selection remained available to operators
- [x] Docker stopped normally without deleting volumes

## Invariant Confirmation

- [x] No schema or migration changes
- [x] No building creation changes
- [x] No custody, event, receipt, queue, preview, or commit behavior changes
- [x] No authentication boundary was weakened

## Notes

Manual verification used isolated cookie jars against the rebuilt Docker application because GUI incognito automation was unavailable.

Local verification records were removed from the working tree before commit.