### PR TITLE
Issue 27-181: update pypdf and pip security versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 FROM python:3.12.13-alpine3.23
 
-RUN python -m pip install --upgrade "pip==26.0"
+RUN python -m pip install --upgrade "pip==26.1"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==2.4.1
 openpyxl==3.1.5
 pandas==3.0.0
 pillow==12.2.0
-pypdf==6.10.1
+pypdf==6.12.0
 python-dateutil==2.9.0.post0
 reportlab==4.4.9
 six==1.17.0


### PR DESCRIPTION
## Summary

Updates the pinned `pypdf` and `pip` versions to resolve the Medium Trivy findings reported in the latest filesystem and container image scans.

## Related Issue

Closes #911

## Changes

- Updated `pypdf` from `6.10.1` to `6.12.0`.
- Updated Dockerfile `pip` pin from `26.0` to `26.1`.
- No unrelated dependency, schema, route, receipt, custody, event, permission, or persistence changes.

## Verification

- `python -m pytest tests/test_receipt_detail.py tests/test_receipts_list.py tests/test_issue_23_2_preview_commit_seam.py -q`
  - 70 passed
- `python -m compileall assettrack tests`
  - passed
- `docker compose up -d --build`
  - container built and ran healthy
- Verified installed container versions:
  - `pip 26.1`
  - `pypdf 6.12.0`
- Manual receipt/PDF smoke:
  - logged in
  - opened existing receipt
  - downloaded PDF
  - confirmed PDF opened normally
  - confirmed holder, asset, date, and custody proof were present
  - confirmed download did not change custody or receipt state

## Security Results

Expected to clear:

- `pypdf` findings:
  - CVE-2026-41312
  - CVE-2026-41313
  - CVE-2026-41314
  - CVE-2026-48155
  - CVE-2026-48156
- `pip` findings:
  - CVE-2026-3219
  - CVE-2026-6357

Final Trivy confirmation should be verified in the GitHub Actions security workflow after push.

## Notes

This was a narrow Class 5 dependency-security update. No application behavior was intentionally changed.