### PR TITLE
Issue 29-15: define local admin recovery procedure

### DIFF
--- a/docs/security/local-admin-account-recovery.md
+++ b/docs/security/local-admin-account-recovery.md
@@ -1,0 +1,101 @@
+# Local Admin Account Recovery
+
+Issue: 29-15
+
+Classification: Class 4 - Security / Authentication
+
+This policy defines the approved local-only procedure for restoring access to
+an existing primary AssetTrack admin account when that account is inactive or
+its password is unavailable.
+
+## Security boundary
+
+This is not a web password recovery feature.
+
+Do not add:
+
+- a public recovery route
+- a hidden admin account
+- a hard-coded password
+- a role-promotion path
+- a stored password hash display
+- a cloud or external identity dependency
+
+The executable recovery artifact is not stored in this repository. The
+authorized system owner stores it separately and runs it locally only when
+needed.
+
+## Approved recovery behavior
+
+The local recovery procedure may:
+
+- target an explicitly named existing account, normally `admin`
+- verify the account exists
+- verify the account already has the `admin` role
+- reactivate that admin account when inactive
+- reset its password through AssetTrack's existing temporary-password behavior
+- print the generated temporary password once
+- require the normal forced password-change flow on next login
+
+The procedure must fail safely when:
+
+- the named account does not exist
+- the named account is not already an admin
+- database access fails
+- any assumption is not met
+
+The procedure must not create, modify, or delete custody events, audit history,
+assets, holders, receipts, slots, or operational data.
+
+## Why this is needed
+
+AssetTrack already protects against disabling or demoting the last active
+admin. That guard works as designed.
+
+The observed lockout condition came from active smoke-test admin accounts that
+remained in the development database. Because more than one active admin
+existed, the primary `admin` account could be disabled without triggering the
+last-active-admin safeguard. The operator then did not know the generated
+passwords for those remaining smoke-test admin accounts.
+
+Root cause: admin access still existed in the database, but no known local
+credential was available to use it.
+
+## Procedure
+
+1. Work on the local machine that owns the AssetTrack deployment.
+2. Stop public access to the app if the machine is reachable by others.
+3. Confirm the target username, normally `admin`.
+4. Run the separately stored recovery script against the existing Docker
+   deployment.
+5. Confirm the script reports the target account exists and is already an
+   admin.
+6. Copy the printed temporary password immediately. It is shown once.
+7. Log in as the target admin with the temporary password.
+8. Complete the forced password-change flow.
+9. Store the new password through the approved local channel.
+10. Resume normal operation.
+
+## Expected result
+
+- the target admin account is active
+- the old password no longer works
+- the temporary password works only until changed
+- the admin is forced to change password before normal app use
+- normal role enforcement remains active
+- no custody, receipt, event, audit, schema, or persistence behavior changes
+
+## Smoke-test admin cleanup follow-up
+
+Do not fold smoke-test account cleanup into account recovery.
+
+Recommended separate issue: define a development-database cleanup procedure for
+manual smoke-test admin accounts.
+
+Smallest safe scope:
+
+- inventory known smoke-test admin usernames in local development data
+- confirm they are not operational accounts
+- disable or remove only approved development-only accounts
+- preserve at least one known active admin
+- document when cleanup is safe to run

