### PR TITLE
Issue 27 173 reduce return workflow presentation load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,9 @@ If any other document conflicts with this file:
 
 AssetTrack is:
 
-- offline-first
-- append-only
-- event-sourced
+* offline-first
+* append-only
+* event-sourced
 
 State is derived from immutable event history.
 
@@ -23,15 +23,15 @@ State is derived from immutable event history.
 
 These must NEVER be violated:
 
-- events are append-only
-- audit history is never modified or deleted
-- state derives from event history
-- custody state must reconcile with event log
-- offline-first operation must remain intact
-- SQLite persistence must not change without approval
-- role enforcement must not be bypassable
-- no hidden refactors
-- no silent behavior changes
+* events are append-only
+* audit history is never modified or deleted
+* state derives from event history
+* custody state must reconcile with event log
+* offline-first operation must remain intact
+* SQLite persistence must not change without approval
+* role enforcement must not be bypassable
+* no hidden refactors
+* no silent behavior changes
 
 If a task risks any invariant:
 → STOP immediately
@@ -40,16 +40,16 @@ If a task risks any invariant:
 
 ## 3. Execution Discipline
 
-- one issue per branch
-- branch: issue-X-Y-description
-- commit: Issue X-Y: <plain English>
-- explicit file staging only (no git add .)
-- no scope expansion
-- after an issue branch is merged and the user is back on main, delete the completed local branch:
+* one issue per branch
+* branch: issue-X-Y-description
+* commit: Issue X-Y: <plain English>
+* explicit file staging only (no git add .)
+* no scope expansion
+* after an issue branch is merged and the user is back on main, delete the completed local branch:
   `git branch -D <branch-name>`
-- do not delete active or unmerged branches unless the user confirms merge is complete
-- default to one `git status --short --branch` at the end of branch setup
-- ask for extra status checks only when useful: dirty files, failed branch switch, merge/rebase, pre-commit, or confusion
+* do not delete active or unmerged branches unless the user confirms merge is complete
+* default to one `git status --short --branch` at the end of branch setup
+* ask for extra status checks only when useful: dirty files, failed branch switch, merge/rebase, pre-commit, or confusion
 
 ---
 
@@ -57,11 +57,11 @@ If a task risks any invariant:
 
 All work must be classified:
 
-- Class 1 — UI / Presentation
-- Class 2 — Logic / Behavior
-- Class 3 — Schema
-- Class 4 — Security
-- Class 5 — Infrastructure
+* Class 1 — UI / Presentation
+* Class 2 — Logic / Behavior
+* Class 3 — Schema
+* Class 4 — Security
+* Class 5 — Infrastructure
 
 Classes 3–5 require explicit approval.
 
@@ -75,32 +75,32 @@ entry → prerequisite → queue → preview → commit
 
 Rules:
 
-- do not reorder
-- do not shortcut
-- preview requires valid queue
-- entry must not redirect into preview
+* do not reorder
+* do not shortcut
+* preview requires valid queue
+* entry must not redirect into preview
 
 ---
 
 ## 6. Local Settings And Delivery Metadata
 
-- `app_settings` stores local runtime configuration
-- receipt CC may be configured through local app settings
-- local app settings must not become custody truth, receipt truth, event truth, or audit truth
-- schema changes to app settings still require explicit migration approval
-- receipt CC is delivery metadata only
-- receipt CC is not custody truth, receipt truth, event truth, or audit truth
-- receipt CC can be persisted as delivery metadata for sent receipts
-- email delivery failure must not roll back custody or receipt creation
+* `app_settings` stores local runtime configuration
+* receipt CC may be configured through local app settings
+* local app settings must not become custody truth, receipt truth, event truth, or audit truth
+* schema changes to app settings still require explicit migration approval
+* receipt CC is delivery metadata only
+* receipt CC is not custody truth, receipt truth, event truth, or audit truth
+* receipt CC can be persisted as delivery metadata for sent receipts
+* email delivery failure must not roll back custody or receipt creation
 
 ---
 
 ## 7. Manual Add Assets Navigation
 
-- manual Add Assets launchers are hidden from normal navigation
-- `/add-assets` remains available by direct URL
-- import/upload paths remain intact
-- do not re-add Manual Add Assets to normal navigation without explicit approval
+* manual Add Assets launchers are hidden from normal navigation
+* `/add-assets` remains available by direct URL
+* import/upload paths remain intact
+* do not re-add Manual Add Assets to normal navigation without explicit approval
 
 ---
 
@@ -113,13 +113,13 @@ For workflow changes:
 
 Smoke test:
 
