### PR TITLE
Issue 27-170: reduce navigation duplication

### DIFF
--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -6,7 +6,6 @@
 
 {% block content %}
   <nav class="workflow-local-nav" aria-label="Admin asset navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
     <a class="action-secondary" href="{{ url_for('admin_new_asset') }}">Create Asset</a>
   </nav>
 

--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -12,10 +12,6 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="workflow-local-nav" aria-label="Admin import navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
-  </nav>
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -6,7 +6,6 @@
 
 {% block content %}
   <div class="report-actions nav-row">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
     <a class="action-secondary" href="{{ url_for('admin_human_report_pdf') }}">Download PDF</a>
     <a class="action-secondary" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
   </div>

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -14,7 +14,6 @@
 
 {% block content %}
   <nav class="workflow-local-nav" aria-label="Admin asset creation navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
     <a class="action-secondary" href="{{ url_for('admin_edit_asset') }}">Edit Existing Asset</a>
   </nav>
 

--- a/assettrack/intake/templates/admin_receipt_cc.html
+++ b/assettrack/intake/templates/admin_receipt_cc.html
@@ -37,10 +37,6 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="workflow-local-nav" aria-label="Receipt CC settings navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
-  </nav>
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -11,10 +11,6 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="workflow-local-nav" aria-label="Admin reference data navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
-  </nav>
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -70,9 +70,6 @@
 {% endblock %}
 
   {% block content %}
-  <nav class="workflow-local-nav" aria-label="Admin navigation">
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </nav>
 
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}

--- a/assettrack/intake/templates/admin_users.html
+++ b/assettrack/intake/templates/admin_users.html
@@ -45,10 +45,6 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="workflow-local-nav" aria-label="Admin user navigation">
-    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
-  </nav>
-
   {% with messages = get_flashed_messages(with_categories=true) %}
     {% if messages %}
       {% for category, message in messages %}

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -32,12 +32,11 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Contextual navigation">
-    {% if return_to == url_for('human_report') %}
+  {% if return_to == url_for('human_report') %}
+    <nav class="actions" aria-label="Contextual navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
-    {% endif %}
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </nav>
+    </nav>
+  {% endif %}
 
   <section class="card">
     <h2>Case Summary</h2>

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -18,12 +18,11 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions" aria-label="Contextual navigation">
-    {% if return_to == url_for('human_report') %}
+  {% if return_to == url_for('human_report') %}
+    <nav class="actions" aria-label="Contextual navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
-    {% endif %}
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </nav>
+    </nav>
+  {% endif %}
 
   <section class="card">
     <h2>Holders With Assets Out</h2>

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -243,7 +243,6 @@
     {% set receipt_status_tone = "calm" %}
   {% endif %}
   <nav class="actions nav-row mixed-nav-row" aria-label="Receipt navigation">
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
     <a class="chip" href="{{ url_for('receipt_pdf', receipt_id=receipt.id) }}">Download Receipt PDF</a>
     {% if receipt.delivery.state in ["pending", "failed"] %}
       {% if send_blocked_by_recovery %}

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -198,12 +198,11 @@
 {% endblock %}
 
 {% block content %}
-  <nav class="actions nav-row" aria-label="Receipt navigation">
-    {% if return_to == url_for('human_report') %}
+  {% if return_to == url_for('human_report') %}
+    <nav class="actions nav-row" aria-label="Receipt navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
-    {% endif %}
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </nav>
+    </nav>
+  {% endif %}
 
   <section class="card">
     <h2>Search Receipts</h2>

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -59,9 +59,6 @@
 
 {% block content %}
   {% set report_return_to = url_for('human_report', include_retired='1') if include_retired_assets else url_for('human_report') %}
-  <div class="report-actions nav-row">
-    <a class="nav-link" href="{{ url_for('dashboard') }}">Back to Dashboard</a>
-  </div>
 
   {% if report_error %}
     <div class="flash error">{{ report_error }}</div>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -605,6 +605,8 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     response = client_with_temp_db.get("/report")
 
     assert response.status_code == 200
+    assert b"Back to Dashboard" not in response.data
+    assert b'href="/dashboard">Dashboard</a>' in response.data
     assert b"Current State" in response.data
     assert b"Active custody and storage first." in response.data
     assert b"Report Scope" not in response.data
