### PR TITLE
Issue 29-3: Make Asset Search primary

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1637,12 +1637,18 @@ def _lookup_asset_for_verification(
                 holder_label = _holder_display_name(holder_row)
 
         location_type = _normalize_location_type(asset.get("location_type"))
+        equipment_type = str(asset.get("equipment_type") or "").strip()
         movement_proof = _asset_last_movement_proof(conn, str(asset.get("asset_tag") or ""))
         results.append(
             {
                 "id": int(asset["id"]),
                 "asset_tag": str(asset.get("asset_tag") or ""),
                 "serial_number": str(asset.get("serial_number") or ""),
+                "equipment_type": equipment_type,
+                "equipment_type_label": ASSET_EQUIPMENT_TYPE_LABELS.get(
+                    equipment_type,
+                    equipment_type.replace("_", " ").title() if equipment_type else "",
+                ),
                 "location_type": location_type,
                 "state_label": _asset_state_label(asset.get("location_type")),
                 "holder_label": holder_label,

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -9,11 +9,24 @@
     .asset-search-page .asset-search-form {
       width: 100%;
     }
+    .asset-search-page .asset-search-intro {
+      margin: 0 0 0.75rem 0;
+      max-width: 54rem;
+    }
     .asset-search-page .search-grid {
       display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
+      grid-template-columns: minmax(18rem, 1.4fr) minmax(14rem, 0.8fr);
       gap: 0.75rem 1rem;
       width: 100%;
+    }
+    .asset-search-page .search-field-primary .form-input {
+      font-size: 1.12rem;
+      min-height: 2.75rem;
+    }
+    .asset-search-page .field-help {
+      margin: 0.25rem 0 0 0;
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
     }
     .asset-search-page .search-field {
       min-width: 0;
@@ -22,8 +35,46 @@
       display: block;
       max-width: none;
     }
+    .asset-search-page .asset-search-empty {
+      margin: 0;
+      color: var(--color-text-muted);
+    }
+    .asset-search-page .asset-search-no-results {
+      border-left: 6px solid var(--color-warning);
+    }
+    .asset-search-page .asset-search-no-results h2 {
+      margin-top: 0;
+    }
+    .asset-search-page .asset-results-count {
+      margin: -0.25rem 0 0.8rem 0;
+      color: var(--color-text-muted);
+    }
     .result-grid { display: grid; grid-template-columns: repeat(2, minmax(220px, 1fr)); gap: 0.75rem 1rem; }
     .results-table code { white-space: nowrap; }
+    .asset-identity {
+      display: grid;
+      gap: 0.28rem;
+      min-width: 10rem;
+    }
+    .asset-identity code {
+      font-size: 1rem;
+      font-weight: 700;
+    }
+    .asset-type-badge {
+      display: inline-flex;
+      width: fit-content;
+      padding: 0.16rem 0.5rem;
+      border-radius: 999px;
+      background: var(--color-surface-soft);
+      color: var(--color-text);
+      font-size: 0.84rem;
+      font-weight: 700;
+    }
+    .asset-location {
+      display: grid;
+      gap: 0.22rem;
+      min-width: 9rem;
+    }
     .movement-proof {
       display: grid;
       gap: 0.25rem;
@@ -67,7 +118,7 @@
       color: var(--color-text-muted);
     }
     @media (max-width: 720px) {
-      .search-grid {
+      .asset-search-page .search-grid {
         grid-template-columns: 1fr;
       }
     }
@@ -86,20 +137,24 @@
   {% endif %}
 
   <div class="card">
-    <h2>Find Asset</h2>
-    <p class="muted">Search by asset tag or serial number.</p>
+    <h2>Search assets</h2>
+    <p class="asset-search-intro muted">
+      Find a laptop, switch, or router by asset tag. Use serial number when the tag is not available.
+    </p>
     <form class="asset-search-form" method="get" action="{{ url_for('asset_search') }}">
       {% if return_to %}
         <input type="hidden" name="return_to" value="{{ return_to }}" />
       {% endif %}
       <div class="search-grid">
-        <div class="row form-group search-field">
+        <div class="row form-group search-field search-field-primary">
           <label class="form-label" for="asset_tag"><strong>Asset tag</strong></label>
-          <input class="form-input" type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" autofocus />
+          <input class="form-input" type="text" id="asset_tag" name="asset_tag" value="{{ form.asset_tag or '' }}" placeholder="Scan or type asset tag" autofocus />
+          <p class="field-help">Primary lookup for daily custody checks.</p>
         </div>
         <div class="row form-group search-field">
           <label class="form-label" for="serial_number"><strong>Serial number</strong></label>
-          <input class="form-input" type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" />
+          <input class="form-input" type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" placeholder="Optional serial lookup" />
+          <p class="field-help">Use when the asset tag is missing or unreadable.</p>
         </div>
       </div>
       <div class="search-actions">
@@ -118,21 +173,18 @@
   {% if assets %}
     <div class="card">
       <h2>{% if assets|length == 1 %}Asset Found{% else %}Assets Found{% endif %}</h2>
-      {% if assets|length != 1 %}
-        <p class="muted">
-          {{ assets|length }} matches shown.
-        </p>
-      {% endif %}
+      <p class="asset-results-count">
+        {% if assets|length == 1 %}1 match shown.{% else %}{{ assets|length }} matches shown.{% endif %}
+      </p>
       <table class="results-table">
         <thead>
           <tr>
-            <th>Asset tag</th>
-            <th>Serial number</th>
-            <th>Current state</th>
-            <th>Current holder</th>
-            <th>Home case</th>
-            <th>Home slot</th>
-            <th>Last proof</th>
+            <th>Asset</th>
+            <th>Type</th>
+            <th>Current status</th>
+            <th>Assigned holder</th>
+            <th>Assigned location</th>
+            <th>Last movement proof</th>
           </tr>
         </thead>
         <tbody>
@@ -141,13 +193,18 @@
             {% set status = asset.status_cue %}
             <tr>
               <td>
-                {% if authenticated_role == 'admin' and asset.asset_tag %}
-                  <a class="nav-link" href="{{ url_for('admin_edit_asset', asset_tag=asset.asset_tag) }}"><code>{{ asset.asset_tag }}</code></a>
-                {% else %}
-                  <code>{{ asset.asset_tag or "" }}</code>
-                {% endif %}
+                <div class="asset-identity">
+                  {% if authenticated_role == 'admin' and asset.asset_tag %}
+                    <a class="nav-link" href="{{ url_for('admin_edit_asset', asset_tag=asset.asset_tag) }}"><code>{{ asset.asset_tag }}</code></a>
+                  {% else %}
+                    <code>{{ asset.asset_tag or "" }}</code>
+                  {% endif %}
+                  <span>Serial: {{ asset.serial_number or "Not recorded" }}</span>
+                </div>
               </td>
-              <td>{{ asset.serial_number or "Not recorded" }}</td>
+              <td>
+                <span class="asset-type-badge">{{ asset.equipment_type_label or "Type not recorded" }}</span>
+              </td>
               <td>
                 <div class="status-cue" data-tone="{{ status.tone }}">
                   <span class="status-cue-label">{{ status.label }}</span>
@@ -158,13 +215,17 @@
                 </div>
               </td>
               <td>{{ asset.holder_label or "Not assigned" }}</td>
-              <td>{{ asset.home_case_name or "Not assigned" }}</td>
               <td>
-                {% if asset.home_slot_position is not none %}
-                  Slot {{ asset.home_slot_position }}
-                {% else %}
-                  Not assigned
-                {% endif %}
+                <div class="asset-location">
+                  <span>Case: {{ asset.home_case_name or "Not assigned" }}</span>
+                  <span>
+                    {% if asset.home_slot_position is not none %}
+                      Slot: {{ asset.home_slot_position }}
+                    {% else %}
+                      Slot: Not assigned
+                    {% endif %}
+                  </span>
+                </div>
               </td>
               <td>
                 {% if proof and proof.event_id %}
@@ -194,6 +255,18 @@
           {% endfor %}
         </tbody>
       </table>
+    </div>
+  {% elif form.asset_tag or form.serial_number %}
+    <div class="card asset-search-no-results">
+      <h2>No asset found</h2>
+      <p class="muted">Check the asset tag or serial number and search again.</p>
+    </div>
+  {% else %}
+    <div class="card">
+      <h2>Ready to search</h2>
+      <p class="asset-search-empty">
+        Enter an asset tag or serial number to see custody status, holder, assigned location, and existing movement proof.
+      </p>
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -102,6 +102,7 @@ class AssetSearchUiTests(unittest.TestCase):
         location_type: str,
         home_slot_id: int | None,
         current_holder_id: int | None = None,
+        equipment_type: str = "laptop",
     ) -> None:
         self.conn.execute(
             """
@@ -122,9 +123,9 @@ class AssetSearchUiTests(unittest.TestCase):
                 current_holder_id,
                 home_slot_id
             )
-            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '100', 'HQ/100', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?);
+            VALUES (?, ?, 'Dell', ?, 'HQ', '100', 'HQ/100', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?);
             """,
-            (asset_tag, serial_number, location_type, current_holder_id, home_slot_id),
+            (asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id),
         )
         self.conn.commit()
 
@@ -132,7 +133,11 @@ class AssetSearchUiTests(unittest.TestCase):
         response = self.client.get("/assets/search")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Asset Search", response.data)
-        self.assertIn(b"Search by asset tag or serial number", response.data)
+        self.assertIn(b"Search assets", response.data)
+        self.assertIn(b"Scan or type asset tag", response.data)
+        self.assertIn(b"Optional serial lookup", response.data)
+        self.assertIn(b"Ready to search", response.data)
+        self.assertIn(b"custody status, holder, assigned location, and existing movement proof", response.data)
         self.assertNotIn(b">Clear<", response.data)
 
     def test_search_finds_asset_by_asset_tag(self) -> None:
@@ -146,10 +151,11 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertNotIn(b"Matched by asset tag.", response.data)
         self.assertIn(b"AT-100", response.data)
         self.assertIn(b"SER-100", response.data)
+        self.assertIn(b"Laptop", response.data)
         self.assertIn(b"In storage", response.data)
         self.assertIn(b"Alex Holder (Field Ops)", response.data)
-        self.assertIn(b"CASE-A", response.data)
-        self.assertIn(b"Slot 4", response.data)
+        self.assertIn(b"Case: CASE-A", response.data)
+        self.assertIn(b"Slot: 4", response.data)
         self.assertIn(b"Problem: holder still assigned", response.data)
         self.assertIn(b"Current state says stored, but a holder is still assigned.", response.data)
         self.assertIn(b"No movement proof recorded", response.data)
@@ -176,11 +182,35 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"AT-200", response.data)
         self.assertIn(b"SER-200", response.data)
         self.assertIn(b"In custody", response.data)
-        self.assertIn(b"Current holder", response.data)
+        self.assertIn(b"Assigned holder", response.data)
         self.assertIn(b"Not assigned", response.data)
         self.assertIn(b"Not assigned", response.data)
         self.assertIn(b"Problem: holder not recorded", response.data)
         self.assertIn(b"Current state says in custody, but no holder is assigned.", response.data)
+
+    def test_search_keeps_supported_asset_types_readable(self) -> None:
+        self._insert_asset("TYPE-LAPTOP", serial_number="SER-LAPTOP", location_type="STORAGE", home_slot_id=None)
+        self._insert_asset(
+            "TYPE-SWITCH",
+            serial_number="SER-SWITCH",
+            location_type="STORAGE",
+            home_slot_id=None,
+            equipment_type="switch",
+        )
+        self._insert_asset(
+            "TYPE-ROUTER",
+            serial_number="SER-ROUTER",
+            location_type="STORAGE",
+            home_slot_id=None,
+            equipment_type="router",
+        )
+
+        response = self.client.get("/assets/search?asset_tag=TYPE-")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Laptop", response.data)
+        self.assertIn(b"Switch", response.data)
+        self.assertIn(b"Router", response.data)
 
     def test_search_shows_stored_status_cue_for_storage_asset(self) -> None:
         self._insert_asset("AT-STORED-1", serial_number="SER-STORED-1", location_type="STORAGE", home_slot_id=None)
@@ -245,7 +275,7 @@ class AssetSearchUiTests(unittest.TestCase):
         response = self.client.get("/assets/search?asset_tag=AT-PROOF-1")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Last proof", response.data)
+        self.assertIn(b"Last movement proof", response.data)
         self.assertIn(b"<strong>RETURN</strong>", response.data)
         self.assertIn(b"Apr 3, 2026 9:18 AM", response.data)
         self.assertIn(f"Event #{latest_event_id}".encode("utf-8"), response.data)
@@ -380,6 +410,8 @@ class AssetSearchUiTests(unittest.TestCase):
         response = self.client.get("/assets/search?asset_tag=AT-MISSING")
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Asset not found.", response.data)
+        self.assertIn(b"No asset found", response.data)
+        self.assertIn(b"Check the asset tag or serial number and search again.", response.data)
         self.assertNotIn(b"Asset Found", response.data)
         self.assertIn(b'href="/assets/search"', response.data)
         self.assertIn(b">Clear<", response.data)


### PR DESCRIPTION
Issue 29-3: Make Asset Search a primary operator destination

## Summary

Make Asset Search a clearer primary operator destination while preserving existing search behavior.

## Related Issue

Closes #940

## Changes

- Improved the purpose and guidance on `/assets/search`.
- Added clearer empty and no-result states.
- Improved result headings and field presentation.
- Displayed asset identity, equipment type, current status, assigned holder, assigned location, and existing movement proof.
- Preserved asset-tag and serial-number search behavior.
- Added focused coverage for the updated presentation and laptop, switch, and router readability.

## Verification

- [x] `./.venv/bin/python -m pytest tests/test_asset_search_ui.py -q`
- [x] Focused navigation and authorization tests passed.
- [x] `git diff --check`
- [x] Docker image rebuilt and container started healthy.
- [x] Verified operator login and direct `/assets/search` rendering.
- [x] Verified asset-tag search.
- [x] Verified serial-number search.
- [x] Verified empty and no-result states.
- [x] Verified asset result information and existing movement proof.
- [x] Verified Reports retains its separate navigation active state.
- [x] Docker Compose shut down normally without removing volumes.

## Notes

- Equipment type is displayed from data already loaded by the existing Asset Search query.
- No schema, event, custody, receipt, email, authentication, role, report, Docker, persistence, dependency, or search-matching behavior changed.
- No CMDB fields were added.