### PR TITLE
Issue 29-8B: Harden slot movement

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2065,6 +2065,51 @@ def _list_admin_slot_move_sources(conn) -> list[dict]:
     ]
 
 
+def _list_admin_slot_move_destinations(conn, *, source_slot_id: int, building_room: str) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT s.id AS slot_id, s.case_name, s.slot_position
+        FROM slots s
+        LEFT JOIN slot_occupancy so ON so.slot_id = s.id
+        WHERE s.id <> ?
+          AND so.asset_id IS NULL
+          AND TRIM(COALESCE(s.current_asset_tag, '')) = ''
+        ORDER BY UPPER(s.case_name), s.slot_position
+        LIMIT 200;
+        """,
+        (source_slot_id,),
+    ).fetchall()
+    return [
+        {
+            "slot_id": int(row["slot_id"]),
+            "case_name": str(row["case_name"] or ""),
+            "slot_position": int(row["slot_position"]),
+            "building_room": building_room,
+        }
+        for row in rows
+    ]
+
+
+def _build_admin_slot_move_destination_view(conn, slot_id: int, *, building_room: str) -> Optional[dict]:
+    slot_row = conn.execute(
+        """
+        SELECT id, case_name, slot_position
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (slot_id,),
+    ).fetchone()
+    if not slot_row:
+        return None
+    return {
+        "slot_id": int(slot_row["id"]),
+        "case_name": str(slot_row["case_name"] or ""),
+        "slot_position": int(slot_row["slot_position"]),
+        "building_room": building_room,
+    }
+
+
 def _split_building_room(value: object) -> dict[str, str]:
     text = str(value or "").strip()
     if "/" not in text:
@@ -2202,6 +2247,25 @@ def _build_admin_slot_move_preview(
             "room": destination_location["room"],
         },
     }
+
+
+def _validate_admin_slot_move_expected(
+    move_preview: dict,
+    *,
+    expected_asset_id_raw: str,
+    expected_destination_slot_id_raw: str,
+) -> None:
+    if not expected_asset_id_raw or not expected_destination_slot_id_raw:
+        return
+    try:
+        expected_asset_id = int(expected_asset_id_raw)
+        expected_destination_slot_id = int(expected_destination_slot_id_raw)
+    except ValueError as exc:
+        raise ValueError("Move preview is stale. Preview the move again.") from exc
+    if int(move_preview["asset"]["asset_id"]) != expected_asset_id:
+        raise ValueError("Source slot changed. Preview the move again.")
+    if int(move_preview["destination"]["slot_id"]) != expected_destination_slot_id:
+        raise ValueError("Destination slot changed. Preview the move again.")
 
 
 def _build_admin_retire_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
@@ -9401,6 +9465,7 @@ def admin_slot_move():
     notes = ""
     move_preview: Optional[dict] = None
     source_slots: list[dict] = []
+    destination_slots: list[dict] = []
 
     if source_slot_id_raw:
         try:
@@ -9418,15 +9483,24 @@ def admin_slot_move():
                 building_room = str(asset.get("building_room") or "")
                 case_number = str(source_slot.get("case_name") or "")
                 slot_number = str(source_slot.get("slot_position") or "")
+                destination_slots = _list_admin_slot_move_destinations(
+                    conn,
+                    source_slot_id=source_slot_id,
+                    building_room=building_room,
+                )
             elif request.method == "GET":
                 flash("Source slot not found.", "error")
 
         if request.method == "POST":
             action = (request.form.get("action") or "preview").strip().lower()
-            building_room = (request.form.get("building_room") or "").strip()
+            source_asset = (source_slot or {}).get("asset") or {}
+            building_room = str(source_asset.get("building_room") or "").strip()
             case_number = (request.form.get("case_number") or "").strip().upper()
             slot_number = (request.form.get("slot_number") or "").strip()
             notes = (request.form.get("notes") or "").strip()
+            destination_slot_id_raw = (request.form.get("destination_slot_id") or "").strip()
+            expected_asset_id_raw = (request.form.get("expected_asset_id") or "").strip()
+            expected_destination_slot_id_raw = (request.form.get("expected_destination_slot_id") or "").strip()
 
             if source_slot_id is None:
                 flash("Select a source slot.", "error")
@@ -9434,6 +9508,7 @@ def admin_slot_move():
                     "admin_slot_move.html",
                     source_slot=source_slot,
                     source_slots=source_slots,
