### PR TITLE
Issue 29-17: Add printable case inventory report

### DIFF
--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -281,3 +281,59 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
             for row in return_candidate_rows
         ],
     }
+
+
+def get_case_inventory(conn: sqlite3.Connection, case_name: str) -> dict | None:
+    requested_case = str(case_name or "").strip()
+    if not requested_case:
+        return None
+
+    case_row = conn.execute(
+        """
+        SELECT case_name
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+        ORDER BY case_name COLLATE NOCASE ASC
+        LIMIT 1;
+        """,
+        (requested_case,),
+    ).fetchone()
+    if case_row is None:
+        return None
+
+    canonical_case_name = str(case_row["case_name"])
+    rows = conn.execute(
+        """
+        SELECT
+            s.slot_position,
+            a.asset_tag,
+            a.equipment_type,
+            a.manufacturer,
+            a.model
+        FROM slots s
+        JOIN slot_occupancy so
+          ON so.slot_id = s.id
+        JOIN assets a
+          ON a.id = so.asset_id
+        WHERE UPPER(s.case_name) = UPPER(?)
+        ORDER BY s.slot_position ASC, UPPER(a.asset_tag) ASC, a.id ASC;
+        """,
+        (canonical_case_name,),
+    ).fetchall()
+
+    assets = [
+        {
+            "asset_tag": str(row["asset_tag"] or ""),
+            "equipment_type": str(row["equipment_type"] or ""),
+            "manufacturer": str(row["manufacturer"] or ""),
+            "model": str(row["model"] or ""),
+            "slot_position": int(row["slot_position"]),
+        }
+        for row in rows
+    ]
+
+    return {
+        "case_name": canonical_case_name,
+        "asset_count": len(assets),
+        "assets": assets,
+    }

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -48,6 +48,7 @@ from assettrack.assets import (
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import bootstrap_db, get_connection
 from assettrack.drilldowns import (
+    get_case_inventory,
     get_case_slot_detail,
     get_holder_custody_detail,
     list_case_summaries,
@@ -249,6 +250,7 @@ def inject_auth_user():
         "case_status_summary": _case_status_summary,
         "asset_state_label": _asset_state_label,
         "asset_is_terminal": _is_terminal_location_type,
+        "equipment_type_label": equipment_type_label,
         "holder_display_name": _holder_display_name,
         "holder_display_type": _holder_display_type,
         "format_duration_label": _format_duration_label,
@@ -7897,6 +7899,85 @@ def _build_admin_human_report_pdf(report_data: dict, db_path: str) -> bytes:
     return buffer.getvalue()
 
 
+def _case_inventory_case_options(conn: sqlite3.Connection) -> list[str]:
+    return [str(row["case_name"]) for row in list_case_summaries(conn)]
+
+
+def _selected_case_inventory_name() -> str:
+    typed_case = str(request.args.get("case_name") or "").strip()
+    selected_case = str(request.args.get("case_select") or "").strip()
+    return typed_case or selected_case
+
+
+def _build_case_inventory_pdf(inventory: dict, generated_at: datetime) -> bytes:
+    styles = getSampleStyleSheet()
+    body = styles["BodyText"]
+    title = styles["Title"]
+    heading = styles["Heading2"]
+
+    def _p(value: object) -> Paragraph:
+        text = str(value or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        return Paragraph(text, body)
+
+    data = [[Paragraph(f"<b>{header}</b>", body) for header in ["Asset Tag", "Type", "Description / Model", "Slot"]]]
+    for asset in inventory["assets"]:
+        make_model = str(asset["manufacturer"] or "")
+        model = str(asset["model"] or "")
+        if model:
+            make_model = f"{make_model} / {model}" if make_model else model
+        data.append(
+            [
+                _p(asset["asset_tag"]),
+                _p(equipment_type_label(asset["equipment_type"])),
+                _p(make_model),
+                _p(f"Slot {asset['slot_position']}"),
+            ]
+        )
+    if not inventory["assets"]:
+        data.append([_p("No assets currently in this case."), _p(""), _p(""), _p("")])
+
+    table = Table(
+        data,
+        colWidths=[1.25 * inch, 1.0 * inch, 3.3 * inch, 1.0 * inch],
+        repeatRows=1,
+    )
+    table.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#dbe7f3")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#c8d2dc")),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 5),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 5),
+            ]
+        )
+    )
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=letter,
+        leftMargin=0.5 * inch,
+        rightMargin=0.5 * inch,
+        topMargin=0.5 * inch,
+        bottomMargin=0.5 * inch,
+    )
+    story: list[object] = [
+        Paragraph("Case Inventory", title),
+        Spacer(1, 0.15 * inch),
+        Paragraph(f"Case number: {inventory['case_name']}", heading),
+        Paragraph(f"Generated: {generated_at.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}", body),
+        Paragraph(f"Asset count: {inventory['asset_count']}", body),
+        Spacer(1, 0.15 * inch),
+        table,
+    ]
+    doc.build(story)
+    return buffer.getvalue()
+
+
 @app.route("/admin/reference-data", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
@@ -8130,6 +8211,83 @@ def human_report():
         report_error=report_error,
         include_retired_assets=include_retired_assets,
         **report_data,
+    )
+
+
+@app.get("/report/case-inventory")
+@require_login
+def case_inventory():
+    conn = get_connection()
+    try:
+        case_options = _case_inventory_case_options(conn)
+    finally:
+        conn.close()
+
+    return render_template(
+        "case_inventory.html",
+        case_options=case_options,
+        selected_case="",
+        inventory=None,
+        generated_at=None,
+        not_found_case="",
+    )
+
+
+@app.get("/report/case-inventory/preview")
+@require_login
+def case_inventory_preview():
+    selected_case = _selected_case_inventory_name()
+    if not selected_case:
+        return redirect(url_for("case_inventory"))
+
+    generated_at = datetime.now(timezone.utc)
+    conn = get_connection()
+    try:
+        case_options = _case_inventory_case_options(conn)
+        inventory = get_case_inventory(conn, selected_case)
+    finally:
+        conn.close()
+
+    status_code = 200 if inventory is not None else 404
+    return (
+        render_template(
+            "case_inventory.html",
+            case_options=case_options,
+            selected_case=selected_case,
+            inventory=inventory,
+            generated_at=generated_at,
+            not_found_case="" if inventory is not None else selected_case,
+        ),
+        status_code,
+    )
+
+
+@app.get("/report/case-inventory/pdf")
+@require_login
+def case_inventory_pdf():
+    selected_case = _selected_case_inventory_name()
+    if not selected_case:
+        abort(404)
+
+    generated_at = datetime.now(timezone.utc)
+    conn = get_connection()
+    try:
+        inventory = get_case_inventory(conn, selected_case)
+    finally:
+        conn.close()
+
+    if inventory is None:
+        abort(404)
+
+    pdf_bytes = _build_case_inventory_pdf(inventory, generated_at)
+    filename_case = re.sub(r"[^A-Za-z0-9_-]+", "-", str(inventory["case_name"])).strip("-") or "case"
+    download_name = f"assettrack-case-inventory-{filename_case}-{generated_at.strftime('%Y%m%d-%H%M%S')}.pdf"
+    return send_file(
+        BytesIO(pdf_bytes),
+        as_attachment=True,
+        download_name=download_name,
+        mimetype="application/pdf",
+        conditional=False,
     )
 
 

