### PR TITLE
Issue 29-4: Reduce and consolidate Reports

### DIFF
--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -27,25 +27,11 @@
       font-size: 0.92rem;
       font-weight: 700;
     }
-    .report-stat-link {
-      color: inherit;
-      text-decoration: none;
-      transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
-    }
-    .report-stat-link:hover {
-      text-decoration: none;
-      border-color: color-mix(in srgb, var(--color-primary) 45%, var(--color-surface));
-      background: color-mix(in srgb, var(--color-primary-soft) 35%, var(--color-surface-bg));
-      transform: translateY(-1px);
-    }
-    .report-stat-link:focus-visible {
-      outline: 2px solid var(--color-primary);
-      outline-offset: 2px;
-    }
-    .report-stat-action {
+    .report-stat-purpose {
       display: block;
       margin-top: 0.65rem;
-      width: fit-content;
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
     }
     .report-drill-link {
       display: inline-flex;
@@ -66,17 +52,17 @@
 
   <div class="card report-priority">
     <div>
-      <h2>Current State</h2>
+      <h2>Custody, Audit, Reconciliation, and Proof</h2>
       <p class="report-priority-copy">
         {% if include_retired_assets %}
-          Full inventory, including retired assets.
+          Reports shows custody state, audit trail, case reconciliation, and receipt support across active and retired assets.
         {% else %}
-          Active custody and storage first.
+          Reports shows active custody state, audit trail, case reconciliation, and receipt support. Use Assets or Holders for individual lookup.
         {% endif %}
       </p>
     </div>
     <div class="report-actions report-utility-links" aria-label="Report utilities">
-      <span class="report-utility-label">Utilities</span>
+      <span class="report-utility-label">Report utilities</span>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Search receipts</a>
       {% if include_retired_assets %}
         <a class="nav-link" href="{{ url_for('human_report') }}">View active inventory only</a>
@@ -85,24 +71,25 @@
       {% endif %}
     </div>
     <div class="report-grid">
-      <a class="report-stat report-stat-link" href="{{ url_for('asset_search', return_to=report_return_to) }}">
+      <div class="report-stat">
         {% if include_retired_assets %}Total assets{% else %}Active assets{% endif %}
         <strong>{{ asset_summary.total_assets }}</strong>
-        <span class="nav-link report-stat-action">{% if include_retired_assets %}Search all asset records{% else %}Search active asset records{% endif %}</span>
-      </a>
-      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_cases', return_to=report_return_to) }}">
+        <span class="report-stat-purpose">Report table links open asset proof.</span>
+      </div>
+      <div class="report-stat">
         In storage
         <strong>{{ asset_summary.storage_assets }}</strong>
-        <span class="nav-link report-stat-action">Review case space</span>
-      </a>
-      <a class="report-stat report-stat-link" href="{{ url_for('dashboard_holders', return_to=report_return_to) }}">
+        <span class="report-stat-purpose">Case and slot reconciliation.</span>
+      </div>
+      <div class="report-stat">
         In custody
         <strong>{{ asset_summary.in_custody_assets }}</strong>
-        <span class="nav-link report-stat-action">Review holders with assets out</span>
-      </a>
+        <span class="report-stat-purpose">Holder accountability.</span>
+      </div>
       <div class="report-stat">
         {% if include_retired_assets %}Retired shown{% else %}Retired hidden{% endif %}
         <strong>{{ asset_summary.disposed_assets }}</strong>
+        <span class="report-stat-purpose">Retired assets stay reportable when included.</span>
       </div>
     </div>
   </div>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -608,19 +608,20 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert response.status_code == 200
     assert b"Back to Dashboard" not in response.data
     assert b'href="/dashboard">Dashboard</a>' in response.data
-    assert b"Current State" in response.data
-    assert b"Active custody and storage first." in response.data
+    assert b"Custody, Audit, Reconciliation, and Proof" in response.data
+    assert b"Reports shows active custody state, audit trail, case reconciliation, and receipt support." in response.data
+    assert b"Use Assets or Holders for individual lookup." in response.data
     assert b"Report Scope" not in response.data
-    assert b"Review holders with assets out" in response.data
-    assert b"Review case space" in response.data
-    assert b"Search active asset records" in response.data
-    assert b"Utilities" in response.data
+    assert b"Holder accountability." in response.data
+    assert b"Case and slot reconciliation." in response.data
+    assert b"Report table links open asset proof." in response.data
+    assert b"Report utilities" in response.data
     assert b"Search receipts" in response.data
     assert b"Include retired assets" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
-    assert response.data.count(b'href="/assets/search?return_to=/report"') == 1
-    assert b'href="/dashboard/cases?return_to=/report"' in response.data
-    assert b'href="/dashboard/holders?return_to=/report"' in response.data
+    assert b'href="/assets/search?return_to=/report"' not in response.data
+    assert b'href="/dashboard/cases?return_to=/report"' not in response.data
+    assert b'href="/dashboard/holders?return_to=/report"' not in response.data
     assert b'href="/receipts?return_to=/report"' in response.data
     assert b' href="/assets/search?asset_tag=AT-100&amp;return_to=/report"' in response.data
     assert b' href="/holders/1?return_to=/report"' in response.data


### PR DESCRIPTION
Issue 29-4: Reduce and consolidate Reports

## Summary

Consolidate Reports into a clearer custody, audit, reconciliation, and proof destination while preserving all existing report and proof access.

## Related Issue

Closes #941

## Changes

- Clarified the operational purpose of the Reports landing page.
- Organized Reports around custody state, audit proof, reconciliation, and receipt support.
- Removed duplicate generic launcher cards for Asset Search, case lists, and holders with assets out.
- Preserved receipt search and delivery status.
- Preserved the retired-inventory toggle and report tables.
- Preserved row-level asset proof links with safe return navigation.
- Preserved holder, case, and slot drilldowns.
- Preserved administrator reports, PDF reports, database export, backup, and recovery access.
- Updated focused report tests.

## Verification

- [x] `./.venv/bin/python -m pytest tests/test_admin_system_health.py -q` — 17 passed.
- [x] Focused receipt and report-context tests passed — 22 tests.
- [x] Focused Asset Search and dashboard drilldown tests passed — 40 tests.
- [x] Focused navigation and administrator authorization tests passed — 6 tests.
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt and the AssetTrack container started successfully.
- [x] Verified the operator Reports page.
- [x] Verified receipt list and receipt detail access.
- [x] Verified asset proof, holder detail, and case detail access.
- [x] Verified Laptop, Switch, Router, and legacy records remain reportable.
- [x] Verified receipt history and delivery status remain accessible.
- [x] Verified administrator report, PDF report, and database export.
- [x] Verified operator access to administrator report functions returns `403`.
- [x] Docker Compose shut down normally without removing volumes.

## Notes

- No report routes were deleted.
- No report, receipt, drilldown, or proof access was removed.
- Asset Search and Holders remain the canonical destinations for individual asset and holder lookup.
- Dashboard holder and case drilldowns remain intentionally available.
- Further route consolidation or report removal requires separate explicit approval.
- No schema, migration, event, custody, receipt, authentication, role, backup, recovery, Docker, persistence, dependency, or asset-history behavior changed.