### PR TITLE
Issue 27-175: consolidate receipt proof and report navigation

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1420,6 +1420,20 @@ def _safe_local_return_to(return_to: str) -> str | None:
     return None
 
 
+def _safe_report_return_to(return_to: str) -> str | None:
+    target = _safe_local_return_to(return_to)
+    if target and target.startswith("/report"):
+        return target
+    return None
+
+
+def _safe_receipt_context_return_to(return_to: str) -> str | None:
+    target = _safe_local_return_to(return_to)
+    if target and (target.startswith("/report") or target.startswith("/assets/search")):
+        return target
+    return None
+
+
 def _holder_form_error_message(exc: ValueError) -> str:
     message = str(exc)
     if message == "organization is required":
@@ -4681,6 +4695,15 @@ def asset_search():
         finally:
             conn.close()
 
+    receipt_return_args: dict[str, str] = {}
+    if form_state["asset_tag"]:
+        receipt_return_args["asset_tag"] = form_state["asset_tag"]
+    if form_state["serial_number"]:
+        receipt_return_args["serial_number"] = form_state["serial_number"]
+    if _safe_report_return_to(return_to):
+        receipt_return_args["return_to"] = return_to
+    receipt_detail_return_to = url_for("asset_search", **receipt_return_args)
+
     return render_template(
         "asset_search.html",
         form=form_state,
@@ -4688,6 +4711,7 @@ def asset_search():
         error_message=error_message,
         lookup_mode=lookup_mode,
         return_to=return_to,
+        receipt_detail_return_to=receipt_detail_return_to,
     )
 
 
@@ -5484,10 +5508,16 @@ def receipt_detail(receipt_id: int):
         abort(404)
 
     receipt = _receipt_from_queue_row(row)
+    return_to = _safe_receipt_context_return_to(request.args.get("return_to") or "")
+    return_to_label = ""
+    if return_to:
+        return_to_label = "Back to Report" if return_to.startswith("/report") else "Back to Asset Search"
 
     return render_template(
         "receipt_detail.html",
         receipt=receipt,
+        return_to=return_to,
+        return_to_label=return_to_label,
     )
 
 

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -75,7 +75,7 @@
 {% endblock %}
 
 {% block content %}
-  {% if return_to == url_for('human_report') %}
+  {% if return_to and return_to.startswith('/report') %}
     <nav class="actions nav-row" aria-label="Asset search navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
     </nav>
@@ -183,7 +183,7 @@
                     <div><code>Event #{{ proof.event_id }}</code></div>
                     {% if proof.receipt_id %}
                       <div>
-                        <a class="nav-link" href="{{ url_for('receipt_detail', receipt_id=proof.receipt_id) }}">
+                        <a class="nav-link" href="{{ url_for('receipt_detail', receipt_id=proof.receipt_id, return_to=receipt_detail_return_to) }}">
                           Receipt {{ proof.receipt_key or proof.receipt_id }}
                         </a>
                       </div>

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -60,7 +60,7 @@
   {% set status = case_status_summary(total_slots, occupied_slots) %}
   <div class="page-header-bar">
     <nav class="page-header-nav" aria-label="Contextual navigation">
-      {% if return_to == url_for('human_report') %}
+      {% if return_to and return_to.startswith('/report') %}
         <a class="nav-link" href="{{ return_to }}">Back to Report</a>
       {% endif %}
       <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=return_to) }}">Back to Cases</a>

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block content %}
-  {% if return_to == url_for('human_report') %}
+  {% if return_to and return_to.startswith('/report') %}
     <nav class="actions" aria-label="Contextual navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
     </nav>

--- a/assettrack/intake/templates/dashboard_holder_detail.html
+++ b/assettrack/intake/templates/dashboard_holder_detail.html
@@ -26,7 +26,7 @@
 {% block content %}
   <div class="page-header-bar">
     <nav class="page-header-nav" aria-label="Contextual navigation">
-      {% if return_to == url_for('human_report') %}
+      {% if return_to and return_to.startswith('/report') %}
         <a class="nav-link" href="{{ return_to }}">Back to Report</a>
       {% endif %}
       <a class="nav-link" href="{{ url_for('dashboard_holders', return_to=return_to) }}">Back to Holders</a>

