### PR TITLE
Issue 27-168: Lock building creation to admin role

### DIFF
--- a/tests/test_admin_reference_data.py
+++ b/tests/test_admin_reference_data.py
@@ -82,6 +82,35 @@ class AdminReferenceDataTests(unittest.TestCase):
         ).fetchone()
         self.assertIsNone(row)
 
+    def test_operator_direct_post_cannot_create_building(self) -> None:
+        operator_id = create_test_user(username="operator-building-ref-post", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={"action": "create_building", "building_name": "Denied HQ"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = ?;",
+            ("Denied HQ",),
+        ).fetchone()
+        self.assertIsNone(row)
+
+    def test_unauthenticated_direct_post_cannot_create_building(self) -> None:
+        response = self.client.post(
+            "/admin/reference-data",
+            data={"action": "create_building", "building_name": "Anonymous HQ"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = ?;",
+            ("Anonymous HQ",),
+        ).fetchone()
+        self.assertIsNone(row)
+
     def test_admin_can_create_organization_building_and_mapping(self) -> None:
         admin_id = create_test_user(username="admin-ref", password="admin-pass", role="admin")
         login_session(self.client, admin_id)
@@ -94,6 +123,9 @@ class AdminReferenceDataTests(unittest.TestCase):
         self.assertIn(b'name="action" value="create_organization"', response.data)
         self.assertIn(b"name=\"organization_name\"", response.data)
         self.assertIn(b"Create organization", response.data)
+        self.assertIn(b'name="action" value="create_building"', response.data)
+        self.assertIn(b"name=\"building_name\"", response.data)
+        self.assertIn(b"Create building", response.data)
 
         create_org = self.client.post(
             "/admin/reference-data",

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -120,6 +120,9 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     assert b"autofocus" not in issue_page.data
     assert b"HQ North" in issue_page.data
     assert b"Warehouse West" not in issue_page.data
+    assert b'name="action" value="create_building"' not in issue_page.data
+    assert b"name=\"building_name\"" not in issue_page.data
+    assert b"Create building" not in issue_page.data
 
     scan_response = client_with_temp_db.post(
         "/",


### PR DESCRIPTION
## Summary

Locks the existing admin-only building creation boundary with focused security regression coverage.

Closes #893

## Changes

- Added operator direct POST denial coverage for building creation
- Added unauthenticated direct POST denial coverage
- Verifies denied requests create no building record
- Added admin building creation-control visibility assertions
- Added operator Issue location coverage confirming:
  - existing buildings remain selectable
  - building creation controls are unavailable
- Confirmed building-name correction remains separate and unchanged
- Confirmed organization creation remains separate and unchanged

## Creation Paths Reviewed

- `/admin/reference-data` POST with `action=create_building`
- `assettrack/reference_data.py:create_building()`
- building creation form in `admin_reference_data.html`
- Issue current-location dropdown
- Admin slot-assignment building selectors
- building-name correction through `action=update_building_name`
- separate organization creation through `action=create_organization`

Production building creation was already protected by login and admin-role enforcement. This PR adds regression coverage rather than redundant runtime logic.

## Verification

- [x] `python3 -m compileall assettrack tests`
- [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_admin_reference_data.py tests/test_admin_slot_provision.py tests/test_issue_location_wiring.py tests/test_basic_auth_guard.py -q`
- [x] Focused admin, location, and authentication tests passed: 64 passed
- [x] Docker image rebuilt and application started
- [x] Admin building creation succeeded exactly once
- [x] Building-name correction succeeded
- [x] Operator building creation controls were unavailable
- [x] Operator direct POST returned 403 and created no building
- [x] Anonymous direct POST returned 403 and created no building
- [x] Existing building selection remained available
- [x] Issue workflow reached queue and preview using an existing building
- [x] No custody event was committed
- [x] Docker stopped normally without deleting volumes

## Invariant Confirmation

- [x] No schema or migration changes
- [x] No organization creation changes
- [x] No building-name correction behavior changes
- [x] No custody, event, receipt, queue, preview, or commit behavior changes
- [x] No authentication boundary was weakened

## Notes

Manual verification used isolated cookie jars against the rebuilt Docker application because GUI incognito automation was unavailable.

Local verification records were removed from the working tree before commit.