### PR TITLE
Issue 29-27: Run pytest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -r requirements-test.txt
+
+      - name: Run pytest suite
+        run: |
+          python -m pytest -q
 
       - name: Compile all Python files
         run: |


### PR DESCRIPTION
# Issue 29-27: Run pytest in CI

## Summary

Adds the full pytest suite to CI so application behavior regressions cannot pass through compilation checks alone.

## Related Issue

Closes #992

## Changes

* Installed test dependencies from `requirements-test.txt`.
* Added `python -m pytest -q` to the existing CI workflow.
* Preserved the existing runtime dependency installation and compileall check.
* Made no application, Docker, schema, persistence, custody, event, or runtime changes.

## Verification

* [x] Full pytest suite: 565 passed, 2 subtests passed
* [x] `python3 -m compileall assettrack tests`
* [x] Workflow YAML parsed successfully
* [x] `git diff --check`
* [x] Confirmed no tests were deleted, skipped, weakened, or marked xfail

## Notes

Manual operator testing was not required because this change only updates CI validation.
