### PR TITLE
Issue 29-2: Simplify primary operator navigation

### DIFF
--- a/assettrack/intake/templates/base.html
+++ b/assettrack/intake/templates/base.html
@@ -49,8 +49,9 @@
               <a class="chip {% if request.path.startswith('/dashboard') %}active{% endif %}" href="{{ url_for('dashboard') }}">Dashboard</a>
               <a class="chip {% if request.path.startswith('/issue') %}active{% endif %}" href="{{ url_for('issue') }}">Issue</a>
               <a class="chip {% if request.path.startswith('/return') %}active{% endif %}" href="{{ url_for('return_queue') }}">Return</a>
+              <a class="chip {% if request.path.startswith('/assets/search') %}active{% endif %}" href="{{ url_for('asset_search') }}">Assets</a>
               <a class="chip {% if request.path.startswith('/holders') %}active{% endif %}" href="{{ url_for('holders_search') }}">Holders</a>
-              <a class="chip {% if request.path.startswith('/report') or request.path.startswith('/receipts') or request.path.startswith('/assets/search') or request.path.startswith('/dashboard/holders') or request.path.startswith('/dashboard/cases') %}active{% endif %}" href="{{ url_for('human_report') }}">Reports</a>
+              <a class="chip {% if request.path.startswith('/report') or request.path.startswith('/receipts') or request.path.startswith('/dashboard/holders') or request.path.startswith('/dashboard/cases') %}active{% endif %}" href="{{ url_for('human_report') }}">Reports</a>
               {% if authenticated_role == 'admin' %}
                 {% set admin_menu_active = request.path.startswith('/admin') or request.path.startswith('/add-assets') %}
                 <details class="top-nav-admin{% if admin_menu_active %} active{% endif %}">

--- a/tests/test_basic_auth_guard.py
+++ b/tests/test_basic_auth_guard.py
@@ -643,6 +643,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
     assert b">Preview</a>" not in dashboard_response.data
     assert b">Issue</a>" in dashboard_response.data
     assert b">Return</a>" in dashboard_response.data
+    assert b">Assets</a>" in dashboard_response.data
     assert b">Holders</a>" in dashboard_response.data
     assert b">Receipts</a>" not in dashboard_response.data
     assert b">Add Assets</a>" not in dashboard_response.data
@@ -652,6 +653,7 @@ def test_preview_not_shown_in_main_navigation_but_direct_route_still_loads(clien
         b'href="/dashboard">Dashboard</a>',
         b'href="/issue">Issue</a>',
         b'href="/return">Return</a>',
+        b'href="/assets/search">Assets</a>',
         b'href="/holders">Holders</a>',
         b'href="/report">Reports</a>',
     ]
@@ -669,6 +671,7 @@ def test_admin_navigation_shows_admin_only_actions(client_with_temp_db) -> None:
     dashboard_response = client_with_temp_db.get("/dashboard")
 
     assert dashboard_response.status_code == 200
+    assert b">Assets</a>" in dashboard_response.data
     assert b">Holders</a>" in dashboard_response.data
     assert b">Receipts</a>" not in dashboard_response.data
     assert b">Add Assets</a>" not in dashboard_response.data


### PR DESCRIPTION
Issue 29-2: Simplify primary operator navigation

## Summary

Makes Asset Search a direct primary navigation destination while preserving the existing operator workflows, Reports access, and administrator boundaries.

Closes #939

## Changes

- Added **Assets** to the primary navigation.
- Linked Assets directly to `/assets/search`.
- Updated active-navigation behavior so Asset Search highlights **Assets** instead of **Reports**.
- Updated focused navigation tests for operator and administrator views.
- Preserved Reports as the existing history and proof destination.

## Verification

- [x] Operator navigation shows Dashboard, Issue, Return, Assets, Holders, Reports, Account, and Logout
- [x] Administrator navigation retains the separate Admin menu
- [x] Operator access to Admin Tools returns 403
- [x] `/issue` renders the Issue entry page directly
- [x] `/return` renders the Return entry page directly
- [x] Asset Search, Holder Search, Reports, and Account open successfully
- [x] Focused navigation and workflow tests passed: 6 tests
- [x] Docker container built, started, and reported healthy
- [x] Docker shut down normally
- [x] `git diff --check` passed
- [x] No schema, event, custody, receipt, email, role, authentication, dependency, or persistence behavior changed

## Notes

Manual workflow verification used clean curl cookie sessions against the running container rather than a graphical incognito browser.