-- login
-- enter workflow
-- perform action
-- verify queue/state
-- verify preview
-- verify commit
-- verify queue clears
+* login
+* enter workflow
+* perform action
+* verify queue/state
+* verify preview
+* verify commit
+* verify queue clears
 
 ---
 
@@ -138,25 +138,64 @@ For implementation:
 
 ## 10. PR Descriptions
 
-- Codex may provide raw exit-report material
-- final PR descriptions should be prepared/reviewed by Chat from the Codex exit report
-- PR descriptions must use the AssetTrack PR standard
+* Codex may provide raw exit-report material
+* final PR descriptions should be prepared/reviewed by Chat from the Codex exit report
+* PR descriptions must use the AssetTrack PR standard
 
 ---
 
-## 11. Prompt Estimates
+## 11. Codex Prompt Size Discipline
 
-Codex prompts should include:
+Codex prompts must use the smallest safe instruction set for the issue.
 
-- token-use estimate only: low, low-medium, medium, or high
-- fix confidence
-- no cost estimates
+Default prompt sizes:
+
+* Tiny: recon, docs-only work, copy cleanup, and narrow UI presentation changes
+* Small: narrow template changes or workflow presentation changes with focused tests
+* Medium: behavior changes that affect workflow state, queue behavior, preview readiness, commit gating, or coordinated tests
+* Large: avoid unless explicitly approved
+
+Do not include full Constitution restatements in every Codex prompt.
+
+Only expand prompts when the issue touches:
+
+* schema or migrations
+* security or authentication
+* persistence
+* custody/event behavior
+* commit behavior
+* receipt truth
+* Docker/runtime behavior
+* dependency changes
+
+For normal Milestone 27 cleanup work, Codex prompts should be short task cards with:
+
+* issue number and title
+* classification
+* branch name
+* task
+* scope
+* non-goals
+* required checks
+* stop conditions
+* expected exit report
+
+Avoid repeating long invariant lists unless the issue can threaten those invariants.
+
+The goal is safe execution with low token waste.
+
+Codex prompts should still include:
+
+* token-use estimate only: low, low-medium, medium, or high
+* fix confidence
+* no cost estimates
 
 Rules:
 
-- if token use is high, recommend splitting work into smaller GitHub issues first
-- if fix confidence is below 98.7%, recommend splitting work into smaller GitHub issues first
-- medium prompts may proceed only when scope is tight, invariants are protected, and verification is clear
+* if token use is high, recommend splitting work into smaller GitHub issues first
+* if fix confidence is below 99.1%, recommend splitting or narrowing the work first
+* medium prompts may proceed only when scope is tight, invariants are protected, and verification is clear
+* large prompts require explicit user approval before use
 
 ---
 
@@ -164,18 +203,18 @@ Rules:
 
 STOP if:
 
-- schema change required (no approval)
-- event semantics change required
-- persistence behavior changes
-- auth boundaries weaken
-- scope expands
-- requirement unclear
+* schema change required (no approval)
+* event semantics change required
+* persistence behavior changes
+* auth boundaries weaken
+* scope expands
+* requirement unclear
 
 When stopping, report:
 
-- what was attempted
-- what is blocking
-- smallest safe next step
+* what was attempted
+* what is blocking
+* smallest safe next step
 
 ---
 
@@ -183,16 +222,17 @@ When stopping, report:
 
 All communication must follow:
 
-- Lead with the answer
-- Remove non-essential detail
-- Use scannable structure (bullets, short sections)
-- Always answer: "why it matters"
+* Lead with the answer
+* Remove non-essential detail
+* Use scannable structure (bullets, short sections)
+* Always answer: "why it matters"
 
 This applies to:
-- Issues
-- PR descriptions
-- Codex prompts
-- Handoff summaries
+
+* Issues
+* PR descriptions
+* Codex prompts
+* Handoff summaries
 
 Purpose:
 Operators must understand state and next action in seconds under pressure.
@@ -212,17 +252,17 @@ Codex source-of-truth hierarchy:
 
 Do NOT:
 
-- infer from other repos
-- reuse patterns without confirmation
+* infer from other repos
+* reuse patterns without confirmation
 
 Codex memories are non-authoritative recall only.
 Use memories to reduce repeated context setup, never to override:
 
-- direct task instructions
-- AGENTS.md
-- docs/codex/PROJECT_MEMORY.md
-- docs/codex/CURRENT_STATE.md
-- current repo state
+* direct task instructions
+* AGENTS.md
+* docs/codex/PROJECT_MEMORY.md
+* docs/codex/CURRENT_STATE.md
+* current repo state
 
 If unsure:
 → ASK before acting

