### PR TITLE
Issue 27-172: reduce Issue workflow presentation load

### DIFF
--- a/assettrack/intake/templates/issue_preview.html
+++ b/assettrack/intake/templates/issue_preview.html
@@ -110,7 +110,7 @@
           <span>ID {{ selected_holder["identifier"] }}</span>
         {% endif %}
       </div>
-      <p class="holder-subtle">Holder is the custody actor. Location and case/slot are context only.</p>
+      <p class="holder-subtle">Custody actor for this issue.</p>
       <div class="workflow-action-row workflow-action-row--quiet">
         <a class="nav-link action-quiet" href="{{ url_for('holders_search', return_to=url_for('issue')) }}">Change holder</a>
       </div>
@@ -129,7 +129,7 @@
         <strong>Current location:</strong> {{ issue_location_label }}
       </p>
     {% else %}
-      <p>Current location required before issue.</p>
+      <p>Required before commit.</p>
     {% endif %}
     {% if issue_location_constrained_by_org %}
       <p>Building choices are limited to the selected holder's organization.</p>
@@ -179,9 +179,9 @@
             </div>
 
             <div class="asset-review-core">
-              <p><strong>Issue to:</strong> <code>{{ row.after_holder }}</code></p>
+              <p><strong>To holder:</strong> <code>{{ row.after_holder }}</code></p>
               <p><strong>Current location:</strong> <code>{{ before_current_location_display }}</code></p>
-              <p><strong>Issue result:</strong> <code>{{ row.after_location_type }}</code> at <code>{{ after_current_location_display }}</code></p>
+              <p><strong>After commit:</strong> <code>{{ row.after_location_type }}</code> at <code>{{ after_current_location_display }}</code></p>
             </div>
 
             {% if row.asset_issues %}
@@ -211,7 +211,7 @@
 
   <div class="card workflow-card">
     <h2>Commit</h2>
-    <p class="card-intro">Commit only after the holder, current location, and queued assets are fully reviewed.</p>
+    <p class="card-intro">Commit issues staged assets to the selected holder.</p>
     {% if selected_holder %}
       <p class="holder-summary">
         <strong>Commit target holder:</strong> {{ holder_display_name(selected_holder) }}
@@ -227,11 +227,11 @@
       <form method="post" action="{{ url_for('issue_commit') }}">
         <label style="display:block; margin-bottom: 10px;">
           <input type="checkbox" id="confirm_reviewed" name="confirm_reviewed" />
-          I reviewed this batch and want to issue these assets to the selected holder.
+          I reviewed the staged assets.
         </label>
         <label style="display:block; margin-bottom: 10px;">
           <input type="checkbox" id="confirm_responsibility_ack" name="confirm_responsibility_ack" />
-          I confirm the selected holder accepted responsibility for this issue batch.
+          I confirm the selected holder accepted responsibility.
         </label>
         <div class="workflow-action-row">
           <button id="issue_btn" type="submit" data-timeout-lock-target>Commit Issue</button>

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -105,6 +105,62 @@
     .queue-preview-form .workflow-action-row {
       margin-top: 0;
     }
+    .issue-flow-section {
+      margin-top: 1rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--color-surface);
+    }
+    .issue-flow-section h3 {
+      margin: 0 0 0.55rem 0;
+      font-size: 1rem;
+    }
+    .issue-requirements {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 0.8rem;
+      align-items: start;
+    }
+    .issue-requirement {
+      display: grid;
+      gap: 0.45rem;
+      padding: 0.7rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 8px;
+      background: var(--color-surface-bg);
+    }
+    .issue-requirement strong {
+      display: block;
+    }
+    .issue-location-compact {
+      display: grid;
+      gap: 0.55rem;
+      margin: 0.2rem 0 0 0;
+    }
+    .issue-location-compact label {
+      display: grid;
+      gap: 0.25rem;
+      font-weight: 700;
+    }
+    .issue-location-compact .workflow-action-row {
+      margin-top: 0.2rem;
+    }
+    .issue-queue-summary {
+      margin: 0;
+      font-weight: 700;
+    }
+    .issue-queue-details {
+      margin-top: 0.55rem;
+    }
+    .issue-queue-details summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .issue-queue-details .queue-list {
+      margin-top: 0.65rem;
+      max-height: 16rem;
+      overflow: auto;
+      padding-right: 0.25rem;
+    }
   </style>
 {% endblock %}
 
