### PR TITLE
Issue 29-8A: Add slot move preview and confirmation

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1721,12 +1721,12 @@ def _asset_search_status_cue(*, location_type: str, holder_label: str, movement_
 
 
 def _asset_last_movement_proof(conn: sqlite3.Connection, asset_tag: str) -> dict[str, object]:
-    event_type_values = tuple(issue_event_type_values() + return_event_type_values())
+    event_type_values = tuple(issue_event_type_values() + return_event_type_values() + ("SLOT_MOVE",))
     placeholders = ", ".join("?" for _ in event_type_values)
     active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
     event_row = conn.execute(
         f"""
-        SELECT e.id, e.event_type, e.event_date
+        SELECT e.id, e.event_type, e.event_date, e.payload
         FROM asset_events e
         WHERE UPPER(e.asset_tag) = UPPER(?)
           AND UPPER(e.event_type) IN ({placeholders})
@@ -1745,9 +1745,20 @@ def _asset_last_movement_proof(conn: sqlite3.Connection, asset_tag: str) -> dict
             "event_date_display": "",
             "receipt_id": None,
             "receipt_key": "",
+            "source_case": "",
+            "source_slot": "",
+            "destination_case": "",
+            "destination_slot": "",
         }
 
     event_id = int(event_row["id"])
+    payload: dict[str, object] = {}
+    try:
+        payload = json.loads(str(event_row["payload"] or "{}"))
+    except json.JSONDecodeError:
+        payload = {}
+    from_slot = payload.get("from_slot") if isinstance(payload.get("from_slot"), dict) else {}
+    to_slot = payload.get("to_slot") if isinstance(payload.get("to_slot"), dict) else {}
     receipt_row = conn.execute(
         """
         SELECT id, receipt_key
@@ -1770,6 +1781,10 @@ def _asset_last_movement_proof(conn: sqlite3.Connection, asset_tag: str) -> dict
         "event_date_display": _report_event_display_timestamp(event_row["event_date"]),
         "receipt_id": None if receipt_row is None else int(receipt_row["id"]),
         "receipt_key": "" if receipt_row is None else str(receipt_row["receipt_key"] or ""),
+        "source_case": str(from_slot.get("case_number") or ""),
+        "source_slot": str(from_slot.get("slot_number") or ""),
+        "destination_case": str(to_slot.get("case_number") or ""),
+        "destination_slot": str(to_slot.get("slot_number") or ""),
     }
 
 
@@ -2013,6 +2028,179 @@ def _build_admin_slot_move_source_view(conn, slot_id: int) -> Optional[dict]:
         "current_asset_tag": str(slot_row["current_asset_tag"] or ""),
         "occupied": occupied,
         "asset": asset_view,
+    }
+
+
+def _list_admin_slot_move_sources(conn) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            s.id AS slot_id,
+            s.case_name,
+            s.slot_position,
+            a.asset_tag,
+            a.serial_number,
+            a.equipment_type,
+            a.building_room,
+            a.location_type
+        FROM slots s
+        JOIN slot_occupancy so ON so.slot_id = s.id
+        JOIN assets a ON a.id = so.asset_id
+        ORDER BY UPPER(s.case_name), s.slot_position, a.asset_tag
+        LIMIT 200;
+        """
+    ).fetchall()
+    return [
+        {
+            "slot_id": int(row["slot_id"]),
+            "case_name": str(row["case_name"] or ""),
+            "slot_position": int(row["slot_position"]),
+            "asset_tag": str(row["asset_tag"] or ""),
+            "serial_number": str(row["serial_number"] or ""),
+            "equipment_type": str(row["equipment_type"] or ""),
+            "building_room": str(row["building_room"] or ""),
+            "location_type": str(row["location_type"] or ""),
+        }
+        for row in rows
+    ]
+
+
+def _split_building_room(value: object) -> dict[str, str]:
+    text = str(value or "").strip()
+    if "/" not in text:
+        return {"building": text, "room": ""}
+    building, room = text.split("/", 1)
+    return {"building": building.strip(), "room": room.strip()}
+
+
+def _build_admin_slot_move_preview(
+    conn,
+    *,
+    source_slot_id: int,
+    building_room: str,
+    case_number: str,
+    slot_number: str,
+) -> dict:
+    if not building_room:
+        raise ValueError("building/room is required.")
+    if not case_number:
+        raise ValueError("case_number is required.")
+    if not slot_number:
+        raise ValueError("slot_number is required.")
+
+    try:
+        destination_slot_position = int(slot_number)
+    except ValueError as exc:
+        raise ValueError("slot_number must be an integer.") from exc
+
+    source_slot = conn.execute(
+        """
+        SELECT
+            s.id,
+            s.case_name,
+            s.slot_position,
+            so.asset_id,
+            a.asset_tag,
+            a.serial_number,
+            a.equipment_type,
+            a.location_type,
+            a.current_holder_id,
+            a.building_room,
+            a.home_slot_id
+        FROM slots s
+        LEFT JOIN slot_occupancy so ON so.slot_id = s.id
+        LEFT JOIN assets a ON a.id = so.asset_id
+        WHERE s.id = ?
+        LIMIT 1;
+        """,
+        (source_slot_id,),
+    ).fetchone()
+    if not source_slot or source_slot["asset_id"] is None:
+        raise ValueError("Source slot is missing or empty.")
+
+    asset_id = int(source_slot["asset_id"])
+    asset_tag = str(source_slot["asset_tag"] or "")
+    location_type = _normalize_location_type(source_slot["location_type"])
+    if _is_terminal_location_type(location_type):
+        raise ValueError("Asset is retired/disposed and cannot be moved.")
+    if location_type != "STORAGE":
+        raise ValueError("Asset must be location_type=STORAGE.")
+    if location_type == "IN_CUSTODY":
+        raise ValueError("Asset is IN_CUSTODY and cannot be moved.")
+
+    destination_slot = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+          AND slot_position = ?
+        LIMIT 1;
+        """,
+        (case_number, destination_slot_position),
+    ).fetchone()
+    if not destination_slot:
+        raise ValueError("Destination slot does not exist.")
+
+    destination_slot_id = int(destination_slot["id"])
+    if destination_slot_id == int(source_slot["id"]):
+        raise ValueError("Moving to the same slot is not allowed.")
+
+    destination_occupied = conn.execute(
+        """
+        SELECT 1
+        FROM slot_occupancy
+        WHERE slot_id = ?
+        LIMIT 1;
+        """,
+        (destination_slot_id,),
+    ).fetchone()
+    if destination_occupied:
+        raise ValueError("Destination slot is already occupied.")
+    if str(destination_slot["current_asset_tag"] or "").strip():
+        raise ValueError("Destination slot is already occupied.")
+
+    extra_asset_slot = conn.execute(
+        """
+        SELECT slot_id
+        FROM slot_occupancy
+        WHERE asset_id = ? AND slot_id <> ?
+        LIMIT 1;
+        """,
+        (asset_id, source_slot_id),
+    ).fetchone()
+    if extra_asset_slot:
+        raise ValueError("Asset already appears in another slot.")
+
+    source_building_room = str(source_slot["building_room"] or "")
+    source_location = _split_building_room(source_building_room)
+    destination_location = _split_building_room(building_room)
+
+    return {
+        "asset": {
+            "asset_id": asset_id,
+            "asset_tag": asset_tag,
+            "serial_number": str(source_slot["serial_number"] or ""),
+            "equipment_type": str(source_slot["equipment_type"] or ""),
+            "location_type": location_type,
+            "current_holder_id": source_slot["current_holder_id"],
+            "home_slot_id": source_slot["home_slot_id"],
+        },
+        "source": {
+            "slot_id": int(source_slot["id"]),
+            "case_number": str(source_slot["case_name"] or ""),
+            "slot_number": int(source_slot["slot_position"]),
+            "building_room": source_building_room,
+            "building": source_location["building"],
+            "room": source_location["room"],
+        },
+        "destination": {
+            "slot_id": destination_slot_id,
+            "case_number": str(destination_slot["case_name"] or ""),
+            "slot_number": int(destination_slot["slot_position"]),
+            "building_room": building_room,
+            "building": destination_location["building"],
+            "room": destination_location["room"],
+        },
     }
 
 
