### PR TITLE
Issue 27-5A: add global building deactivation

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -353,6 +353,7 @@ def _create_schema(conn: sqlite3.Connection):
         CREATE TABLE IF NOT EXISTS buildings (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+            is_active INTEGER NOT NULL DEFAULT 1 CHECK(is_active IN (0, 1)),
             created_at TEXT NOT NULL,
             updated_at TEXT NOT NULL
         );
@@ -542,6 +543,13 @@ def _create_schema(conn: sqlite3.Connection):
             """
             ALTER TABLE holders
             ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1;
+            """
+        )
+    if _table_exists(conn, "buildings") and not _column_exists(conn, "buildings", "is_active"):
+        cursor.execute(
+            """
+            ALTER TABLE buildings
+            ADD COLUMN is_active INTEGER NOT NULL DEFAULT 1 CHECK(is_active IN (0, 1));
             """
         )
 

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -66,6 +66,7 @@ from assettrack.reference_data import (
     list_buildings,
     list_organization_building_mappings,
     list_organizations,
+    set_building_active,
     update_building_name,
 )
 from assettrack.settings import (
@@ -1859,7 +1860,7 @@ def _assign_slot_location_context(form: Optional[dict[str, str]] = None) -> dict
         "building": str((form or {}).get("building") or "").strip(),
         "room": str((form or {}).get("room") or "").strip(),
     }
