### PR TITLE
Issue 29-7: Narrow supported asset types

### DIFF
--- a/assettrack/assets.py
+++ b/assettrack/assets.py
@@ -14,11 +14,51 @@ No audit/state engine.
 No legacy integration.
 """
 
+APPROVED_NEW_EQUIPMENT_TYPES = ("laptop", "switch", "router")
+SUPPORTED_EQUIPMENT_TYPE_MESSAGE = "Supported asset types are Laptop, Switch, and Router."
+EQUIPMENT_TYPE_LABELS = {
+    "laptop": "Laptop",
+    "switch": "Switch",
+    "router": "Router",
+    "monitor": "Monitor",
+    "large tv": "Large TV",
+    "other network equipment": "Other Network Equipment",
+    "peripheral": "Peripheral",
+    "voip": "VoIP",
+    "other": "Other",
+}
+
+
+def normalize_equipment_type(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def equipment_type_label(value: object) -> str:
+    normalized = normalize_equipment_type(value)
+    if normalized in EQUIPMENT_TYPE_LABELS:
+        return EQUIPMENT_TYPE_LABELS[normalized]
+    return normalized.replace("_", " ").title() if normalized else ""
+
+
+def is_approved_new_equipment_type(value: object) -> bool:
+    return normalize_equipment_type(value) in APPROVED_NEW_EQUIPMENT_TYPES
+
+
+def validate_new_equipment_type(value: object) -> str:
+    normalized = normalize_equipment_type(value)
+    if not normalized:
+        raise ValueError(f"equipment_type is required. {SUPPORTED_EQUIPMENT_TYPE_MESSAGE}")
+    if normalized not in APPROVED_NEW_EQUIPMENT_TYPES:
+        raise ValueError(SUPPORTED_EQUIPMENT_TYPE_MESSAGE)
+    return normalized
+
+
 def get_asset_table_columns(db_connection: sqlite3.Connection) -> set[str]:
     """Return column names for the assets table."""
     cursor = db_connection.execute("PRAGMA table_info(assets);")
     rows = cursor.fetchall()
     return {row[1] for row in rows}
+
 
 def create_asset(
     db_connection: sqlite3.Connection,
@@ -34,7 +74,6 @@ def create_asset(
         raise ValueError("asset_tag is required")
 
     table_columns = get_asset_table_columns(db_connection)
-
     insert_values: dict[str, Any] = {
         key: value
         for key, value in asset_data.items()
@@ -42,6 +81,10 @@ def create_asset(
     }
 
     insert_values["asset_tag"] = asset_tag
+    if "equipment_type" in table_columns:
+        insert_values["equipment_type"] = validate_new_equipment_type(
+            insert_values.get("equipment_type")
+        )
 
     # Required NOT NULL defaults (schema-driven)
     if "custody_state" in table_columns and not insert_values.get("custody_state"):
@@ -49,7 +92,7 @@ def create_asset(
 
     if "accountability_status" in table_columns and not insert_values.get("accountability_status"):
         insert_values["accountability_status"] = "accountable"
-    
+
     if "created_date" in table_columns and not insert_values.get("created_date"):
         insert_values["created_date"] = date.today().isoformat()  # "YYYY-MM-DD"
 
@@ -74,14 +117,18 @@ def create_asset(
         db_connection.execute(sql_statement, sql_values)
     except sqlite3.IntegrityError as error:
         raise ValueError(f"create_asset failed: {error}") from error
-    
+
+    event_payload = dict(asset_data)
+    if "equipment_type" in insert_values:
+        event_payload["equipment_type"] = insert_values["equipment_type"]
+
     record_event(
         db_connection,
         asset_tag=asset_tag,
         event_type="created",
         event_date=str(asset_data.get("created_date") or ""),
         actor="system",
-        payload=dict(asset_data),
+        payload=event_payload,
     )
 
 def get_asset_by_tag(
@@ -183,4 +230,3 @@ def retire_asset(
         event_date=str(updated_date or ""),
         actor="system",
     )
-

--- a/assettrack/ingest/committer.py
+++ b/assettrack/ingest/committer.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
-from assettrack.assets import create_asset, retire_asset, update_asset
+from assettrack.assets import SUPPORTED_EQUIPMENT_TYPE_MESSAGE, create_asset, retire_asset, update_asset, validate_new_equipment_type
 from assettrack.audit import record_event
 from assettrack.db import bootstrap_db, get_connection
 
@@ -264,6 +264,10 @@ def _apply_one_event(conn: sqlite3.Connection, data: dict[str, Any]) -> None:
             raise BatchCommitError(
                 f"Asset {asset_tag} does not exist; equipment_type is required to create it"
             )
+        try:
+            data["equipment_type"] = validate_new_equipment_type(equipment_type)
+        except ValueError as exc:
+            raise BatchCommitError(str(exc) or SUPPORTED_EQUIPMENT_TYPE_MESSAGE) from exc
 
     event_date = _normalize_iso8601_timestamp(str(data.get("timestamp", "")))
     actor = str(data.get("operator_id", "")).strip() or None

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -35,7 +35,16 @@ from reportlab.pdfgen import canvas
 from reportlab.platypus import Paragraph, SimpleDocTemplate, Spacer, Table, TableStyle
 
 import assettrack.db as db_module
-from assettrack.assets import get_asset_table_columns
+from assettrack.assets import (
+    APPROVED_NEW_EQUIPMENT_TYPES,
+    EQUIPMENT_TYPE_LABELS,
+    SUPPORTED_EQUIPMENT_TYPE_MESSAGE,
+    equipment_type_label,
+    get_asset_table_columns,
+    is_approved_new_equipment_type,
+    normalize_equipment_type,
+    validate_new_equipment_type,
+)
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import bootstrap_db, get_connection
 from assettrack.drilldowns import (
@@ -124,26 +133,8 @@ INTAKE_TIMEOUT_SECONDS = int(os.getenv("ASSETTRACK_INTAKE_TIMEOUT_SECONDS", str(
 TERMINAL_LOCATION_TYPE = "DISPOSED"
 TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
-ASSET_EQUIPMENT_TYPE_OPTIONS = (
-    "laptop",
-    "monitor",
-    "large tv",
-    "switch",
-    "other network equipment",
-    "peripheral",
-    "voip",
-    "other",
-)
-ASSET_EQUIPMENT_TYPE_LABELS = {
-    "laptop": "Laptop",
-    "monitor": "Monitor",
-    "large tv": "Large TV",
-    "switch": "Switch",
-    "other network equipment": "Other Network Equipment",
-    "peripheral": "Peripheral",
-    "voip": "VoIP",
-    "other": "Other",
-}
+ASSET_EQUIPMENT_TYPE_OPTIONS = APPROVED_NEW_EQUIPMENT_TYPES
+ASSET_EQUIPMENT_TYPE_LABELS = EQUIPMENT_TYPE_LABELS
 DEMO_SUMMARY = {
     "assets_in_custody": 18,
     "pending_receipts": 2,
@@ -207,12 +198,14 @@ def _equipment_type_form_options(current_value: object = "") -> list[dict[str, o
 
 
 def _equipment_type_is_allowed(value: object, *, allow_current: object = "") -> bool:
-    selected = str(value or "").strip()
+    selected_raw = str(value or "").strip()
+    selected = normalize_equipment_type(selected_raw)
     if not selected:
         return False
-    if selected in ASSET_EQUIPMENT_TYPE_OPTIONS:
+    if is_approved_new_equipment_type(selected):
         return True
-    return bool(str(allow_current or "").strip()) and selected == str(allow_current or "").strip()
+    current_raw = str(allow_current or "").strip()
+    return bool(current_raw) and selected_raw == current_raw
 
 
 @app.after_request
@@ -1312,8 +1305,11 @@ def _validate_admin_new_asset_form(
         errors.append("Enter a manufacturer.")
     if not form_state["equipment_type"]:
         errors.append("Choose an asset type.")
-    elif form_state["equipment_type"] not in ASSET_EQUIPMENT_TYPE_OPTIONS:
-        errors.append("Choose a valid asset type.")
+    else:
+        try:
+            form_state["equipment_type"] = validate_new_equipment_type(form_state["equipment_type"])
+        except ValueError as exc:
+            errors.append(str(exc))
     if not form_state["building"]:
         errors.append("Enter the building.")
     if not form_state["room"]:
@@ -2331,6 +2327,7 @@ def _create_admin_asset_in_tx(
     assign_case_number: Optional[str],
     assign_slot_number: Optional[int],
 ) -> dict:
+    equipment_type = validate_new_equipment_type(equipment_type)
     existing_asset = conn.execute(
         """
         SELECT 1
