### PR TITLE
Issue 27-182: update pypdf security version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==2.4.1
 openpyxl==3.1.5
 pandas==3.0.0
 pillow==12.2.0
-pypdf==6.12.0
+pypdf==6.13.3
 python-dateutil==2.9.0.post0
 reportlab==4.4.9
 six==1.17.0


### PR DESCRIPTION
## Summary

Updates the pinned `pypdf` version to clear the remaining Medium Trivy findings reported after Issue 27-181.

## Related Issue

Closes #913 

## Changes

- Updated `pypdf` from `6.12.0` to `6.13.3`.
- No unrelated dependency, Dockerfile, schema, route, receipt, custody, event, permission, or persistence changes.

## Verification

- `python -m pytest tests/test_receipt_detail.py tests/test_receipts_list.py tests/test_issue_23_2_preview_commit_seam.py -q`
  - 70 passed
- `python -m compileall assettrack tests`
  - passed
- `docker compose up -d --build`
  - container built and ran healthy
- Verified installed container version:
  - `pypdf 6.13.3`
- Manual receipt/PDF smoke:
  - opened existing return receipt
  - downloaded PDF
  - confirmed PDF opened normally
  - confirmed holder, asset, date, location, and custody proof were present
  - confirmed no receipt or custody behavior changed

## Security Results

Expected to clear:

- CVE-2026-48735
- CVE-2026-49460
- CVE-2026-49461
- CVE-2026-54530
- CVE-2026-54531
- GHSA-jm82-fx9c-mx94

Final Trivy confirmation should be verified in the GitHub Actions security workflow after push.

## Notes

This was a narrow Class 5 dependency-security update. No application behavior was intentionally changed.