### PR TITLE
Issue 29-29: Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
# Issue 29-29: Enable Dependabot for Python and GitHub Actions

## Summary

Adds weekly Dependabot checks for Python and GitHub Actions dependencies while keeping all updates subject to pull-request review and existing security gates.

## Related Issue

Closes #994

## Changes

* Added `.github/dependabot.yml`.
* Configured weekly checks for Python dependencies.
* Configured weekly checks for GitHub Actions dependencies.
* Limited each dependency ecosystem to five open pull requests.
* Did not enable automatic merging.
* Made no application, workflow, Docker, schema, persistence, custody, event, branch-protection, or security-gate changes.

## Verification

* [x] Dependabot configuration parsed successfully.
* [x] `pip` dependency monitoring is configured.
* [x] `github-actions` dependency monitoring is configured.
* [x] Both ecosystems use a weekly schedule.
* [x] Both ecosystems limit open pull requests to five.
* [x] No auto-merge configuration exists.
* [x] `git diff --check`
* [ ] Required CI check passes on the pull request.
* [ ] Required Security Baseline checks pass on the pull request.

## Notes

The full local test suite was not run because this is a configuration-only change with no application behavior impact.