@@ -4188,9 +4185,9 @@ def intake():
         if submitted_equipment_type is None:
             selected_equipment_type = current_equipment_type
         else:
-            selected_equipment_type = (submitted_equipment_type or "").strip() or "laptop"
-        if not _equipment_type_is_allowed(selected_equipment_type, allow_current=current_equipment_type):
-            flash("Choose a valid asset type.", "error")
+            selected_equipment_type = normalize_equipment_type(submitted_equipment_type) or "laptop"
+        if not is_approved_new_equipment_type(selected_equipment_type):
+            flash(SUPPORTED_EQUIPMENT_TYPE_MESSAGE, "error")
             touch_session()
             if redirect_target.startswith("/") and not redirect_target.startswith("//"):
                 return redirect(redirect_target)
@@ -4412,8 +4409,12 @@ def add_assets():
         queue=SCAN_QUEUE,
         queue_len=len(SCAN_QUEUE),
         latest=(SCAN_QUEUE[-1].asset_tag if SCAN_QUEUE else ""),
-        equipment_type=(session.get("equipment_type") or "laptop").strip() or "laptop",
-        equipment_type_options=_equipment_type_form_options((session.get("equipment_type") or "laptop").strip() or "laptop"),
+        equipment_type=(
+            normalize_equipment_type(session.get("equipment_type"))
+            if is_approved_new_equipment_type(session.get("equipment_type"))
+            else "laptop"
+        ),
+        equipment_type_options=_equipment_type_form_options(),
         slot_options=slot_options,
         case_options=case_options,
     )
