### PR TITLE
Issue 29-20: Initialize Docker data permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR /app
 # Keep base OS packages patched (pulls fixed libpng, etc.)
 RUN apk update && apk upgrade --no-cache
 
-RUN addgroup -S assettrack && adduser -S -G assettrack -h /app assettrack
+RUN addgroup -S -g 101 assettrack \
+    && adduser -S -u 100 -G assettrack -h /app assettrack
 
 # System deps for common scientific + imaging stacks
 RUN apk add --no-cache --upgrade \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,15 @@ cd AssetTrack
 ./scripts/bootstrap_docker.sh
 ```
 
-The bootstrap script creates the host `./data` directory if it is missing, applies first-run write permissions for the non-root container user, and then runs `docker compose up -d --build`.
+The bootstrap script delegates startup and persistent data initialization to Docker Compose.
+
+Docker Compose also supports the direct startup command:
+
+```bash
+docker compose up -d --build
+```
+
+On a fresh clone with no `./data` directory, Compose may create the host bind-mount directory as root-owned. AssetTrack handles that with a one-shot `assettrack-data-init` service that runs before the web app, sets `/app/data` to UID `100` and GID `101`, and uses directory mode `0750`. The final `assettrack` web service still runs as the non-root `assettrack` user.
 
 On a first run with no database file, AssetTrack initializes the approved SQLite schema automatically in the mounted `/app/data/assettrack.db` path before the web app starts.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,21 @@
 # assettrack/docker-compose.yml
 services:
+  assettrack-data-init:
+    build: .
+    user: "0:0"
+    command:
+      - sh
+      - -c
+      - mkdir -p /app/data && chown 100:101 /app/data && chmod 0750 /app/data
+    volumes:
+      - ./data:/app/data
+    restart: "no"
+
   assettrack:
     build: .
+    depends_on:
+      assettrack-data-init:
+        condition: service_completed_successfully
     ports:
       - "8000:8000"
     environment:

--- a/docs/docker-data-persistence.md
+++ b/docs/docker-data-persistence.md
@@ -57,7 +57,15 @@ Use the repo-managed bootstrap from the repository root:
 ./scripts/bootstrap_docker.sh
 ```
 
-That script creates `./data` if it is missing, applies first-run write permissions, and then starts Docker Compose with the existing `./data:/app/data` bind mount.
+Or run Docker Compose directly:
+
+```bash
+docker compose up -d --build
+```
+
+On a fresh clone, Docker Compose may create the missing host `./data` bind-mount directory as `root:root`. AssetTrack corrects that during startup with the `assettrack-data-init` service. That service runs as root only long enough to initialize `/app/data` with owner UID `100`, group GID `101`, and mode `0750`; the final web application service still runs as the non-root `assettrack` user.
+
+The bootstrap script does not apply host-side permission repair. It delegates startup and persistent directory initialization to Docker Compose.
 
 ## How to verify it’s working
 

