### PR TITLE
Issue 29-11: add read-only asset history

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1788,6 +1788,151 @@ def _asset_last_movement_proof(conn: sqlite3.Connection, asset_tag: str) -> dict
     }
 
 
+def _asset_history_payload_items(payload_text: object) -> list[dict[str, str]]:
+    try:
+        payload = json.loads(str(payload_text or "{}"))
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, dict):
+        return []
+    items: list[dict[str, str]] = []
+    for key in sorted(payload.keys()):
+        value = payload.get(key)
+        if isinstance(value, (dict, list)):
+            display_value = json.dumps(value, sort_keys=True)
+        else:
+            display_value = str(value if value is not None else "")
+        items.append({"key": str(key), "value": display_value})
+    return items
+
+
+def _build_asset_history_view(conn: sqlite3.Connection, asset_tag: str) -> Optional[dict[str, object]]:
+    asset = conn.execute(
+        """
+        SELECT
+            a.*,
+            h.id AS holder_record_id,
+            h.holder_type AS holder_record_type,
+            h.name AS holder_record_name,
+            h.organization AS holder_record_organization
+        FROM assets a
+        LEFT JOIN holders h
+          ON h.id = a.current_holder_id
+        WHERE UPPER(a.asset_tag) = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_tag,),
+    ).fetchone()
+    if asset is None:
+        return None
+
+    asset_dict = dict(asset)
+    holder = None
+    if asset_dict.get("holder_record_id") is not None:
+        holder = {
+            "id": int(asset_dict["holder_record_id"]),
+            "holder_type": str(asset_dict.get("holder_record_type") or ""),
+            "name": str(asset_dict.get("holder_record_name") or ""),
+            "organization": str(asset_dict.get("holder_record_organization") or ""),
+        }
+    current_slot = _asset_current_slot(conn, int(asset_dict["id"]), str(asset_dict["asset_tag"]))
+    home_slot = _asset_home_slot(conn, asset_dict.get("home_slot_id"))
+
+    event_rows = conn.execute(
+        """
+        SELECT
+            e.id,
+            e.asset_tag,
+            e.event_type,
+            e.event_date,
+            e.actor,
+            e.notes,
+            e.payload,
+            e.holder_id,
+            e.supersedes_event_id,
+            e.correction_reason,
+            superseder.id AS superseded_by_event_id,
+            h.name AS holder_name,
+            h.organization AS holder_organization
+        FROM asset_events e
+        LEFT JOIN asset_events superseder
+          ON superseder.supersedes_event_id = e.id
+        LEFT JOIN holders h
+          ON h.id = e.holder_id
+        WHERE UPPER(e.asset_tag) = UPPER(?)
+        ORDER BY e.event_date ASC, e.id ASC;
+        """,
+        (asset_dict["asset_tag"],),
+    ).fetchall()
+
+    events: list[dict[str, object]] = []
+    for event_row in event_rows:
+        receipts = [
+            {
+                "id": int(receipt_row["id"]),
+                "receipt_key": str(receipt_row["receipt_key"] or ""),
+                "receipt_type": str(receipt_row["receipt_type"] or ""),
+            }
+            for receipt_row in conn.execute(
+                """
+                SELECT id, receipt_key, receipt_type
+                FROM receipt_queue
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM json_each(receipt_queue.source_event_ids_json)
+                    WHERE CAST(json_each.value AS INTEGER) = ?
+                )
+                ORDER BY commit_at ASC, id ASC;
+                """,
+                (int(event_row["id"]),),
+            ).fetchall()
+        ]
+        events.append(
+            {
+                "id": int(event_row["id"]),
+                "event_type": normalize_event_type(event_row["event_type"]),
+                "event_date": str(event_row["event_date"] or ""),
+                "event_date_display": _report_event_display_timestamp(event_row["event_date"]),
+                "actor": str(event_row["actor"] or ""),
+                "notes": str(event_row["notes"] or ""),
+                "holder_id": event_row["holder_id"],
+                "holder_name": str(event_row["holder_name"] or ""),
+                "holder_organization": str(event_row["holder_organization"] or ""),
+                "supersedes_event_id": event_row["supersedes_event_id"],
+                "superseded_by_event_id": event_row["superseded_by_event_id"],
+                "correction_reason": str(event_row["correction_reason"] or ""),
+                "payload_items": _asset_history_payload_items(event_row["payload"]),
+                "receipts": receipts,
+            }
+        )
+
+    equipment_type = str(asset_dict.get("equipment_type") or "").strip()
+    return {
+        "asset": {
+            "asset_tag": str(asset_dict.get("asset_tag") or ""),
+            "serial_number": str(asset_dict.get("serial_number") or ""),
+            "equipment_type": equipment_type,
+            "equipment_type_label": ASSET_EQUIPMENT_TYPE_LABELS.get(
+                equipment_type,
+                equipment_type.replace("_", " ").title() if equipment_type else "",
+            ),
+            "manufacturer": str(asset_dict.get("manufacturer") or ""),
+            "model": str(asset_dict.get("model") or ""),
+            "location_type": _normalize_location_type(asset_dict.get("location_type")),
+            "state_label": _asset_state_label(asset_dict.get("location_type")),
+            "building_room": str(asset_dict.get("building_room") or ""),
+            "building": str(asset_dict.get("building") or ""),
+            "room": str(asset_dict.get("room") or ""),
+            "case_number": str(asset_dict.get("case_number") or ""),
+            "slot_number": str(asset_dict.get("slot_number") or ""),
+        },
+        "holder": holder,
+        "current_slot": current_slot,
+        "home_slot": home_slot,
+        "events": events,
+    }
+
+
 def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     errors: list[str] = []
     asset = _find_asset_for_scan_tag(conn, scan_tag)
@@ -5006,6 +5151,31 @@ def asset_search():
         return_to=return_to,
         receipt_detail_return_to=receipt_detail_return_to,
     )
+
+
+@app.get("/assets/history")
+@require_login
+def asset_history():
+    authed = enforce_inactivity_timeout()
+    if auth_enabled() and not authed:
+        flash("Locked. Re-enter access code.", "error")
+        return redirect(url_for("intake"))
+
+    asset_tag = (request.args.get("asset_tag") or "").strip().upper()
+    return_to = _safe_local_return_to(request.args.get("return_to") or "")
+    if not asset_tag:
+        return redirect(url_for("asset_search"))
+
+    conn = get_connection()
+    try:
+        history = _build_asset_history_view(conn, asset_tag)
+    finally:
+        conn.close()
+
+    if history is None:
+        abort(404)
+
+    return render_template("asset_history.html", history=history, return_to=return_to)
 
 
 @app.get("/preview")

--- a/assettrack/intake/templates/asset_history.html
+++ b/assettrack/intake/templates/asset_history.html
@@ -1,0 +1,126 @@
+{% extends "base.html" %}
+
+{% block title %}Asset History{% endblock %}
+{% block page_heading %}Asset History: {{ history.asset.asset_tag }}{% endblock %}
+{% block page_class %} page-wide asset-history-page{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .asset-history-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.75rem 1rem;
+    }
+    .asset-history-event {
+      border-left: 4px solid var(--color-surface);
+      padding-left: 0.75rem;
+    }
+    .asset-history-event.is-correction {
+      border-left-color: var(--color-warning);
+    }
+    .asset-history-event.is-superseded {
+      color: var(--color-text-muted);
+    }
+    .asset-history-event h3 {
+      margin-bottom: 0.25rem;
+    }
+    .asset-history-meta,
+    .asset-history-payload {
+      margin: 0.25rem 0 0;
+      color: var(--color-text-muted);
+    }
+    .asset-history-payload {
+      padding-left: 1rem;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="workflow-local-nav" aria-label="Asset history navigation">
+    {% if return_to %}
+      <a class="nav-link" href="{{ return_to }}">Back</a>
+    {% endif %}
+    <a class="nav-link" href="{{ url_for('asset_search', asset_tag=history.asset.asset_tag) }}">Back to Asset Search</a>
+  </nav>
+
+  <section class="card">
+    <h2>Current State</h2>
+    <div class="asset-history-grid">
+      <div><strong>Asset tag:</strong> <code>{{ history.asset.asset_tag }}</code></div>
+      <div><strong>Serial:</strong> {{ history.asset.serial_number or "Not recorded" }}</div>
+      <div><strong>Type:</strong> {{ history.asset.equipment_type_label or "Type not recorded" }}</div>
+      <div><strong>Status:</strong> <span class="state-badge{% if asset_is_terminal(history.asset.location_type) %} terminal{% endif %}">{{ history.asset.state_label }}</span></div>
+      <div>
+        <strong>Holder:</strong>
+        {% if history.holder %}
+          {{ holder_display_name(history.holder) }}
+        {% else %}
+          Not assigned
+        {% endif %}
+      </div>
+      <div><strong>Location:</strong> {{ history.asset.building_room or history.asset.building or "Not recorded" }}</div>
+      <div>
+        <strong>Current slot:</strong>
+        {% if history.current_slot %}
+          {{ history.current_slot.case_name }} / {{ history.current_slot.slot_position }}
+        {% else %}
+          Not currently slotted
+        {% endif %}
+      </div>
+      <div>
+        <strong>Home slot:</strong>
+        {% if history.home_slot %}
+          {{ history.home_slot.case_name }} / {{ history.home_slot.slot_position }}
+        {% else %}
+          Not assigned
+        {% endif %}
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Append-Only Event History ({{ history.events|length }})</h2>
+    {% for event in history.events %}
+      <article class="asset-history-event{% if event.correction_reason or event.supersedes_event_id %} is-correction{% endif %}{% if event.superseded_by_event_id %} is-superseded{% endif %}">
+        <h3>{{ event.event_type }} <code>#{{ event.id }}</code></h3>
+        <p class="asset-history-meta">
+          {{ event.event_date_display or event.event_date or "Date not recorded" }}
+          {% if event.actor %} / Actor: {{ event.actor }}{% endif %}
+          {% if event.holder_name %} / Holder: {{ event.holder_name }}{% if event.holder_organization and event.holder_organization != event.holder_name %} ({{ event.holder_organization }}){% endif %}{% endif %}
+        </p>
+        {% if event.supersedes_event_id %}
+          <p class="asset-history-meta"><strong>Correction:</strong> supersedes event <code>#{{ event.supersedes_event_id }}</code>.</p>
+        {% endif %}
+        {% if event.superseded_by_event_id %}
+          <p class="asset-history-meta"><strong>Superseded by:</strong> event <code>#{{ event.superseded_by_event_id }}</code>.</p>
+        {% endif %}
+        {% if event.correction_reason %}
+          <p class="asset-history-meta"><strong>Reason:</strong> {{ event.correction_reason }}</p>
+        {% endif %}
+        {% if event.notes %}
+          <p class="asset-history-meta"><strong>Notes:</strong> {{ event.notes }}</p>
+        {% endif %}
+        {% if event.receipts %}
+          <p class="asset-history-meta">
+            <strong>Receipts:</strong>
+            {% for receipt in event.receipts %}
+              <a class="nav-link" href="{{ url_for('receipt_detail', receipt_id=receipt.id, return_to=request.full_path.rstrip('?')) }}">{{ receipt.receipt_key or receipt.id }}</a>{% if not loop.last %}, {% endif %}
+            {% endfor %}
+          </p>
+        {% endif %}
+        {% if event.payload_items %}
+          <details>
+            <summary>Recorded facts</summary>
+            <ul class="asset-history-payload">
+              {% for item in event.payload_items %}
+                <li><code>{{ item.key }}</code>: {{ item.value }}</li>
+              {% endfor %}
+            </ul>
+          </details>
+        {% endif %}
+      </article>
+    {% else %}
+      <p class="muted">No events recorded for this asset.</p>
+    {% endfor %}
+  </section>
+{% endblock %}

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -200,6 +200,9 @@
                     <code>{{ asset.asset_tag or "" }}</code>
                   {% endif %}
                   <span>Serial: {{ asset.serial_number or "Not recorded" }}</span>
+                  {% if asset.asset_tag %}
+                    <a class="nav-link" href="{{ url_for('asset_history', asset_tag=asset.asset_tag, return_to=request.full_path.rstrip('?')) }}">History</a>
+                  {% endif %}
                 </div>
               </td>
               <td>

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -41,6 +41,8 @@ class AssetSearchUiTests(unittest.TestCase):
         event_type: str,
         event_date: str,
         payload: dict[str, object] | None = None,
+        holder_id: int | None = None,
+        notes: str | None = None,
         supersedes_event_id: int | None = None,
         correction_reason: str | None = None,
     ) -> int:
@@ -57,13 +59,15 @@ class AssetSearchUiTests(unittest.TestCase):
                 supersedes_event_id,
                 correction_reason
             )
-            VALUES (?, ?, ?, 'system', NULL, ?, NULL, ?, ?);
+            VALUES (?, ?, ?, 'system', ?, ?, ?, ?, ?);
             """,
             (
                 asset_tag,
                 event_type,
                 event_date,
+                notes,
                 json.dumps(payload or {}),
+                holder_id,
                 supersedes_event_id,
                 correction_reason,
             ),
