### PR TITLE
Issue 27-184: allow asset-first issue staging

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4170,26 +4170,15 @@ def intake():
         if scan_text:
             if return_to_path == "/issue":
                 selected_holder = _selected_holder_from_session(require_active=True)
-                issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
-                    selected_holder,
-                    _issue_location_form_for_holder(selected_holder),
-                )
-                if selected_holder is None:
-                    flash("Select a holder before issuing assets.", "error")
-                    touch_session()
-                    return redirect(url_for("holders_search", return_to=url_for("issue")))
-                if issue_location_errors:
-                    flash(
-                        f"Scan not added. {issue_location_errors[0]}",
-                        "error scan-feedback",
+                if selected_holder is not None:
+                    issue_location_form, issue_location_errors, _ = _validate_issue_location_form(
+                        selected_holder,
+                        _issue_location_form_for_holder(selected_holder),
                     )
-                    touch_session()
-                    if redirect_target.startswith("/") and not redirect_target.startswith("//"):
-                        return redirect(redirect_target)
-                    return redirect(url_for("issue"))
-                session["issue_building"] = issue_location_form["building"]
-                session["issue_room"] = issue_location_form["room"]
-                _remember_last_issue_location(issue_location_form)
+                    if not issue_location_errors:
+                        session["issue_building"] = issue_location_form["building"]
+                        session["issue_room"] = issue_location_form["room"]
+                        _remember_last_issue_location(issue_location_form)
 
             value = sanitize_scan(scan_text)
             if not value:
@@ -4945,10 +4934,6 @@ def issue():
         touch_session()
 
     selected_holder = _selected_holder_from_session(require_active=True)
-    if selected_holder is None:
-        flash("Select a holder before issuing assets.", "error")
-        return redirect(url_for("holders_search", return_to=url_for("issue")))
-
     issue_location_form, issue_location_errors, issue_location_context = _validate_issue_location_form(
         selected_holder,
         _issue_location_form_for_holder(selected_holder),

--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -112,12 +112,12 @@
       </div>
       <p class="holder-subtle">Holder is the custody actor. Location and case/slot are context only.</p>
       <div class="workflow-action-row workflow-action-row--quiet">
-        <a class="nav-link action-quiet" href="{{ url_for('holders_search') }}">Change holder</a>
+        <a class="nav-link action-quiet" href="{{ url_for('holders_search', return_to=url_for('issue')) }}">Change holder</a>
       </div>
     {% else %}
       <p>No holder selected.</p>
       <div class="workflow-action-row workflow-action-row--quiet">
-        <a class="nav-link action-quiet" href="{{ url_for('holders_search') }}">Select holder</a>
+        <a class="nav-link action-quiet" href="{{ url_for('holders_search', return_to=url_for('issue')) }}">Select holder</a>
       </div>
     {% endif %}
   </div>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -172,7 +172,7 @@
             {% if issue_location_ready %}
               <code class="issue-location-status-value">{{ issue_location_label }}</code>
             {% else %}
-              <span class="issue-location-status-value">Set where these assets are leaving from before scanning.</span>
+              <span class="issue-location-status-value">Set where these assets are leaving from before preview.</span>
             {% endif %}
           </div>
           {% if message_ns.location_messages %}
@@ -198,7 +198,7 @@
   <div class="card workflow-card">
     <h2>{{ scan_heading or "Add to Queue" }}</h2>
     {% if issue_location_form is defined %}
-      <p class="card-intro">Select who is receiving the asset, set current location, then scan. Staged scans stay in the queue until review.</p>
+      <p class="card-intro">Scan assets into the Issue queue. Select the receiving holder and current location before preview.</p>
       {% if selected_holder %}
         <div class="workflow-summary workflow-summary--prereq">
           <strong>Receiving holder</strong>
@@ -209,6 +209,12 @@
           {% if selected_holder["identifier"] %}
             <span>ID {{ selected_holder["identifier"] }}</span>
           {% endif %}
+        </div>
+      {% else %}
+        <div class="workflow-summary workflow-summary--prereq">
+          <strong>Receiving holder</strong>
+          <span>Select before preview and commit.</span>
+          <a class="nav-link" href="{{ url_for('holders_search', return_to=queue_return_to) }}">Select holder</a>
         </div>
       {% endif %}
     {% else %}

--- a/tests/test_holder_creation_viability.py
+++ b/tests/test_holder_creation_viability.py
@@ -501,7 +501,7 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 403)
 
-    def test_issue_redirects_back_to_holder_selection_when_selected_holder_becomes_inactive(self) -> None:
+    def test_issue_clears_inactive_selected_holder_and_still_renders(self) -> None:
         organization_id = self._create_org("Issue Org")
         self.client.post(
             "/holders/new",
@@ -531,8 +531,13 @@ class HolderCreationViabilityTests(unittest.TestCase):
 
         response = self.client.get("/issue")
 
-        self.assertEqual(response.status_code, 302)
-        self.assertTrue((response.headers["Location"]).endswith("/holders?return_to=/issue"))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b">Issue<", response.data)
+        self.assertIn(b"Select holder", response.data)
+        self.assertIn(b'href="/holders?return_to=/issue"', response.data)
+
+        with self.client.session_transaction() as sess:
+            self.assertIsNone(sess.get("holder_id"))
 
     def test_holder_detail_shows_metadata_and_assigned_assets(self) -> None:
         organization_id = self._create_org("Org Detail")

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -90,7 +90,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Back to Batch Preview" not in issue_preview.data
     assert b"Ready to Issue" in issue_preview.data
     assert b">Change holder</a>" in issue_preview.data
-    assert b'href="/holders">Change holder</a>' in issue_preview.data
+    assert b'href="/holders?return_to=/issue">Change holder</a>' in issue_preview.data
     assert b"Issue to:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data
     assert b"1 asset queued" in issue_preview.data

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -20,6 +20,30 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
         VALUES (1, 'PERSON', 'Issue Holder', 'Issue Org', 'IH-1', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
         """
     )
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (101, 'CASE-1', 1, 'ISSUE-100');
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO assets (
+            id, asset_tag, serial_number, equipment_type, manufacturer, model,
+            location_type, current_holder_id, home_slot_id
+        )
+        VALUES (
+            501, 'ISSUE-100', 'SN-1', 'laptop', 'Dell', 'Latitude',
+            'STORAGE', NULL, 101
+        );
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (101, 501, '2026-01-01T00:00:00Z');
+        """
+    )
     conn.commit()
     conn.close()
 
@@ -28,24 +52,110 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return intake_app.app.test_client()
 
 
-def test_issue_requires_holder_selection_before_queue_access(client_with_temp_db) -> None:
+def test_issue_renders_without_holder_and_enables_issue_mode(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-prereq", password="op-pass", role="operator")
     login_session(client_with_temp_db, operator_id)
 
     response = client_with_temp_db.get("/issue")
 
-    assert response.status_code == 302
-    location = response.headers.get("Location") or ""
-    assert location.endswith("/holders?return_to=/issue")
+    assert response.status_code == 200
+    assert b">Issue<" in response.data
+    assert b"Review Before Issue" in response.data
+    assert b"Select holder" in response.data
+    assert b'href="/holders?return_to=/issue"' in response.data
+    assert b"0 assets queued" in response.data
+    assert b"Select before preview and commit." in response.data
+
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["issue_mode"] is True
+
+
+def test_valid_issue_asset_can_stage_before_holder_without_custody_side_effects(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-stage-before-holder", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
+    assert b"Queue (1)" in response.data
+    assert b"No holder selected. Select a holder before issuing assets." in response.data
+    assert b"Select a holder before choosing the current location." in response.data
+
+    conn = db.get_connection()
+    try:
+        asset = conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = 'ISSUE-100' LIMIT 1;"
+        ).fetchone()
+        event_count = conn.execute("SELECT COUNT(*) AS c FROM asset_events WHERE event_type = 'ISSUE';").fetchone()
+        receipt_count = conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+    finally:
+        conn.close()
+
+    assert asset is not None
+    assert str(asset["location_type"]) == "STORAGE"
+    assert asset["current_holder_id"] is None
+    assert event_count is not None
+    assert int(event_count["c"]) == 0
+    assert receipt_count is not None
+    assert int(receipt_count["c"]) == 0
+
+
+def test_issue_preview_and_commit_remain_blocked_without_holder(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-stage-blocked-holder", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+
+    preview = client_with_temp_db.get("/issue/preview")
+
+    assert preview.status_code == 200
+    assert b"Needs Review" in preview.data
+    assert b"No holder selected. Select a holder before issuing assets." in preview.data
+    assert b"Select a holder before choosing the current location." in preview.data
+
+    commit = client_with_temp_db.post(
+        "/issue/commit",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        follow_redirects=False,
+    )
+
+    assert commit.status_code == 302
+    assert (commit.headers.get("Location") or "").endswith("/issue/preview")
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
+
+    conn = db.get_connection()
+    try:
+        event_count = conn.execute("SELECT COUNT(*) AS c FROM asset_events WHERE event_type = 'ISSUE';").fetchone()
+        receipt_count = conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+    finally:
+        conn.close()
+
+    assert event_count is not None
+    assert int(event_count["c"]) == 0
+    assert receipt_count is not None
+    assert int(receipt_count["c"]) == 0
 
 
 def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-return", password="op-pass", role="operator")
     login_session(client_with_temp_db, operator_id)
 
-    issue_redirect = client_with_temp_db.get("/issue")
-    assert issue_redirect.status_code == 302
-    assert (issue_redirect.headers.get("Location") or "").endswith("/holders?return_to=/issue")
+    stage_response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ISSUE-100", "return_to": "/issue"},
+        follow_redirects=True,
+    )
+    assert stage_response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
 
     select_response = client_with_temp_db.post(
         "/holders/select",
@@ -58,6 +168,9 @@ def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     assert issue_page.status_code == 200
     assert b"Issue" in issue_page.data
     assert b"Review Before Issue" in issue_page.data
+    assert b"Issue Holder" in issue_page.data
+    assert b"Queue (1)" in issue_page.data
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
 
 
 def test_holders_issue_navigation_targets_issue_entry_and_preserves_selected_holder(client_with_temp_db) -> None:

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -96,16 +96,15 @@ def _login_issue_operator(client) -> None:
         sess["issue_mode"] = True
 
 
-def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) -> None:
+def test_issue_scan_stages_before_current_location_but_preview_blocks(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db)
 
     issue_page = client_with_temp_db.get("/issue")
 
     assert issue_page.status_code == 200
     assert b"Current Location" in issue_page.data
-    assert b"Set where these assets are leaving from before scanning." in issue_page.data
-    assert b"Select who is receiving the asset, set current location, then scan." in issue_page.data
-    assert b"Staged scans stay in the queue until review." in issue_page.data
+    assert b"Set where these assets are leaving from before preview." in issue_page.data
+    assert b"Scan assets into the Issue queue. Select the receiving holder and current location before preview." in issue_page.data
     assert b"Add to Queue" in issue_page.data
     assert b"Scan or enter asset tag" in issue_page.data
     assert b"Add to queue" in issue_page.data
@@ -131,8 +130,14 @@ def test_issue_scan_requires_current_location_prerequisite(client_with_temp_db) 
     )
 
     assert scan_response.status_code == 200
-    assert len(intake_app.SCAN_QUEUE) == 0
-    assert b"Scan not added. Choose the current building." in scan_response.data
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
+    assert b"Queue (1)" in scan_response.data
+    assert b"Choose the current building." in scan_response.data
+
+    preview = client_with_temp_db.get("/issue/preview")
+    assert preview.status_code == 200
+    assert b"Needs Review" in preview.data
+    assert b"Choose the current building." in preview.data
 
 
 def test_issue_location_dropdown_orders_allowed_buildings_alphabetically(client_with_temp_db) -> None:
@@ -265,8 +270,9 @@ def test_issue_does_not_reuse_last_current_location_blocked_for_selected_holder(
     )
 
     assert scan_response.status_code == 200
-    assert len(intake_app.SCAN_QUEUE) == 0
-    assert b"Scan not added. Choose the current building." in scan_response.data
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
+    assert b"Queue (1)" in scan_response.data
+    assert b"Choose the current building." in scan_response.data
 
 
 def test_issue_commit_updates_current_location_and_preserves_home_location_context(client_with_temp_db) -> None:


### PR DESCRIPTION
## Summary

Allows Issue asset-first staging before holder selection while keeping custody transfer gated behind preview and commit validation.

## Related Issue

Closes #918

## Changes

* `/issue` now renders directly without requiring holder selection first.
* Valid Issue assets can be staged before holder/current location selection.
* Holder/current location remain required before preview-ready state and commit.
* Issue Preview holder links preserve `return_to=/issue`.
* Updated focused Issue workflow tests for staging, no pre-commit side effects, holder return flow, and location gating.

## Verification

* Required focused Issue/Return pytest set

  * 61 passed
* Touched holder viability tests

  * 33 passed
* `python -m compileall assettrack tests`

  * passed
* `git diff --check`

  * passed
* Docker/manual incognito smoke

  * PASS
  * `/issue` rendered directly
  * valid storage asset staged before holder selection
  * no custody/event/receipt change occurred during staging
  * holder selection returned to `/issue` with queue intact
  * current location enabled preview readiness
  * commit opened receipt, moved custody, and cleared queue
  * Return workflow still loaded

## Notes

No schema, migrations, event model, receipt behavior, authentication model, Docker/runtime behavior, dependencies, SQLite persistence, or Return behavior changed.