--- a/assettrack/intake/templates/dashboard_holders.html
+++ b/assettrack/intake/templates/dashboard_holders.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block content %}
-  {% if return_to == url_for('human_report') %}
+  {% if return_to and return_to.startswith('/report') %}
     <nav class="actions" aria-label="Contextual navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
     </nav>

--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -243,6 +243,9 @@
     {% set receipt_status_tone = "calm" %}
   {% endif %}
   <nav class="actions nav-row mixed-nav-row" aria-label="Receipt navigation">
+    {% if return_to %}
+      <a class="nav-link" href="{{ return_to }}">{{ return_to_label }}</a>
+    {% endif %}
     <a class="chip" href="{{ url_for('receipt_pdf', receipt_id=receipt.id) }}">Download Receipt PDF</a>
     {% if receipt.delivery.state in ["pending", "failed"] %}
       {% if send_blocked_by_recovery %}

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -198,7 +198,7 @@
 {% endblock %}
 
 {% block content %}
-  {% if return_to == url_for('human_report') %}
+  {% if return_to and return_to.startswith('/report') %}
     <nav class="actions nav-row" aria-label="Receipt navigation">
       <a class="nav-link" href="{{ return_to }}">Back to Report</a>
     </nav>
@@ -258,7 +258,11 @@
             <td data-label="Receipt">
               <div class="receipt-primary">
                 <div class="receipt-title">
-                  <a class="receipt-link" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">{{ receipt.display_title }}</a>
+                  {% if return_to and return_to.startswith('/report') %}
+                    <a class="receipt-link" href="{{ url_for('receipt_detail', receipt_id=receipt.id, return_to=return_to) }}">{{ receipt.display_title }}</a>
+                  {% else %}
+                    <a class="receipt-link" href="{{ url_for('receipt_detail', receipt_id=receipt.id) }}">{{ receipt.display_title }}</a>
+                  {% endif %}
                 </div>
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
                 {% if receipt.delivery_state %}

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -77,7 +77,7 @@
     </div>
     <div class="report-actions report-utility-links" aria-label="Report utilities">
       <span class="report-utility-label">Utilities</span>
-      <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Open receipts</a>
+      <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Search receipts</a>
       {% if include_retired_assets %}
         <a class="nav-link" href="{{ url_for('human_report') }}">View active inventory only</a>
       {% else %}
@@ -98,7 +98,7 @@
       <a class="report-stat report-stat-link" href="{{ url_for('dashboard_holders', return_to=report_return_to) }}">
         In custody
         <strong>{{ asset_summary.in_custody_assets }}</strong>
-        <span class="nav-link report-stat-action">Open manual holder follow-up</span>
+        <span class="nav-link report-stat-action">Review holders with assets out</span>
       </a>
       <div class="report-stat">
         {% if include_retired_assets %}Retired shown{% else %}Retired hidden{% endif %}

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -611,11 +611,11 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b"Current State" in response.data
     assert b"Active custody and storage first." in response.data
     assert b"Report Scope" not in response.data
-    assert b"Open manual holder follow-up" in response.data
+    assert b"Review holders with assets out" in response.data
     assert b"Review case space" in response.data
     assert b"Search active asset records" in response.data
     assert b"Utilities" in response.data
-    assert b"Open receipts" in response.data
+    assert b"Search receipts" in response.data
     assert b"Include retired assets" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
     assert response.data.count(b'href="/assets/search?return_to=/report"') == 1