@@ -71,7 +75,14 @@ class AssetSearchUiTests(unittest.TestCase):
         self.conn.commit()
         return int(cursor.lastrowid)
 
-    def _insert_receipt(self, receipt_id: int, receipt_key: str, source_event_ids: list[int]) -> None:
+    def _insert_receipt(
+        self,
+        receipt_id: int,
+        receipt_key: str,
+        source_event_ids: list[int],
+        *,
+        receipt_type: str = "ISSUE",
+    ) -> None:
         self.conn.execute(
             """
             INSERT INTO receipt_queue (
@@ -86,9 +97,9 @@ class AssetSearchUiTests(unittest.TestCase):
                 created_at,
                 updated_at
             )
-            VALUES (?, ?, 'ISSUE', ?, '{}', '2026-04-03T09:20:00+00:00', 1, NULL, '2026-04-03T09:20:00+00:00', '2026-04-03T09:20:00+00:00');
+            VALUES (?, ?, ?, ?, '{}', '2026-04-03T09:20:00+00:00', 1, NULL, '2026-04-03T09:20:00+00:00', '2026-04-03T09:20:00+00:00');
             """,
-            (receipt_id, receipt_key, json.dumps(source_event_ids)),
+            (receipt_id, receipt_key, receipt_type, json.dumps(source_event_ids)),
         )
         self.conn.commit()
 
