### PR TITLE
Issue 27-178: normalize admin guidance copy

### DIFF
--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -91,7 +91,7 @@
   {% if asset %}
     <div class="card">
       <h2>Edit Asset</h2>
-      <p class="muted">Home location stays relationship-based through `slots` and `home_slot_id`.</p>
+      <p class="muted">Use case and slot only for the asset's confirmed home location.</p>
       <form method="post" action="{{ url_for('admin_edit_asset') }}">
         <input type="hidden" name="action" value="update" />
         <input type="hidden" name="lookup_asset_tag" value="{{ form.lookup_asset_tag or asset.asset_tag }}" />

--- a/assettrack/intake/templates/admin_human_report.html
+++ b/assettrack/intake/templates/admin_human_report.html
@@ -16,7 +16,7 @@
 
   <div class="card">
     <h2>Report Scope</h2>
-    <p class="card-intro">Read-only operational report. This surface does not replace a database backup.</p>
+    <p class="card-intro">Read-only report; not a database backup.</p>
     <p><strong>Database path:</strong> <code>{{ db_path }}</code></p>
     <p><strong>Recent events:</strong> active events only.</p>
   </div>

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -31,7 +31,7 @@
 
   <div class="card">
     <h2>New Asset</h2>
-    <p class="card-intro">Fill in the required fields below. Asset type defaults to Laptop.</p>
+    <p class="card-intro">Asset type defaults to Laptop.</p>
     <form method="post" action="{{ url_for('admin_new_asset') }}">
       <div class="admin-maintenance-grid">
         <div class="row">

--- a/assettrack/intake/templates/admin_receipt_cc.html
+++ b/assettrack/intake/templates/admin_receipt_cc.html
@@ -88,6 +88,5 @@
         <button type="submit">Save CC</button>
       </div>
     </form>
-    <p class="muted">Clearing the local setting restores the environment fallback when it exists.</p>
   </div>
 {% endblock %}

--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -26,7 +26,7 @@
   <div class="grid">
     <div class="card">
       <h2>Organizations</h2>
-      <p class="card-intro">Create reference values before using them in workflow or asset maintenance screens.</p>
+      <p class="card-intro">Used in workflows and asset maintenance.</p>
       <form method="post" action="{{ url_for('admin_reference_data') }}">
         <input type="hidden" name="action" value="create_organization" />
         <div class="row">
@@ -60,7 +60,7 @@
 
     <div class="card">
       <h2>Buildings</h2>
-      <p class="card-intro">Building values appear in operator-facing location selection and maintenance forms.</p>
+      <p class="card-intro">Buildings appear in operator location choices and maintenance forms.</p>
       <form method="post" action="{{ url_for('admin_reference_data') }}">
         <input type="hidden" name="action" value="create_building" />
         <div class="row">
@@ -105,7 +105,7 @@
 
   <div class="card">
     <h2>Organization to Building Mapping</h2>
-    <p class="card-intro">Map organizations to the buildings they can operate in.</p>
+    <p class="card-intro">Controls which buildings each organization can use.</p>
     <form method="post" action="{{ url_for('admin_reference_data') }}">
       <input type="hidden" name="action" value="map_organization_building" />
       <div class="grid">


### PR DESCRIPTION
## Summary

Normalizes low-risk admin guidance copy so admin pages are easier to scan while keeping safety warnings visible.

Closes #906

## Changes

* Shortened low-value helper text on selected admin pages.
* Removed duplicate Receipt CC fallback guidance.
* Replaced implementation-facing slot wording with operator-facing wording.
* Kept restore/recovery safety warnings visible.
* Kept receipt custody-vs-email boundary copy visible.
* Kept slot guidance and asset removal/retire-flow guidance visible.

## Files Changed

* `assettrack/intake/templates/admin_receipt_cc.html`
* `assettrack/intake/templates/admin_human_report.html`
* `assettrack/intake/templates/admin_edit_asset.html`
* `assettrack/intake/templates/admin_new_asset.html`
* `assettrack/intake/templates/admin_reference_data.html`

## Verification

* [x] Focused pytest passed:

  * `./.venv/bin/python -m pytest tests/test_admin_receipt_cc_settings.py tests/test_admin_system_health.py tests/test_admin_add_asset_ui.py tests/test_admin_edit_asset_ui.py tests/test_admin_reference_data.py -q`
  * 69 passed
* [x] `python3 -m compileall assettrack tests`
* [x] `git diff --check`
* [x] Docker/manual smoke performed:

  * `docker compose up -d --build`
  * used fresh isolated cookie-jar session against `http://127.0.0.1:8000`
  * created local ignored-DB smoke admin because existing admin passwords were not known
  * inspected Receipt CC
  * inspected Operational Report
  * inspected Edit Asset
  * inspected New Asset
  * inspected Reference Data
  * confirmed primary actions still render
  * confirmed restore/recovery safety copy still renders on untouched recovery pages
  * confirmed receipt detail still shows custody-vs-email boundary copy and send action
  * `docker compose down`

## Notes

Copy/presentation-only change. No forms, links, conditions, routes, auth checks, persistence, schema, events, custody logic, receipt delivery, reports behavior, backup/restore behavior, or recovery state code changed.