--- a/assettrack/intake/templates/return_queue.html
+++ b/assettrack/intake/templates/return_queue.html
@@ -161,6 +161,32 @@
       overflow: auto;
       padding-right: 0.25rem;
     }
+    .return-flow-section {
+      margin-top: 1rem;
+      padding-top: 1rem;
+      border-top: 1px solid var(--color-surface);
+    }
+    .return-flow-section h3 {
+      margin: 0 0 0.55rem 0;
+      font-size: 1rem;
+    }
+    .return-queue-summary {
+      margin: 0;
+      font-weight: 700;
+    }
+    .return-queue-details {
+      margin-top: 0.55rem;
+    }
+    .return-queue-details summary {
+      cursor: pointer;
+      font-weight: 600;
+    }
+    .return-queue-details .queue-list {
+      margin-top: 0.65rem;
+      max-height: 16rem;
+      overflow: auto;
+      padding-right: 0.25rem;
+    }
   </style>
 {% endblock %}
 
@@ -191,10 +217,6 @@
         <a href="{{ url_for('dashboard_case_detail', case_name=case_name) }}">{{ case_name }}</a>{% if not loop.last %}, {% endif %}
       {% endfor %}
     </div>
-  {% endif %}
-
-  {% if workflow_banner_title and issue_location_form is not defined %}
-    {% include "_workflow_context_banner.html" %}
   {% endif %}
 
   {% if issue_location_form is defined %}
@@ -339,8 +361,8 @@
     </div>
   {% else %}
   <div class="card workflow-card">
-    <h2>{{ scan_heading or "Add to Queue" }}</h2>
-      <p class="card-intro">Scan assets into the queue. Review before commit.</p>
+    <h2>{{ scan_heading or "Stage Returned Assets" }}</h2>
+      <p class="card-intro">Staged only. Nothing returns until commit.</p>
     {% if message_ns.scan_messages %}
       {% for category, message in message_ns.scan_messages %}
         <div class="flash {{ category|e }}">{{ message }}</div>
@@ -372,6 +394,46 @@
           </div>
         </div>
 
+      </div>
+
+      <div class="return-flow-section" id="queue-section">
+        <h3>Queue</h3>
+        {% if queue %}
+          <p class="return-queue-summary">{{ queue_len }} staged return{% if queue_len != 1 %}s{% endif %}</p>
+          <details class="return-queue-details">
+            <summary>Inspect or remove staged returns</summary>
+            <ul id="queue-list" class="queue-list" role="list">
+              {% for s in queue %}
+                <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
+                  <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
+                  <code>{{ s.asset_tag }}</code>
+                  <form method="post" action="{{ url_for('intake') }}">
+                    <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
+                    <input type="hidden" name="action" value="remove" />
+                    <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
+                    <button type="submit" class="queue-remove action-secondary" data-timeout-lock-target>Remove</button>
+                  </form>
+                </li>
+              {% endfor %}
+            </ul>
+          </details>
+        {% else %}
+          <p class="queue-empty">No returns staged.</p>
+        {% endif %}
+      </div>
+
+      {% if blocking_issues %}
+        <div class="return-flow-section">
+          <h3>Before Review</h3>
+          <div class="validation-messages">
+            {% for issue in blocking_issues %}
+              <p class="validation-message">{{ issue }}</p>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
+
+      <div class="return-flow-section">
         <form method="get" action="{{ preview_url or url_for('return_preview') }}" class="queue-preview-form">
           <div class="workflow-action-row">
             <button type="submit" class="preview-step" data-timeout-lock-target>{{ preview_label or review_action_label }}</button>
@@ -379,39 +441,6 @@
         </form>
       </div>
   </div>
-
-  <div class="card workflow-card" id="queue-section">
-    <h2>Queue ({{ queue_len }})</h2>
-    {% if queue %}
-      <ul id="queue-list" class="queue-list" role="list">
-        {% for s in queue %}
-          <li class="queue-item" data-asset-tag="{{ s.asset_tag }}">
-            <time class="queue-ts" datetime="{{ s.scanned_at.isoformat() }}">{{ s.scanned_at.strftime('%H:%M:%S') }} UTC</time>
-            <code>{{ s.asset_tag }}</code>
-            <form method="post" action="{{ url_for('intake') }}">
-              <input type="hidden" name="return_to" value="{{ queue_return_to }}" />
-              <input type="hidden" name="action" value="remove" />
-              <input type="hidden" name="queue_index" value="{{ loop.index0 }}" />
-              <button type="submit" class="queue-remove action-secondary" data-timeout-lock-target>Remove</button>
-            </form>
-          </li>
-        {% endfor %}
-      </ul>
-    {% else %}
-      <p class="queue-empty">No assets queued.</p>
-    {% endif %}
-  </div>
-
-  {% if blocking_issues %}
-    <div class="card workflow-card">
-      <h2>Blocked Items</h2>
-      <div class="validation-messages">
-        {% for issue in blocking_issues %}
-          <p class="validation-message">{{ issue }}</p>
-        {% endfor %}
-      </div>
-    </div>
-  {% endif %}
   {% endif %}
 
 {% endblock %}

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -85,15 +85,16 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(render.status_code, 200)
         self.assertIn(b"Return", render.data)
         self.assertIn(b">Return<", render.data)