@@ -7879,7 +7880,7 @@ def admin_new_asset():
                 "asset_tag": (request.form.get("asset_tag") or "").strip().upper(),
                 "serial_number": (request.form.get("serial_number") or "").strip(),
                 "manufacturer": (request.form.get("manufacturer") or "").strip(),
-                "equipment_type": (request.form.get("equipment_type") or "").strip() or "laptop",
+                "equipment_type": normalize_equipment_type(request.form.get("equipment_type")) or "laptop",
                 "building": (request.form.get("building") or "").strip(),
                 "room": (request.form.get("room") or "").strip(),
                 "model": (request.form.get("model") or "").strip(),
@@ -8102,7 +8103,7 @@ def admin_edit_asset():
                     form_state["equipment_type"],
                     allow_current=asset_view["equipment_type"],
                 ):
-                    errors.append("Choose a valid asset type.")
+                    errors.append(SUPPORTED_EQUIPMENT_TYPE_MESSAGE)
                 if not form_state["building"]:
                     errors.append("building is required.")
                 if not form_state["room"]:
@@ -8430,7 +8431,7 @@ def admin_replace_asset():
             "replacement_asset_tag": (request.form.get("replacement_asset_tag") or "").strip().upper(),
             "replacement_serial_number": (request.form.get("replacement_serial_number") or "").strip(),
             "replacement_manufacturer": (request.form.get("replacement_manufacturer") or "").strip(),
-            "replacement_equipment_type": (request.form.get("replacement_equipment_type") or "").strip() or "laptop",
+            "replacement_equipment_type": normalize_equipment_type(request.form.get("replacement_equipment_type")) or "laptop",
             "replacement_model": (request.form.get("replacement_model") or "").strip(),
             "replacement_model_code": (request.form.get("replacement_model_code") or "").strip(),
             "replacement_notes": (request.form.get("replacement_notes") or "").strip(),
@@ -8466,6 +8467,8 @@ def admin_replace_asset():
                     errors.append("replacement manufacturer is required.")
                 if not form_state["replacement_equipment_type"]:
                     errors.append("replacement equipment_type is required.")
+                elif not is_approved_new_equipment_type(form_state["replacement_equipment_type"]):
+                    errors.append(SUPPORTED_EQUIPMENT_TYPE_MESSAGE)
                 if not form_state["confirm_retire"]:
                     errors.append("You must confirm the failed asset is being retired.")
                 if not form_state["confirm_slot"]:
@@ -8480,6 +8483,7 @@ def admin_replace_asset():
                         failed_asset=failed_asset_view,
                         error_message=error_message,
                         failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                        equipment_type_options=_equipment_type_form_options(form_state["replacement_equipment_type"]),
                     )
 
                 try:
@@ -8578,6 +8582,7 @@ def admin_replace_asset():
                         failed_asset=failed_asset_view,
                         error_message=error_message,
                         failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                        equipment_type_options=_equipment_type_form_options(form_state["replacement_equipment_type"]),
                     )
                 except sqlite3.IntegrityError as e:
                     conn.rollback()
@@ -8588,6 +8593,7 @@ def admin_replace_asset():
                         failed_asset=failed_asset_view,
                         error_message=error_message,
                         failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+                        equipment_type_options=_equipment_type_form_options(form_state["replacement_equipment_type"]),
                     )
                 except Exception:
                     conn.rollback()
@@ -8610,6 +8616,7 @@ def admin_replace_asset():
         failed_asset=failed_asset_view,
         error_message=error_message,
         failure_type_options=sorted(RETIRE_FAILURE_TYPES),