@@ -137,97 +193,21 @@
     </div>
   {% endif %}
 
-  {% if workflow_banner_title %}
+  {% if workflow_banner_title and issue_location_form is not defined %}
     {% include "_workflow_context_banner.html" %}
   {% endif %}
 
   {% if issue_location_form is defined %}
-    <div class="card workflow-card">
-      <h2>Current Location</h2>
-      <div class="issue-location-layout">
-        <form method="post" action="{{ url_for('issue_location_update') }}" class="issue-location-form">
-          <label for="issue-building"><strong>Current building</strong></label><br />
-          {% if issue_location_building_options %}
-            <select id="issue-building" name="building" data-timeout-lock-target>
-              <option value="">Choose building</option>
-              {% for building_name in issue_location_building_options %}
-                <option value="{{ building_name }}" {% if issue_location_form.building == building_name %}selected{% endif %}>{{ building_name }}</option>
-              {% endfor %}
-            </select>
-          {% else %}
-            <input id="issue-building" type="text" name="building" value="{{ issue_location_form.building }}" data-timeout-lock-target />
-          {% endif %}
-          <br /><br />
-          <label for="issue-room"><strong>Current room / area</strong></label><br />
-          <input id="issue-room" type="text" name="room" value="{{ issue_location_form.room }}" data-timeout-lock-target />
-          <br /><br />
-          <div class="workflow-action-row">
-            <button type="submit" data-timeout-lock-target>Save current location</button>
-          </div>
-        </form>
-
-        <aside class="issue-location-status-panel" aria-label="Current location status">
-          <div class="workflow-summary workflow-summary--prereq">
-            <strong class="issue-location-status-title">Current location</strong>
-            {% if issue_location_ready %}
-              <code class="issue-location-status-value">{{ issue_location_label }}</code>
-            {% else %}
-              <span class="issue-location-status-value">Set where these assets are leaving from before preview.</span>
-            {% endif %}
-          </div>
-          {% if message_ns.location_messages %}
-            {% for category, message in message_ns.location_messages %}
-              <div class="flash {{ category|e }}">{{ message }}</div>
-            {% endfor %}
-          {% endif %}
-          {% if issue_location_constrained_by_org %}
-            <p class="workflow-summary issue-location-status-note">Building choices are limited to the selected holder's organization.</p>
-          {% endif %}
-          {% if issue_location_errors %}
-            <div class="validation-messages">
-              {% for issue in issue_location_errors %}
-                <p class="validation-message">{{ issue }}</p>
-              {% endfor %}
-            </div>
-          {% endif %}
-        </aside>
-      </div>
-    </div>
-  {% endif %}
-
-  <div class="card workflow-card">
-    <h2>{{ scan_heading or "Add to Queue" }}</h2>
-    {% if issue_location_form is defined %}
-      <p class="card-intro">Scan assets into the Issue queue. Select the receiving holder and current location before preview.</p>
-      {% if selected_holder %}
-        <div class="workflow-summary workflow-summary--prereq">
-          <strong>Receiving holder</strong>
-          <span>{{ holder_display_name(selected_holder) }}</span>
-          {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
-            <span>{{ selected_holder["organization"] }}</span>
-          {% endif %}
-          {% if selected_holder["identifier"] %}
-            <span>ID {{ selected_holder["identifier"] }}</span>
-          {% endif %}
-        </div>
-      {% else %}
-        <div class="workflow-summary workflow-summary--prereq">
-          <strong>Receiving holder</strong>
-          <span>Select before preview and commit.</span>
-          <a class="nav-link" href="{{ url_for('holders_search', return_to=queue_return_to) }}">Select holder</a>
-        </div>
+    <div class="card workflow-card" id="queue-actions">
+      <h2>Stage Assets</h2>
+      <p class="card-intro">Staged only. Nothing issues until commit.</p>
+      {% if message_ns.scan_messages %}
+        {% for category, message in message_ns.scan_messages %}
+          <div class="flash {{ category|e }}">{{ message }}</div>
+        {% endfor %}
       {% endif %}
-    {% else %}
-      <p class="card-intro">Scan assets into the queue. Review before commit.</p>
-    {% endif %}
-    {% if message_ns.scan_messages %}
-      {% for category, message in message_ns.scan_messages %}
-        <div class="flash {{ category|e }}">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
 
-    {% if issue_location_form is defined %}
-      <div class="queue-control-group" id="queue-actions">
+      <div class="queue-control-group">
         <div class="queue-entry-form">
           <form id="issue-queue-form" method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
             <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
@@ -236,29 +216,137 @@
               type="text"
               name="scan_text"
               placeholder="Scan or enter asset tag"
-              {% if issue_location_form is not defined %}autofocus{% endif %}
               data-timeout-lock-target
             />
           </form>
           <div class="workflow-action-row queue-action-cluster">
-              <button type="submit" form="issue-queue-form" data-timeout-lock-target>Add to queue</button>
-              <form method="post" action="{{ url_for('intake') }}" class="queue-clear-form">
-                <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
-                <input type="hidden" name="action" value="clear" />
-                <div class="workflow-action-row workflow-action-row--danger">
-                  <button type="submit" class="action-secondary" onclick="return confirm('Clear the queue?');" data-timeout-lock-target>Clear queue</button>
-                </div>
-              </form>
-            </div>
+            <button type="submit" form="issue-queue-form" data-timeout-lock-target>Add to queue</button>
+            <form method="post" action="{{ url_for('intake') }}" class="queue-clear-form">
+              <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
+              <input type="hidden" name="action" value="clear" />
+              <div class="workflow-action-row workflow-action-row--danger">
+                <button type="submit" class="action-secondary" onclick="return confirm('Clear the queue?');" data-timeout-lock-target>Clear queue</button>
+              </div>
+            </form>
+          </div>
         </div>
+      </div>
 
+      <div class="issue-flow-section" id="queue-section">
+        <h3>Queue</h3>
+        {% if queue %}
+          <p class="issue-queue-summary">{{ queue_len }} staged asset{% if queue_len != 1 %}s{% endif %}</p>
+          <details class="issue-queue-details">
+            <summary>Inspect or remove staged assets</summary>
+            <ul id="queue-list" class="queue-list" role="list">
+              {% for s in queue %}
+                <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
+                  <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
+                  <code>{{ s.asset_tag }}</code>
+                  <form method="post" action="{{ url_for('intake') }}">
+                    <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
+                    <input type="hidden" name="action" value="remove" />
+                    <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
+                    <button type="submit" class="queue-remove action-secondary" data-timeout-lock-target>Remove</button>
+                  </form>
+                </li>
+              {% endfor %}
+            </ul>
+          </details>
+        {% else %}
+          <p class="queue-empty">No assets staged.</p>
+        {% endif %}
+      </div>
+
+      <div class="issue-flow-section">
+        <h3>Requirements</h3>
+        <div class="issue-requirements">
+          <div class="issue-requirement">
+            <strong>Holder</strong>
+            {% if selected_holder %}
+              <span>{{ holder_display_name(selected_holder) }}</span>
+              {% if selected_holder["organization"] and selected_holder["organization"] != holder_display_name(selected_holder) %}
+                <span>{{ selected_holder["organization"] }}</span>
+              {% endif %}
+              {% if selected_holder["identifier"] %}
+                <span>ID {{ selected_holder["identifier"] }}</span>
+              {% endif %}
+            {% else %}
+              <span>Required before preview.</span>
+            {% endif %}
+            <a class="nav-link" href="{{ url_for('holders_search', return_to=queue_return_to) }}">{{ "Change holder" if selected_holder else "Select holder" }}</a>
+          </div>
+
+          <div class="issue-requirement">
+            <strong>Current location</strong>
+            {% if issue_location_ready %}
+              <code class="issue-location-status-value">{{ issue_location_label }}</code>
+            {% else %}
+              <span class="issue-location-status-value">Required before preview.</span>
+            {% endif %}
+            {% if message_ns.location_messages %}
+              {% for category, message in message_ns.location_messages %}
+                <div class="flash {{ category|e }}">{{ message }}</div>
+              {% endfor %}
+            {% endif %}
+            {% if issue_location_constrained_by_org %}
+              <span class="issue-location-status-note">Building list follows selected holder.</span>
+            {% endif %}
+            <form method="post" action="{{ url_for('issue_location_update') }}" class="issue-location-compact">
+              <label for="issue-building">
+                Building
+                {% if issue_location_building_options %}
+                  <select id="issue-building" name="building" data-timeout-lock-target>
+                    <option value="">Choose building</option>
+                    {% for building_name in issue_location_building_options %}
+                      <option value="{{ building_name }}" {% if issue_location_form.building == building_name %}selected{% endif %}>{{ building_name }}</option>
+                    {% endfor %}
+                  </select>
+                {% else %}
+                  <input id="issue-building" type="text" name="building" value="{{ issue_location_form.building }}" data-timeout-lock-target />
+                {% endif %}
+              </label>
+              <label for="issue-room">
+                Room / area
+                <input id="issue-room" type="text" name="room" value="{{ issue_location_form.room }}" data-timeout-lock-target />
+              </label>
+              <div class="workflow-action-row">
+                <button type="submit" data-timeout-lock-target>Save location</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      {% if blocking_issues and queue_len > 0 %}
+        <div class="issue-flow-section">
+          <h3>Before Review</h3>
+          <div class="validation-messages">
+            {% for issue in blocking_issues %}
+              <p class="validation-message">{{ issue }}</p>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
+      <div class="issue-flow-section">
         <form method="get" action="{{ preview_url or url_for('return_preview') }}" class="queue-preview-form">
           <div class="workflow-action-row">
             <button type="submit" class="preview-step" data-timeout-lock-target>{{ preview_label or review_action_label }}</button>
           </div>
         </form>
       </div>
-    {% else %}
+    </div>
+  {% else %}
+  <div class="card workflow-card">
+    <h2>{{ scan_heading or "Add to Queue" }}</h2>
+      <p class="card-intro">Scan assets into the queue. Review before commit.</p>
+    {% if message_ns.scan_messages %}
+      {% for category, message in message_ns.scan_messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+
       <div class="queue-control-group">
         <div class="queue-entry-form">
           <form id="return-queue-form" method="post" action="{{ url_for('intake') }}" style="margin-top: 10px;">
@@ -290,7 +378,6 @@
           </div>
         </form>
       </div>
-    {% endif %}
   </div>
 
   <div class="card workflow-card" id="queue-section">
@@ -324,6 +411,7 @@
         {% endfor %}
       </div>
     </div>
+  {% endif %}
   {% endif %}
 
 {% endblock %}

--- a/tests/test_issue_23_2_preview_commit_seam.py
+++ b/tests/test_issue_23_2_preview_commit_seam.py
@@ -91,18 +91,18 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert b"Ready to Issue" in issue_preview.data
     assert b">Change holder</a>" in issue_preview.data
     assert b'href="/holders?return_to=/issue">Change holder</a>' in issue_preview.data
-    assert b"Issue to:</strong>" in issue_preview.data
+    assert b"To holder:</strong>" in issue_preview.data
     assert b"Issue Holder" in issue_preview.data
     assert b"1 asset queued" in issue_preview.data
     assert b"Current location:</strong> HQ North / 210" in issue_preview.data
     assert b"Commit target holder:</strong> Issue Holder" in issue_preview.data
     assert b"| ID IH-1" in issue_preview.data
-    assert b"Issue result:</strong> <code>IN_CUSTODY</code> at <code>HQ North / 210</code>" in issue_preview.data
+    assert b"After commit:</strong> <code>IN_CUSTODY</code> at <code>HQ North / 210</code>" in issue_preview.data
     assert b"Technical details" in issue_preview.data
     assert b"Home location:</strong> <code>CASE-1 / 1</code>" in issue_preview.data
-    assert b"I reviewed this batch and want to issue these assets to the selected holder." in issue_preview.data
+    assert b"I reviewed the staged assets." in issue_preview.data
     assert b'name="confirm_responsibility_ack"' in issue_preview.data
-    assert b"accepted responsibility for this issue batch" in issue_preview.data
+    assert b"accepted responsibility" in issue_preview.data
     assert b'id="issue_btn" type="submit" data-timeout-lock-target' in issue_preview.data
     assert b"/issue/commit?json=1" not in issue_preview.data
     assert b"null" not in issue_preview.data
@@ -130,7 +130,7 @@ def test_issue_mode_preview_posts_to_issue_commit_and_allows_operator_commit(cli
     assert follow_up_scan.status_code == 200
     assert b">Issue<" in follow_up_scan.data
     assert b"Issue Holder" in follow_up_scan.data
-    assert b"1 asset queued" in follow_up_scan.data
+    assert b"1 staged asset" in follow_up_scan.data
 
     conn = db.get_connection()
     try:
@@ -269,7 +269,8 @@ def test_issue_queue_remove_updates_preview_and_commit_for_remaining_items(clien
 
     assert remove.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["DDC4CY002645", "DDC4CY002647"]
-    assert b"Queue (2)" in remove.data
+    assert b"2 staged assets" in remove.data
+    assert b"Inspect or remove staged assets" in remove.data
     assert b"Blocked Items" not in remove.data
 
     issue_preview = client_with_temp_db.get("/issue/preview")

--- a/tests/test_issue_holder_prerequisite.py
+++ b/tests/test_issue_holder_prerequisite.py
@@ -63,8 +63,8 @@ def test_issue_renders_without_holder_and_enables_issue_mode(client_with_temp_db
     assert b"Review Before Issue" in response.data
     assert b"Select holder" in response.data
     assert b'href="/holders?return_to=/issue"' in response.data
-    assert b"0 assets queued" in response.data
-    assert b"Select before preview and commit." in response.data
+    assert b"No assets staged." in response.data
+    assert b"Required before preview." in response.data
 
     with client_with_temp_db.session_transaction() as sess:
         assert sess["issue_mode"] is True
@@ -82,7 +82,8 @@ def test_valid_issue_asset_can_stage_before_holder_without_custody_side_effects(
 
     assert response.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
-    assert b"Queue (1)" in response.data
+    assert b"1 staged asset" in response.data
+    assert b"Inspect or remove staged assets" in response.data
     assert b"No holder selected. Select a holder before issuing assets." in response.data
     assert b"Select a holder before choosing the current location." in response.data
 
@@ -169,7 +170,7 @@ def test_selecting_holder_returns_user_to_issue(client_with_temp_db) -> None:
     assert b"Issue" in issue_page.data
     assert b"Review Before Issue" in issue_page.data
     assert b"Issue Holder" in issue_page.data
-    assert b"Queue (1)" in issue_page.data
+    assert b"1 staged asset" in issue_page.data
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
 
 
@@ -292,11 +293,11 @@ def test_issue_page_displays_selected_holder_context(client_with_temp_db) -> Non
     assert b"Issue" in response.data
     assert b"Issue Holder" in response.data
     assert b"Issue Org" in response.data
-    assert b"Receiving holder" in response.data
+    assert b"Holder" in response.data
     assert b"ID IH-1" in response.data
-    assert b"Change Holder" in response.data
+    assert b"Change holder" in response.data
     assert b'href="/holders?return_to=/issue"' in response.data
-    assert b"0 assets queued" in response.data
+    assert b"No assets staged." in response.data
 
 
 def test_issue_page_displays_selected_group_holder_context(client_with_temp_db) -> None:

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -102,12 +102,13 @@ def test_issue_scan_stages_before_current_location_but_preview_blocks(client_wit
     issue_page = client_with_temp_db.get("/issue")
 
     assert issue_page.status_code == 200
-    assert b"Current Location" in issue_page.data
-    assert b"Set where these assets are leaving from before preview." in issue_page.data
-    assert b"Scan assets into the Issue queue. Select the receiving holder and current location before preview." in issue_page.data
-    assert b"Add to Queue" in issue_page.data
-    assert b"Scan or enter asset tag" in issue_page.data
+    assert b"Stage Assets" in issue_page.data
+    assert b"Staged only. Nothing issues until commit." in issue_page.data
+    assert b"Requirements" in issue_page.data
+    assert b"Current location" in issue_page.data
+    assert b"Required before preview." in issue_page.data
     assert b"Add to queue" in issue_page.data
+    assert b"Scan or enter asset tag" in issue_page.data
     assert b"Review Before Issue" in issue_page.data
     assert b"Preview Queue" not in issue_page.data
     assert b"#issue-building," in issue_page.data
@@ -131,7 +132,7 @@ def test_issue_scan_stages_before_current_location_but_preview_blocks(client_wit
 
     assert scan_response.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
-    assert b"Queue (1)" in scan_response.data
+    assert b"1 staged asset" in scan_response.data
     assert b"Choose the current building." in scan_response.data
 
     preview = client_with_temp_db.get("/issue/preview")
@@ -271,7 +272,7 @@ def test_issue_does_not_reuse_last_current_location_blocked_for_selected_holder(
 
     assert scan_response.status_code == 200
     assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ISSUE100"]
-    assert b"Queue (1)" in scan_response.data
+    assert b"1 staged asset" in scan_response.data
     assert b"Choose the current building." in scan_response.data
 
 


### PR DESCRIPTION
## Summary

Reduces Issue workflow presentation load after asset-first staging by collapsing the `/issue` page into one operator-flow card and making large staged queues compact.

## Related Issue

Closes #900

## Changes

* Removed the duplicate Issue workflow summary banner from `/issue`.
* Collapsed scan, queue, holder, current location, blockers, and review action into one flow card.
* Kept scan/stage as the primary first action.
* Moved holder and current location into compact requirements.
* Made large Issue queues compact with a staged count and expandable inspection/removal list.
* Preserved per-asset remove controls inside the expandable queue section.
* Shortened Issue Preview copy and confirmation labels.
* Updated focused copy tests.

## Verification

* `python -m pytest tests/test_issue_holder_prerequisite.py tests/test_issue_location_wiring.py tests/test_issue_23_2_preview_commit_seam.py tests/test_return_batch.py -q`

  * 45 passed
* `python -m compileall assettrack tests`

  * passed
* `git diff --check`

  * passed
* Docker/incognito smoke

  * PASS
  * `/issue` renders as one operator-flow card
  * valid asset staging remains clear as staged, not issued
  * full-case staging shows staged count without burying requirements/review
  * expandable queue inspection/removal works
  * holder/location selection enables preview flow
  * commit opens receipt and clears queue
  * Return workflow still loads

## Notes

Presentation-only change. No routes, redirects, queue behavior, remove/clear behavior, preview behavior, commit behavior, custody logic, event creation, receipt behavior, schema, migrations, auth, role enforcement, Return behavior, generic `/preview`, Docker/runtime behavior, or dependencies changed.