@@ -713,6 +713,13 @@ def test_report_drill_ins_show_back_to_report_only_for_safe_report_context(clien
     assert b'href="/report"' in asset_response.data
     assert b"Back to Report" in asset_response.data
 
+    asset_report_filter_response = client_with_temp_db.get(
+        "/assets/search?asset_tag=RET-100&return_to=/report?include_retired=1"
+    )
+    assert asset_report_filter_response.status_code == 200
+    assert b'href="/report?include_retired=1"' in asset_report_filter_response.data
+    assert b"Back to Report" in asset_report_filter_response.data
+
     holder_response = client_with_temp_db.get("/holders/1?return_to=/report")
     assert holder_response.status_code == 200
     assert b"Back to Report" in holder_response.data
@@ -723,16 +730,33 @@ def test_report_drill_ins_show_back_to_report_only_for_safe_report_context(clien
     assert b"Back to Dashboard" not in receipts_response.data
     assert b"Open Current Status Report" not in receipts_response.data
 
+    receipts_report_filter_response = client_with_temp_db.get("/receipts?return_to=/report?include_retired=1")
+    assert receipts_report_filter_response.status_code == 200
+    assert b'href="/report?include_retired=1"' in receipts_report_filter_response.data
+    assert b"Back to Report" in receipts_report_filter_response.data
+
     cases_response = client_with_temp_db.get("/dashboard/cases?return_to=/report")
     assert cases_response.status_code == 200
     assert b"Back to Report" in cases_response.data
     assert b"Back to Dashboard" not in cases_response.data
     assert b'href="/dashboard/cases/CASE-RETURN?return_to=/report"' in cases_response.data
 
+    cases_report_filter_response = client_with_temp_db.get("/dashboard/cases?return_to=/report?include_retired=1")
+    assert cases_report_filter_response.status_code == 200
+    assert b'href="/report?include_retired=1"' in cases_report_filter_response.data
+    assert b"Back to Report" in cases_report_filter_response.data
+
     case_detail_response = client_with_temp_db.get("/dashboard/cases/CASE-RETURN?return_to=/report")
     assert case_detail_response.status_code == 200
     assert b"Back to Report" in case_detail_response.data
     assert b'href="/dashboard/cases?return_to=/report"' in case_detail_response.data
+
+    case_detail_report_filter_response = client_with_temp_db.get(
+        "/dashboard/cases/CASE-RETURN?return_to=/report?include_retired=1"
+    )
+    assert case_detail_report_filter_response.status_code == 200
+    assert b'href="/report?include_retired=1"' in case_detail_report_filter_response.data
+    assert b"Back to Report" in case_detail_report_filter_response.data
 
     direct_asset_response = client_with_temp_db.get("/assets/search?asset_tag=RET-100")
     assert direct_asset_response.status_code == 200

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -266,8 +266,31 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"<strong>ISSUE</strong>", response.data)
         self.assertIn(f"Event #{event_id}".encode("utf-8"), response.data)
-        self.assertIn(b'href="/receipts/42"', response.data)
+        self.assertIn(b'href="/receipts/42?return_to=/assets/search?', response.data)
+        self.assertIn(b"asset_tag%3DAT-RECEIPT-1", response.data)
         self.assertIn(b"Receipt ISSUE:42", response.data)
+
+    def test_search_receipt_link_preserves_report_return_context(self) -> None:
+        self._insert_asset(
+            "AT-REPORT-RECEIPT",
+            serial_number="SER-REPORT-RECEIPT",
+            location_type="IN_CUSTODY",
+            home_slot_id=None,
+        )
+        event_id = self._insert_event(
+            "AT-REPORT-RECEIPT",
+            event_type="ISSUE",
+            event_date="2026-04-03T09:18:00+00:00",
+        )
+        self._insert_receipt(43, "ISSUE:43", [event_id])
+
+        response = self.client.get("/assets/search?asset_tag=AT-REPORT-RECEIPT&return_to=/report?include_retired=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'href="/receipts/43?return_to=/assets/search?', response.data)
+        self.assertIn(b"asset_tag%3DAT-REPORT-RECEIPT", response.data)
+        self.assertIn(b"return_to%3D/report", response.data)
+        self.assertIn(b"include_retired", response.data)
 
     def test_search_ignores_superseded_movement_events(self) -> None:
         self._insert_asset("AT-CORRECTED-1", serial_number="SER-CORRECTED-1", location_type="IN_CUSTODY", home_slot_id=None)

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -4,6 +4,7 @@ import json
 from email.message import EmailMessage
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import quote
 
 import pytest
 from pypdf import PdfReader
@@ -369,6 +370,44 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     assert b"Apple" in response.data
     assert b"iPad" in response.data
     assert b"CASE-20 / 1" in response.data
+
+
+def test_receipt_detail_shows_report_contextual_back_link(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}?return_to=/report?include_retired=1")
+
+    assert response.status_code == 200
+    assert b'href="/report?include_retired=1"' in response.data
+    assert b"Back to Report" in response.data
+    assert b"Download Receipt PDF" in response.data
+    assert b"Receipt delivery queued \xe2\x80\x94 custody already recorded" in response.data
+    assert b"Send Receipt Email" in response.data
+
+
+def test_receipt_detail_shows_asset_search_contextual_back_link(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+    return_to = quote("/assets/search?asset_tag=ISSUE-100&return_to=/report?include_retired=1", safe="")
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}?return_to={return_to}")
+
+    assert response.status_code == 200
+    assert b"Back to Asset Search" in response.data
+    assert b"asset_tag=ISSUE-100" in response.data
+    assert b"return_to=/report?include_retired=1" in response.data
+    assert b"Back to Report" not in response.data
+    assert b"Download Receipt PDF" in response.data
+
+
+def test_receipt_detail_omits_unsafe_contextual_back_link(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get(f"/receipts/{receipt_id}?return_to=//evil.example")
+
+    assert response.status_code == 200
+    assert b"Back to Report" not in response.data
+    assert b"Back to Asset Search" not in response.data
+    assert b"Download Receipt PDF" in response.data
 
 
 def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(client_with_temp_db) -> None:

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -223,6 +223,28 @@ def test_receipts_list_links_to_existing_receipt_detail(client_with_temp_db) -> 
     assert detail_response.status_code == 200
 
 
+def test_receipts_list_preserves_safe_report_return_context_in_detail_links(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts?return_to=/report?include_retired=1")
+
+    assert response.status_code == 200
+    assert b'href="/report?include_retired=1"' in response.data
+    assert b"Back to Report" in response.data
+    assert f'href="/receipts/{receipt_id}?return_to='.encode("utf-8") in response.data
+    assert b"include_retired" in response.data
+
+
+def test_receipts_list_omits_unsafe_report_return_context(client_with_temp_db) -> None:
+    receipt_id = _create_issue_receipt(client_with_temp_db)
+
+    response = client_with_temp_db.get("/receipts?return_to=//evil.example")
+
+    assert response.status_code == 200
+    assert b"Back to Report" not in response.data
+    assert f'href="/receipts/{receipt_id}?return_to='.encode("utf-8") not in response.data
+
+
 def test_receipts_list_renders_distinct_issue_and_return_titles(client_with_temp_db) -> None:
     issue_receipt_id = _create_issue_receipt(client_with_temp_db)
     return_receipt_id = _create_return_receipt(client_with_temp_db)


### PR DESCRIPTION
## Summary

Consolidates receipt, proof, and report navigation so users can move between reports, receipts, and asset proof without losing safe local return context.

Closes #903

## Changes

* Renamed `/report` navigation labels:

  * `Open receipts` -> `Search receipts`
  * `Open manual holder follow-up` -> `Review holders with assets out`
* Added safe return handling for `/report...` and receipt-detail contexts.
* Preserved asset-search receipt proof context into receipt detail.
* Added contextual receipt-detail back links:

  * `Back to Report` for safe `/report...` return targets
  * `Back to Asset Search` for safe `/assets/search...` return targets
* Updated dashboard holder/case report-return checks to accept safe `/report...` targets.
* Left receipt PDF, delivery, resend, retry, custody wording, report data, auth, schema, persistence, and events unchanged.

## Verification

* [x] Focused pytest passed:

  * `./.venv/bin/python -m pytest tests/test_admin_system_health.py tests/test_asset_search_ui.py tests/test_receipts_list.py tests/test_receipt_detail.py tests/test_dashboard_drilldowns.py tests/test_dashboard.py -q`
  * 142 passed
* [x] `python3 -m compileall assettrack tests`
* [x] `git diff --check`
* [x] Docker/manual smoke performed:

  * `docker compose up -d --build`
  * logged in with a fresh cookie jar
  * verified `/report` shows clearer labels
  * verified receipts opened from report show `Back to Report`
  * verified `/receipts?return_to=/report?include_retired=1` preserves filtered report return
  * verified asset search proof link opens receipt detail with `Back to Asset Search`
  * verified receipt detail still shows custody/email wording, PDF link, and send action
  * verified receipt PDF endpoint returns `200 application/pdf`
  * `docker compose down`

## Notes

Class 2 because this preserves safe local navigation context through receipt/proof/report surfaces.

Return targets remain local-only. Report return behavior is limited to `/report...`. Receipt detail only accepts `/report...` or `/assets/search...` contextual returns.

No receipt delivery, receipt PDF, custody, event, report data, auth, role, persistence, schema, dependency, or Docker behavior changed.