+                    destination_slots=destination_slots,
                     source_slot_id=source_slot_id_raw,
                     building_room=building_room,
                     case_number=case_number,
@@ -9450,6 +9525,7 @@ def admin_slot_move():
                     "admin_slot_move.html",
                     source_slot=source_slot,
                     source_slots=source_slots,
+                    destination_slots=destination_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
@@ -9459,6 +9535,23 @@ def admin_slot_move():
                 )
 
             try:
+                if action in {"preview", "commit"}:
+                    if not destination_slot_id_raw:
+                        raise ValueError("Select a destination slot.")
+                    try:
+                        destination_slot_id = int(destination_slot_id_raw)
+                    except ValueError as exc:
+                        raise ValueError("Select a valid destination slot.") from exc
+                    destination_slot = _build_admin_slot_move_destination_view(
+                        conn,
+                        destination_slot_id,
+                        building_room=building_room,
+                    )
+                    if not destination_slot:
+                        raise ValueError("Destination slot does not exist.")
+                    building_room = str(destination_slot["building_room"] or "")
+                    case_number = str(destination_slot["case_name"] or "")
+                    slot_number = str(destination_slot["slot_position"])
                 move_preview = _build_admin_slot_move_preview(
                     conn,
                     source_slot_id=source_slot_id,
@@ -9466,12 +9559,19 @@ def admin_slot_move():
                     case_number=case_number,
                     slot_number=slot_number,
                 )