--- a/tests/test_local_admin_account_recovery_policy.py
+++ b/tests/test_local_admin_account_recovery_policy.py
@@ -1,0 +1,110 @@
+# file: tests/test_local_admin_account_recovery_policy.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from assettrack.users import (
+    change_own_password,
+    get_user_by_id,
+    get_user_by_username,
+    is_temporary_password,
+    reset_user_password,
+    set_user_active,
+    verify_password,
+)
+from tests.auth_test_utils import create_test_user
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.ADMIN_ROUTE_ATTEMPTS.clear()
+    intake_app.LOGIN_FAILURE_ATTEMPTS.clear()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _recover_existing_admin_account(username: str) -> dict[str, object]:
+    user = get_user_by_username(username)
+    if user is None:
+        raise ValueError("Target account does not exist.")
+    if str(user.get("role") or "").strip().lower() != "admin":
+        raise ValueError("Target account is not an admin.")
+
+    if int(user.get("active") or 0) != 1:
+        user = set_user_active(int(user["id"]), True)
+
+    reset_result = reset_user_password(int(user["id"]))
+    updated = reset_result["user"]
+    return {
+        "user": updated,
+        "temporary_password": reset_result["temporary_password"],
+    }
+
+
+def test_local_admin_recovery_rejects_missing_account(client_with_temp_db) -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        _recover_existing_admin_account("admin")
+
+
+def test_local_admin_recovery_rejects_non_admin_account(client_with_temp_db) -> None:
+    create_test_user(username="operator-a", password="op-pass", role="operator")
+
+    with pytest.raises(ValueError, match="not an admin"):
+        _recover_existing_admin_account("operator-a")
+
+
+def test_local_admin_recovery_reactivates_existing_admin_and_forces_password_change(client_with_temp_db) -> None:
+    admin_user_id = create_test_user(username="admin", password="old-admin-pass", role="admin", active=False)
+    create_test_user(username="smoke-admin", password="unknown-smoke-pass", role="admin", active=True)
+
+    conn = db.get_connection()
+    try:
+        before_events = int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0])
+        before_receipts = int(conn.execute("SELECT COUNT(*) FROM receipt_queue;").fetchone()[0])
+    finally:
+        conn.close()
+
+    result = _recover_existing_admin_account("admin")
+
+    recovered = get_user_by_id(admin_user_id)
+    assert recovered is not None
+    assert result["user"]["id"] == admin_user_id
+    assert recovered["role"] == "admin"
+    assert int(recovered["active"]) == 1
+    assert is_temporary_password(recovered)
+    assert not verify_password(recovered, "old-admin-pass")
+
+    temporary_password = str(result["temporary_password"])
+    assert temporary_password
+    assert temporary_password not in str(recovered["password_hash"])
+    assert verify_password(recovered, temporary_password)
+
+    conn = db.get_connection()
+    try:
+        after_events = int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0])
+        after_receipts = int(conn.execute("SELECT COUNT(*) FROM receipt_queue;").fetchone()[0])
+    finally:
+        conn.close()
+    assert after_events == before_events
+    assert after_receipts == before_receipts
+
+    login_response = client_with_temp_db.post("/", data={"username": "admin", "password": temporary_password})
+    assert login_response.status_code == 302
+
+    blocked_dashboard = client_with_temp_db.get("/dashboard")
+    assert blocked_dashboard.status_code == 302
+    assert (blocked_dashboard.headers.get("Location") or "").endswith("/account/change-password")
+
+    change_own_password(admin_user_id, temporary_password, "RecoveredAdmin123")
+    changed = get_user_by_id(admin_user_id)
+    assert changed is not None
+    assert not is_temporary_password(changed)
+    assert verify_password(changed, "RecoveredAdmin123")
+    assert not verify_password(changed, temporary_password)


### PR DESCRIPTION
PR Title: Issue 29-15: Define local admin recovery procedure

## Summary

Define and verify a safe local-only recovery procedure for restoring access to an existing AssetTrack admin account.

The recovery process uses existing AssetTrack user-management functions, preserves the forced temporary-password change flow, and does not create a permanent authentication bypass.

## Related Issue

Closes #969

## Changes

* Added a security runbook for local admin account recovery.
* Documented that the executable recovery script is stored separately by the authorized system owner and is not committed to the repository.
* Documented the root cause of the primary admin lockout risk: accumulated active smoke-test admin accounts meant the primary `admin` account was not the last active admin.
* Added focused tests covering:

  * missing-account rejection
  * non-admin rejection
  * inactive admin reactivation
  * temporary-password reset behavior
  * forced password-change preservation
  * event and receipt non-modification

## Verification

* [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_local_admin_account_recovery_policy.py -q` - 3 passed
* [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_admin_user_management.py -q` - 16 passed
* [x] `bash .codex/skills/assettrack-test-runner/run_tests.sh tests/test_basic_auth_guard.py -q` - 36 passed
* [x] `python3 -m compileall assettrack tests`
* [x] `git diff --check`
* [x] No-index whitespace checks for the two new files
* [x] Read-only development database inventory confirmed accumulated active smoke/development admin accounts
* [x] Recovery behavior exercised against isolated temporary test databases
* [ ] Standalone recovery script not run against the current development or operational database
* [ ] Full pytest suite not run

## Notes

* Class 4 Security / Authentication implementation was explicitly approved.
* No executable recovery script was committed to the repository.
* No normal authentication behavior changed.
* No route, web recovery endpoint, role bypass, schema, persistence, custody, receipt, event, audit, dependency, or infrastructure changes were introduced.
* The real end-to-end recovery smoke test will be performed later on the standalone operational computer during Issue 29-13.
* Smoke-test admin cleanup should be handled as a separate narrowly scoped issue.