@@ -167,6 +178,7 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"Problem: holder still assigned", response.data)
         self.assertIn(b"Current state says stored, but a holder is still assigned.", response.data)
         self.assertIn(b"No movement proof recorded", response.data)
+        self.assertIn(b'href="/assets/history?asset_tag=AT-100', response.data)
         self.assertNotIn(b'href="/admin/assets/edit?asset_tag=AT-100"', response.data)
 
     def test_admin_search_links_asset_tag_to_admin_edit_asset(self) -> None:
@@ -430,6 +442,130 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(f"Event #{active_event_id}".encode("utf-8"), response.data)
         self.assertNotIn(f"Event #{superseded_event_id}".encode("utf-8"), response.data)
         self.assertNotIn(f"Event #{correction_event_id}".encode("utf-8"), response.data)
+
+    def test_asset_history_requires_login(self) -> None:
+        anonymous_client = intake_app.app.test_client()
+
+        response = anonymous_client.get("/assets/history?asset_tag=AT-100")
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_asset_history_shows_complete_events_receipts_and_corrections(self) -> None:
+        self._insert_holder(3, "Casey Holder", "Signal")
+        self._insert_slot(41, "CASE-HIST", 1)
+        self._insert_asset(
+            "HIST-LAPTOP",
+            serial_number="SER-HIST-LAPTOP",
+            location_type="STORAGE",
+            home_slot_id=41,
+            current_holder_id=None,
+            equipment_type="laptop",
+        )
+        asset_row = self.conn.execute("SELECT id FROM assets WHERE asset_tag = 'HIST-LAPTOP';").fetchone()
+        self.conn.execute(
+            "INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at) VALUES (41, ?, '2026-04-03T09:00:00+00:00');",
+            (int(asset_row["id"]),),
+        )
+        self.conn.commit()
+        created_event_id = self._insert_event(
+            "HIST-LAPTOP",
+            event_type="ASSET_CREATED",
+            event_date="2026-04-01T08:00:00+00:00",
+            payload={"equipment_type": "laptop"},
+            notes="Initial import",
+        )
+        issue_event_id = self._insert_event(
+            "HIST-LAPTOP",
+            event_type="ISSUE",
+            event_date="2026-04-02T09:00:00+00:00",
+            holder_id=3,
+        )
+        return_event_id = self._insert_event(
+            "HIST-LAPTOP",
+            event_type="RETURN",
+            event_date="2026-04-03T09:00:00+00:00",
+            holder_id=3,
+        )
+        superseded_event_id = self._insert_event(
+            "HIST-LAPTOP",
+            event_type="RETURN",
+            event_date="2026-04-04T09:00:00+00:00",
+        )
+        correction_event_id = self._insert_event(
+            "HIST-LAPTOP",
+            event_type="ASSET_UPDATED",
+            event_date="2026-04-05T09:00:00+00:00",
+            supersedes_event_id=superseded_event_id,
+            correction_reason="Incorrect duplicate return.",
+        )
+        self._insert_receipt(51, "ISSUE:51", [issue_event_id])
+        self._insert_receipt(52, "RETURN:52", [return_event_id], receipt_type="RETURN")
+        before_state = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id FROM assets WHERE asset_tag = 'HIST-LAPTOP';"
+        ).fetchone()
+
+        response = self.client.get("/assets/history?asset_tag=HIST-LAPTOP")
+        after_state = self.conn.execute(
+            "SELECT location_type, current_holder_id, home_slot_id FROM assets WHERE asset_tag = 'HIST-LAPTOP';"
+        ).fetchone()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset History: HIST-LAPTOP", response.data)
+        self.assertIn(b"Type:</strong> Laptop", response.data)
+        self.assertIn(b"Status:</strong>", response.data)
+        self.assertIn(b"In storage", response.data)
+        self.assertIn(b"Holder:</strong>", response.data)
+        self.assertIn(b"Not assigned", response.data)
+        self.assertIn(b"Current slot:</strong>", response.data)
+        self.assertIn(b"CASE-HIST / 1", response.data)
+        self.assertIn(b"Append-Only Event History (5)", response.data)
+        for event_id in [created_event_id, issue_event_id, return_event_id, superseded_event_id, correction_event_id]:
+            self.assertIn(f"#{event_id}".encode("utf-8"), response.data)
+        self.assertLess(response.data.index(f"#{created_event_id}".encode("utf-8")), response.data.index(f"#{issue_event_id}".encode("utf-8")))
+        self.assertLess(response.data.index(f"#{issue_event_id}".encode("utf-8")), response.data.index(f"#{return_event_id}".encode("utf-8")))
+        self.assertIn(b"Initial import", response.data)
+        self.assertIn(b"Casey Holder (Signal)", response.data)
+        self.assertIn(b'href="/receipts/51?return_to=/assets/history?', response.data)
+        self.assertIn(b"ISSUE:51", response.data)
+        self.assertIn(b"RETURN:52", response.data)
+        self.assertIn(b"Correction:</strong> supersedes event", response.data)
+        self.assertIn(b"Superseded by:</strong> event", response.data)
+        self.assertIn(b"Incorrect duplicate return.", response.data)
+        self.assertIn(b"<summary>Recorded facts</summary>", response.data)
+        self.assertNotIn(b"<form", response.data)
+        self.assertEqual(dict(before_state), dict(after_state))
+
+    def test_asset_history_supports_switch_and_router_without_holder(self) -> None:
+        for equipment_type, asset_tag in [("switch", "HIST-SWITCH"), ("router", "HIST-ROUTER")]:
+            with self.subTest(equipment_type=equipment_type):
+                self._insert_asset(
+                    asset_tag,
+                    serial_number=f"SER-{asset_tag}",
+                    location_type="STORAGE",
+                    home_slot_id=None,
+                    equipment_type=equipment_type,
+                )
+                event_id = self._insert_event(
+                    asset_tag,
+                    event_type="SLOT_MOVE",
+                    event_date="2026-04-04T10:15:00+00:00",
+                    payload={
+                        "from_slot": {"case_number": "CASE-OLD", "slot_number": 1},
+                        "to_slot": {"case_number": "CASE-NEW", "slot_number": 2},
+                    },
+                )
+
+                response = self.client.get(f"/assets/history?asset_tag={asset_tag}")
+
+                self.assertEqual(response.status_code, 200)
+                self.assertIn(asset_tag.encode("utf-8"), response.data)
+                self.assertIn(equipment_type.title().encode("utf-8"), response.data)
+                self.assertIn(b"Holder:</strong>", response.data)
+                self.assertIn(b"Not assigned", response.data)
+                self.assertIn(b"SLOT_MOVE", response.data)
+                self.assertIn(f"#{event_id}".encode("utf-8"), response.data)
+                self.assertIn(b"CASE-OLD", response.data)
+                self.assertIn(b"CASE-NEW", response.data)
 
     def test_partial_asset_tag_search_returns_matching_assets(self) -> None:
         self._insert_holder(1, "Alex Holder", "Field Ops")