--- a/docs/release/deployment.md
+++ b/docs/release/deployment.md
@@ -31,14 +31,27 @@ From the repository root, run:
 ./scripts/bootstrap_docker.sh
 ```
 
+Equivalent direct Docker Compose command:
+
+```bash
+docker compose up -d --build
+```
+
 What this does:
 
 1. Builds the AssetTrack Docker image.
 2. Ensures the host `./data` bind-mount directory exists.
-3. Applies first-run write permissions so the non-root container can create SQLite files.
+3. Runs a one-shot `assettrack-data-init` service that initializes `/app/data` for the non-root AssetTrack user.
 4. Starts the AssetTrack container in the background.
 5. Exposes the application on port `8000`.
 6. On first run, initializes the approved SQLite schema in `/app/data/assettrack.db` if the database file is missing or empty.
+
+Persistent data permissions:
+
+- Docker may create a missing host `./data` directory as `root:root`.
+- The init service sets the mounted `/app/data` directory to UID `100`, GID `101`, and mode `0750`.
+- The final AssetTrack web application process runs as the non-root `assettrack` user.
+- Do not use `chmod 777` or manual host `chown` as part of normal deployment.
 
 After startup, open:
 

--- a/docs/release/troubleshooting.md
+++ b/docs/release/troubleshooting.md
@@ -31,6 +31,25 @@ What to do:
 2. Wait until Docker reports that it is ready.
 3. Re-run `./scripts/bootstrap_docker.sh`.
 
+## Fresh Docker start cannot open SQLite database
+
+Symptom:
+
+- The container restarts repeatedly on a fresh clone.
+- Logs show `sqlite3.OperationalError: unable to open database file`.
+
+What to check:
+
+1. Start with the supported command: `docker compose up -d --build`.
+2. Confirm the one-shot `assettrack-data-init` service completed successfully with `docker compose ps -a`.
+3. Confirm the `assettrack` service is running as the non-root `assettrack` user.
+
+Why this works:
+
+- Docker may create a missing bind-mounted `./data` directory as `root:root`.
+- AssetTrack initializes that mounted directory to UID `100`, GID `101`, and mode `0750` before the web app starts.
+- Manual `chmod 777` or manual `chown 100:101 data` is not part of the documented startup path.
+
 ## Login failure
 
 Symptom:

--- a/scripts/bootstrap_docker.sh
+++ b/scripts/bootstrap_docker.sh
@@ -5,16 +5,7 @@ cd "$(dirname "$0")/.."
 
 DATA_DIR="data"
 
-echo "Ensuring ${DATA_DIR}/ exists for Docker bind mount..."
-mkdir -p "$DATA_DIR"
-
-echo "Setting ${DATA_DIR}/ permissions for first-run SQLite creation..."
-chmod 0777 "$DATA_DIR"
-
-if [ ! -w "$DATA_DIR" ]; then
-    echo "AssetTrack bootstrap failed: ${DATA_DIR}/ is not writable." >&2
-    exit 1
-fi
-
 echo "Starting AssetTrack with Docker Compose..."
+echo "Docker Compose will initialize ${DATA_DIR}/ ownership for the non-root AssetTrack user."
+
 exec docker compose up -d --build

--- a/tests/test_bootstrap_docker_script.py
+++ b/tests/test_bootstrap_docker_script.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import os
 import shutil
-import stat
 import subprocess
 from pathlib import Path
 
 
-def test_bootstrap_docker_script_prepares_data_dir_and_starts_compose(tmp_path: Path) -> None:
+def test_bootstrap_docker_script_starts_compose_without_host_permission_repair(tmp_path: Path) -> None:
     repo_root = tmp_path / "repo"
     scripts_dir = repo_root / "scripts"
     scripts_dir.mkdir(parents=True)
@@ -38,6 +37,14 @@ def test_bootstrap_docker_script_prepares_data_dir_and_starts_compose(tmp_path: 
     )
 
     data_dir = repo_root / "data"
-    assert data_dir.is_dir()
-    assert stat.S_IMODE(data_dir.stat().st_mode) == 0o777
+    assert not data_dir.exists()
     assert docker_args_path.read_text(encoding="utf-8").splitlines() == ["compose", "up", "-d", "--build"]
+
+
+def test_bootstrap_docker_script_does_not_apply_world_writable_permissions() -> None:
+    source_script = Path(__file__).resolve().parents[1] / "scripts" / "bootstrap_docker.sh"
+
+    script_text = source_script.read_text(encoding="utf-8")
+
+    assert "chmod 0777" not in script_text
+    assert "chmod 777" not in script_text

--- a/tests/test_docker_data_permissions.py
+++ b/tests/test_docker_data_permissions.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_dockerfile_pins_assettrack_runtime_user_ids() -> None:
+    dockerfile = (REPO_ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "addgroup -S -g 101 assettrack" in dockerfile
+    assert "adduser -S -u 100 -G assettrack" in dockerfile
+    assert "USER assettrack" in dockerfile
+
+
+def test_compose_initializes_bind_mount_before_non_root_app_start() -> None:
+    compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    assert "assettrack-data-init:" in compose
+    assert 'user: "0:0"' in compose
+    assert "chown 100:101 /app/data" in compose
+    assert "chmod 0750 /app/data" in compose
+    assert "condition: service_completed_successfully" in compose
+    assert "- ./data:/app/data" in compose
+
+
+def test_compose_does_not_make_persistent_data_world_writable() -> None:
+    compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
+
+    assert "chmod 0777" not in compose
+    assert "chmod 777" not in compose


### PR DESCRIPTION
Issue 29-20: Fix fresh Docker data directory initialization

## Summary

Fix fresh Docker deployments where a missing `data/` bind mount could prevent the non-root AssetTrack process from creating its SQLite database.

AssetTrack now initializes the persistent data directory before the application starts while keeping the final application process non-root.

## Related Issue

Closes #977

## Changes

- Pin the Docker `assettrack` user and group to UID `100` and GID `101`.
- Add a one-shot `assettrack-data-init` Compose service.
- Initialize `/app/data` with ownership `100:101` and mode `0750`.
- Keep the AssetTrack application running as the non-root `assettrack` user.
- Remove the previous bootstrap-script `chmod 0777` behavior.
- Update Docker deployment, persistence, and troubleshooting documentation.
- Add focused tests for Docker data-directory permissions and bootstrap behavior.

## Verification

- [x] Focused Docker permission tests passed: `5 passed`
- [x] Python compilation passed for `assettrack` and `tests`
- [x] `git diff --check` passed
- [x] Clean deployment started with no existing `data/` directory
- [x] `assettrack-data-init` exited successfully
- [x] AssetTrack created `data/assettrack.db`
- [x] Application container reached healthy status
- [x] Runtime user verified as `uid=100(assettrack) gid=101(assettrack)`
- [x] `/app/data` verified as `100:101` with mode `0750`
- [x] SQLite database verified as `100:101` with mode `0644`
- [x] Local `/bootstrap/admin` was available before administrator creation
- [x] Local administrator creation succeeded
- [x] Forced password change succeeded
- [x] Local administrator login and Dashboard access succeeded
- [x] `/bootstrap/admin` returned `403` after administrator creation
- [x] Container restart completed successfully
- [x] Administrator login and database persisted after restart
- [x] Manual verification used an incognito browser at `localhost:8000`

## Notes

On macOS Docker Desktop, host-side ownership may display the macOS file-sharing UID and GID. Inside the Linux container, the persistent directory is correctly owned by UID `100` and GID `101`.

No schema, event-history, custody, authentication, receipt, email, or unrelated application behavior changed. No dependency was added.