@@ -9211,15 +9399,18 @@ def admin_slot_move():
     case_number = ""
     slot_number = ""
     notes = ""
+    move_preview: Optional[dict] = None
+    source_slots: list[dict] = []
 
     if source_slot_id_raw:
         try:
             source_slot_id = int(source_slot_id_raw)
         except ValueError:
-            flash("slot_id must be an integer.", "error")
+            flash("Select a valid source slot.", "error")
 
     conn = get_connection()
     try:
+        source_slots = _list_admin_slot_move_sources(conn)
         if source_slot_id is not None:
             source_slot = _build_admin_slot_move_source_view(conn, source_slot_id)
             if source_slot:
@@ -9229,132 +9420,105 @@ def admin_slot_move():
                 slot_number = str(source_slot.get("slot_position") or "")
             elif request.method == "GET":
                 flash("Source slot not found.", "error")
-        elif request.method == "GET":
-            flash("slot_id is required.", "error")
 
         if request.method == "POST":
+            action = (request.form.get("action") or "preview").strip().lower()
             building_room = (request.form.get("building_room") or "").strip()
             case_number = (request.form.get("case_number") or "").strip().upper()
             slot_number = (request.form.get("slot_number") or "").strip()
             notes = (request.form.get("notes") or "").strip()
 
             if source_slot_id is None:
-                flash("slot_id is required.", "error")
+                flash("Select a source slot.", "error")
                 return render_template(
                     "admin_slot_move.html",
                     source_slot=source_slot,
+                    source_slots=source_slots,
                     source_slot_id=source_slot_id_raw,
                     building_room=building_room,
                     case_number=case_number,
                     slot_number=slot_number,
                     notes=notes,
+                    move_preview=move_preview,
                 )
 
-            if not building_room:
-                flash("building/room is required.", "error")
-            if not case_number:
-                flash("case_number is required.", "error")
-            if not slot_number:
-                flash("slot_number is required.", "error")
             if not source_slot or not source_slot.get("occupied"):
                 flash("Source slot is missing or empty.", "error")
 