+                if action == "commit":
+                    _validate_admin_slot_move_expected(
+                        move_preview,
+                        expected_asset_id_raw=expected_asset_id_raw,
+                        expected_destination_slot_id_raw=expected_destination_slot_id_raw,
+                    )
             except ValueError as e:
                 flash(str(e), "error")
                 return render_template(
                     "admin_slot_move.html",
                     source_slot=source_slot,
                     source_slots=source_slots,
+                    destination_slots=destination_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
@@ -9485,6 +9585,7 @@ def admin_slot_move():
                     "admin_slot_move.html",
                     source_slot=source_slot,
                     source_slots=source_slots,
+                    destination_slots=destination_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
@@ -9498,6 +9599,7 @@ def admin_slot_move():
                     "admin_slot_move.html",
                     source_slot=source_slot,
                     source_slots=source_slots,
+                    destination_slots=destination_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
@@ -9509,12 +9611,33 @@ def admin_slot_move():
             try:
                 conn.execute("BEGIN;")
 
+                if not destination_slot_id_raw:
+                    raise ValueError("Select a destination slot.")
+                try:
+                    destination_slot_id = int(destination_slot_id_raw)
+                except ValueError as exc:
+                    raise ValueError("Select a valid destination slot.") from exc
+                destination_slot = _build_admin_slot_move_destination_view(
+                    conn,
+                    destination_slot_id,
+                    building_room=building_room,
+                )
+                if not destination_slot:
+                    raise ValueError("Destination slot does not exist.")
+                building_room = str(destination_slot["building_room"] or "")
+                case_number = str(destination_slot["case_name"] or "")
+                slot_number = str(destination_slot["slot_position"])
                 move_preview = _build_admin_slot_move_preview(
                     conn,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
                     slot_number=slot_number,
+                )
+                _validate_admin_slot_move_expected(
+                    move_preview,
+                    expected_asset_id_raw=expected_asset_id_raw,
+                    expected_destination_slot_id_raw=expected_destination_slot_id_raw,
                 )
                 asset_id = int(move_preview["asset"]["asset_id"])
                 asset_tag = str(move_preview["asset"]["asset_tag"])
@@ -9634,6 +9757,7 @@ def admin_slot_move():
                     "admin_slot_move.html",
                     source_slot=source_slot,
                     source_slots=source_slots,
+                    destination_slots=destination_slots,
                     source_slot_id=source_slot_id,
                     building_room=building_room,
                     case_number=case_number,
@@ -9658,6 +9782,7 @@ def admin_slot_move():
         "admin_slot_move.html",
         source_slot=source_slot,
         source_slots=source_slots,
+        destination_slots=destination_slots,
         source_slot_id=source_slot_id,
         building_room=building_room,
         case_number=case_number,

--- a/assettrack/intake/templates/admin_slot_move.html
+++ b/assettrack/intake/templates/admin_slot_move.html
@@ -9,7 +9,9 @@
   <style>
     .grid { display: grid; grid-template-columns: repeat(2, minmax(240px, 1fr)); gap: 0.75rem 1rem; }
     .slot-move-source-table td:last-child,
-    .slot-move-source-table th:last-child {
+    .slot-move-source-table th:last-child,
+    .slot-move-destination-table td:last-child,
+    .slot-move-destination-table th:last-child {
       text-align: right;
       white-space: nowrap;
     }
@@ -21,6 +23,15 @@
       color: var(--color-text-muted);
       font-size: 0.85rem;
       margin-top: 0.15rem;
+    }
+    .slot-list-toggle summary {
+      cursor: pointer;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+    }
+    .slot-list-toggle summary .muted {
+      font-weight: 400;
+      margin-left: 0.35rem;
     }
   </style>
 {% endblock %}
@@ -38,10 +49,30 @@
     {% endif %}
   {% endwith %}
 
-  {% if not source_slot or not source_slot.occupied %}
+  {% if source_slot %}
+    <div class="card">
+      <h2>Source Slot Details</h2>
+      <div class="grid">
+        <div><strong>slot_id:</strong> <code>{{ source_slot.slot_id }}</code></div>
+        <div><strong>case_number:</strong> <code>{{ source_slot.case_name }}</code></div>
+        <div><strong>slot_number:</strong> <code>{{ source_slot.slot_position }}</code></div>
+        <div><strong>occupied:</strong> <code>{{ "yes" if source_slot.occupied else "no" }}</code></div>
+        <div><strong>building/room:</strong> {{ source_slot.asset.building_room if source_slot.asset else "" }}</div>
+        <div><strong>asset_tag:</strong> <code>{{ source_slot.asset.asset_tag if source_slot.asset else source_slot.current_asset_tag or "" }}</code></div>
+        <div><strong>location_type:</strong> <code>{{ source_slot.asset.location_type if source_slot.asset else "" }}</code></div>
+        <div><strong>home_slot_id:</strong> {{ source_slot.asset.home_slot_id if source_slot.asset and source_slot.asset.home_slot_id is not none else "none" }}</div>
+      </div>
+    </div>
+  {% endif %}
+
+  {% if source_slots %}
     <div class="card">
       <h2>Select Source Slot</h2>
-      {% if source_slots %}
+      <details class="slot-list-toggle"{% if not source_slot or not source_slot.occupied %} open{% endif %}>
+        <summary>
+          Occupied Source Slots
+          <span class="muted">{{ source_slots|length }} shown</span>
+        </summary>
         <table class="slot-move-source-table">
           <thead>
             <tr>
@@ -73,89 +104,12 @@
             {% endfor %}
           </tbody>
         </table>
-      {% else %}
-        <p class="muted">No occupied source slots found.</p>
-      {% endif %}
+      </details>
     </div>
-  {% endif %}
-
-  {% if source_slot %}
+  {% elif not source_slot or not source_slot.occupied %}
     <div class="card">
-      <h2>Source Slot Details</h2>
-      <div class="grid">
-        <div><strong>slot_id:</strong> <code>{{ source_slot.slot_id }}</code></div>
-        <div><strong>case_number:</strong> <code>{{ source_slot.case_name }}</code></div>
-        <div><strong>slot_number:</strong> <code>{{ source_slot.slot_position }}</code></div>
-        <div><strong>occupied:</strong> <code>{{ "yes" if source_slot.occupied else "no" }}</code></div>
-        <div><strong>building/room:</strong> {{ source_slot.asset.building_room if source_slot.asset else "" }}</div>
-        <div><strong>asset_tag:</strong> <code>{{ source_slot.asset.asset_tag if source_slot.asset else source_slot.current_asset_tag or "" }}</code></div>
-        <div><strong>location_type:</strong> <code>{{ source_slot.asset.location_type if source_slot.asset else "" }}</code></div>
-        <div><strong>home_slot_id:</strong> {{ source_slot.asset.home_slot_id if source_slot.asset and source_slot.asset.home_slot_id is not none else "none" }}</div>
-      </div>
-    </div>
-  {% endif %}
-
-  {% if source_slot and source_slot.occupied %}
-    <div class="card">
-      <h2>Move To Destination Slot</h2>
-      <p class="muted">Destination must exist and be empty.</p>
-      <form method="post" action="{{ url_for('admin_slot_move') }}">
-        <input type="hidden" name="action" value="preview" />
-        <input type="hidden" name="source_slot_id" value="{{ source_slot.slot_id }}" />
-
-        <div class="row">
-          <label for="building_room"><strong>building/room</strong> (required)</label><br />
-          <input
-            type="text"
-            id="building_room"
-            name="building_room"
-            value="{{ building_room or '' }}"
-            placeholder="e.g. BQ26-101"
-            autocomplete="off"
-            required
-          />
-        </div>
-
-        <div class="row">
-          <label for="case_number"><strong>case_number</strong> (required)</label><br />
-          <input
-            type="text"
-            id="case_number"
-            name="case_number"
-            value="{{ case_number or '' }}"
-            placeholder="e.g. CASE-01"
-            autocomplete="off"
-            required
-          />
-        </div>
-
-        <div class="row">
-          <label for="slot_number"><strong>slot_number</strong> (required)</label><br />
-          <input
-            type="text"
-            id="slot_number"
-            name="slot_number"
-            value="{{ slot_number or '' }}"
-            placeholder="e.g. 2"
-            autocomplete="off"
-            required
-          />
-        </div>
-
-        <div class="row">
-          <label for="notes"><strong>notes</strong> (optional)</label><br />
-          <input
-            type="text"
-            id="notes"
-            name="notes"
-            value="{{ notes or '' }}"
-            placeholder="Optional move note"
-            autocomplete="off"
-          />
-        </div>
-
-        <button type="submit">Preview Move</button>
-      </form>
+      <h2>Select Source Slot</h2>
+      <p class="muted">No occupied source slots found.</p>
     </div>
   {% endif %}
 
@@ -191,12 +145,57 @@
       <form method="post" action="{{ url_for('admin_slot_move') }}">
         <input type="hidden" name="action" value="commit" />
         <input type="hidden" name="source_slot_id" value="{{ move_preview.source.slot_id }}" />
-        <input type="hidden" name="building_room" value="{{ building_room or '' }}" />
-        <input type="hidden" name="case_number" value="{{ case_number or '' }}" />
-        <input type="hidden" name="slot_number" value="{{ slot_number or '' }}" />
+        <input type="hidden" name="destination_slot_id" value="{{ move_preview.destination.slot_id }}" />
+        <input type="hidden" name="expected_asset_id" value="{{ move_preview.asset.asset_id }}" />
+        <input type="hidden" name="expected_destination_slot_id" value="{{ move_preview.destination.slot_id }}" />
         <input type="hidden" name="notes" value="{{ notes or '' }}" />
         <button type="submit">Confirm Move</button>
       </form>
+    </div>
+  {% endif %}
+
+  {% if source_slot and source_slot.occupied %}
+    <div class="card">
+      <h2>Move To Destination Slot</h2>
+      <p class="muted">Only empty slots are shown. Building/room stays with the selected asset.</p>
+      {% if destination_slots %}
+        <details class="slot-list-toggle"{% if not move_preview %} open{% endif %}>
+          <summary>
+            Empty Destination Slots
+            <span class="muted">{{ destination_slots|length }} shown</span>
+          </summary>
+          <table class="slot-move-destination-table">
+            <thead>
+              <tr>
+                <th>Building/room</th>
+                <th>Case</th>
+                <th>Slot</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in destination_slots %}
+                <tr>
+                  <td>{{ row.building_room or "Not recorded" }}</td>
+                  <td><code>{{ row.case_name }}</code></td>
+                  <td><code>{{ row.slot_position }}</code></td>
+                  <td>
+                    <form method="post" action="{{ url_for('admin_slot_move') }}">
+                      <input type="hidden" name="action" value="preview" />
+                      <input type="hidden" name="source_slot_id" value="{{ source_slot.slot_id }}" />
+                      <input type="hidden" name="destination_slot_id" value="{{ row.slot_id }}" />
+                      <input type="hidden" name="notes" value="{{ notes or '' }}" />
+                      <button type="submit">Select</button>
+                    </form>
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </details>
+      {% else %}
+        <p class="muted">No empty destination slots found.</p>
+      {% endif %}
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -42,6 +42,8 @@ def _create_building(name: str) -> None:
 def _insert_slot_move_fixture(
     *,
     asset_tag: str = "MOVE-100",
+    equipment_type: str = "switch",
+    location_type: str = "STORAGE",
     source_slot_id: int = 810,
     destination_slot_id: int = 811,
     destination_occupied: bool = False,
@@ -85,11 +87,11 @@ def _insert_slot_move_fixture(
                 case_number,
                 slot_number
             )
-            VALUES (?, 'SER-MOVE-100', 'switch', 'Cisco', 'Catalyst', 'SRC', '101', 'SRC/101',
+            VALUES (?, 'SER-MOVE-100', ?, 'Cisco', 'Catalyst', 'SRC', '101', 'SRC/101',
                     'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z',
-                    'STORAGE', ?, ?, 'CASE-SRC', '1');
+                    ?, ?, ?, 'CASE-SRC', '1');
             """,
-            (asset_tag, current_holder_id, source_slot_id),
+            (asset_tag, equipment_type, location_type, current_holder_id, source_slot_id),
         )
         asset_id = int(cursor.lastrowid)
         conn.execute(
@@ -182,6 +184,41 @@ def _slot_move_state(asset_tag: str = "MOVE-100") -> dict[str, object]:
         "events": [dict(row) for row in events],
         "receipt_count": int(receipts["c"]),
     }
+
+
+def _slot_move_expected_fields(asset_tag: str = "MOVE-100", destination_slot_id: int = 811) -> dict[str, str]:
+    conn = db.get_connection()
+    try:
+        asset = conn.execute("SELECT id FROM assets WHERE asset_tag = ? LIMIT 1;", (asset_tag,)).fetchone()
+    finally:
+        conn.close()
+    return {
+        "expected_asset_id": str(int(asset["id"])),
+        "expected_destination_slot_id": str(destination_slot_id),
+    }
+
+
+def _slot_move_commit_data(
+    source_slot_id: int = 810,
+    case_number: str = "CASE-DST",
+    slot_number: str = "2",
+    *,
+    expected_asset_tag: str = "MOVE-100",
+    destination_slot_id: int = 811,
+    include_expected: bool = True,
+) -> dict[str, str]:
+    data = {
+        "action": "commit",
+        "source_slot_id": str(source_slot_id),
+        "destination_slot_id": str(destination_slot_id),
+        "building_room": "DST/202",
+        "case_number": case_number,
+        "slot_number": slot_number,
+        "notes": "rack move",
+    }
+    if include_expected:
+        data.update(_slot_move_expected_fields(expected_asset_tag, destination_slot_id))
+    return data
 
 
 def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_db) -> None:
@@ -736,8 +773,80 @@ def test_slot_move_selecting_source_continues_to_destination_selection(client_wi
     assert response.status_code == 200
     assert b"Source Slot Details" in response.data
     assert b"Move To Destination Slot" in response.data
-    assert b"Preview Move" in response.data
+    assert b"Occupied Source Slots" in response.data
+    assert b"Empty Destination Slots" in response.data
+    assert b"Only empty slots are shown." in response.data
     assert b'name="source_slot_id" value="810"' in response.data
+    assert b'name="destination_slot_id" value="811"' in response.data
+    source_details_index = response.data.index(b"Source Slot Details")
+    source_list_index = response.data.index(b"Occupied Source Slots")
+    destination_list_index = response.data.index(b"Empty Destination Slots")
+    destination_slot_index = response.data.index(b'name="destination_slot_id" value="811"')
+    assert source_details_index < source_list_index
+    assert destination_list_index < destination_slot_index
+
+
+def test_slot_move_destination_list_shows_empty_slots_and_excludes_source(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+
+    response = client_with_temp_db.get("/admin/slot-move?slot_id=810")
+
+    assert response.status_code == 200
+    assert b"SRC/101" in response.data
+    assert b"<code>CASE-DST</code>" in response.data
+    assert b"<code>2</code>" in response.data
+    assert b'name="destination_slot_id" value="811"' in response.data
+    assert b'name="destination_slot_id" value="810"' not in response.data
+    assert b'id="building_room"' not in response.data
+    assert b'id="case_number"' not in response.data
+    assert b'id="slot_number"' not in response.data
+
+
+def test_slot_move_destination_list_hides_occupied_slots(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(destination_occupied=True)
+
+    response = client_with_temp_db.get("/admin/slot-move?slot_id=810")
+
+    assert response.status_code == 200
+    assert b'name="destination_slot_id" value="811"' not in response.data
+    assert b"No empty destination slots found." in response.data
+
+
+def test_slot_move_selecting_destination_reaches_preview(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+    before = _slot_move_state()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data={
+            "action": "preview",
+            "source_slot_id": "810",
+            "destination_slot_id": "811",
+            "building_room": "SRC/101",
+        },
+    )
+    after = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Preview Move" in response.data
+    assert b"Confirm Move" in response.data
+    assert b"MOVE-100" in response.data
+    assert b"CASE-SRC" in response.data
+    assert b"CASE-DST" in response.data
+    assert b"Empty Destination Slots" in response.data
+    assert b'name="destination_slot_id" value="811"' in response.data
+    assert b'name="expected_destination_slot_id" value="811"' in response.data
+    preview_index = response.data.index(b"Preview Move")
+    confirm_index = response.data.index(b"Confirm Move")
+    destination_list_index = response.data.index(b"Empty Destination Slots")
+    destination_select_index = response.data.rindex(b'name="destination_slot_id" value="811"')
+    assert preview_index < destination_list_index
+    assert confirm_index < destination_list_index
+    assert destination_list_index < destination_select_index
+    assert after == before
 
 
 def test_slot_move_valid_slot_id_deep_link_still_works(client_with_temp_db) -> None:
@@ -762,9 +871,7 @@ def test_slot_move_preview_displays_facts_without_changing_state(client_with_tem
         data={
             "action": "preview",
             "source_slot_id": "810",
-            "building_room": "DST/202",
-            "case_number": "CASE-DST",
-            "slot_number": "2",
+            "destination_slot_id": "811",
             "notes": "rack move",
         },
     )
@@ -780,11 +887,51 @@ def test_slot_move_preview_displays_facts_without_changing_state(client_with_tem
     assert b"SRC" in response.data
     assert b"101" in response.data
     assert b"DST" in response.data
-    assert b"202" in response.data
+    assert b"101" in response.data
     assert b"Custody will not change." in response.data
     assert b"No custody receipt will be generated." in response.data
     assert b"Confirm Move" in response.data
     assert after == before
+
+
+@pytest.mark.parametrize(
+    ("equipment_type", "holder_id"),
+    [
+        ("laptop", 44),
+        ("switch", None),
+        ("router", None),
+    ],
+)
+def test_slot_move_confirm_moves_supported_stored_asset_types_without_custody_or_receipt_change(
+    client_with_temp_db,
+    equipment_type: str,
+    holder_id: int | None,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(equipment_type=equipment_type, current_holder_id=holder_id)
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data=_slot_move_commit_data(),
+        follow_redirects=True,
+    )
+    state = _slot_move_state()
+
+    assert response.status_code == 200
+    assert state["source_slot"]["current_asset_tag"] is None
+    assert state["destination_slot"]["current_asset_tag"] == "MOVE-100"
+    assert state["occupancy_slots"] == [811]
+    assert state["receipt_count"] == 0
+    assert state["asset"]["location_type"] == "STORAGE"
+    assert state["asset"]["current_holder_id"] == holder_id
+    assert int(state["asset"]["home_slot_id"]) == 811
+    assert state["asset"]["building"] == "SRC"
+    assert state["asset"]["room"] == "101"
+    assert state["asset"]["building_room"] == "SRC/101"
+    assert state["asset"]["case_number"] == "CASE-DST"
+    assert str(state["asset"]["slot_number"]) == "2"
+    assert [event["event_type"] for event in state["events"]] == ["SLOT_MOVE"]
+    assert state["events"][0]["holder_id"] is None
 
 
 def test_slot_move_confirm_moves_storage_asset_without_custody_or_receipt_change(client_with_temp_db) -> None:
@@ -793,14 +940,7 @@ def test_slot_move_confirm_moves_storage_asset_without_custody_or_receipt_change
 
     response = client_with_temp_db.post(
         "/admin/slot-move",
-        data={
-            "action": "commit",
-            "source_slot_id": "810",
-            "building_room": "DST/202",
-            "case_number": "CASE-DST",
-            "slot_number": "2",
-            "notes": "rack move",
-        },
+        data=_slot_move_commit_data(),
         follow_redirects=True,
     )
     state = _slot_move_state()
@@ -816,9 +956,9 @@ def test_slot_move_confirm_moves_storage_asset_without_custody_or_receipt_change
     assert asset["location_type"] == "STORAGE"
     assert int(asset["current_holder_id"]) == 44
     assert int(asset["home_slot_id"]) == 811
-    assert asset["building"] == "DST"
-    assert asset["room"] == "202"
-    assert asset["building_room"] == "DST/202"
+    assert asset["building"] == "SRC"
+    assert asset["room"] == "101"
+    assert asset["building_room"] == "SRC/101"
     assert asset["case_number"] == "CASE-DST"
     assert str(asset["slot_number"]) == "2"
 
@@ -834,10 +974,106 @@ def test_slot_move_confirm_moves_storage_asset_without_custody_or_receipt_change
     }
     assert payload["to_slot"] == {
         "slot_id": 811,
-        "building_room": "DST/202",
+        "building_room": "SRC/101",
         "case_number": "CASE-DST",
         "slot_number": 2,
     }
+
+
+def test_slot_move_repeated_confirmation_does_not_append_second_slot_move(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+    stale_commit_data = _slot_move_commit_data()
+
+    first = client_with_temp_db.post("/admin/slot-move", data=stale_commit_data, follow_redirects=True)
+    second = client_with_temp_db.post("/admin/slot-move", data=stale_commit_data, follow_redirects=True)
+    state = _slot_move_state()
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert b"Source slot is missing or empty." in second.data
+    assert state["source_slot"]["current_asset_tag"] is None
+    assert state["destination_slot"]["current_asset_tag"] == "MOVE-100"
+    assert state["occupancy_slots"] == [811]
+    assert [event["event_type"] for event in state["events"]] == ["SLOT_MOVE"]
+    assert state["receipt_count"] == 0
+
+
+def test_slot_move_rejects_stale_source_reoccupied_by_different_asset_without_partial_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+    stale_commit_data = _slot_move_commit_data()
+    conn = db.get_connection()
+    try:
+        move_asset = conn.execute("SELECT id FROM assets WHERE asset_tag = 'MOVE-100';").fetchone()
+        conn.execute("DELETE FROM slot_occupancy WHERE slot_id = 810;")
+        other_cursor = conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                equipment_type,
+                manufacturer,
+                building,
+                room,
+                building_room,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                updated_date,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                case_number,
+                slot_number
+            )
+            VALUES ('OTHER-SOURCE', 'SER-OTHER-SOURCE', 'router', 'Cisco', 'SRC', '101', 'SRC/101',
+                    'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z',
+                    'STORAGE', NULL, 810, 'CASE-SRC', '1');
+            """
+        )
+        conn.execute(
+            "INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at) VALUES (810, ?, '2026-01-02T00:00:00Z');",
+            (int(other_cursor.lastrowid),),
+        )
+        conn.execute("UPDATE slots SET current_asset_tag = 'OTHER-SOURCE' WHERE id = 810;")
+        conn.commit()
+        before_move = conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id, building_room, case_number, slot_number FROM assets WHERE id = ?;",
+            (int(move_asset["id"]),),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post("/admin/slot-move", data=stale_commit_data, follow_redirects=True)
+
+    conn = db.get_connection()
+    try:
+        after_move = conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id, building_room, case_number, slot_number FROM assets WHERE asset_tag = 'MOVE-100';"
+        ).fetchone()
+        other_occupancy = conn.execute(
+            """
+            SELECT so.slot_id
+            FROM slot_occupancy so
+            JOIN assets a ON a.id = so.asset_id
+            WHERE a.asset_tag = 'OTHER-SOURCE';
+            """
+        ).fetchone()
+        destination = conn.execute("SELECT current_asset_tag FROM slots WHERE id = 811;").fetchone()
+        events = conn.execute("SELECT event_type FROM asset_events ORDER BY id ASC;").fetchall()
+        receipts = conn.execute("SELECT COUNT(*) AS c FROM receipt_queue;").fetchone()
+    finally:
+        conn.close()
+
+    assert response.status_code == 200
+    assert b"Source slot changed. Preview the move again." in response.data
+    assert dict(after_move) == dict(before_move)
+    assert int(other_occupancy["slot_id"]) == 810
+    assert destination["current_asset_tag"] is None
+    assert events == []
+    assert int(receipts["c"]) == 0
 
 
 def test_slot_move_commit_rejects_stale_empty_source_without_partial_change(client_with_temp_db) -> None:
@@ -856,9 +1092,7 @@ def test_slot_move_commit_rejects_stale_empty_source_without_partial_change(clie
         data={
             "action": "commit",
             "source_slot_id": "810",
-            "building_room": "DST/202",
-            "case_number": "CASE-DST",
-            "slot_number": "2",
+            "destination_slot_id": "811",
         },
         follow_redirects=True,
     )
@@ -873,6 +1107,29 @@ def test_slot_move_commit_rejects_stale_empty_source_without_partial_change(clie
     assert state["receipt_count"] == 0
 
 
+def test_slot_move_commit_rejects_marker_only_occupied_destination_without_partial_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE slots SET current_asset_tag = 'MARKER-ONLY' WHERE id = 811;")
+        conn.commit()
+    finally:
+        conn.close()
+    before = _slot_move_state()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data=_slot_move_commit_data(),
+        follow_redirects=True,
+    )
+    after = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Destination slot is already occupied." in response.data
+    assert after == before
+
+
 def test_slot_move_commit_rejects_stale_occupied_destination_without_partial_change(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
     _insert_slot_move_fixture(destination_occupied=True)
@@ -882,9 +1139,7 @@ def test_slot_move_commit_rejects_stale_occupied_destination_without_partial_cha
         data={
             "action": "commit",
             "source_slot_id": "810",
-            "building_room": "DST/202",
-            "case_number": "CASE-DST",
-            "slot_number": "2",
+            "destination_slot_id": "811",
         },
         follow_redirects=True,
     )