-    building_names = _ordered_location_names([str(row.get("name") or "") for row in list_buildings()])
+    building_names = _ordered_location_names([str(row.get("name") or "") for row in list_buildings(active_only=True)])
     return {
         "form": normalized_form,
         "building_options": building_names,
@@ -2941,7 +2942,7 @@ def _issue_location_context(selected_holder: Optional[dict], form: Optional[dict
         "building": str((form or {}).get("building") or "").strip(),
         "room": str((form or {}).get("room") or "").strip(),
     }
-    all_building_names = _ordered_location_names([str(row.get("name") or "") for row in list_buildings()])
+    all_building_names = _ordered_location_names([str(row.get("name") or "") for row in list_buildings(active_only=True)])
     allowed_building_names = list(all_building_names)
     constrained_by_org = False
 
@@ -2952,14 +2953,19 @@ def _issue_location_context(selected_holder: Optional[dict], form: Optional[dict
         normalized_holder_org_id = None
 
     if normalized_holder_org_id is not None:
-        mapped_buildings = [
-            str(mapping.get("building_name") or "").strip()
+        holder_mappings = [
+            mapping
             for mapping in list_organization_building_mappings()
             if int(mapping["organization_id"]) == normalized_holder_org_id
         ]
-        mapped_buildings = _ordered_location_names(mapped_buildings)
-        if mapped_buildings:
+        if holder_mappings:
             constrained_by_org = True
+            mapped_buildings = [
+                str(mapping.get("building_name") or "").strip()
+                for mapping in holder_mappings
+                if int(mapping.get("building_is_active") or 0) == 1
+            ]
+            mapped_buildings = _ordered_location_names(mapped_buildings)
             allowed_building_names = mapped_buildings
 
     return {
@@ -2995,6 +3001,10 @@ def _validate_issue_location_form(selected_holder: Optional[dict], form: dict[st
                 errors.append("Choose a valid building.")
         else:
             normalized_form["building"] = matched_name
+    elif context["constrained_by_org"]:
+        errors.append("Choose a building allowed for the selected organization.")
+    elif context["has_reference_buildings"]:
+        errors.append("Choose a valid building.")
 
     if not room:
         errors.append("Enter the current room or area.")
@@ -7459,6 +7469,13 @@ def admin_reference_data():
                     (request.form.get("building_name") or "").strip(),
                 )
                 flash("Updated building name.", "success")
+            elif action == "set_building_active":
+                updated_building = set_building_active(
+                    int((request.form.get("building_id") or "").strip()),
+                    _is_truthy(request.form.get("is_active")),
+                )
+                status_label = "Reactivated" if int(updated_building["is_active"]) == 1 else "Deactivated"
+                flash(f"{status_label} building.", "success")
             elif action == "map_organization_building":
                 create_organization_building_mapping(
                     int((request.form.get("organization_id") or "").strip()),
@@ -7474,6 +7491,7 @@ def admin_reference_data():
         "admin_reference_data.html",
         organizations=list_organizations(),
         buildings=list_buildings(),
+        mapping_buildings=list_buildings(active_only=True),
         mappings=list_organization_building_mappings(),
         error_message=error_message,
     )

--- a/assettrack/intake/templates/admin_reference_data.html
+++ b/assettrack/intake/templates/admin_reference_data.html
@@ -75,7 +75,9 @@
           <tr>
             <th>ID</th>
             <th>Name</th>
+            <th>Status</th>
             <th>Correction</th>
+            <th>Availability</th>
           </tr>
         </thead>
         <tbody>
@@ -83,6 +85,7 @@
             <tr>
               <td><code>{{ building.id }}</code></td>
               <td>{{ building.name }}</td>
+              <td>{% if building.is_active %}Active{% else %}Inactive{% endif %}</td>
               <td>
                 <form method="post" action="{{ url_for('admin_reference_data') }}">
                   <input type="hidden" name="action" value="update_building_name" />
@@ -92,10 +95,23 @@
                   <button type="submit">Correct name</button>
                 </form>
               </td>
+              <td>
+                <form method="post" action="{{ url_for('admin_reference_data') }}">
+                  <input type="hidden" name="action" value="set_building_active" />
+                  <input type="hidden" name="building_id" value="{{ building.id }}" />
+                  {% if building.is_active %}
+                    <input type="hidden" name="is_active" value="0" />
+                    <button type="submit">Deactivate</button>
+                  {% else %}
+                    <input type="hidden" name="is_active" value="1" />
+                    <button type="submit">Reactivate</button>
+                  {% endif %}
+                </form>
+              </td>
             </tr>
           {% else %}
             <tr>
-              <td colspan="3">No buildings yet.</td>
+              <td colspan="5">No buildings yet.</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -122,7 +138,7 @@
           <label for="building_id"><strong>Building</strong></label><br />
           <select id="building_id" name="building_id">
             <option value="">Select building</option>
-            {% for building in buildings %}
+            {% for building in mapping_buildings %}
               <option value="{{ building.id }}">{{ building.name }}</option>
             {% endfor %}
           </select>
@@ -142,7 +158,12 @@
         {% for mapping in mappings %}
           <tr>
             <td>{{ mapping.organization_name }}</td>
-            <td>{{ mapping.building_name }}</td>
+            <td>
+              {{ mapping.building_name }}
+              {% if mapping.building_is_active is defined and not mapping.building_is_active %}
+                (Inactive)
+              {% endif %}
+            </td>
           </tr>
         {% else %}
           <tr>

--- a/assettrack/reference_data.py
+++ b/assettrack/reference_data.py
@@ -89,13 +89,15 @@ def create_organization(name: str) -> dict:
         conn.close()
 
 
-def list_buildings() -> list[dict]:
+def list_buildings(*, active_only: bool = False) -> list[dict]:
     conn = get_connection()
     try:
+        where_clause = "WHERE is_active = 1" if active_only else ""
         rows = conn.execute(
-            """
-            SELECT id, name, created_at, updated_at
+            f"""
+            SELECT id, name, is_active, created_at, updated_at
             FROM buildings
+            {where_clause}
             ORDER BY name COLLATE NOCASE ASC, id ASC;
             """
         ).fetchall()
@@ -109,7 +111,7 @@ def get_building(building_id: int) -> dict | None:
     try:
         row = conn.execute(
             """
-            SELECT id, name, created_at, updated_at
+            SELECT id, name, is_active, created_at, updated_at
             FROM buildings
             WHERE id = ?;
             """,
@@ -128,7 +130,7 @@ def create_building(name: str) -> dict:
     try:
         existing = conn.execute(
             """
-            SELECT id, name, created_at, updated_at
+            SELECT id, name, is_active, created_at, updated_at
             FROM buildings
             WHERE UPPER(name) = UPPER(?)
             LIMIT 1;
@@ -150,7 +152,7 @@ def create_building(name: str) -> dict:
         return dict(
             conn.execute(
                 """
-                SELECT id, name, created_at, updated_at
+                SELECT id, name, is_active, created_at, updated_at
                 FROM buildings
                 WHERE id = ?;
                 """,
@@ -169,7 +171,7 @@ def update_building_name(building_id: int, name: str) -> dict:
     try:
         current = conn.execute(
             """
-            SELECT id, name, created_at, updated_at
+            SELECT id, name, is_active, created_at, updated_at
             FROM buildings
             WHERE id = ?;
             """,
@@ -202,7 +204,7 @@ def update_building_name(building_id: int, name: str) -> dict:
         return dict(
             conn.execute(
                 """
-                SELECT id, name, created_at, updated_at
+                SELECT id, name, is_active, created_at, updated_at
                 FROM buildings
                 WHERE id = ?;
                 """,
@@ -213,22 +215,65 @@ def update_building_name(building_id: int, name: str) -> dict:
         conn.close()
 
 
-def list_organization_building_mappings() -> list[dict]:
+def set_building_active(building_id: int, is_active: bool) -> dict:
+    now_iso = _utc_now_iso()
+    active_value = 1 if is_active else 0
+
     conn = get_connection()
     try:
-        rows = conn.execute(
+        current = conn.execute(
             """
+            SELECT id
+            FROM buildings
+            WHERE id = ?;
+            """,
+            (int(building_id),),
+        ).fetchone()
+        if current is None:
+            raise ValueError("building not found")
+
+        conn.execute(
+            """
+            UPDATE buildings
+            SET is_active = ?, updated_at = ?
+            WHERE id = ?;
+            """,
+            (active_value, now_iso, int(building_id)),
+        )
+        conn.commit()
+        return dict(
+            conn.execute(
+                """
+                SELECT id, name, is_active, created_at, updated_at
+                FROM buildings
+                WHERE id = ?;
+                """,
+                (int(building_id),),
+            ).fetchone()
+        )
+    finally:
+        conn.close()
+
+
+def list_organization_building_mappings(*, active_only: bool = False) -> list[dict]:
+    conn = get_connection()
+    try:
+        where_clause = "WHERE b.is_active = 1" if active_only else ""
+        rows = conn.execute(
+            f"""
             SELECT
                 ob.organization_id,
                 o.name AS organization_name,
                 ob.building_id,
                 b.name AS building_name,
+                b.is_active AS building_is_active,
                 ob.created_at
             FROM organization_buildings ob
             JOIN organizations o
               ON o.id = ob.organization_id
             JOIN buildings b
               ON b.id = ob.building_id
+            {where_clause}
             ORDER BY o.name COLLATE NOCASE ASC, b.name COLLATE NOCASE ASC, ob.organization_id ASC, ob.building_id ASC;
             """
         ).fetchall()
@@ -250,11 +295,13 @@ def create_organization_building_mapping(organization_id: int, building_id: int)
             raise ValueError("organization not found")
 
         building = conn.execute(
-            "SELECT id, name FROM buildings WHERE id = ?;",
+            "SELECT id, name, is_active FROM buildings WHERE id = ?;",
             (int(building_id),),
         ).fetchone()
         if building is None:
             raise ValueError("building not found")
+        if int(building["is_active"]) != 1:
+            raise ValueError("building is inactive")
 
         existing = conn.execute(
             """
@@ -281,6 +328,7 @@ def create_organization_building_mapping(organization_id: int, building_id: int)
             "organization_name": str(organization["name"]),
             "building_id": int(building["id"]),
             "building_name": str(building["name"]),
+            "building_is_active": int(building["is_active"]),
             "created_at": now_iso,
         }
     finally:

--- a/tests/test_admin_reference_data.py
+++ b/tests/test_admin_reference_data.py
@@ -283,6 +283,149 @@ class AdminReferenceDataTests(unittest.TestCase):
         ).fetchone()
         self.assertEqual(unchanged["name"], "HQ Nroth")
 
+    def test_admin_can_deactivate_and_reactivate_building(self) -> None:
+        admin_id = create_test_user(username="admin-ref-building-active", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES ('HQ North', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
+        building_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'HQ North';"
+        ).fetchone()
+
+        deactivate = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "set_building_active",
+                "building_id": str(building_row["id"]),
+                "is_active": "0",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(deactivate.status_code, 200)
+        self.assertIn(b"Deactivated building.", deactivate.data)
+        self.assertIn(b"HQ North", deactivate.data)
+        self.assertIn(b"Inactive", deactivate.data)
+        self.assertIn(b"Reactivate", deactivate.data)
+        inactive = self.conn.execute(
+            "SELECT is_active FROM buildings WHERE id = ?;",
+            (building_row["id"],),
+        ).fetchone()
+        self.assertEqual(inactive["is_active"], 0)
+
+        reactivate = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "set_building_active",
+                "building_id": str(building_row["id"]),
+                "is_active": "1",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(reactivate.status_code, 200)
+        self.assertIn(b"Reactivated building.", reactivate.data)
+        self.assertIn(b"Active", reactivate.data)
+        active = self.conn.execute(
+            "SELECT is_active FROM buildings WHERE id = ?;",
+            (building_row["id"],),
+        ).fetchone()
+        self.assertEqual(active["is_active"], 1)
+
+    def test_operator_cannot_deactivate_building(self) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES ('HQ North', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
+        building_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'HQ North';"
+        ).fetchone()
+
+        operator_id = create_test_user(username="operator-ref-building-active", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "set_building_active",
+                "building_id": str(building_row["id"]),
+                "is_active": "0",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
+        unchanged = self.conn.execute(
+            "SELECT is_active FROM buildings WHERE id = ?;",
+            (building_row["id"],),
+        ).fetchone()
+        self.assertEqual(unchanged["is_active"], 1)
+
+    def test_inactive_building_is_hidden_from_new_mapping_select_and_stale_post_rejected(self) -> None:
+        admin_id = create_test_user(username="admin-ref-inactive-map", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.conn.execute(
+            """
+            INSERT INTO organizations (name, created_at, updated_at)
+            VALUES ('Operations', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, is_active, created_at, updated_at)
+            VALUES
+                ('Active HQ', 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
+                ('Closed HQ', 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        self.conn.commit()
+        organization_row = self.conn.execute(
+            "SELECT id FROM organizations WHERE name = 'Operations';"
+        ).fetchone()
+        closed_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'Closed HQ';"
+        ).fetchone()
+
+        page = self.client.get("/admin/reference-data")
+        self.assertEqual(page.status_code, 200)
+        html = page.data.decode("utf-8")
+        select_start = html.index('<select id="building_id" name="building_id">')
+        select_end = html.index("</select>", select_start)
+        building_select = html[select_start:select_end]
+        self.assertIn("Active HQ", building_select)
+        self.assertNotIn("Closed HQ", building_select)
+        self.assertIn("Closed HQ", html)
+        self.assertIn("Inactive", html)
+
+        stale_post = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "map_organization_building",
+                "organization_id": str(organization_row["id"]),
+                "building_id": str(closed_row["id"]),
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(stale_post.status_code, 200)
+        self.assertIn(b"building is inactive", stale_post.data)
+        mapping = self.conn.execute(
+            """
+            SELECT 1
+            FROM organization_buildings
+            WHERE organization_id = ? AND building_id = ?;
+            """,
+            (organization_row["id"], closed_row["id"]),
+        ).fetchone()
+        self.assertIsNone(mapping)
+
     def test_building_name_correction_validates_blank_and_duplicate_names(self) -> None:
         admin_id = create_test_user(username="admin-ref-correct-validation", password="admin-pass", role="admin")
         login_session(self.client, admin_id)
@@ -397,6 +540,78 @@ class AdminReferenceDataTests(unittest.TestCase):
         ).fetchone()["payload"]
         receipt_after = self.conn.execute(
             "SELECT snapshot_json FROM receipt_queue WHERE receipt_key = 'receipt-history-proof';"
+        ).fetchone()["snapshot_json"]
+        self.assertEqual(event_after, event_before)
+        self.assertEqual(receipt_after, receipt_before)
+
+    def test_building_deactivation_does_not_rewrite_events_or_receipt_snapshots(self) -> None:
+        admin_id = create_test_user(username="admin-ref-deactivate-history", password="admin-pass", role="admin")
+        login_session(self.client, admin_id)
+        self.conn.execute(
+            """
+            INSERT INTO buildings (name, created_at, updated_at)
+            VALUES ('HQ North', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        building_row = self.conn.execute(
+            "SELECT id FROM buildings WHERE name = 'HQ North';"
+        ).fetchone()
+        event_payload = {
+            "from_building_room": "Storage/A1",
+            "to_building_room": "HQ North/210",
+        }
+        receipt_snapshot = {
+            "receipt_type": "ISSUE",
+            "location_context": {
+                "building": "HQ North",
+                "room": "210",
+                "building_room": "HQ North/210",
+            },
+        }
+        self.conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES ('AT-100', 'ISSUE', '2026-01-01T00:00:00Z', 'admin', NULL, ?, NULL);
+            """,
+            (json.dumps(event_payload, sort_keys=True),),
+        )
+        self.conn.execute(
+            """
+            INSERT INTO receipt_queue (
+                receipt_key, receipt_type, source_event_ids_json, snapshot_json, commit_at,
+                commit_operator_user_id, holder_id, created_at, updated_at
+            )
+            VALUES (
+                'receipt-deactivate-proof', 'ISSUE', '[1]', ?, '2026-01-01T00:00:00Z',
+                ?, NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+            );
+            """,
+            (json.dumps(receipt_snapshot, sort_keys=True), admin_id),
+        )
+        self.conn.commit()
+        event_before = self.conn.execute(
+            "SELECT payload FROM asset_events WHERE asset_tag = 'AT-100';"
+        ).fetchone()["payload"]
+        receipt_before = self.conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE receipt_key = 'receipt-deactivate-proof';"
+        ).fetchone()["snapshot_json"]
+
+        response = self.client.post(
+            "/admin/reference-data",
+            data={
+                "action": "set_building_active",
+                "building_id": str(building_row["id"]),
+                "is_active": "0",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        event_after = self.conn.execute(
+            "SELECT payload FROM asset_events WHERE asset_tag = 'AT-100';"
+        ).fetchone()["payload"]
+        receipt_after = self.conn.execute(
+            "SELECT snapshot_json FROM receipt_queue WHERE receipt_key = 'receipt-deactivate-proof';"
         ).fetchone()["snapshot_json"]
         self.assertEqual(event_after, event_before)
         self.assertEqual(receipt_after, receipt_before)

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -350,6 +350,111 @@ def test_assign_slot_page_shows_known_buildings_as_choices(client_with_temp_db) 
     assert b'<option value="HQ South"' in response.data
 
 
+def test_assign_slot_page_hides_inactive_buildings_from_choices(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ North")
+    _create_building("Closed HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE buildings SET is_active = 0 WHERE name = 'Closed HQ';")
+        conn.commit()
+    finally:
+        conn.close()
+
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-ACTIVE-BUILDING-CHOICE",
+            "serial_number": "SER-ACTIVE-BUILDING-CHOICE",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ North",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-ACTIVE-BUILDING-CHOICE"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b'<option value="HQ North"' in response.data
+    assert b'<option value="Closed HQ"' not in response.data
+
+
+def test_assign_slot_rejects_stale_inactive_building_without_appending_slot_assign(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    _create_building("Closed HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (701, 'CASE-INACTIVE-BLD', 1, NULL);
+            """
+        )
+        conn.execute("UPDATE buildings SET is_active = 0 WHERE name = 'Closed HQ';")
+        conn.commit()
+    finally:
+        conn.close()
+
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-INACTIVE-BLD",
+            "serial_number": "SER-INACTIVE-BLD",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    assign_attempt = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "assign",
+            "asset_tag": "AT-INACTIVE-BLD",
+            "building": "Closed HQ",
+            "room": "100",
+            "case_name": "CASE-INACTIVE-BLD",
+            "slot_id": "701",
+        },
+        follow_redirects=True,
+    )
+
+    assert assign_attempt.status_code == 200
+    assert b"Choose a valid building." in assign_attempt.data
+
+    verify_conn = db.get_connection()
+    try:
+        asset_row = verify_conn.execute(
+            "SELECT id, home_slot_id FROM assets WHERE asset_tag = 'AT-INACTIVE-BLD' LIMIT 1;"
+        ).fetchone()
+        occupancy = verify_conn.execute(
+            "SELECT 1 FROM slot_occupancy WHERE asset_id = ? LIMIT 1;",
+            (int(asset_row["id"]),),
+        ).fetchone()
+        slot_row = verify_conn.execute(
+            "SELECT current_asset_tag FROM slots WHERE id = 701;"
+        ).fetchone()
+        events = verify_conn.execute(
+            "SELECT event_type FROM asset_events WHERE asset_tag = 'AT-INACTIVE-BLD' ORDER BY id ASC;"
+        ).fetchall()
+    finally:
+        verify_conn.close()
+
+    assert asset_row["home_slot_id"] is None
+    assert occupancy is None
+    assert slot_row["current_asset_tag"] is None
+    assert [str(row["event_type"]) for row in events] == ["ASSET_CREATED"]
+
+
 def test_assign_slot_rejects_arbitrary_building_without_appending_slot_assign(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
     _create_building("HQ")

--- a/tests/test_db_init_startup.py
+++ b/tests/test_db_init_startup.py
@@ -416,6 +416,78 @@ def test_initialize_schema_adds_holders_organization_column(tmp_path: Path) -> N
     assert "app_settings" in tables
 
 
+def test_initialize_schema_creates_buildings_is_active_column(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(buildings);").fetchall()}
+    finally:
+        conn.close()
+
+    assert "is_active" in columns
+
+
+def test_initialize_schema_adds_building_is_active_column_to_existing_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE buildings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO buildings (id, name, created_at, updated_at)
+            VALUES (1, 'HQ North', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL UNIQUE
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                event_date TEXT NOT NULL,
+                actor TEXT,
+                notes TEXT,
+                payload TEXT
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(buildings);").fetchall()}
+        building = conn.execute("SELECT is_active FROM buildings WHERE id = 1;").fetchone()
+    finally:
+        conn.close()
+
+    assert "is_active" in columns
+    assert building is not None
+    assert building[0] == 1
+
+
 def test_initialize_schema_creates_default_ad_hoc_organization(tmp_path: Path) -> None:
     db_path = tmp_path / "assettrack.db"
     db.initialize_schema(db_path)

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -276,6 +276,116 @@ def test_issue_does_not_reuse_last_current_location_blocked_for_selected_holder(
     assert b"Choose the current building." in scan_response.data
 
 
+def test_issue_hides_inactive_mapped_building_without_falling_back_to_global_buildings(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE buildings SET is_active = 0 WHERE name = 'HQ North';")
+        conn.commit()
+    finally:
+        conn.close()
+
+    issue_page = client_with_temp_db.get("/issue")
+
+    assert issue_page.status_code == 200
+    assert b'value="HQ North"' not in issue_page.data
+    assert b'value="Warehouse West"' not in issue_page.data
+    assert b"Required before preview." in issue_page.data
+
+
+def test_issue_does_not_reuse_last_current_location_when_building_becomes_inactive(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE buildings SET is_active = 0 WHERE name = 'HQ North';")
+        conn.commit()
+    finally:
+        conn.close()
+
+    with client_with_temp_db.session_transaction() as sess:
+        sess["last_issue_building"] = "HQ North"
+        sess["last_issue_room"] = "210"
+        sess.pop("issue_building", None)
+        sess.pop("issue_room", None)
+
+    issue_page = client_with_temp_db.get("/issue")
+
+    assert issue_page.status_code == 200
+    assert b'value="HQ North" selected' not in issue_page.data
+    assert b'id="issue-room" type="text" name="room" value=""' in issue_page.data
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["issue_building"] == ""
+        assert sess["issue_room"] == ""
+        assert sess["last_issue_building"] == "HQ North"
+        assert sess["last_issue_room"] == "210"
+
+
+def test_issue_location_post_rejects_inactive_building(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE buildings SET is_active = 0 WHERE name = 'HQ North';")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/issue/location",
+        data={"building": "HQ North", "room": "210"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Choose a building allowed for the selected organization." in response.data
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess.get("last_issue_building") != "HQ North"
+        assert sess.get("last_issue_room") != "210"
+
+
+def test_issue_commit_rejects_stale_inactive_building_without_appending_event(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+    with client_with_temp_db.session_transaction() as sess:
+        sess["issue_building"] = "HQ North"
+        sess["issue_room"] = "210"
+
+    intake_app.SCAN_QUEUE.append(intake_app.Scan.now("ISSUE-100"))
+
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE buildings SET is_active = 0 WHERE name = 'HQ North';")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/issue/commit?json=1",
+        data={"confirm_reviewed": "on", "confirm_responsibility_ack": "on"},
+    )
+
+    assert response.status_code == 400
+    assert response.json["ok"] is False
+    assert response.json["committed"] == 0
+    assert response.json["error"] == "Choose a building allowed for the selected organization."
+
+    conn = db.get_connection()
+    try:
+        event_count = conn.execute(
+            "SELECT COUNT(*) AS c FROM asset_events WHERE asset_tag = 'ISSUE-100' AND event_type = 'ISSUE';"
+        ).fetchone()
+        asset_row = conn.execute(
+            "SELECT location_type, current_holder_id, building_room FROM assets WHERE id = 501 LIMIT 1;"
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert event_count is not None
+    assert int(event_count["c"]) == 0
+    assert asset_row is not None
+    assert str(asset_row["location_type"]) == "STORAGE"
+    assert asset_row["current_holder_id"] is None
+    assert str(asset_row["building_room"]) == "Storage/A1"
+
+
 def test_issue_commit_updates_current_location_and_preserves_home_location_context(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db)
 


### PR DESCRIPTION
## Summary

Adds global building deactivation so inactive buildings are unavailable for new operational selections while historical labels remain visible and unchanged.

Closes #929

## Changes

* Added `buildings.is_active` to the new database schema.
* Added startup migration for existing databases without `buildings.is_active`.
* Existing buildings migrate as active by default.
* Added active-aware building helpers.
* Added admin activate/deactivate support for buildings.
* Admin Reference Data now shows all buildings with Active/Inactive status.
* Building correction remains available for inactive buildings.
* New organization-building mappings only offer active buildings.
* Issue current-location selectors now use active buildings only.
* Admin Assign Slot selectors now use active buildings only.
* Stale inactive Issue and Assign Slot submissions fail closed server-side.
* Historical event payloads and receipt snapshots are not rewritten.

## Verification

* [x] Focused pytest passed:

  * `./.venv/bin/python -m pytest tests/test_db_init_startup.py tests/test_admin_reference_data.py tests/test_issue_location_wiring.py tests/test_admin_slot_provision.py -q`
  * 57 passed
* [x] Related auth/admin tests passed:

  * `./.venv/bin/python -m pytest tests/test_basic_auth_guard.py tests/test_admin_user_management.py -q`
  * 52 passed
* [x] `python3 -m compileall assettrack tests`
* [x] `git diff --check`
* [x] Docker/manual smoke performed:

  * `docker compose up -d --build`
  * used fresh isolated cookie jars for admin/operator smoke
  * created two buildings in Admin Reference Data
  * deactivated one building
  * confirmed inactive status remains visible in Reference Data
  * confirmed inactive building is absent from new mapping select
  * confirmed inactive building is absent from operator Issue current-location selection
  * selected active building, staged asset, opened preview, and committed Issue
  * confirmed commit redirected to receipt and queue cleared
  * confirmed Admin Assign Slot shows active building and hides inactive building
  * confirmed receipt/report/asset-search proof surfaces retained historical building labels
  * confirmed receipt PDF/download and delivery/custody wording remained present
  * `docker compose down`

## Notes

Class 3 change approved before implementation.

Global building deactivation only:

* no scoped buildings
* no duplicate building names
* no per-organization building lifecycle
* no import behavior changes
* no Admin New/Edit Asset free-text building conversion
* no historical label rewrites
* no building deletion

Runtime smoke created disposable local rows in ignored `data/assettrack.db`. Tracked changes are limited to code, template, and focused tests.