-            if not building_room or not case_number or not slot_number or not source_slot or not source_slot.get("occupied"):
+            if not source_slot or not source_slot.get("occupied"):
                 return render_template(
                     "admin_slot_move.html",
                     source_slot=source_slot,
+                    source_slots=source_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
                     slot_number=slot_number,
                     notes=notes,
+                    move_preview=move_preview,
                 )
 
             try:
-                destination_slot_position = int(slot_number)
-            except ValueError:
-                flash("slot_number must be an integer.", "error")
+                move_preview = _build_admin_slot_move_preview(
+                    conn,
+                    source_slot_id=source_slot_id,
+                    building_room=building_room,
+                    case_number=case_number,
+                    slot_number=slot_number,
+                )
+            except ValueError as e:
+                flash(str(e), "error")
                 return render_template(
                     "admin_slot_move.html",
                     source_slot=source_slot,
+                    source_slots=source_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
                     slot_number=slot_number,
                     notes=notes,
+                    move_preview=move_preview,
+                )
+
+            if action == "preview":
+                return render_template(
+                    "admin_slot_move.html",
+                    source_slot=source_slot,
+                    source_slots=source_slots,
+                    source_slot_id=source_slot_id,
+                    building_room=building_room,
+                    case_number=case_number,
+                    slot_number=slot_number,
+                    notes=notes,
+                    move_preview=move_preview,
+                )
+            if action != "commit":
+                flash("Unknown action.", "error")
+                return render_template(
+                    "admin_slot_move.html",
+                    source_slot=source_slot,
+                    source_slots=source_slots,
+                    source_slot_id=source_slot_id,
+                    building_room=building_room,
+                    case_number=case_number,
+                    slot_number=slot_number,
+                    notes=notes,
+                    move_preview=move_preview,
                 )
 
             try:
                 conn.execute("BEGIN;")
 