@@ -897,3 +1152,79 @@ def test_slot_move_commit_rejects_stale_occupied_destination_without_partial_cha
     assert state["occupancy_slots"] == [810]
     assert state["events"] == []
     assert state["receipt_count"] == 0
+
+
+def test_slot_move_commit_rejects_identical_source_and_destination_without_partial_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture()
+    before = _slot_move_state()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data=_slot_move_commit_data(case_number="CASE-SRC", slot_number="1", destination_slot_id=810),
+        follow_redirects=True,
+    )
+    after = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Moving to the same slot is not allowed." in response.data
+    assert after == before
+
+
+def test_slot_move_commit_rejects_in_custody_asset_without_partial_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(location_type="IN_CUSTODY", current_holder_id=44)
+    before = _slot_move_state()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data=_slot_move_commit_data(),
+        follow_redirects=True,
+    )
+    after = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Asset must be location_type=STORAGE." in response.data
+    assert after == before
+
+
+@pytest.mark.parametrize(
+    ("location_type", "failure_type"),
+    [
+        ("RETIRED", "HARDWARE"),
+        ("DISPOSED", "HARDWARE"),
+        ("DISPOSED", "LOST"),
+        ("DISPOSED", "OTHER"),
+    ],
+)
+def test_slot_move_commit_rejects_terminal_assets_without_partial_change(
+    client_with_temp_db,
+    location_type: str,
+    failure_type: str,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot_move_fixture(location_type=location_type)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES ('MOVE-100', 'ASSET_RETIRED', '2026-01-01T01:00:00Z', 'admin', NULL, ?, NULL);
+            """,
+            (json.dumps({"failure_type": failure_type, "to_location_type": location_type}),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    before = _slot_move_state()
+
+    response = client_with_temp_db.post(
+        "/admin/slot-move",
+        data=_slot_move_commit_data(),
+        follow_redirects=True,
+    )
+    after = _slot_move_state()
+
+    assert response.status_code == 200
+    assert b"Asset is retired/disposed and cannot be moved." in response.data
+    assert after == before


### PR DESCRIPTION
Issue 29-8B: Harden slot movement

## Summary

Hardens slot movement against stale confirmations and improves source and destination selection.

## Related Issue

Closes #965

Parent issue: #950

## Changes

- Rejects stale slot-move confirmations.
- Prevents repeated confirmation from moving a different asset.
- Lists only valid empty destination slots.
- Makes source and destination lists expandable.
- Keeps preview and confirmation controls easy to reach.
- Adds regression coverage for Laptop, Switch, and Router movement.

## Verification

- [x] 36 focused slot-move tests passed.
- [x] 245 related regression tests passed.
- [x] `python3 -m compileall assettrack tests` passed.
- [x] `git diff --check` passed.
- [x] Docker build and smoke test passed.
- [x] Empty destination filtering manually verified.
- [x] Expandable source and destination lists manually verified.
- [x] Duplicate confirmation manually verified: first succeeded, second was rejected.
- [x] Only one new `SLOT_MOVE` event was recorded.
- [x] Operator access remained denied.

## Notes

No schema, event-type, custody, receipt, role, dependency, Docker, or persistence changes.