### PR TITLE
Issue 29-1A: Update container pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile
 FROM python:3.12.13-alpine3.23
 
-RUN python -m pip install --upgrade "pip==26.1"
+RUN python -m pip install --upgrade "pip==26.1.2"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1


### PR DESCRIPTION
Issue 29-1A: Update container pip

## Summary

Updates the container pip version from 26.1 to 26.1.2 to resolve CVE-2026-8643 and restore the Security Baseline workflow.

Closes #945 

## Changes

- Updated the Dockerfile pip pin from 26.1 to 26.1.2.
- Made no application, schema, event, authentication, receipt, email, database, volume, or persistence changes.

## Verification

- [x] `docker compose up -d --build`
- [x] Container reports pip 26.1.2
- [x] Trivy image scan reports 0 vulnerabilities
- [x] `git diff --check` passed
- [x] `docker compose down`
- [x] Only `Dockerfile` changed