-        self.assertIn(b"Add to Queue", render.data)
-        self.assertIn(b"Scan assets into the queue. Review before commit.", render.data)
+        self.assertIn(b"Stage Returned Assets", render.data)
+        self.assertIn(b"Staged only. Nothing returns until commit.", render.data)
         self.assertNotIn(b"Stage scans in the queue, then review the batch before commit.", render.data)
         self.assertIn(b"Scan or enter asset tag", render.data)
         self.assertIn(b"Add to queue", render.data)
         self.assertIn(b"Review Before Return", render.data)
         self.assertNotIn(b"Preview Queue", render.data)
-        self.assertIn(b"Home location: Home slots", render.data)
-        self.assertIn(b"1 asset queued", render.data)
+        self.assertNotIn(b"Home location: Home slots", render.data)
+        self.assertIn(b"1 staged return", render.data)
+        self.assertIn(b"Inspect or remove staged returns", render.data)
 
         preview_render = self.client.get("/return/preview")
         self.assertEqual(preview_render.status_code, 200)
@@ -313,7 +314,7 @@ class ReturnBatchTests(unittest.TestCase):
         render = self.client.get("/return")
         self.assertEqual(render.status_code, 200)
         self.assertIn(
-            b"No assets queued.",
+            b"No returns staged.",
             render.data,
         )
 
@@ -523,7 +524,8 @@ class ReturnBatchTests(unittest.TestCase):
 
         self.assertEqual(remove.status_code, 200)
         self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["KEEP-ME"])
-        self.assertIn(b"Queue (1)", remove.data)
+        self.assertIn(b"1 staged return", remove.data)
+        self.assertIn(b"Inspect or remove staged returns", remove.data)
 
         preview = self.client.get("/return/preview")
         self.assertEqual(preview.status_code, 200)
@@ -546,7 +548,7 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT100", "RT101"])
         self.assertIn(b"Case CASE-2 added 2 assets to queue.", response.data)
-        self.assertIn(b"Queue (2)", response.data)
+        self.assertIn(b"2 staged returns", response.data)
         self.assertNotIn(b"CASE2", response.data)
 
     def test_return_case_scan_excludes_assets_already_returned_to_storage(self) -> None:
@@ -606,7 +608,7 @@ class ReturnBatchTests(unittest.TestCase):
 
         self.assertEqual(removed.status_code, 200)
         self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT301"])
-        self.assertIn(b"Queue (1)", removed.data)
+        self.assertIn(b"1 staged return", removed.data)
 
         preview = self.client.get("/return/preview")
         self.assertEqual(preview.status_code, 200)


### PR DESCRIPTION
## Summary

Reduces Return workflow presentation load so the operator sees one cleaner flow from staging returned assets through review.

Closes #901

## Changes

- Simplified `/return` into one operator flow card:
  - Stage Returned Assets
  - Queue
  - Review Before Return
- Removed the separate Return workflow banner.
- Replaced the separate Queue card with a compact queue summary.
- Kept large staged return queues behind expandable inspection/removal details.
- Moved blocked Return guidance into a short Before Review section.
- Updated focused Return presentation expectations.

## Verification

- [x] Focused pytest passed:
  - `python -m pytest tests/test_issue_holder_prerequisite.py tests/test_issue_location_wiring.py tests/test_issue_23_2_preview_commit_seam.py tests/test_return_batch.py tests/test_issue_22_2_timeout_ui_lock.py -q`
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker/manual smoke performed:
  - `docker compose up -d --build`
  - incognito browser session
  - logged in
  - entered Return workflow
  - staged returned asset/assets
  - verified queue/state changed
  - verified compact queue presentation
  - verified review/preview remained reachable
  - committed return
  - verified queue cleared
  - verified receipt behavior still worked
  - `docker compose down`

## Notes

Presentation-only change. No custody, event, receipt, route, auth, persistence, schema, dependency, queue, or generic preview behavior changed.