+        equipment_type_options=_equipment_type_form_options(form_state["replacement_equipment_type"]),
     )
 
 

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -100,7 +100,13 @@
           </div>
           <div class="row">
             <label for="replacement_equipment_type"><strong>equipment_type</strong> (required)</label><br />
-            <input type="text" id="replacement_equipment_type" name="replacement_equipment_type" value="{{ form.replacement_equipment_type or 'laptop' }}" required />
+            <select id="replacement_equipment_type" name="replacement_equipment_type" required>
+              {% for option in equipment_type_options %}
+                <option value="{{ option.value }}" {% if (form.replacement_equipment_type or 'laptop') == option.value %}selected{% endif %}>
+                  {{ option.label }}
+                </option>
+              {% endfor %}
+            </select>
           </div>
           <div class="row">
             <label for="replacement_model"><strong>model</strong> (optional)</label><br />

--- a/docs/BAREBONES_APPLICATION_BOUNDARY.md
+++ b/docs/BAREBONES_APPLICATION_BOUNDARY.md
@@ -15,7 +15,7 @@ AssetTrack records:
 - every custody, location, and status change
 - email communication associated with Issue and Return custody actions
 
-The smallest useful AssetTrack product is a local, role-protected, SQLite-backed custody system for field operators. It must support person-assigned assets such as laptops and location-assigned assets such as switches, routers, access points, and other physical network devices without splitting them into separate systems.
+The smallest useful AssetTrack product is a local, role-protected, SQLite-backed custody system for field operators. It must support person-assigned laptops and location-assigned switches and routers without splitting them into separate systems.
 
 The append-only event history remains the authoritative custody record. Email receipts communicate and document Issue and Return activity, but email delivery never creates, reverses, or modifies custody state. Delivery failure must not roll back committed events or receipt records.
 
@@ -145,7 +145,7 @@ Pages that can create unnecessary operator load if surfaced too broadly: generic
 
 ## Minimum Network-Device Workflow
 
-Barebones operator/admin flow for a switch, router, access point, or similar physical network device:
+Barebones operator/admin flow for a switch or router:
 
 1. Find the device in `/assets/search`, `/report`, Dashboard custody map, or case/slot drilldowns.
 2. Review current location type, building/case/slot, status, and last movement proof.
@@ -236,7 +236,7 @@ Do not implement these in Issue 29-1. They are candidate issue cards only.
 - Whether admin and operator reports should be consolidated.
 - Whether any report/export is low-value enough for future removal.
 - Whether a dedicated asset detail/history page is needed beyond current Asset Search proof rows.
-- Whether future schema changes are ever needed for access point equipment typing, location movement, receipt delivery history, or network-device status detail.
+- Whether future schema changes are ever needed for location movement, receipt delivery history, or network-device status detail.
 - Whether any candidate removal would require security, persistence, schema, event, or email behavior approval before implementation.
 
 ## Non-Negotiable Implementation Guardrails For Future Issues

--- a/docs/models/asset.md
+++ b/docs/models/asset.md
@@ -53,8 +53,8 @@ Other optional identifiers (future-friendly, not required now):
 
 **equipment_type** (enum)
 - Required
-- For now, we can keep this narrow (ex: `laptop`)
-- Expand later if needed (tablet, printer, etc.)
+- New assets support `laptop`, `switch`, and `router`.
+- Legacy values remain readable for existing records.
 
 ---
 

--- a/docs/release/user-manual.md
+++ b/docs/release/user-manual.md
@@ -241,7 +241,7 @@ This is an admin workflow. The named manual `Add Assets` launcher is not shown i
 1. Enter `asset_tag`.
 2. Enter `serial_number`.
 3. Enter `manufacturer`.
-4. Enter `equipment_type`.
+4. Choose `equipment_type` (`laptop`, `switch`, or `router`).
 5. Enter `building`.
 6. Enter `room`.
 

--- a/scripts/import_inventory.py
+++ b/scripts/import_inventory.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pandas as pd
 from assettrack.audit import record_event
+from assettrack.assets import SUPPORTED_EQUIPMENT_TYPE_MESSAGE, validate_new_equipment_type
 from assettrack.db import assert_schema_present
 
 DB_PATH = Path("data/assettrack.db")
@@ -132,6 +133,18 @@ def load_rows() -> list[ImportRow]:
             )
         seen_slots[slot_key] = (asset_tag, row_number, case_number, slot_number)
 