### PR DESCRIPTION
PR Title: Issue 29-11: Add read-only asset history

## Summary

Add a minimal read-only per-asset history page after repository review showed that existing proof surfaces did not provide complete per-asset chronology in one operator-readable place.

## Related Issue

Closes #953

## Changes

- Added protected `/assets/history?asset_tag=...` route.
- Added a read-only asset history page showing current asset state and full append-only event history.
- Added History links from Asset Search results.
- Added receipt links for events with associated receipt records.
- Kept corrections and superseded events visible.
- Added focused coverage for Laptop, Switch, Router, receipts, corrections, read-only behavior, and current-state preservation.

## Verification

- [x] `./.venv/bin/python -m pytest tests/test_asset_search_ui.py -q` - 25 passed, 2 subtests passed
- [x] `./.venv/bin/python -m pytest tests/test_receipt_detail.py tests/test_receipts_list.py -q` - 71 passed
- [x] `./.venv/bin/python -m pytest tests/test_admin_system_health.py -q` - 53 passed
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] New template whitespace check
- [x] `docker compose up -d --build`
- [x] Fresh-cookie running-app smoke for Asset Search -> History -> Receipt detail
- [x] Manual incognito browser smoke on a Laptop asset
- [ ] Manual Switch browser smoke not performed because no Switch records exist
- [ ] Manual Router browser smoke not performed because no Router records exist

## Notes

- No event editing or deletion was added.
- No schema, persistence, custody, receipt, role, dependency, dashboard, report redesign, or CMDB behavior changed.
- Switch and Router history behavior is covered by focused automated tests.
- Manual browser verification was completed with an available Laptop record.