### PR TITLE
Issue 27-176: reduce Admin Tools presentation load

### DIFF
--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -12,9 +12,9 @@
     }
     .admin-tool-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 0.75rem;
-      margin: 0.5rem 0 0.9rem;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.5rem;
+      margin: 0.45rem 0 0.8rem;
     }
     .admin-tool-section {
       margin-top: 1rem;
@@ -26,10 +26,10 @@
     }
     .admin-tool-link {
       display: block;
-      min-height: 3.25rem;
-      padding: 0.85rem 0.95rem;
+      min-height: 2.35rem;
+      padding: 0.6rem 0.75rem;
       border: 1px solid var(--color-surface);
-      border-radius: 10px;
+      border-radius: 8px;
       background: var(--color-surface-bg);
       color: var(--color-primary);
       font-weight: 800;
@@ -142,40 +142,40 @@
     <div class="admin-tool-section">
       <h3>Access</h3>
       <nav class="admin-tool-grid" aria-label="Access admin tools">
-        <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Manage Users</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_users') }}">Users</a>
       </nav>
     </div>
     <div class="admin-tool-section">
       <h3>Setup Data</h3>
       <nav class="admin-tool-grid" aria-label="Setup data admin tools">
-        <a class="admin-tool-link" href="{{ url_for('admin_reference_data') }}">Manage Organizations and Buildings</a>
-        <a class="admin-tool-link" href="{{ url_for('admin_holder_import') }}">Import Holders from CSV</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_reference_data') }}">Organizations / Buildings</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_holder_import') }}">Import Holders</a>
       </nav>
     </div>
     <div class="admin-tool-section">
       <h3>Storage</h3>
       <nav class="admin-tool-grid" aria-label="Storage admin tools">
-        <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">Create empty slots</a>
-        <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign unslotted asset</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">Empty Slots</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">Assign Slot</a>
       </nav>
     </div>
     <div class="admin-tool-section">
       <h3>Delivery</h3>
       <nav class="admin-tool-grid" aria-label="Delivery admin tools">
-        <a class="admin-tool-link" href="{{ url_for('admin_receipt_cc_settings') }}">Receipt CC Settings</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_receipt_cc_settings') }}">Receipt CC</a>
       </nav>
     </div>
     <div class="admin-tool-section">
       <h3>Reports/Backup</h3>
       <nav class="admin-tool-grid" aria-label="Reports and backup admin tools">
-        <a class="admin-tool-link" href="{{ url_for('admin_human_report') }}">Open Operational Report</a>
-        <a class="admin-tool-link" href="{{ url_for('admin_db_export') }}">Download Database Backup</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_human_report') }}">Status Report</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_db_export') }}">DB Backup</a>
       </nav>
     </div>
     <div class="admin-tool-section">
       <h3>Recovery</h3>
       <nav class="admin-tool-grid" aria-label="Recovery admin tools">
-        <a class="admin-tool-link" href="{{ url_for('admin_db_restore') }}">Restore Database Backup</a>
+        <a class="admin-tool-link" href="{{ url_for('admin_db_restore') }}">Restore Backup</a>
       </nav>
     </div>
   </div>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -121,14 +121,15 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Delivery" in response.data
     assert b"Reports/Backup" in response.data
     assert b"Recovery" in response.data
-    assert b"Manage Users" in response.data
-    assert b"Create empty slots" in response.data
-    assert b"Assign unslotted asset" in response.data
-    assert b"Receipt CC Settings" in response.data
-    assert b"Import Holders from CSV" in response.data
-    assert b"Open Operational Report" in response.data
-    assert b"Restore Database Backup" in response.data
-    assert b"Download Database Backup" in response.data
+    assert b"Users" in response.data
+    assert b"Organizations / Buildings" in response.data
+    assert b"Import Holders" in response.data
+    assert b"Empty Slots" in response.data
+    assert b"Assign Slot" in response.data
+    assert b"Receipt CC" in response.data
+    assert b"Status Report" in response.data
+    assert b"DB Backup" in response.data
+    assert b"Restore Backup" in response.data
     assert response.data.count(b"<details class=\"disclosure-section") >= 3
     assert b"System Snapshot" in response.data
     assert b"Restore History" in response.data


### PR DESCRIPTION
## Summary

Reduces Admin Tools presentation load so admin actions are easier to scan without changing behavior.

Closes #904

## Changes

- Tightened Admin Tools card spacing and width.
- Shortened admin action labels:
  - Manage Users -> Users
  - Manage Organizations and Buildings -> Organizations / Buildings
  - Import Holders from CSV -> Import Holders
  - Create empty slots -> Empty Slots
  - Assign unslotted asset -> Assign Slot
  - Receipt CC Settings -> Receipt CC
  - Open Operational Report -> Status Report
  - Download Database Backup -> DB Backup
  - Restore Database Backup -> Restore Backup
- Preserved existing Admin Tools groups.
- Preserved existing `url_for(...)` link destinations.
- Updated focused Admin Tools presentation expectations.

## Verification

- [x] Focused pytest passed:
  - `python -m pytest tests/test_admin_system_health.py tests/test_basic_auth_guard.py tests/test_issue_23_3_admin_system_nav.py tests/test_admin_db_restore.py -q`
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker/manual smoke performed:
  - `docker compose up -d --build`
  - incognito admin login
  - opened Admin Tools
  - verified existing groups/actions remained visible
  - verified action links remained reachable
  - verified non-admin cannot access Admin Tools
  - `docker compose down`

## Notes

Presentation-only change. No admin route, link destination, auth, role enforcement, recovery, receipt, report, persistence, schema, dependency, event, custody, or Docker behavior changed.