+        equipment_type = as_text(row["equipment_type"])
+        try:
+            equipment_type = validate_new_equipment_type(equipment_type)
+        except ValueError as exc:
+            raise ImportStopError(
+                "Unsupported equipment_type.\n"
+                f"row_number={row_number}\n"
+                f"asset_tag={asset_tag}\n"
+                f"equipment_type={equipment_type}\n"
+                f"{exc or SUPPORTED_EQUIPMENT_TYPE_MESSAGE}"
+            ) from exc
+
         prepared.append(
             ImportRow(
                 row_number=row_number,
@@ -141,7 +154,7 @@ def load_rows() -> list[ImportRow]:
                 slot_position=slot_position,
                 slot_number=slot_number,
                 serial_number=as_text(row["serial_number"]),
-                equipment_type=as_text(row["equipment_type"]),
+                equipment_type=equipment_type,
                 manufacturer=as_text(row["manufacturer"]),
                 model=as_text(row["model"]),
                 model_code=as_text(row["model_code"]),

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -94,8 +94,11 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Admin: Add Asset", response.data)
         self.assertIn(b"Asset type", response.data)
         self.assertIn(b'<option value="laptop"', response.data)
-        self.assertIn(b'<option value="other network equipment"', response.data)
-        self.assertIn(b'<option value="voip"', response.data)
+        self.assertIn(b'<option value="switch"', response.data)
+        self.assertIn(b'<option value="router"', response.data)
+        self.assertNotIn(b'<option value="monitor"', response.data)
+        self.assertNotIn(b'<option value="other network equipment"', response.data)
+        self.assertNotIn(b'<option value="voip"', response.data)
         self.assertIn(b'name="case_name"', response.data)
         self.assertIn(b'name="slot_id"', response.data)
 
@@ -138,7 +141,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         response = self.client.post(
             "/",
-            data={"scan_text": "", "equipment_type": "monitor", "return_to": "/add-assets"},
+            data={"scan_text": "", "equipment_type": "switch", "return_to": "/add-assets"},
             follow_redirects=True,
         )
 
@@ -163,7 +166,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         first = self.client.post(
             "/",
-            data={"scan_text": "AT-QUEUE-1", "equipment_type": "monitor"},
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "switch"},
         )
         self.assertEqual(first.status_code, 302)
 
@@ -173,12 +176,12 @@ class AdminAddAssetUiTests(unittest.TestCase):
         )
         self.assertEqual(second.status_code, 302)
 
-        self.assertEqual([scan.equipment_type for scan in intake_app.SCAN_QUEUE], ["monitor", "laptop"])
+        self.assertEqual([scan.equipment_type for scan in intake_app.SCAN_QUEUE], ["switch", "laptop"])
 
         preview = self.client.get("/preview?json=1")
         self.assertEqual(preview.status_code, 200)
         rows = preview.json["rows"]
-        self.assertEqual(rows[0]["equipment_type"], "monitor")
+        self.assertEqual(rows[0]["equipment_type"], "switch")
         self.assertEqual(rows[1]["equipment_type"], "laptop")
 
     def test_add_assets_queue_rows_show_operator_verification_details(self) -> None:
@@ -187,7 +190,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             Scan(
                 asset_tag="AT-VERIFY-1",
                 scanned_at=datetime(2026, 1, 1, 14, 3, 22, tzinfo=timezone.utc),
-                equipment_type="monitor",
+                equipment_type="router",
                 case_name="CASE-V",
                 slot_position=3,
             )
@@ -204,7 +207,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"AT-VERIFY-1", response.data)
-        self.assertIn(b"Equipment type:</strong> monitor", response.data)
+        self.assertIn(b"Equipment type:</strong> router", response.data)
         self.assertIn(b"Case:</strong> CASE-V", response.data)
         self.assertIn(b"Slot:</strong> Slot 3", response.data)
         self.assertIn(b"AT-VERIFY-2", response.data)
@@ -217,7 +220,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             Scan(
                 asset_tag="AT-PREVIEW-1",
                 scanned_at=datetime(2026, 1, 1, 14, 5, 22, tzinfo=timezone.utc),
-                equipment_type="monitor",
+                equipment_type="switch",
             )
         )
 
@@ -236,11 +239,11 @@ class AdminAddAssetUiTests(unittest.TestCase):
     def test_blank_equipment_type_uses_default_and_missing_field_preserves_selection(self) -> None:
         intake_app.SCAN_QUEUE.clear()
 
