### PR TITLE
Issue 29-9: improve switch and router import discoverability

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -7332,6 +7332,26 @@ def admin_holder_import():
     return render_template("admin_holder_import.html", report=report)
 
 
+@app.get("/admin/network-assets/import")
+@require_login
+@require_role("admin")
+def admin_network_asset_import():
+    return render_template("admin_network_asset_import.html")
+
+
+@app.get("/admin/network-assets/import/template.csv")
+@require_login
+@require_role("admin")
+def admin_network_asset_import_template():
+    template_path = Path(__file__).resolve().parents[2] / "docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv"
+    return send_file(
+        template_path,
+        mimetype="text/csv",
+        as_attachment=True,
+        download_name="network_switch_router_staging_template_v1.csv",
+    )
+
+
 def _load_admin_human_report_data(resolved_db_path: Path, *, include_retired_assets: bool = True) -> dict:
     recent_events_limit = 10
     conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)

--- a/assettrack/intake/templates/admin_network_asset_import.html
+++ b/assettrack/intake/templates/admin_network_asset_import.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block title %}Import Switch/Router CSV{% endblock %}
+{% block page_heading %}Admin: Import Switch/Router CSV{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .import-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
+    .command-block { display: block; overflow-x: auto; padding: 0.75rem; }
+    .compact-list { margin: 0.5rem 0 0 1.25rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="workflow-local-nav" aria-label="Network asset import navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
+
+  <div class="card">
+    <h2>Switch/Router Import</h2>
+    <p class="import-help">
+      Use the existing command-line CSV importer for custody-only switch and router records.
+      AssetTrack supports Laptop, Switch, and Router; this CSV path imports Switch and Router only.
+    </p>
+    <p>
+      <a class="nav-link" href="{{ url_for('admin_network_asset_import_template') }}">Download CSV template</a>
+    </p>
+  </div>
+
+  <details class="disclosure-section" open>
+    <summary>
+      <span class="disclosure-title">Import command</span>
+      <span class="disclosure-hint">Run from the AssetTrack project</span>
+    </summary>
+    <div class="disclosure-body">
+      <code class="command-block">python scripts/import_network_assets_csv.py path/to/network_switch_router_staging_template_v1.csv --db data/assettrack.db --actor admin</code>
+      <p class="import-help">Review the CSV before running. The importer validates rows and stops on errors.</p>
+    </div>
+  </details>
+
+  <details class="disclosure-section">
+    <summary>
+      <span class="disclosure-title">CSV requirements</span>
+      <span class="disclosure-hint">Custody fields only</span>
+    </summary>
+    <div class="disclosure-body">
+      <p class="import-help">Allowed columns:</p>
+      <ul class="compact-list">
+        <li><code>asset_tag</code>, <code>barcode</code>, <code>serial_number</code></li>
+        <li><code>equipment_type</code>: <code>switch</code> or <code>router</code></li>
+        <li><code>manufacturer</code>, <code>model</code>, <code>location_building</code></li>
+        <li><code>case_identifier</code>, <code>slot_identifier</code>, <code>notes_comments</code></li>
+      </ul>
+      <p class="import-help">Do not add IP address, MAC address, VLAN, switch port, topology, patch panel, firmware, monitoring, configuration, or CMDB relationship data.</p>
+    </div>
+  </details>
+
+  <details class="disclosure-section">
+    <summary>
+      <span class="disclosure-title">Validation</span>
+      <span class="disclosure-hint">Existing behavior</span>
+    </summary>
+    <div class="disclosure-body">
+      <p class="import-help">Duplicate asset tags and serial numbers are rejected before import.</p>
+      <p class="import-help">Unsupported equipment types are rejected. Empty slots must already exist before assignment.</p>
+      <p class="import-help">No upload page is provided here; use the validated command-line path.</p>
+    </div>
+  </details>
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -192,6 +192,9 @@
         <a class="admin-tool-link" href="{{ url_for('admin_replace_asset') }}">
           <strong>Replace Asset</strong>
         </a>
+        <a class="admin-tool-link" href="{{ url_for('admin_network_asset_import') }}">
+          <strong>Import Switch/Router CSV</strong>
+        </a>
       </nav>
     </div>
     <div class="admin-tool-section">

--- a/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
+++ b/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
@@ -2,11 +2,13 @@
 
 ## Purpose
 
-Use `network_switch_router_staging_template_v1.csv` to prepare switch and router custody records for operator review.
+Use `network_switch_router_staging_template_v1.csv` to prepare switch and router custody records for administrator review and import.
 
-This template is a planning and staging artifact only. It does not upload data, create assets, append events, or implement import behavior.
+This template feeds the existing command-line importer. It does not create an admin upload page or add network-management behavior.
 
 AssetTrack tracks equipment custody and storage. It is not a CMDB or network configuration system.
+
+AssetTrack supports these asset categories: Laptop, Switch, and Router. This CSV import path is only for Switch and Router records.
 
 ## Allowed Rows
 
@@ -48,9 +50,10 @@ AssetTrack tracks equipment custody and storage. It is not a CMDB or network con
 
 ## Duplicate Handling
 
-- Treat repeated `asset_tag`, `barcode`, or `serial_number` values as review items.
-- Do not silently merge, overwrite, or discard duplicate rows.
-- Resolve duplicates during staging review before any future import attempt.
+- Repeated canonical `asset_tag` values are rejected.
+- Repeated `serial_number` values are rejected.
+- Existing matching `asset_tag` or `serial_number` values in AssetTrack are rejected.
+- The importer does not silently merge, overwrite, or discard duplicate rows.
 
 ## Rejected Fields
 
@@ -66,8 +69,12 @@ Do not add or record CMDB-like or network configuration fields, including:
 - running configuration
 - device configuration
 
-## Review Before Import
+## Import Command
 
-Operators must review staged rows against this CSV and Markdown contract before any future import work proceeds.
+Run from the AssetTrack project after reviewing the CSV:
 
-Import behavior is intentionally out of scope. A later issue must define validation, preview, duplicate resolution, event behavior, and commit boundaries before runtime implementation begins.
+```bash
+python scripts/import_network_assets_csv.py path/to/network_switch_router_staging_template_v1.csv --db data/assettrack.db --actor admin
+```
+
+The importer validates headers, supported equipment types, duplicates, CMDB-like columns, and optional slot assignment before committing rows.

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -129,6 +129,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Edit Asset" in response.data
     assert b"Retire Asset" in response.data
     assert b"Replace Asset" in response.data
+    assert b"Import Switch/Router CSV" in response.data
     assert b"Provision Slots" in response.data
     assert b"Assign Slot" in response.data
     assert b"Move Slot" in response.data
@@ -158,6 +159,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
         b'href="/admin/assets/edit"',
         b'href="/admin/assets/retire"',
         b'href="/admin/assets/replace"',
+        b'href="/admin/network-assets/import"',
         b'href="/admin/slots/provision"',
         b'href="/admin/assign-slot"',
         b'href="/admin/slot-move"',
@@ -185,6 +187,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
         "/admin/assets/edit",
         "/admin/assets/retire",
         "/admin/assets/replace",
+        "/admin/network-assets/import",
         "/admin/slots/provision",
         "/admin/assign-slot",
         "/admin/slot-move",
@@ -215,6 +218,8 @@ def test_admin_tools_link_destinations_remain_reachable_for_admin(client_with_te
         "/admin/assets/edit",
         "/admin/assets/retire",
         "/admin/assets/replace",
+        "/admin/network-assets/import",
+        "/admin/network-assets/import/template.csv",
         "/admin/slots/provision",
         "/admin/assign-slot",
         "/admin/slot-move",
@@ -257,6 +262,37 @@ def test_operator_is_forbidden_for_holder_import_page(client_with_temp_db) -> No
     response = client_with_temp_db.get("/admin/holders/import")
 
     assert response.status_code == 403
+
+
+def test_admin_network_asset_import_page_exposes_existing_cli_process(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-network-import", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/network-assets/import")
+
+    assert response.status_code == 200
+    assert b"Import Switch/Router CSV" in response.data
+    assert b"AssetTrack supports Laptop, Switch, and Router" in response.data
+    assert b"python scripts/import_network_assets_csv.py" in response.data
+    assert b"network_switch_router_staging_template_v1.csv" in response.data
+    assert b'href="/admin/network-assets/import/template.csv"' in response.data
+    assert b"Duplicate asset tags and serial numbers are rejected" in response.data
+    assert b"switch</code> or <code>router" in response.data
+    assert b"No upload page is provided here" in response.data
+    assert b"IP address" in response.data
+    assert b"CMDB relationship" in response.data
+
+
+def test_admin_network_asset_import_template_downloads_existing_csv(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-network-template", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.get("/admin/network-assets/import/template.csv")
+
+    assert response.status_code == 200
+    assert response.mimetype == "text/csv"
+    assert b"asset_tag,barcode,serial_number,equipment_type" in response.data
+    assert b"case_identifier,slot_identifier,notes_comments" in response.data
 
 
 def test_admin_can_import_holders_from_csv(client_with_temp_db) -> None:


### PR DESCRIPTION
PR Title: Issue 29-9: Improve switch and router import discoverability

## Summary

Improve discoverability for the existing custody-only Switch and Router CSV import process without adding a new upload workflow.

The existing CLI importer, validation, duplicate protection, and CSV template remain unchanged.

## Related Issue

Closes #951

## Changes

- Added an admin-only Switch/Router import instructions page.
- Added an Admin Tools link for Switch/Router CSV import.
- Added a protected CSV template download route.
- Updated the network staging documentation to reference the existing import process.
- Added focused tests for admin navigation, route protection, instructions, and template download.

## Verification

- [x] `./.venv/bin/python -m pytest tests/test_admin_system_health.py -q` - 53 passed
- [x] `./.venv/bin/python -m pytest tests/test_network_asset_import.py -q` - 12 passed
- [x] `./.venv/bin/python -m pytest tests/test_import_inventory.py -q` - 4 passed
- [x] `git diff --check`
- [x] New template whitespace check
- [x] `docker compose up -d --build`
- [x] Running-app smoke confirmed Admin Tools link, instructions page, and CSV template download
- [ ] Incognito browser navigation smoke test

## Notes

- No admin upload page was added.
- No live Switch or Router import was performed.
- Import remains custody-only.
- No schema, persistence, dependency, role, event, custody, receipt, or importer behavior changed.
- No CMDB or network-management fields or behavior were introduced.