--- a/assettrack/intake/templates/case_inventory.html
+++ b/assettrack/intake/templates/case_inventory.html
@@ -1,0 +1,133 @@
+<!-- file: assettrack/intake/templates/case_inventory.html -->
+{% extends "base.html" %}
+
+{% block title %}Case Inventory{% endblock %}
+{% block page_heading %}Case Inventory{% endblock %}
+{% block page_class %} page-wide{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .case-inventory-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-top: 1rem;
+    }
+    .case-inventory-form {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+      gap: 0.75rem;
+      align-items: end;
+      margin-top: 0.75rem;
+    }
+    .case-inventory-meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+      gap: 0.65rem;
+      margin: 0.75rem 0 1rem;
+    }
+    .case-inventory-meta div {
+      padding: 0.65rem 0.75rem;
+      border: 1px solid var(--color-border);
+      border-radius: 6px;
+      background: var(--color-surface-muted);
+    }
+    @media print {
+      .page-tools,
+      .top-nav,
+      .case-inventory-entry,
+      .case-inventory-actions {
+        display: none !important;
+      }
+      .page,
+      .card {
+        width: auto;
+        max-width: none;
+        box-shadow: none;
+      }
+      table {
+        page-break-inside: auto;
+      }
+      tr {
+        page-break-inside: avoid;
+        page-break-after: auto;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="actions" aria-label="Contextual navigation">
+    <a class="nav-link" href="{{ url_for('human_report') }}">Back to Reports</a>
+    <a class="nav-link" href="{{ url_for('dashboard_cases') }}">Case Status</a>
+  </nav>
+
+  <section class="card case-inventory-entry">
+    <h2>Select Case</h2>
+    <form method="get" action="{{ url_for('case_inventory_preview') }}" class="case-inventory-form">
+      <div>
+        <label for="case-select"><strong>Choose case</strong></label><br />
+        <select id="case-select" name="case_select">
+          <option value="">Select a case</option>
+          {% for case_name in case_options %}
+            <option value="{{ case_name }}" {% if selected_case and selected_case|upper == case_name|upper %}selected{% endif %}>{{ case_name }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label for="case-name"><strong>Enter case number</strong></label><br />
+        <input id="case-name" name="case_name" type="text" value="" placeholder="CASE-12" />
+      </div>
+      <div>
+        <button type="submit">Preview Inventory</button>
+      </div>
+    </form>
+  </section>
+
+  {% if not_found_case %}
+    <section class="card">
+      <h2>Case Not Found</h2>
+      <p>No case exists for <code>{{ not_found_case }}</code>.</p>
+    </section>
+  {% endif %}
+
+  {% if inventory %}
+    <section class="card">
+      <h2>Preview</h2>
+      <div class="case-inventory-meta">
+        <div><strong>Case number:</strong><br />{{ inventory.case_name }}</div>
+        <div><strong>Generated:</strong><br />{{ generated_at.strftime('%Y-%m-%d %H:%M:%S UTC') }}</div>
+        <div><strong>Asset count:</strong><br />{{ inventory.asset_count }}</div>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            <th>Asset Tag</th>
+            <th>Type</th>
+            <th>Description / Model</th>
+            <th>Slot</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for asset in inventory.assets %}
+            <tr>
+              <td><code>{{ asset.asset_tag }}</code></td>
+              <td>{{ equipment_type_label(asset.equipment_type) }}</td>
+              <td>{{ asset.manufacturer }}{% if asset.model %} / {{ asset.model }}{% endif %}</td>
+              <td>Slot {{ asset.slot_position }}</td>
+            </tr>
+          {% else %}
+            <tr>
+              <td colspan="4">No assets currently in this case.</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <div class="case-inventory-actions" aria-label="Case inventory actions">
+        <button type="button" onclick="window.print()">Print</button>
+        <a class="nav-link" href="{{ url_for('case_inventory_pdf', case_name=inventory.case_name) }}">Download PDF</a>
+      </div>
+    </section>
+  {% endif %}
+{% endblock %}

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -64,6 +64,7 @@
         <a class="nav-link" href="{{ return_to }}">Back to Report</a>
       {% endif %}
       <a class="nav-link" href="{{ url_for('dashboard_cases', return_to=return_to) }}">Back to Cases</a>
+      <a class="nav-link" href="{{ url_for('case_inventory_preview', case_select=case_detail.case_name) }}">Printable Inventory</a>
     </nav>
   </div>
 

--- a/assettrack/intake/templates/dashboard_cases.html
+++ b/assettrack/intake/templates/dashboard_cases.html
@@ -40,6 +40,9 @@
 
   <section class="card">
     <h2>Case Summary</h2>
+    <div class="actions" aria-label="Case report actions">
+      <a class="nav-link" href="{{ url_for('case_inventory') }}">Printable case inventory</a>
+    </div>
     <form method="get" action="{{ url_for('dashboard_cases') }}" class="row" style="margin: 0.5rem 0 1rem; gap: 0.75rem; align-items: flex-start;">
       <div>
         <label for="case-filter-query" class="sr-only">Case name filter</label>

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -63,6 +63,7 @@
     </div>
     <div class="report-actions report-utility-links" aria-label="Report utilities">
       <span class="report-utility-label">Report utilities</span>
+      <a class="nav-link" href="{{ url_for('case_inventory') }}">Case inventory</a>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Search receipts</a>
       {% if include_retired_assets %}
         <a class="nav-link" href="{{ url_for('human_report') }}">View active inventory only</a>

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
 
 import pytest
+from pypdf import PdfReader
 
 import assettrack.db as db
 from assettrack.drilldowns import (
@@ -120,6 +122,11 @@ def _occupy_slot(conn, slot_id: int, asset_id: int) -> None:
 
 def _count_rows(conn, table_name: str) -> int:
     return int(conn.execute(f"SELECT COUNT(*) AS c FROM {table_name};").fetchone()["c"])
+
+
+def _extract_pdf_text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
 
 
 def test_dashboard_holders_route_returns_200_and_is_read_only(app_client) -> None:
@@ -256,6 +263,176 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
     assert b"AT-SLOTTED" in response.data
     assert b"AT-OUT" in response.data
     assert b"Empty" in response.data
+
+
+def test_case_inventory_preview_supports_mixed_case_and_is_read_only(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 101, "CASE-PRINT", 1)
+    _insert_slot(conn, 102, "CASE-PRINT", 2)
+    _insert_slot(conn, 103, "CASE-PRINT", 3)
+    laptop_id = _insert_asset(
+        conn,
+        "LAP-100",
+        location_type="STORAGE",
+        equipment_type="laptop",
+        manufacturer="Dell",
+        model="Latitude",
+    )
+    switch_id = _insert_asset(
+        conn,
+        "SW-100",
+        location_type="STORAGE",
+        equipment_type="switch",
+        manufacturer="Cisco",
+        model="Catalyst",
+    )
+    router_id = _insert_asset(
+        conn,
+        "RTR-100",
+        location_type="STORAGE",
+        equipment_type="router",
+        manufacturer="Juniper",
+        model="MX",
+    )
+    _occupy_slot(conn, 101, laptop_id)
+    _occupy_slot(conn, 102, switch_id)
+    _occupy_slot(conn, 103, router_id)
+    conn.commit()
+
+    counts_before = (
+        _count_rows(conn, "assets"),
+        _count_rows(conn, "asset_events"),
+        _count_rows(conn, "slot_occupancy"),
+    )
+
+    response = client.get("/report/case-inventory/preview?case_select=CASE-PRINT")
+
+    counts_after = (
+        _count_rows(conn, "assets"),
+        _count_rows(conn, "asset_events"),
+        _count_rows(conn, "slot_occupancy"),
+    )
+    assert response.status_code == 200
+    assert b"Case Inventory" in response.data
+    assert b"Case number:</strong><br />CASE-PRINT" in response.data
+    assert b"Asset count:</strong><br />3" in response.data
+    assert b"LAP-100" in response.data
+    assert b"SW-100" in response.data
+    assert b"RTR-100" in response.data
+    assert b"Laptop" in response.data
+    assert b"Switch" in response.data
+    assert b"Router" in response.data
+    assert b"Dell / Latitude" in response.data
+    assert b"Cisco / Catalyst" in response.data
+    assert b"Juniper / MX" in response.data
+    assert b"Slot 1" in response.data
+    assert b"Download PDF" in response.data
+    assert counts_before == counts_after
+
+
+def test_case_inventory_entry_supports_empty_and_invalid_cases(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 110, "CASE-EMPTY", 1)
+    conn.commit()
+
+    entry_response = client.get("/report/case-inventory")
+    assert entry_response.status_code == 200
+    assert b"Preview Inventory" in entry_response.data
+    assert b"CASE-EMPTY" in entry_response.data
+
+    empty_response = client.get("/report/case-inventory/preview?case_name=case-empty")
+    assert empty_response.status_code == 200
+    assert b"Case number:</strong><br />CASE-EMPTY" in empty_response.data
+    assert b"Asset count:</strong><br />0" in empty_response.data
+    assert b"No assets currently in this case." in empty_response.data
+
+    invalid_response = client.get("/report/case-inventory/preview?case_name=CASE-MISSING")
+    assert invalid_response.status_code == 404
+    assert b"Case Not Found" in invalid_response.data
+    assert b"CASE-MISSING" in invalid_response.data
+
+
+def test_case_inventory_routes_require_login(app_client) -> None:
+    _, client = app_client
+    with client.session_transaction() as sess:
+        sess.clear()
+
+    for path in [
+        "/report/case-inventory",
+        "/report/case-inventory/preview?case_name=CASE-1",
+        "/report/case-inventory/pdf?case_name=CASE-1",
+    ]:
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 403
+
+
+def test_case_inventory_pdf_uses_existing_data_and_is_read_only(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 120, "CASE-PDF", 1)
+    asset_id = _insert_asset(
+        conn,
+        "PDF-100",
+        location_type="STORAGE",
+        equipment_type="laptop",
+        manufacturer="HP",
+        model="EliteBook",
+    )
+    _occupy_slot(conn, 120, asset_id)
+    conn.commit()
+
+    counts_before = (
+        _count_rows(conn, "assets"),
+        _count_rows(conn, "asset_events"),
+        _count_rows(conn, "slot_occupancy"),
+    )
+
+    response = client.get("/report/case-inventory/pdf?case_name=CASE-PDF")
+
+    counts_after = (
+        _count_rows(conn, "assets"),
+        _count_rows(conn, "asset_events"),
+        _count_rows(conn, "slot_occupancy"),
+    )
+    assert response.status_code == 200
+    assert response.mimetype == "application/pdf"
+    assert response.data.startswith(b"%PDF-")
+    assert "assettrack-case-inventory-CASE-PDF-" in (response.headers.get("Content-Disposition") or "")
+    pdf_text = _extract_pdf_text(response.data)
+    assert "Case Inventory" in pdf_text
+    assert "Case number: CASE-PDF" in pdf_text
+    assert "Asset count: 1" in pdf_text
+    assert "PDF-100" in pdf_text
+    assert "Laptop" in pdf_text
+    assert "HP / EliteBook" in pdf_text
+    assert "Slot 1" in pdf_text
+    assert counts_before == counts_after
+
+
+def test_case_inventory_pdf_supports_multi_page_case(app_client) -> None:
+    conn, client = app_client
+    for index in range(1, 90):
+        slot_id = 200 + index
+        _insert_slot(conn, slot_id, "CASE-LONG", index)
+        asset_id = _insert_asset(
+            conn,
+            f"LONG-{index:03d}",
+            location_type="STORAGE",
+            equipment_type="laptop",
+            manufacturer="Lenovo",
+            model=f"T{index:03d}",
+        )
+        _occupy_slot(conn, slot_id, asset_id)
+    conn.commit()
+
+    response = client.get("/report/case-inventory/pdf?case_name=CASE-LONG")
+
+    assert response.status_code == 200
+    reader = PdfReader(BytesIO(response.data))
+    assert len(reader.pages) > 1
+    pdf_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    assert "LONG-001" in pdf_text
+    assert "LONG-089" in pdf_text
+    assert "Asset count: 89" in pdf_text
 
 
 def test_case_detail_start_issue_populates_queue_without_events_or_receipts(app_client) -> None:


### PR DESCRIPTION
Issue 29-17: Add printable Case inventory report

## Summary

Add an authorized, read-only Case Inventory workflow with printable preview and PDF download.

## Related Issue

Closes #974

## Changes

- Added Case selection, preview, and PDF routes.
- Shows Case number, timestamp, asset count, asset details, and slot.
- Supports mixed, empty, invalid, and multi-page Cases.
- Added links from Reports, Case Status, and Case Detail.
- Added focused authorization and read-only tests.

## Verification

- [x] Focused tests passed: 60
- [x] Python compilation passed
- [x] `git diff --check` passed
- [x] Docker build passed and container reached healthy status
- [x] Populated and empty Cases verified
- [x] Invalid Case returns 404
- [x] PDF downloads, opens, and prints
- [x] Report links work
- [x] No events, custody, asset state, or slot occupancy changed
- [x] Incognito browser smoke test passed

## Notes

No schema, dependency, authentication, role, persistence, custody, event-history, Issue, or Return behavior changed.