-        select_monitor = self.client.post(
+        select_switch = self.client.post(
             "/",
-            data={"scan_text": "AT-QUEUE-1", "equipment_type": "monitor"},
+            data={"scan_text": "AT-QUEUE-1", "equipment_type": "switch"},
         )
-        self.assertEqual(select_monitor.status_code, 302)
+        self.assertEqual(select_switch.status_code, 302)
 
         preserve_selection = self.client.post(
             "/",
@@ -249,7 +252,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertEqual(preserve_selection.status_code, 302)
 
         with self.client.session_transaction() as sess:
-            self.assertEqual(sess["equipment_type"], "monitor")
+            self.assertEqual(sess["equipment_type"], "switch")
 
         default_scan = self.client.post(
             "/",
@@ -319,7 +322,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
                 "asset_tag": "AT-600",
                 "serial_number": "SER-600",
                 "manufacturer": "HP",
-                "equipment_type": "monitor",
+                "equipment_type": "router",
                 "building": "HQ",
                 "room": "220",
                 "case_name": "CASE-A",
@@ -401,7 +404,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Enter an asset tag.", response.data)
         self.assertIn(b"Enter a serial number.", response.data)
         self.assertIn(b"Enter a manufacturer.", response.data)
-        self.assertIn(b"Choose a valid asset type.", response.data)
+        self.assertIn(b"Supported asset types are Laptop, Switch, and Router.", response.data)
         self.assertIn(b"Enter the building.", response.data)
         self.assertIn(b"Enter the room.", response.data)
         self.assertIn(b"Choose both a case and a slot, or leave both blank.", response.data)
@@ -449,7 +452,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             "/",
             data={
                 "scan_text": "AT-LIVE-1",
-                "equipment_type": "monitor",
+                "equipment_type": "switch",
                 "case_name": "CASE-Q",
                 "slot_id": "120",
                 "return_to": "/add-assets",
@@ -482,7 +485,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             ).fetchone()
             self.assertIsNotNone(asset_row)
             self.assertEqual(asset_row["asset_tag"], stored_tag)
-            self.assertEqual(asset_row["equipment_type"], "monitor")
+            self.assertEqual(asset_row["equipment_type"], "switch")
             self.assertEqual(asset_row["location_type"], "STORAGE")
             self.assertIsNone(asset_row["current_holder_id"])
             self.assertEqual(asset_row["home_slot_id"], 120)
@@ -509,18 +512,19 @@ class AdminAddAssetUiTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Choose a valid asset type.", response.data)
+        self.assertIn(b"Supported asset types are Laptop, Switch, and Router.", response.data)
         self.assertEqual(len(intake_app.SCAN_QUEUE), 0)
 
-    def test_add_assets_route_preserves_legacy_session_equipment_type_in_dropdown(self) -> None:
+    def test_add_assets_route_hides_legacy_session_equipment_type_from_dropdown(self) -> None:
         with self.client.session_transaction() as sess:
             sess["equipment_type"] = "tablet"
 
         response = self.client.get("/add-assets")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'<option value="tablet" selected>', response.data)
-        self.assertIn(b"tablet (existing value)", response.data)
+        self.assertIn(b'<option value="laptop" selected>', response.data)
+        self.assertNotIn(b'<option value="tablet"', response.data)
+        self.assertNotIn(b"tablet (existing value)", response.data)
 
     def test_add_assets_live_seam_rejects_occupied_slot_on_commit(self) -> None:
         existing_id = self._insert_asset("AT-OCC-LIVE", "SER-OCC-LIVE")

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -230,7 +230,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
                 "asset_tag": "AT-EDIT-1",
                 "serial_number": "SER-EDIT-1A",
                 "manufacturer": "Lenovo",
-                "equipment_type": "monitor",
+                "equipment_type": "switch",
                 "building": "HQ",
                 "room": "210",
                 "model": "X1",
@@ -252,7 +252,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         ).fetchone()
         self.assertEqual(asset_row["serial_number"], "SER-EDIT-1A")
         self.assertEqual(asset_row["manufacturer"], "Lenovo")
-        self.assertEqual(asset_row["equipment_type"], "monitor")
+        self.assertEqual(asset_row["equipment_type"], "switch")
         self.assertEqual(asset_row["building_room"], "HQ/210")
         self.assertEqual(asset_row["home_slot_id"], 202)
         self.assertEqual(asset_row["case_number"], "CASE-B")
@@ -351,7 +351,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         )
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b"Choose a valid asset type.", response.data)
+        self.assertIn(b"Supported asset types are Laptop, Switch, and Router.", response.data)
 
     def test_edit_in_custody_asset_updates_home_slot_without_occupancy(self) -> None:
         self._insert_slot(301, "CASE-C", 3)

--- a/tests/test_admin_replace_asset.py
+++ b/tests/test_admin_replace_asset.py
@@ -114,6 +114,28 @@ class AdminReplaceAssetTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Admin: Replace Failed Asset", response.data)
 