-                source_slot_locked = conn.execute(
-                    """
-                    SELECT s.id, s.case_name, s.slot_position, so.asset_id, a.asset_tag, a.location_type
-                    FROM slots s
-                    LEFT JOIN slot_occupancy so ON so.slot_id = s.id
-                    LEFT JOIN assets a ON a.id = so.asset_id
-                    WHERE s.id = ?
-                    LIMIT 1;
-                    """,
-                    (source_slot_id,),
-                ).fetchone()
-                if not source_slot_locked:
-                    raise ValueError("Source slot is missing or empty.")
-                if source_slot_locked["asset_id"] is None:
-                    raise ValueError("Source slot is missing or empty.")
-
-                asset_id = int(source_slot_locked["asset_id"])
-                asset_tag = str(source_slot_locked["asset_tag"] or "")
-                location_type = _normalize_location_type(source_slot_locked["location_type"])
-                if _is_terminal_location_type(location_type):
-                    raise ValueError("Asset is retired/disposed and cannot be moved.")
-                if location_type != "STORAGE":
-                    raise ValueError("Asset must be location_type=STORAGE.")
-                if location_type == "IN_CUSTODY":
-                    raise ValueError("Asset is IN_CUSTODY and cannot be moved.")
-
-                destination_slot = conn.execute(
-                    """
-                    SELECT id, case_name, slot_position, current_asset_tag
-                    FROM slots
-                    WHERE UPPER(case_name) = UPPER(?)
-                      AND slot_position = ?
-                    LIMIT 1;
-                    """,
-                    (case_number, destination_slot_position),
-                ).fetchone()
-                if not destination_slot:
-                    raise ValueError("Destination slot does not exist.")
-
-                destination_slot_id = int(destination_slot["id"])
-                if destination_slot_id == int(source_slot_locked["id"]):
-                    raise ValueError("Moving to the same slot is not allowed.")
-
-                destination_occupied = conn.execute(
-                    """
-                    SELECT 1
-                    FROM slot_occupancy
-                    WHERE slot_id = ?
-                    LIMIT 1;
-                    """,
-                    (destination_slot_id,),
-                ).fetchone()
-                if destination_occupied:
-                    raise ValueError("Destination slot is already occupied.")
-                if str(destination_slot["current_asset_tag"] or "").strip():
-                    raise ValueError("Destination slot is already occupied.")
-
-                extra_asset_slot = conn.execute(
-                    """
-                    SELECT slot_id
-                    FROM slot_occupancy
-                    WHERE asset_id = ? AND slot_id <> ?
-                    LIMIT 1;
-                    """,
-                    (asset_id, source_slot_id),
-                ).fetchone()
-                if extra_asset_slot:
-                    raise ValueError("Asset already appears in another slot.")
+                move_preview = _build_admin_slot_move_preview(
+                    conn,
+                    source_slot_id=source_slot_id,
+                    building_room=building_room,
+                    case_number=case_number,
+                    slot_number=slot_number,
+                )
+                asset_id = int(move_preview["asset"]["asset_id"])
+                asset_tag = str(move_preview["asset"]["asset_tag"])
+                destination_slot_id = int(move_preview["destination"]["slot_id"])
 
                 delete_source = conn.execute(
                     """
@@ -9398,15 +9562,21 @@ def admin_slot_move():
                 if "home_slot_id" in asset_columns:
                     update_clauses.append("home_slot_id = ?")
                     update_values.append(destination_slot_id)
+                if "building" in asset_columns:
+                    update_clauses.append("building = ?")
+                    update_values.append(str(move_preview["destination"]["building"]))
+                if "room" in asset_columns:
+                    update_clauses.append("room = ?")
+                    update_values.append(str(move_preview["destination"]["room"]))
                 if "building_room" in asset_columns:
                     update_clauses.append("building_room = ?")
                     update_values.append(building_room)
                 if "case_number" in asset_columns:
                     update_clauses.append("case_number = ?")
-                    update_values.append(str(destination_slot["case_name"]))
+                    update_values.append(str(move_preview["destination"]["case_number"]))
                 if "slot_number" in asset_columns:
                     update_clauses.append("slot_number = ?")
-                    update_values.append(str(destination_slot["slot_position"]))
+                    update_values.append(str(move_preview["destination"]["slot_number"]))
                 if "updated_date" in asset_columns:
                     update_clauses.append("updated_date = ?")
                     update_values.append(now_iso)
@@ -9419,15 +9589,16 @@ def admin_slot_move():
 
                 payload = {
                     "from_slot": {
-                        "slot_id": int(source_slot_locked["id"]),
-                        "case_number": str(source_slot_locked["case_name"] or ""),
-                        "slot_number": int(source_slot_locked["slot_position"]),
+                        "slot_id": int(move_preview["source"]["slot_id"]),
+                        "building_room": str(move_preview["source"]["building_room"]),
+                        "case_number": str(move_preview["source"]["case_number"]),
+                        "slot_number": int(move_preview["source"]["slot_number"]),
                     },
                     "to_slot": {
                         "slot_id": destination_slot_id,
                         "building_room": building_room,
-                        "case_number": str(destination_slot["case_name"] or ""),
-                        "slot_number": int(destination_slot["slot_position"]),
+                        "case_number": str(move_preview["destination"]["case_number"]),
+                        "slot_number": int(move_preview["destination"]["slot_number"]),
                     },
                 }
                 conn.execute(
@@ -9462,19 +9633,21 @@ def admin_slot_move():
                 return render_template(
                     "admin_slot_move.html",
                     source_slot=source_slot,
+                    source_slots=source_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
                     slot_number=slot_number,
                     notes=notes,
+                    move_preview=move_preview,
                 )
             except Exception:
                 conn.rollback()
                 raise
 
             flash(
-                f"Moved asset {asset_tag} from {source_slot_locked['case_name']} slot {source_slot_locked['slot_position']} "
-                f"to {destination_slot['case_name']} slot {destination_slot['slot_position']}.",
+                f"Moved asset {asset_tag} from case {move_preview['source']['case_number']}, slot {move_preview['source']['slot_number']} "
+                f"to case {move_preview['destination']['case_number']}, slot {move_preview['destination']['slot_number']}.",
                 "success",
             )
             return redirect(url_for("admin_slot_move", slot_id=destination_slot_id))
@@ -9484,11 +9657,13 @@ def admin_slot_move():
     return render_template(
         "admin_slot_move.html",
         source_slot=source_slot,
+        source_slots=source_slots,
         source_slot_id=source_slot_id,
         building_room=building_room,
         case_number=case_number,
         slot_number=slot_number,
         notes=notes,
+        move_preview=move_preview,
     )
 
 

--- a/assettrack/intake/templates/admin_slot_move.html
+++ b/assettrack/intake/templates/admin_slot_move.html
@@ -8,6 +8,20 @@
 {% block extra_head %}
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(240px, 1fr)); gap: 0.75rem 1rem; }
+    .slot-move-source-table td:last-child,
+    .slot-move-source-table th:last-child {
+      text-align: right;
+      white-space: nowrap;
+    }
+    .slot-move-source-table .asset-tag-cell code {
+      font-size: 1rem;
+      font-weight: 700;
+    }
+    .slot-move-source-table .asset-meta {
+      color: var(--color-text-muted);
+      font-size: 0.85rem;
+      margin-top: 0.15rem;
+    }
   </style>
 {% endblock %}
 
@@ -24,9 +38,50 @@
     {% endif %}
   {% endwith %}
 
-  <div class="card">
-    <h2>Source Slot Details</h2>
-    {% if source_slot %}
+  {% if not source_slot or not source_slot.occupied %}
+    <div class="card">
+      <h2>Select Source Slot</h2>
+      {% if source_slots %}
+        <table class="slot-move-source-table">
+          <thead>
+            <tr>
+              <th>Asset</th>
+              <th>Source slot</th>
+              <th>Location</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in source_slots %}
+              <tr>
+                <td class="asset-tag-cell">
+                  <code>{{ row.asset_tag }}</code>
+                  <div class="asset-meta">
+                    {{ row.equipment_type or "Unknown" }}
+                    {% if row.serial_number %} &middot; {{ row.serial_number }}{% endif %}
+                  </div>
+                </td>
+                <td><code>{{ row.case_name }}</code> slot <code>{{ row.slot_position }}</code></td>
+                <td>{{ row.building_room or "Not recorded" }}</td>
+                <td>
+                  <form method="get" action="{{ url_for('admin_slot_move') }}">
+                    <input type="hidden" name="slot_id" value="{{ row.slot_id }}" />
+                    <button type="submit">Select</button>
+                  </form>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <p class="muted">No occupied source slots found.</p>
+      {% endif %}
+    </div>
+  {% endif %}
+
+  {% if source_slot %}
+    <div class="card">
+      <h2>Source Slot Details</h2>
       <div class="grid">
         <div><strong>slot_id:</strong> <code>{{ source_slot.slot_id }}</code></div>
         <div><strong>case_number:</strong> <code>{{ source_slot.case_name }}</code></div>
@@ -37,16 +92,15 @@
         <div><strong>location_type:</strong> <code>{{ source_slot.asset.location_type if source_slot.asset else "" }}</code></div>
         <div><strong>home_slot_id:</strong> {{ source_slot.asset.home_slot_id if source_slot.asset and source_slot.asset.home_slot_id is not none else "none" }}</div>
       </div>
-    {% else %}
-      <p class="muted">Provide a valid <code>slot_id</code> query param, e.g. <code>/admin/slot-move?slot_id=1</code>.</p>
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 
-  {% if source_slot %}
+  {% if source_slot and source_slot.occupied %}
     <div class="card">
       <h2>Move To Destination Slot</h2>
       <p class="muted">Destination must exist and be empty.</p>
       <form method="post" action="{{ url_for('admin_slot_move') }}">
+        <input type="hidden" name="action" value="preview" />
         <input type="hidden" name="source_slot_id" value="{{ source_slot.slot_id }}" />
 
         <div class="row">
@@ -100,7 +154,48 @@
           />
         </div>
 
-        <button type="submit">Move Asset</button>
+        <button type="submit">Preview Move</button>
+      </form>
+    </div>
+  {% endif %}
+
+  {% if move_preview %}
+    <div class="card" id="move-preview">
+      <h2>Preview Move</h2>
+      <div class="grid">
+        <div><strong>asset_tag:</strong> <code>{{ move_preview.asset.asset_tag }}</code></div>
+        <div><strong>serial number:</strong> {{ move_preview.asset.serial_number or "Not recorded" }}</div>
+        <div><strong>equipment type:</strong> {{ move_preview.asset.equipment_type or "Unknown" }}</div>
+        <div><strong>location_type:</strong> <code>{{ move_preview.asset.location_type }}</code></div>
+      </div>
+
+      <h3>Source</h3>
+      <div class="grid">
+        <div><strong>case:</strong> <code>{{ move_preview.source.case_number }}</code></div>
+        <div><strong>slot:</strong> <code>{{ move_preview.source.slot_number }}</code></div>
+        <div><strong>building:</strong> {{ move_preview.source.building or "Not recorded" }}</div>
+        <div><strong>room:</strong> {{ move_preview.source.room or "Not recorded" }}</div>
+      </div>
+
+      <h3>Destination</h3>
+      <div class="grid">
+        <div><strong>case:</strong> <code>{{ move_preview.destination.case_number }}</code></div>
+        <div><strong>slot:</strong> <code>{{ move_preview.destination.slot_number }}</code></div>
+        <div><strong>building:</strong> {{ move_preview.destination.building or "Not recorded" }}</div>
+        <div><strong>room:</strong> {{ move_preview.destination.room or "Not recorded" }}</div>
+      </div>
+
+      <p><strong>Custody will not change.</strong></p>
+      <p><strong>No custody receipt will be generated.</strong></p>
+
+      <form method="post" action="{{ url_for('admin_slot_move') }}">
+        <input type="hidden" name="action" value="commit" />
+        <input type="hidden" name="source_slot_id" value="{{ move_preview.source.slot_id }}" />
+        <input type="hidden" name="building_room" value="{{ building_room or '' }}" />
+        <input type="hidden" name="case_number" value="{{ case_number or '' }}" />
+        <input type="hidden" name="slot_number" value="{{ slot_number or '' }}" />
+        <input type="hidden" name="notes" value="{{ notes or '' }}" />
+        <button type="submit">Confirm Move</button>
       </form>
     </div>
   {% endif %}

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -237,6 +237,14 @@
                       {% endif %}
                     </div>
                     <div><code>Event #{{ proof.event_id }}</code></div>
+                    {% if proof.source_case or proof.destination_case %}
+                      <div>
+                        From case <code>{{ proof.source_case or "Not recorded" }}</code>,
+                        slot <code>{{ proof.source_slot or "Not recorded" }}</code>
+                        to case <code>{{ proof.destination_case or "Not recorded" }}</code>,
+                        slot <code>{{ proof.destination_slot or "Not recorded" }}</code>
+                      </div>
+                    {% endif %}
                     {% if proof.receipt_id %}
                       <div>
                         <a class="nav-link" href="{{ url_for('receipt_detail', receipt_id=proof.receipt_id, return_to=receipt_detail_return_to) }}">

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -36,6 +37,151 @@ def _create_building(name: str) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def _insert_slot_move_fixture(
+    *,
+    asset_tag: str = "MOVE-100",
+    source_slot_id: int = 810,
+    destination_slot_id: int = 811,
+    destination_occupied: bool = False,
+    current_holder_id: int | None = None,
+) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES
+                (?, 'CASE-SRC', 1, ?),
+                (?, 'CASE-DST', 2, ?);
+            """,
+            (
+                source_slot_id,
+                asset_tag,
+                destination_slot_id,
+                "OTHER-DEST" if destination_occupied else None,
+            ),
+        )
+        cursor = conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                equipment_type,
+                manufacturer,
+                model,
+                building,
+                room,
+                building_room,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                updated_date,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                case_number,
+                slot_number
+            )
+            VALUES (?, 'SER-MOVE-100', 'switch', 'Cisco', 'Catalyst', 'SRC', '101', 'SRC/101',
+                    'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z',
+                    'STORAGE', ?, ?, 'CASE-SRC', '1');
+            """,
+            (asset_tag, current_holder_id, source_slot_id),
+        )
+        asset_id = int(cursor.lastrowid)
+        conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (?, ?, '2026-01-01T00:00:00Z');
+            """,
+            (source_slot_id, asset_id),
+        )
+        if destination_occupied:
+            other_cursor = conn.execute(
+                """
+                INSERT INTO assets (
+                    asset_tag,
+                    serial_number,
+                    equipment_type,
+                    manufacturer,
+                    building,
+                    room,
+                    building_room,
+                    custody_state,
+                    accountability_status,
+                    condition,
+                    created_date,
+                    updated_date,
+                    location_type,
+                    current_holder_id,
+                    home_slot_id,
+                    case_number,
+                    slot_number
+                )
+                VALUES ('OTHER-DEST', 'SER-OTHER-DEST', 'router', 'Cisco', 'DST', '202', 'DST/202',
+                        'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z',
+                        'STORAGE', NULL, ?, 'CASE-DST', '2');
+                """,
+                (destination_slot_id,),
+            )
+            conn.execute(
+                """
+                INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                VALUES (?, ?, '2026-01-01T00:00:00Z');
+                """,
+                (destination_slot_id, int(other_cursor.lastrowid)),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _slot_move_state(asset_tag: str = "MOVE-100") -> dict[str, object]:
+    conn = db.get_connection()
+    try:
+        asset = conn.execute(
+            """
+            SELECT id, location_type, current_holder_id, home_slot_id, building, room, building_room, case_number, slot_number
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            (asset_tag,),
+        ).fetchone()
+        source_slot = conn.execute("SELECT current_asset_tag FROM slots WHERE id = 810;").fetchone()
+        destination_slot = conn.execute("SELECT current_asset_tag FROM slots WHERE id = 811;").fetchone()
+        occupancy = conn.execute(
+            """
+            SELECT slot_id
+            FROM slot_occupancy
+            WHERE asset_id = ?
+            ORDER BY slot_id ASC;
+            """,
+            (int(asset["id"]),),
+        ).fetchall()
+        events = conn.execute(
+            """
+            SELECT event_type, payload, holder_id
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id ASC;
+            """,
+            (asset_tag,),
+        ).fetchall()
+        receipts = conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+    finally:
+        conn.close()
+
+    return {
+        "asset": dict(asset),
+        "source_slot": dict(source_slot),
+        "destination_slot": dict(destination_slot),
+        "occupancy_slots": [int(row["slot_id"]) for row in occupancy],
+        "events": [dict(row) for row in events],
+        "receipt_count": int(receipts["c"]),
+    }
 
 
 def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_db) -> None:
@@ -240,7 +386,7 @@ def test_assign_slot_page_can_select_unslotted_asset_from_list(client_with_temp_
             "asset_tag": "AT-SELECT-1",
             "serial_number": "SER-SELECT-1",
             "manufacturer": "Dell",
-            "equipment_type": "monitor",
+            "equipment_type": "laptop",
             "building": "HQ",
             "room": "100",
         },
@@ -516,3 +662,238 @@ def test_assign_slot_rejects_arbitrary_building_without_appending_slot_assign(cl
     assert asset_row["home_slot_id"] is None
     assert occupancy is None
     assert [str(row["event_type"]) for row in events] == ["ASSET_CREATED"]
+
+
+def test_operator_denied_slot_move_preview_and_commit(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-slot-move", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    _insert_slot_move_fixture()
+
+    entry_response = client_with_temp_db.get("/admin/slot-move")
+    preview_response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "preview",
+            "source_slot_id": "810",
+            "building_room": "DST/202",
+            "case_number": "CASE-DST",
+            "slot_number": "2",
+        },
+    )
+    commit_response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "commit",
+            "source_slot_id": "810",
+            "building_room": "DST/202",
+            "case_number": "CASE-DST",
+            "slot_number": "2",
+        },
+    )
+
+    assert entry_response.status_code == 403
+    assert preview_response.status_code == 403
+    assert commit_response.status_code == 403
+    assert _slot_move_state()["occupancy_slots"] == [810]
+
+
+def test_slot_move_entry_lists_occupied_sources_without_slot_id(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+
+    response = client_with_temp_db.get("/admin/slot-move")
+
+    assert response.status_code == 200
+    assert b"Select Source Slot" in response.data
+    assert b"MOVE-100" in response.data
+    assert b"SER-MOVE-100" in response.data
+    assert b"switch" in response.data
+    assert b"CASE-SRC" in response.data
+    assert b"SRC/101" in response.data
+    assert b"Select" in response.data
+    assert b"slot_id is required" not in response.data
+    assert b"Provide a valid" not in response.data
+    assert b"/admin/slot-move?slot_id=" not in response.data
+
+
+def test_slot_move_entry_does_not_offer_empty_slots_as_sources(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+
+    response = client_with_temp_db.get("/admin/slot-move")
+
+    assert response.status_code == 200
+    assert b"CASE-SRC" in response.data
+    assert b"CASE-DST" not in response.data
+
+
+def test_slot_move_selecting_source_continues_to_destination_selection(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+
+    response = client_with_temp_db.get("/admin/slot-move?slot_id=810")
+
+    assert response.status_code == 200
+    assert b"Source Slot Details" in response.data
+    assert b"Move To Destination Slot" in response.data
+    assert b"Preview Move" in response.data
+    assert b'name="source_slot_id" value="810"' in response.data
+
+
+def test_slot_move_valid_slot_id_deep_link_still_works(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(source_slot_id=820, destination_slot_id=821)
+
+    response = client_with_temp_db.get("/admin/slot-move?slot_id=820")
+
+    assert response.status_code == 200
+    assert b"MOVE-100" in response.data
+    assert b"CASE-SRC" in response.data
+    assert b"Move To Destination Slot" in response.data
+
+
+def test_slot_move_preview_displays_facts_without_changing_state(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(current_holder_id=44)
+    before = _slot_move_state()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "preview",
+            "source_slot_id": "810",
+            "building_room": "DST/202",
+            "case_number": "CASE-DST",
+            "slot_number": "2",
+            "notes": "rack move",
+        },
+    )
+    after = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Preview Move" in response.data
+    assert b"MOVE-100" in response.data
+    assert b"SER-MOVE-100" in response.data
+    assert b"switch" in response.data
+    assert b"CASE-SRC" in response.data
+    assert b"CASE-DST" in response.data
+    assert b"SRC" in response.data
+    assert b"101" in response.data
+    assert b"DST" in response.data
+    assert b"202" in response.data
+    assert b"Custody will not change." in response.data
+    assert b"No custody receipt will be generated." in response.data
+    assert b"Confirm Move" in response.data
+    assert after == before
+
+
+def test_slot_move_confirm_moves_storage_asset_without_custody_or_receipt_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(current_holder_id=44)
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "commit",
+            "source_slot_id": "810",
+            "building_room": "DST/202",
+            "case_number": "CASE-DST",
+            "slot_number": "2",
+            "notes": "rack move",
+        },
+        follow_redirects=True,
+    )
+    state = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Moved asset MOVE-100 from case CASE-SRC, slot 1 to case CASE-DST, slot 2." in response.data
+    assert state["source_slot"]["current_asset_tag"] is None
+    assert state["destination_slot"]["current_asset_tag"] == "MOVE-100"
+    assert state["occupancy_slots"] == [811]
+    assert state["receipt_count"] == 0
+
+    asset = state["asset"]
+    assert asset["location_type"] == "STORAGE"
+    assert int(asset["current_holder_id"]) == 44
+    assert int(asset["home_slot_id"]) == 811
+    assert asset["building"] == "DST"
+    assert asset["room"] == "202"
+    assert asset["building_room"] == "DST/202"
+    assert asset["case_number"] == "CASE-DST"
+    assert str(asset["slot_number"]) == "2"
+
+    events = state["events"]
+    assert [event["event_type"] for event in events] == ["SLOT_MOVE"]
+    assert events[0]["holder_id"] is None
+    payload = json.loads(str(events[0]["payload"]))
+    assert payload["from_slot"] == {
+        "slot_id": 810,
+        "building_room": "SRC/101",
+        "case_number": "CASE-SRC",
+        "slot_number": 1,
+    }
+    assert payload["to_slot"] == {
+        "slot_id": 811,
+        "building_room": "DST/202",
+        "case_number": "CASE-DST",
+        "slot_number": 2,
+    }
+
+
+def test_slot_move_commit_rejects_stale_empty_source_without_partial_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+    conn = db.get_connection()
+    try:
+        conn.execute("DELETE FROM slot_occupancy WHERE slot_id = 810;")
+        conn.execute("UPDATE slots SET current_asset_tag = NULL WHERE id = 810;")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "commit",
+            "source_slot_id": "810",
+            "building_room": "DST/202",
+            "case_number": "CASE-DST",
+            "slot_number": "2",
+        },
+        follow_redirects=True,
+    )
+    state = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Source slot is missing or empty." in response.data
+    assert state["source_slot"]["current_asset_tag"] is None
+    assert state["destination_slot"]["current_asset_tag"] is None
+    assert state["occupancy_slots"] == []
+    assert state["events"] == []
+    assert state["receipt_count"] == 0
+
+
+def test_slot_move_commit_rejects_stale_occupied_destination_without_partial_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(destination_occupied=True)
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "commit",
+            "source_slot_id": "810",
+            "building_room": "DST/202",
+            "case_number": "CASE-DST",
+            "slot_number": "2",
+        },
+        follow_redirects=True,
+    )
+    state = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Destination slot is already occupied." in response.data
+    assert state["source_slot"]["current_asset_tag"] == "MOVE-100"
+    assert state["destination_slot"]["current_asset_tag"] == "OTHER-DEST"
+    assert state["occupancy_slots"] == [810]
+    assert state["events"] == []
+    assert state["receipt_count"] == 0

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -40,6 +40,7 @@ class AssetSearchUiTests(unittest.TestCase):
         *,
         event_type: str,
         event_date: str,
+        payload: dict[str, object] | None = None,
         supersedes_event_id: int | None = None,
         correction_reason: str | None = None,
     ) -> int:
@@ -56,9 +57,16 @@ class AssetSearchUiTests(unittest.TestCase):
                 supersedes_event_id,
                 correction_reason
             )
-            VALUES (?, ?, ?, 'system', NULL, '{}', NULL, ?, ?);
+            VALUES (?, ?, ?, 'system', NULL, ?, NULL, ?, ?);
             """,
-            (asset_tag, event_type, event_date, supersedes_event_id, correction_reason),
+            (
+                asset_tag,
+                event_type,
+                event_date,
+                json.dumps(payload or {}),
+                supersedes_event_id,
+                correction_reason,
+            ),
         )
         self.conn.commit()
         return int(cursor.lastrowid)
@@ -296,6 +304,65 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(f"Event #{latest_event_id}".encode("utf-8"), response.data)
         self.assertNotIn(f"Event #{old_event_id}".encode("utf-8"), response.data)
         self.assertIn(b"No receipt linked", response.data)
+
+    def test_search_shows_slot_move_event_as_movement_proof_without_state_change(self) -> None:
+        self._insert_slot(30, "1", 4)
+        self._insert_asset("55555", serial_number="SER-55555", location_type="STORAGE", home_slot_id=30)
+        asset_row = self.conn.execute("SELECT id FROM assets WHERE asset_tag = '55555';").fetchone()
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (30, ?, '2026-04-04T10:00:00+00:00');
+            """,
+            (int(asset_row["id"]),),
+        )
+        self.conn.commit()
+        before_state = self.conn.execute(
+            """
+            SELECT location_type, current_holder_id, home_slot_id
+            FROM assets
+            WHERE asset_tag = '55555';
+            """
+        ).fetchone()
+        before_occupancy = self.conn.execute(
+            "SELECT slot_id FROM slot_occupancy WHERE asset_id = ? ORDER BY slot_id;",
+            (int(asset_row["id"]),),
+        ).fetchall()
+        event_id = self._insert_event(
+            "55555",
+            event_type="SLOT_MOVE",
+            event_date="2026-04-04T10:15:00+00:00",
+            payload={
+                "from_slot": {"case_number": "1", "slot_number": 4},
+                "to_slot": {"case_number": "CASE-1", "slot_number": 3},
+            },
+        )
+
+        response = self.client.get("/assets/search?asset_tag=55555")
+
+        after_state = self.conn.execute(
+            """
+            SELECT location_type, current_holder_id, home_slot_id
+            FROM assets
+            WHERE asset_tag = '55555';
+            """
+        ).fetchone()
+        after_occupancy = self.conn.execute(
+            "SELECT slot_id FROM slot_occupancy WHERE asset_id = ? ORDER BY slot_id;",
+            (int(asset_row["id"]),),
+        ).fetchall()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"<strong>SLOT_MOVE</strong>", response.data)
+        self.assertIn(b"Apr 4, 2026 10:15 AM", response.data)
+        self.assertIn(f"Event #{event_id}".encode("utf-8"), response.data)
+        self.assertIn(b"From case <code>1</code>,", response.data)
+        self.assertIn(b"slot <code>4</code>", response.data)
+        self.assertIn(b"to case <code>CASE-1</code>,", response.data)
+        self.assertIn(b"slot <code>3</code>", response.data)
+        self.assertIn(b"No receipt linked", response.data)
+        self.assertEqual(dict(before_state), dict(after_state))
+        self.assertEqual([int(row["slot_id"]) for row in before_occupancy], [int(row["slot_id"]) for row in after_occupancy])
 
     def test_search_shows_receipt_link_for_movement_proof(self) -> None:
         self._insert_asset("AT-RECEIPT-1", serial_number="SER-RECEIPT-1", location_type="IN_CUSTODY", home_slot_id=None)


### PR DESCRIPTION
Issue 29-8A: Add slot move preview and confirmed commit workflow

## Summary

Adds a complete admin slot-movement workflow with source selection, preview, confirmation, and clear movement proof.

## Related Issue

Closes #964

Parent issue: #950

## Changes

- Added occupied-source selection to `/admin/slot-move`.
- Added preview before any state change.
- Revalidated source and destination during commit.
- Preserved custody and STORAGE state.
- Created no Issue or Return receipt.
- Added `SLOT_MOVE` proof to Asset Search.
- Displayed exact source and destination case and slot.
- Added focused workflow and presentation tests.

## Verification

- [x] Slot-move tests passed: 21 tests.
- [x] Asset Search and slot-move tests passed: 43 tests.
- [x] Related authorization, Issue, Return, receipt, and drilldown tests passed.
- [x] `python3 -m compileall assettrack tests` passed.
- [x] `git diff --check` passed.
- [x] Docker build and clean-cookie HTTP smoke passed.
- [x] Incognito-browser source selection, preview, confirmation, and success flow passed.
- [x] Asset Search displayed `SLOT_MOVE` event #123 from case 1, slot 4 to case 1, slot 3.
- [x] Database checks confirmed no duplicate slot or asset occupancy.
- [x] Docker was shut down normally.

## Notes

- No schema, migration, event-type, role, receipt, dependency, or persistence changes.
- Duplicate-submission hardening remains scoped to Issue 29-8B, #965.