@@ -717,11 +719,13 @@ def test_report_drill_ins_show_back_to_report_only_for_safe_report_context(clien
     receipts_response = client_with_temp_db.get("/receipts?return_to=/report")
     assert receipts_response.status_code == 200
     assert b"Back to Report" in receipts_response.data
+    assert b"Back to Dashboard" not in receipts_response.data
     assert b"Open Current Status Report" not in receipts_response.data
 
     cases_response = client_with_temp_db.get("/dashboard/cases?return_to=/report")
     assert cases_response.status_code == 200
     assert b"Back to Report" in cases_response.data
+    assert b"Back to Dashboard" not in cases_response.data
     assert b'href="/dashboard/cases/CASE-RETURN?return_to=/report"' in cases_response.data
 
     case_detail_response = client_with_temp_db.get("/dashboard/cases/CASE-RETURN?return_to=/report")
@@ -732,6 +736,11 @@ def test_report_drill_ins_show_back_to_report_only_for_safe_report_context(clien
     direct_asset_response = client_with_temp_db.get("/assets/search?asset_tag=RET-100")
     assert direct_asset_response.status_code == 200
     assert b"Back to Report" not in direct_asset_response.data
+
+    direct_cases_response = client_with_temp_db.get("/dashboard/cases")
+    assert direct_cases_response.status_code == 200
+    assert b"Back to Dashboard" not in direct_cases_response.data
+    assert b"Back to Report" not in direct_cases_response.data
 
     unsafe_asset_response = client_with_temp_db.get("/assets/search?asset_tag=RET-100&return_to=//evil.example")
     assert unsafe_asset_response.status_code == 200

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -575,14 +575,53 @@ def test_admin_allowed_admin_endpoint(client_with_temp_db) -> None:
     _login(client_with_temp_db, "admin", "admin-pass")
     response = client_with_temp_db.get("/admin/assets/new")
     assert response.status_code == 200
+    assert b"Back to Admin Tools" not in response.data
+    assert b'href="/admin/system">Admin Tools</a>' in response.data
+    assert b"Edit Existing Asset" in response.data
     edit_response = client_with_temp_db.get("/admin/assets/edit")
     assert edit_response.status_code == 200
+    assert b"Back to Admin Tools" not in edit_response.data
+    assert b"Create Asset" in edit_response.data
     retire_response = client_with_temp_db.get("/admin/assets/retire")
     assert retire_response.status_code == 200
+    assert b"Back to Admin Tools" in retire_response.data
     reference_data_response = client_with_temp_db.get("/admin/reference-data")
     assert reference_data_response.status_code == 200
+    assert b"Back to Admin Tools" not in reference_data_response.data
     slot_provision_response = client_with_temp_db.get("/admin/slots/provision")
     assert slot_provision_response.status_code == 200
+    assert b"Back to Admin Tools" in slot_provision_response.data
+
+
+def test_simple_admin_child_pages_use_global_admin_navigation(client_with_temp_db) -> None:
+    create_user("admin-simple-nav", "admin-pass", "admin", True)
+    _login(client_with_temp_db, "admin-simple-nav", "admin-pass")
+
+    simple_child_paths = [
+        "/admin/users",
+        "/admin/reference-data",
+        "/admin/receipt-cc",
+        "/admin/holders/import",
+        "/admin/report",
+    ]
+
+    for path in simple_child_paths:
+        response = client_with_temp_db.get(path)
+
+        assert response.status_code == 200
+        assert b"Back to Admin Tools" not in response.data
+        assert b'href="/admin/system">Admin Tools</a>' in response.data
+
+
+def test_admin_tools_hub_uses_global_dashboard_navigation(client_with_temp_db) -> None:
+    create_user("admin-hub-nav", "admin-pass", "admin", True)
+    _login(client_with_temp_db, "admin-hub-nav", "admin-pass")
+
+    response = client_with_temp_db.get("/admin/system")
+
+    assert response.status_code == 200
+    assert b"Back to Dashboard" not in response.data
+    assert b'href="/dashboard">Dashboard</a>' in response.data
 
 
 def test_asset_search_requires_login(client_with_temp_db) -> None:

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -137,6 +137,8 @@ def test_dashboard_holders_route_returns_200_and_is_read_only(app_client) -> Non
     response = client.get("/dashboard/holders")
     assert response.status_code == 200
     assert b"Holders With Assets Out" in response.data
+    assert b"Back to Dashboard" not in response.data
+    assert b"Back to Report" not in response.data
 
     counts_after = (
         conn.execute("SELECT COUNT(*) AS c FROM assets;").fetchone()["c"],

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -89,6 +89,8 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Back to Issue Review" in issue_preview.data
     assert b"Back to Batch Preview" not in issue_preview.data
     assert b"Ready to Issue" in issue_preview.data
+    assert b">Change holder</a>" in issue_preview.data
+    assert b'href="/holders">Change holder</a>' in issue_preview.data
     assert b"Issue to:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data
     assert b"1 asset queued" in issue_preview.data

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -668,6 +668,8 @@ def test_receipt_detail_links_to_receipt_pdf(client_with_temp_db) -> None:
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}/pdf"'.encode("utf-8") in response.data
     assert b"Download Receipt PDF" in response.data
+    assert b"Back to Dashboard" not in response.data
+    assert b'href="/dashboard">Dashboard</a>' in response.data
 
 
 def test_receipt_detail_uses_stable_holder_fallback_when_snapshot_name_is_missing(client_with_temp_db) -> None:

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -22,6 +22,9 @@ def test_receipts_list_renders_newest_first(client_with_temp_db) -> None:
     response = client_with_temp_db.get("/receipts")
 
     assert response.status_code == 200
+    assert b"Back to Dashboard" not in response.data
+    assert b"Back to Report" not in response.data
+    assert b'href="/dashboard">Dashboard</a>' in response.data
     assert response.data.find(f"/receipts/{newer_receipt_id}".encode("utf-8")) < response.data.find(
         f"/receipts/{older_receipt_id}".encode("utf-8")
     )


### PR DESCRIPTION
## Summary

Reduces duplicate page-level navigation while preserving workflow context, report drilldown returns, admin role boundaries, and safe return navigation.

## Related Issue

Closes #898

## Changes

* Removed duplicate local `Back to Dashboard` links where global Dashboard navigation remains visible.
* Removed duplicate local `Back to Admin Tools` links from simple admin child pages where the admin menu remains available.
* Kept contextual return links for Reports, Holders, Cases, receipts, and Asset Search.
* Kept Issue holder-selection and Change Holder navigation.
* Kept recovery, maintenance, destructive-action, and multi-step admin return links.
* Added focused tests for removed duplicate links and retained contextual navigation.

## Verification

* [x] Targeted test pass: 42 passed
* [x] Expanded focused suite: 249 passed
* [x] `python3 -m compileall assettrack tests`
* [x] `docker compose up -d --build`
* [x] Manual operator and admin navigation smoke test
* [x] Unsafe `return_to=//...` remained blocked
* [x] `docker compose down`

## Notes

No routes, redirects, `return_to` validation, workflows, custody behavior, events, receipts, permissions, schema, dependencies, or persistence behavior changed.

Runtime smoke users were created only in the local Docker-backed database for manual verification.