+    def test_loaded_replace_form_offers_only_supported_replacement_types(self) -> None:
+        self._insert_slot(9, "CASE-TYPES", 1, None)
+        failed_id = self._insert_asset(
+            "FAIL-TYPES",
+            serial_number="SER-FAIL-TYPES",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=9,
+        )
+        self._assign_slot(9, failed_id, "FAIL-TYPES")
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={"action": "lookup", "failed_asset_tag": "FAIL-TYPES"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<option value="laptop"', response.data)
+        self.assertIn(b'<option value="switch"', response.data)
+        self.assertIn(b'<option value="router"', response.data)
+        self.assertNotIn(b'<option value="monitor"', response.data)
+
     def test_swap_from_storage_success(self) -> None:
         self._insert_slot(10, "CASE-A", 1, None)
         failed_id = self._insert_asset(
@@ -389,6 +411,44 @@ class AdminReplaceAssetTests(unittest.TestCase):
         self.assertEqual(failed["location_type"], "STORAGE")
         self.assertEqual(failed["home_slot_id"], 13)
         replacement = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = 'NEW-500';").fetchone()
+        self.assertIsNone(replacement)
+
+    def test_unsupported_replacement_equipment_type_is_rejected_without_partial_updates(self) -> None:
+        self._insert_slot(14, "CASE-E", 5, None)
+        failed_id = self._insert_asset(
+            "FAIL-600",
+            serial_number="SER-FAIL-600",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=14,
+        )
+        self._assign_slot(14, failed_id, "FAIL-600")
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-600",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Broken.",
+                "replacement_asset_tag": "NEW-600",
+                "replacement_serial_number": "SER-NEW-600",
+                "replacement_manufacturer": "Lenovo",
+                "replacement_equipment_type": "monitor",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Supported asset types are Laptop, Switch, and Router.", response.data)
+        failed = self.conn.execute(
+            "SELECT location_type, home_slot_id FROM assets WHERE id = ?;",
+            (failed_id,),
+        ).fetchone()
+        self.assertEqual(failed["location_type"], "STORAGE")
+        self.assertEqual(failed["home_slot_id"], 14)
+        replacement = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = 'NEW-600';").fetchone()
         self.assertIsNone(replacement)
 
 

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -86,7 +86,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
             'AT-100',
             'SN-100',
             'Dell',
-            'laptop',
+            'tablet',
             'HQ',
             '100',
             'ModelX',
@@ -372,12 +372,12 @@ def test_admin_can_open_human_readable_report_with_data_sections(client_with_tem
             current_holder_id,
             home_slot_id
         )
-        VALUES (
-            'AT-100',
-            'SN-100',
-            'Dell',
-            'laptop',
-            'Report HQ',
+            VALUES (
+                'AT-100',
+                'SN-100',
+                'Dell',
+                'tablet',
+                'Report HQ',
             '100',
             'Latitude',
             'LAT',
@@ -512,12 +512,12 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
             current_holder_id,
             home_slot_id
         )
-        VALUES (
-            'AT-100',
-            'SN-100',
-            'Dell',
-            'laptop',
-            'Report HQ',
+            VALUES (
+                'AT-100',
+                'SN-100',
+                'Dell',
+                'tablet',
+                'Report HQ',
             '100',
             'Latitude',
             'LAT',
@@ -628,6 +628,7 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b"Last 10 Events" in response.data
     assert b"Active assets" in response.data
     assert b"1 active records" in response.data
+    assert b"tablet" in response.data
     assert b"Retired hidden" in response.data
     assert b"AT-OLD-1" not in response.data
     assert b'<details class="report-section" open>' not in response.data

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -212,6 +212,21 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Switch", response.data)
         self.assertIn(b"Router", response.data)
 
+    def test_search_keeps_legacy_asset_type_readable(self) -> None:
+        self._insert_asset(
+            "TYPE-LEGACY",
+            serial_number="SER-LEGACY",
+            location_type="STORAGE",
+            home_slot_id=None,
+            equipment_type="tablet",
+        )
+
+        response = self.client.get("/assets/search?asset_tag=TYPE-LEGACY")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"TYPE-LEGACY", response.data)
+        self.assertIn(b"Tablet", response.data)
+
     def test_search_shows_stored_status_cue_for_storage_asset(self) -> None:
         self._insert_asset("AT-STORED-1", serial_number="SER-STORED-1", location_type="STORAGE", home_slot_id=None)
 

--- a/tests/test_import_inventory.py
+++ b/tests/test_import_inventory.py
@@ -126,6 +126,53 @@ def test_inventory_xlsx_import_appends_events_and_reconciles_current_state(
         persisted.close()
 
 
+def test_inventory_xlsx_import_accepts_laptop_switch_and_router(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_path, excel_path = _configure_import(monkeypatch, tmp_path)
+    _write_inventory(
+        excel_path,
+        [
+            _inventory_row(clean_asset_tag="IMPORT-LAPTOP", serial_number="SER-LAPTOP", equipment_type="laptop"),
+            _inventory_row(clean_asset_tag="IMPORT-SWITCH", serial_number="SER-SWITCH", equipment_type="switch", slot_helper=2, slot_number="2"),
+            _inventory_row(clean_asset_tag="IMPORT-ROUTER", serial_number="SER-ROUTER", equipment_type="router", slot_helper=3, slot_number="3"),
+        ],
+    )
+
+    rows = import_inventory.load_rows()
+    result = import_inventory.run_import(rows)
+
+    assert result == (3, 3, 3)
+    conn = sqlite3.connect(db_path)
+    try:
+        values = conn.execute(
+            "SELECT equipment_type FROM assets ORDER BY asset_tag;"
+        ).fetchall()
+        assert [row[0] for row in values] == ["laptop", "router", "switch"]
+    finally:
+        conn.close()
+
+
+def test_inventory_xlsx_import_rejects_unsupported_equipment_type_before_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_path, excel_path = _configure_import(monkeypatch, tmp_path)
+    _write_inventory(excel_path, [_inventory_row(equipment_type="monitor")])
+
+    with pytest.raises(import_inventory.ImportStopError) as excinfo:
+        import_inventory.load_rows()
+
+    assert "Supported asset types are Laptop, Switch, and Router." in str(excinfo.value)
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_inventory_import_rolls_back_current_state_and_events_together(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -367,6 +367,7 @@ def test_return_receipt_detail_renders_from_snapshot(client_with_temp_db) -> Non
     assert b"Return Holder One" in response.data
     assert b"return.one@example.org" in response.data
     assert b"RETURN-200" in response.data
+    assert b"Tablet" in response.data
     assert b"Apple" in response.data
     assert b"iPad" in response.data
     assert b"CASE-20 / 1" in response.data

--- a/tools/import_bq26_inventory.py
+++ b/tools/import_bq26_inventory.py
@@ -3,6 +3,7 @@
 import sqlite3
 from datetime import datetime, timezone
 import pandas as pd
+from assettrack.assets import validate_new_equipment_type
 
 DB_PATH = "data/assettrack.db"
 EXCEL_PATH = "data/import/BQ26 ETP.xlsx"
@@ -36,7 +37,7 @@ def main():
             case_name = f"CASE-{case_number}"
 
             serial_number = as_text(r["serial_number"])
-            equipment_type = as_text(r["equipment_type"])
+            equipment_type = validate_new_equipment_type(as_text(r["equipment_type"]))
             manufacturer = as_text(r["manufacturer"])
             model = as_text(r["model"])
             model_code = as_text(r["model_code"])


### PR DESCRIPTION
Issue 29-7: Narrow supported asset types to laptops, switches, and routers

## Summary

Limit new AssetTrack asset types to Laptop, Switch, and Router while preserving existing legacy records and history.

## Related Issue

Closes #949

## Changes

- Added one shared application-level definition for approved new asset types.
- Limited new asset choices to Laptop, Switch, and Router.
- Enforced approved types during asset creation, scan-based creation, asset replacement, and inventory import.
- Added a clear rejection message for unsupported new asset types.
- Preserved legacy asset types in edit, search, report, dashboard, and receipt views.
- Preserved switch and router records assigned to locations without holders.
- Updated focused tests and directly affected documentation.

## Verification

- [x] Focused asset creation, editing, replacement, import, search, and network-device tests passed: 79 tests.
- [x] Focused receipt, report, dashboard, and workflow tests passed: 5 tests.
- [x] `python -m compileall assettrack scripts tools`
- [x] `git diff --check`
- [x] Docker image rebuilt and the AssetTrack container started healthy.
- [x] Verified the new asset form offers only Laptop, Switch, and Router.
- [x] Verified Laptop, Switch, and Router creation.
- [x] Verified unsupported Monitor creation is rejected clearly.
- [x] Verified approved inventory imports succeed.
- [x] Verified unsupported inventory types are rejected.
- [x] Verified a legacy Tablet remains readable through edit, Asset Search, Reports, and receipt detail.
- [x] Verified switches and routers can remain in storage without an assigned holder.
- [x] Docker Compose shut down normally without removing volumes.

## Notes

- No legacy asset-type values were rewritten, normalized, deleted, or migrated.
- Unsupported legacy values remain readable, searchable, and reportable.
- Any future historical type migration requires a separate approved issue.
- No schema, migration, event, custody, receipt, authentication, role, Docker, persistence, dependency, or CMDB behavior changed.