### PR TITLE
Issue 27-14A: align return home-slot occupancy checks

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1183,6 +1183,44 @@ def _asset_home_slot(conn, home_slot_id: object) -> Optional[dict]:
     return dict(row) if row else None
 
 
+def _slot_occupancy_status(conn, slot_id: object) -> Optional[dict]:
+    row = conn.execute(
+        """
+        SELECT
+            s.id,
+            s.case_name,
+            s.slot_position,
+            s.current_asset_tag,
+            so.asset_id AS occupied_asset_id,
+            a.asset_tag AS occupied_asset_tag
+        FROM slots s
+        LEFT JOIN slot_occupancy so ON so.slot_id = s.id
+        LEFT JOIN assets a ON a.id = so.asset_id
+        WHERE s.id = ?
+        LIMIT 1;
+        """,
+        (int(slot_id),),
+    ).fetchone()
+    if row is None:
+        return None
+
+    marker_present = row["current_asset_tag"] is not None
+    occupied_by = str(row["occupied_asset_tag"] or row["current_asset_tag"] or "").strip()
+    if not occupied_by and row["occupied_asset_id"] is not None:
+        occupied_by = f"asset_id {row['occupied_asset_id']}"
+
+    return {
+        "id": int(row["id"]),
+        "case_name": str(row["case_name"] or ""),
+        "slot_position": int(row["slot_position"]),
+        "current_asset_tag": row["current_asset_tag"],
+        "occupied_asset_id": row["occupied_asset_id"],
+        "occupied_asset_tag": str(row["occupied_asset_tag"] or ""),
+        "occupied": bool(row["occupied_asset_id"] is not None or marker_present),
+        "occupied_by": occupied_by or "unknown asset",
+    }
+
+
 def _list_slot_options(conn) -> list[dict]:
     rows = conn.execute(
         """
@@ -3255,14 +3293,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
                 assets.append(row)
                 continue
 
-            slot = conn.execute(
-                """
-                SELECT id, case_name, slot_position, current_asset_tag
-                FROM slots
-                WHERE id = ?;
-                """,
-                (home_slot_id,),
-            ).fetchone()
+            slot = _slot_occupancy_status(conn, home_slot_id)
             if not slot:
                 row["asset_issues"].append("Assigned home slot not found. Return cannot commit until a valid home slot is assigned.")
                 no_home_slot.append(canon_tag)
@@ -3271,9 +3302,9 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
 
             row["destination_case_name"] = str(slot["case_name"])
             row["destination_slot"] = f"{slot['case_name']} / {slot['slot_position']}"
-            if slot["current_asset_tag"] is not None:
+            if slot["occupied"]:
                 row["asset_issues"].append(
-                    f"Assigned home slot {row['destination_slot']} is occupied by {slot['current_asset_tag']}."
+                    f"Assigned home slot {row['destination_slot']} is occupied by {slot['occupied_by']}."
                 )
                 occupied_home_slot.append(canon_tag)
                 row["before_slot_occupancy"] = "occupied"
@@ -3996,19 +4027,12 @@ def _return_batch(
                     no_home_slot.append(canon_tag)
                     continue
 
-                slot = conn.execute(
-                    """
-                    SELECT id, case_name, slot_position, current_asset_tag
-                    FROM slots
-                    WHERE id = ?;
-                    """,
-                    (home_slot_id,),
-                ).fetchone()
+                slot = _slot_occupancy_status(conn, home_slot_id)
                 if not slot:
                     no_home_slot.append(canon_tag)
                     continue
 
-                if slot["current_asset_tag"] is not None:
+                if slot["occupied"]:
                     occupied_home_slot.append(canon_tag)
 
                 validated_rows.append(

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -312,6 +312,138 @@ class ReturnBatchTests(unittest.TestCase):
         )
         self.assertIn(b"Conflicts must be resolved before committing this batch.", preview.data)
 
+    def test_return_preview_blocks_home_slot_occupied_by_slot_occupancy_when_marker_is_null(self) -> None:
+        self._insert_slot(13, "CASE-DRIFT", 1, None)
+        self._insert_asset("RETURN-DRIFT", location_type="IN_CUSTODY", holder_id=5, home_slot_id=13)
+        self._insert_asset("OCCUPANT-DRIFT", location_type="STORAGE", holder_id=None, home_slot_id=13)
+        occupant_id = int(
+            self.conn.execute(
+                "SELECT id FROM assets WHERE asset_tag = ? LIMIT 1;",
+                ("OCCUPANT-DRIFT",),
+            ).fetchone()[0]
+        )
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, ?);
+            """,
+            (13, occupant_id, "2026-01-01T00:00:00Z"),
+        )
+        self.conn.commit()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-DRIFT", equipment_type="laptop"))
+
+        preview = self.client.get("/return/preview")
+
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"Assigned home slot occupied: RETURN-DRIFT", preview.data)
+        self.assertIn(
+            b"Assigned home slot CASE-DRIFT / 1 is occupied by OCCUPANT-DRIFT.",
+            preview.data,
+        )
+        self.assertIn(b"Conflicts must be resolved before committing this batch.", preview.data)
+        self.assertNotIn(b"Commit Return", preview.data)
+
+    def test_return_commit_blocks_home_slot_occupied_by_slot_occupancy_when_marker_is_null(self) -> None:
+        self._insert_slot(14, "CASE-COMMIT-DRIFT", 2, None)
+        self._insert_asset("RETURN-COMMIT-DRIFT", location_type="IN_CUSTODY", holder_id=5, home_slot_id=14)
+        self._insert_asset("OCCUPANT-COMMIT-DRIFT", location_type="STORAGE", holder_id=None, home_slot_id=14)
+        occupant_id = int(
+            self.conn.execute(
+                "SELECT id FROM assets WHERE asset_tag = ? LIMIT 1;",
+                ("OCCUPANT-COMMIT-DRIFT",),
+            ).fetchone()[0]
+        )
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, ?);
+            """,
+            (14, occupant_id, "2026-01-01T00:00:00Z"),
+        )
+        self.conn.commit()
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-COMMIT-DRIFT", equipment_type="laptop"))
+
+        blocked = self.client.post(
+            "/return/commit?json=1",
+            data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        )
+
+        self.assertEqual(blocked.status_code, 400)
+        self.assertFalse(blocked.json["ok"])
+        self.assertEqual(blocked.json["committed"], 0)
+        self.assertIn("Assigned home slot occupied: RETURN-COMMIT-DRIFT", blocked.json["error"])
+
+        returned_asset = self.conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
+            ("RETURN-COMMIT-DRIFT",),
+        ).fetchone()
+        self.assertEqual(returned_asset["location_type"], "IN_CUSTODY")
+        self.assertEqual(returned_asset["current_holder_id"], 5)
+        event_count = self.conn.execute(
+            "SELECT COUNT(*) AS c FROM asset_events WHERE asset_tag = ? AND event_type = 'RETURN';",
+            ("RETURN-COMMIT-DRIFT",),
+        ).fetchone()
+        receipt_count = self.conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+        self.assertEqual(int(event_count["c"]), 0)
+        self.assertEqual(int(receipt_count["c"]), 0)
+
+    def test_return_preview_blocks_home_slot_marker_occupied_when_slot_occupancy_is_missing(self) -> None:
+        self._insert_slot(15, "CASE-MARKER-DRIFT", 3, "MARKER-OCCUPANT")
+        self._insert_asset("RETURN-MARKER-DRIFT", location_type="IN_CUSTODY", holder_id=5, home_slot_id=15)
+        self.assertIsNone(
+            self.conn.execute(
+                "SELECT 1 FROM slot_occupancy WHERE slot_id = ? LIMIT 1;",
+                (15,),
+            ).fetchone()
+        )
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-MARKER-DRIFT", equipment_type="laptop"))
+
+        preview = self.client.get("/return/preview")
+
+        self.assertEqual(preview.status_code, 200)
+        self.assertIn(b"Assigned home slot occupied: RETURN-MARKER-DRIFT", preview.data)
+        self.assertIn(
+            b"Assigned home slot CASE-MARKER-DRIFT / 3 is occupied by MARKER-OCCUPANT.",
+            preview.data,
+        )
+        self.assertIn(b"Conflicts must be resolved before committing this batch.", preview.data)
+        self.assertNotIn(b"Commit Return", preview.data)
+
+    def test_return_commit_blocks_home_slot_marker_occupied_when_slot_occupancy_is_missing(self) -> None:
+        self._insert_slot(16, "CASE-COMMIT-MARKER-DRIFT", 4, "MARKER-COMMIT-OCCUPANT")
+        self._insert_asset("RETURN-COMMIT-MARKER-DRIFT", location_type="IN_CUSTODY", holder_id=5, home_slot_id=16)
+        self.assertIsNone(
+            self.conn.execute(
+                "SELECT 1 FROM slot_occupancy WHERE slot_id = ? LIMIT 1;",
+                (16,),
+            ).fetchone()
+        )
+        intake_app.SCAN_QUEUE.append(intake_app.Scan.now(asset_tag="RETURN-COMMIT-MARKER-DRIFT", equipment_type="laptop"))
+
+        blocked = self.client.post(
+            "/return/commit?json=1",
+            data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+        )
+
+        self.assertEqual(blocked.status_code, 400)
+        self.assertFalse(blocked.json["ok"])
+        self.assertEqual(blocked.json["committed"], 0)
+        self.assertIn("Assigned home slot occupied: RETURN-COMMIT-MARKER-DRIFT", blocked.json["error"])
+
+        returned_asset = self.conn.execute(
+            "SELECT location_type, current_holder_id FROM assets WHERE asset_tag = ?;",
+            ("RETURN-COMMIT-MARKER-DRIFT",),
+        ).fetchone()
+        self.assertEqual(returned_asset["location_type"], "IN_CUSTODY")
+        self.assertEqual(returned_asset["current_holder_id"], 5)
+        event_count = self.conn.execute(
+            "SELECT COUNT(*) AS c FROM asset_events WHERE asset_tag = ? AND event_type = 'RETURN';",
+            ("RETURN-COMMIT-MARKER-DRIFT",),
+        ).fetchone()
+        receipt_count = self.conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+        self.assertEqual(int(event_count["c"]), 0)
+        self.assertEqual(int(receipt_count["c"]), 0)
+
     def test_return_queue_and_preview_empty_states_show_next_step_guidance(self) -> None:
         render = self.client.get("/return")
         self.assertEqual(render.status_code, 200)


### PR DESCRIPTION
## Summary

Aligns Return home-slot occupancy checks so Return preview and Return commit both fail closed when either slot occupancy source says the home slot is occupied.

Closes #927

## Changes

* Added `_slot_occupancy_status()` to evaluate slot occupancy from both:

  * `slot_occupancy`
  * `slots.current_asset_tag`
* Updated Return preview validation to block when either source says the home slot is occupied.
* Updated Return commit validation to use the same occupancy rule before writing the Return event.
* Added focused drift tests for:

  * `slot_occupancy` populated while `slots.current_asset_tag` is blank
  * `slots.current_asset_tag` populated while `slot_occupancy` has no row
* Verified stale/bypassed commit cases do not append a Return event or create a receipt.

## Verification

* [x] Focused Return tests passed:

  * `./.venv/bin/python -m pytest tests/test_return_batch.py -q`
  * 23 passed
* [x] Related slot occupancy tests passed:

  * `./.venv/bin/python -m pytest tests/test_issue_slot_occupancy_consistency.py -q`
  * 2 passed
* [x] `python3 -m compileall assettrack tests`
* [x] `git diff --check`
* [x] Docker/manual smoke performed:

  * `docker compose up -d --build`
  * logged in with a fresh isolated cookie jar
  * committed Issue
  * staged Return asset
  * verified Return queue clears
  * opened Return receipt page
  * `docker compose down`

## Notes

Class 2 because Return preview and commit validation behavior now use the same fail-closed occupancy check.

No schema, migration, custody event semantics, receipt behavior, Issue workflow, Return workflow order, import behavior, admin slot tooling, or persistence semantics changed.
