### PR TITLE
Issue 29-5: Simplify receipt support

### DIFF
--- a/assettrack/intake/templates/receipt_detail.html
+++ b/assettrack/intake/templates/receipt_detail.html
@@ -59,6 +59,17 @@
       font-size: 0.92rem;
       line-height: 1.5;
     }
+    .receipt-action-form {
+      display: inline-grid;
+      gap: 0.25rem;
+      align-items: start;
+    }
+    .receipt-action-note {
+      max-width: 19rem;
+      color: var(--color-text-muted);
+      font-size: 0.86rem;
+      line-height: 1.35;
+    }
     .receipt-summary {
       display: grid;
       grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -207,8 +218,9 @@
   {% set operator = receipt.commit_operator %}
   {% set holder = receipt.holder_snapshot %}
   {% set organization = receipt.organization_snapshot %}
-  {% set email_status_label = "Queued" if receipt.delivery.state == "pending" else receipt.delivery.state %}
-  {% set receipt_action_label = "Retry Send" if receipt.delivery.state == "failed" else "Send Receipt Email" %}
+  {% set email_status_label = "Pending" if receipt.delivery.state == "pending" else "Sent" if receipt.delivery.state == "sent" else "Failed" if receipt.delivery.state == "failed" else receipt.delivery.state %}
+  {% set receipt_action_label = "Retry Failed Delivery" if receipt.delivery.state == "failed" else "Send Initial Receipt Email" %}
+  {% set receipt_action_note = "Retry sends the same receipt again. Custody and event history stay unchanged." if receipt.delivery.state == "failed" else "Initial send emails the receipt for this completed custody action." %}
   {% set email_timing_label = "Delivered" if receipt.delivery.sent_at else "Last attempted" if receipt.delivery.last_attempt_at else "" %}
   {% set email_timing_value = receipt.delivery_display.sent_at or receipt.delivery_display.last_attempt_at %}
   {% set holder_display_name = holder.name if holder and holder.name else receipt.holder_display_name %}
@@ -251,8 +263,9 @@
       {% if send_blocked_by_recovery %}
         <span class="pill bad">Recovery mode blocks {{ receipt_action_label|lower }}</span>
       {% else %}
-        <form method="post" action="{{ url_for('receipt_send', receipt_id=receipt.id) }}">
+        <form class="receipt-action-form" method="post" action="{{ url_for('receipt_send', receipt_id=receipt.id) }}">
           <button type="submit">{{ receipt_action_label }}</button>
+          <span class="receipt-action-note">{{ receipt_action_note }}</span>
         </form>
       {% endif %}
     {% endif %}
@@ -260,8 +273,9 @@
       {% if recovery_mode.active %}
         <span class="pill bad">Recovery mode blocks resend receipt email</span>
       {% else %}
-        <form method="post" action="{{ url_for('receipt_resend', receipt_id=receipt.id) }}">
-          <button type="submit">Resend receipt email</button>
+        <form class="receipt-action-form" method="post" action="{{ url_for('receipt_resend', receipt_id=receipt.id) }}">
+          <button type="submit">Resend Delivered Receipt</button>
+          <span class="receipt-action-note">Resend emails another copy. Custody and event history stay unchanged.</span>
         </form>
       {% endif %}
     {% endif %}
@@ -315,7 +329,7 @@
         </section>
 
         <section class="summary-group summary-status">
-          <h2 class="summary-group-title">Do I Need To Act?</h2>
+          <h2 class="summary-group-title">Delivery Support</h2>
           {% if receipt.delivery.state %}
             <div class="summary-value">
               <div class="summary-label">Receipt email status</div>
@@ -346,7 +360,7 @@
           {% endif %}
           {% if receipt.delivery.last_error %}
             <div class="summary-value">
-              <div class="summary-label">Current issue</div>
+              <div class="summary-label">Delivery issue</div>
               <div class="summary-copy">{{ receipt.delivery.last_error }}</div>
             </div>
           {% endif %}
@@ -356,6 +370,25 @@
               <div class="summary-copy">
                 {{ "Blocked during recovery mode" if send_blocked_by_recovery else receipt_action_label }}
               </div>
+            </div>
+            <div class="summary-value">
+              <div class="summary-label">Custody impact</div>
+              <div class="summary-copy">Email delivery does not create, reverse, or change custody.</div>
+            </div>
+          {% elif receipt.delivery.state == "sent" %}
+            <div class="summary-value">
+              <div class="summary-label">Available action</div>
+              <div class="summary-copy">
+                {% if authenticated_role == "admin" %}
+                  {{ "Blocked during recovery mode" if recovery_mode.active else "Resend Delivered Receipt" }}
+                {% else %}
+                  No delivery action available for your role.
+                {% endif %}
+              </div>
+            </div>
+            <div class="summary-value">
+              <div class="summary-label">Custody impact</div>
+              <div class="summary-copy">Resend emails another copy only. Custody is already recorded.</div>
             </div>
           {% endif %}
         </section>

--- a/assettrack/intake/templates/receipts_list.html
+++ b/assettrack/intake/templates/receipts_list.html
@@ -108,6 +108,15 @@
       background: color-mix(in srgb, var(--color-danger) 14%, white);
       color: var(--color-danger);
     }
