### PR TITLE
Issue 29-26: Pin GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       # Trivy setup is supply-chain-sensitive. Keep the setup action pinned to a
       # full commit SHA and review both the action ref and CLI version before any
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload filesystem scan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-filesystem-reports
           path: trivy-reports/
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       # Trivy setup is supply-chain-sensitive. Keep the setup action pinned to a
       # full commit SHA and review both the action ref and CLI version before any
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload image scan artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trivy-image-reports
           path: trivy-reports/


### PR DESCRIPTION
# Issue 29-26: Pin and restrict GitHub Actions dependencies

## Summary

Pins all active GitHub Actions dependencies to reviewed commit SHAs and restricts repository Actions usage to approved sources.

## Related Issue

Closes #991

## Changes

* Pinned `actions/checkout` to a reviewed SHA with a `v5` comment.
* Pinned `actions/setup-python` to a reviewed SHA with a `v5` comment.
* Pinned `actions/upload-artifact` to a reviewed SHA with a `v4` comment.
* Preserved the existing pinned Aqua Security Trivy setup action.
* Restricted repository Actions to GitHub-owned actions and the specifically approved Aqua Security SHA.
* Enabled required SHA pinning.
* Made no application, database, schema, persistence, custody, event, Docker, or runtime changes.

## Verification

* [x] No active workflow uses movable action tags.
* [x] Both workflow files parse as valid YAML.
* [x] Repository Actions restrictions read back correctly.
* [x] `git diff --check`
* [x] Full pytest suite passed: 565 tests and 2 subtests.
* [x] `python3 -m compileall assettrack tests`
* [ ] Required CI check passes on the pull request.
* [ ] Required Security Baseline checks pass on the pull request.

## Notes

Manual operator testing was not required because this change only affects GitHub Actions references and repository Actions policy.