+    .receipt-delivery-note {
+      color: var(--color-text-muted);
+      font-size: 0.9rem;
+      line-height: 1.35;
+    }
+    .receipt-delivery-note[data-state="failed"] {
+      color: var(--color-danger);
+      font-weight: 600;
+    }
     .match-values {
       display: flex;
       flex-wrap: wrap;
@@ -253,7 +262,8 @@
       </thead>
       <tbody>
         {% for receipt in receipts %}
-          {% set email_status_label = "Queued" if receipt.delivery_state == "pending" else receipt.delivery_state %}
+          {% set email_status_label = "Pending" if receipt.delivery_state == "pending" else "Sent" if receipt.delivery_state == "sent" else "Failed" if receipt.delivery_state == "failed" else receipt.delivery_state %}
+          {% set email_status_note = "Initial receipt email has not been sent yet." if receipt.delivery_state == "pending" else "Receipt email has been delivered." if receipt.delivery_state == "sent" else "Email delivery failed; custody remains recorded." if receipt.delivery_state == "failed" else "" %}
           <tr>
             <td data-label="Receipt">
               <div class="receipt-primary">
@@ -267,6 +277,9 @@
                 <div class="receipt-meta">{{ receipt.asset_count }} asset{% if receipt.asset_count != 1 %}s{% endif %}</div>
                 {% if receipt.delivery_state %}
                   <div class="receipt-status" data-state="{{ receipt.delivery_state }}">{{ email_status_label }}</div>
+                  {% if email_status_note %}
+                    <div class="receipt-delivery-note" data-state="{{ receipt.delivery_state }}">{{ email_status_note }}</div>
+                  {% endif %}
                 {% endif %}
                 {% if receipt.matched_asset_tags %}
                   <div class="asset-tag-match match-label">Asset tag search match</div>

--- a/tests/test_receipt_detail.py
+++ b/tests/test_receipt_detail.py
@@ -383,7 +383,8 @@ def test_receipt_detail_shows_report_contextual_back_link(client_with_temp_db) -
     assert b"Back to Report" in response.data
     assert b"Download Receipt PDF" in response.data
     assert b"Receipt delivery queued \xe2\x80\x94 custody already recorded" in response.data
-    assert b"Send Receipt Email" in response.data
+    assert b"Send Initial Receipt Email" in response.data
+    assert b"Initial send emails the receipt for this completed custody action." in response.data
 
 
 def test_receipt_detail_shows_asset_search_contextual_back_link(client_with_temp_db) -> None:
@@ -452,13 +453,14 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
     failed_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert failed_response.status_code == 200
     assert b"Receipt email status" in failed_response.data
-    assert b">failed<" in failed_response.data
-    assert b"Retry Send" in failed_response.data
-    assert b"Send Receipt Email" not in failed_response.data
+    assert b">Failed<" in failed_response.data
+    assert b"Retry Failed Delivery" in failed_response.data
+    assert b"Send Initial Receipt Email" not in failed_response.data
     assert b"Last attempted" in failed_response.data
     assert b"Mar 29, 2026 at 12:00 UTC" in failed_response.data
-    assert b"Current issue" in failed_response.data
+    assert b"Delivery issue" in failed_response.data
     assert b"smtp offline" in failed_response.data
+    assert b"Retry sends the same receipt again. Custody and event history stay unchanged." in failed_response.data
 
     conn = db.get_connection()
     try:
@@ -480,9 +482,9 @@ def test_receipt_detail_shows_delivery_state_from_persisted_queue_metadata(clien
 
     sent_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert sent_response.status_code == 200
-    assert b">sent<" in sent_response.data
-    assert b"Retry Send" not in sent_response.data
-    assert b"Send Receipt Email" not in sent_response.data
+    assert b">Sent<" in sent_response.data
+    assert b"Retry Failed Delivery" not in sent_response.data
+    assert b"Send Initial Receipt Email" not in sent_response.data
     assert b"Delivered" in sent_response.data
     assert b"Mar 29, 2026 at 12:05 UTC" in sent_response.data
 
@@ -532,7 +534,7 @@ def test_receipt_detail_shows_cc_email_when_delivery_metadata_present(client_wit
     assert b"Recipient email" in response.data
     assert b"issue@example.org" in response.data
     assert b"Receipt email status" in response.data
-    assert b">sent<" in response.data
+    assert b">Sent<" in response.data
     assert b"CC email" in response.data
     assert b"oversight@example.org" in response.data
 
@@ -547,7 +549,7 @@ def test_receipt_detail_shows_neutral_cc_state_when_delivery_metadata_missing(cl
     assert b"issue@example.org" in response.data
     assert b"Receipt email status" in response.data
     assert b'data-state="pending"' in response.data
-    assert b">Queued<" in response.data
+    assert b">Pending<" in response.data
     assert b"CC email" in response.data
     assert b"None" in response.data
 
@@ -587,8 +589,8 @@ def test_receipt_detail_hides_delivery_state_for_historical_nonqueued_receipt(cl
 
     assert response.status_code == 200
     assert b"Receipt email status" not in response.data
-    assert b"Retry Send" not in response.data
-    assert b"Send Receipt Email" not in response.data
+    assert b"Retry Failed Delivery" not in response.data
+    assert b"Send Initial Receipt Email" not in response.data
     assert b">pending<" not in response.data
 
 
@@ -1144,8 +1146,8 @@ def test_receipt_send_failed_retry_remains_recoverable_after_repeated_failure(
 
     detail_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert detail_response.status_code == 200
-    assert b">failed<" in detail_response.data
-    assert b"Retry Send" in detail_response.data
+    assert b">Failed<" in detail_response.data
+    assert b"Retry Failed Delivery" in detail_response.data
 
     conn = db.get_connection()
     try:
@@ -1572,14 +1574,15 @@ def test_receipt_detail_shows_resend_action_only_to_admin_after_send(client_with
 
     operator_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert operator_response.status_code == 200
-    assert b"Resend receipt email" not in operator_response.data
+    assert b"Resend Delivered Receipt" not in operator_response.data
 
     admin_id = create_test_user(username="receipt-resend-view-admin", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
     admin_response = client_with_temp_db.get(f"/receipts/{receipt_id}")
     assert admin_response.status_code == 200
     assert f'action="/receipts/{receipt_id}/resend"'.encode("utf-8") in admin_response.data
-    assert b"Resend receipt email" in admin_response.data
+    assert b"Resend Delivered Receipt" in admin_response.data
+    assert b"Resend emails another copy. Custody and event history stay unchanged." in admin_response.data
 
 
 def test_send_receipt_email_adds_configured_cc_recipient(

--- a/tests/test_receipts_list.py
+++ b/tests/test_receipts_list.py
@@ -91,7 +91,8 @@ def test_receipts_list_shows_asset_tag_in_default_results(client_with_temp_db) -
     assert response.status_code == 200
     assert b"Asset Tag" in response.data
     assert b"ISSUE-100" in response.data
-    assert b">Queued<" in response.data
+    assert b">Pending<" in response.data
+    assert b"Initial receipt email has not been sent yet." in response.data
 
 
 def test_receipts_list_shows_failed_delivery_state_from_persisted_queue_metadata(client_with_temp_db) -> None:
@@ -119,7 +120,8 @@ def test_receipts_list_shows_failed_delivery_state_from_persisted_queue_metadata
 
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
-    assert b">failed<" in response.data
+    assert b">Failed<" in response.data
+    assert b"Email delivery failed; custody remains recorded." in response.data
 
 
 def test_receipts_list_hides_delivery_state_for_historical_nonqueued_receipt(client_with_temp_db) -> None:
@@ -158,8 +160,8 @@ def test_receipts_list_hides_delivery_state_for_historical_nonqueued_receipt(cli
     assert response.status_code == 200
     assert f'href="/receipts/{receipt_id}"'.encode("utf-8") in response.data
     assert b">pending<" not in response.data
-    assert b">sent<" not in response.data
-    assert b">failed<" not in response.data
+    assert b">Sent<" not in response.data
+    assert b">Failed<" not in response.data
 
 
 def test_receipts_list_renders_clear_search_link_when_filters_are_active(client_with_temp_db) -> None:

--- a/tests/test_recovery_mode.py
+++ b/tests/test_recovery_mode.py
@@ -160,7 +160,7 @@ def test_receipt_detail_shows_recovery_block_message_for_resend_action(client_wi
     response = client_with_temp_db.get(f"/receipts/{receipt_id}")
 
     assert response.status_code == 200
-    assert b"Recovery mode blocks retry send" in response.data
+    assert b"Recovery mode blocks retry failed delivery" in response.data
     assert b"Receipt resend and retry actions are paused until an admin acknowledges recovery mode." in response.data
     assert b"Blocked during recovery mode" in response.data
 


### PR DESCRIPTION
Issue 29-5: Simplify receipt support and resend access

## Summary

Make receipt delivery status and available email actions easier to understand without changing custody, receipt, recovery, or authorization behavior.

## Related Issue

Closes #942

## Changes

- Clarified Pending, Sent, and Failed delivery states on receipt list and detail pages.
- Added short operator-facing explanations for each delivery state.
- Renamed contextual actions to distinguish:
  - initial receipt delivery
  - failed-delivery retry
  - delivered-receipt resend
- Added clear wording that email delivery actions do not create, reverse, or change custody.
- Kept receipt actions contextual on receipt detail.
- Preserved recipient, CC, event link, PDF, and receipt-history access.
- Updated focused receipt and recovery-mode tests.

## Verification

- [x] `./.venv/bin/python -m pytest tests/test_receipt_detail.py tests/test_receipts_list.py -q` — 71 passed.
- [x] `./.venv/bin/python -m pytest tests/test_recovery_mode.py tests/test_admin_receipt_cc_settings.py -q` — 11 passed.
- [x] Focused navigation and authorization tests passed — 2 tests.
- [x] Focused Issue and Return commit tests passed — 4 tests.
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt and the AssetTrack container started successfully.
- [x] Completed the operator Issue workflow and verified receipt creation.
- [x] Completed the operator Return workflow and verified receipt creation.
- [x] Verified receipt detail, recipient, CC, event link, delivery status, and PDF access.
- [x] Verified failed-delivery and retry wording using safe local fixture data.
- [x] Verified retry did not change custody state or event count.
- [x] Verified operator direct resend remains blocked with `403`.
- [x] Verified administrators retain delivered-receipt resend access.
- [x] Verified recovery mode continues to block send and resend actions.
- [x] Docker Compose shut down normally without removing volumes.

## Notes

- No external SMTP delivery was performed or claimed.
- No role, authorization, schema, migration, event, custody, receipt-history, SMTP, recovery, Docker, persistence, dependency, or navigation behavior changed.
- `tests/test_issue_case_scan.py::test_issue_case_scan_expands_expected_assets` currently fails because the response renders the Return queue while the test expects the Issue queue.
- The same failure was reproduced independently on clean `main` at commit `8e66df6`, confirming it predates and is unrelated to this receipt-support branch.
- The pre-existing workflow failure was not fixed here because doing so would exceed Issue 29-5 scope.