### PR TITLE
Issue 30-4: Allow blank building and room for individual assets

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1312,11 +1312,6 @@ def _validate_admin_new_asset_form(
             form_state["equipment_type"] = validate_new_equipment_type(form_state["equipment_type"])
         except ValueError as exc:
             errors.append(str(exc))
-    if not form_state["building"]:
-        errors.append("Enter the building.")
-    if not form_state["room"]:
-        errors.append("Enter the room.")
-
     selected_slot, slot_errors = _resolve_slot_selection(
         conn,
         case_name=form_state["case_name"],
@@ -2698,6 +2693,14 @@ def _is_truthy(value: object) -> bool:
     return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _combine_building_room(building: object, room: object) -> str:
+    building_text = str(building or "").strip()
+    room_text = str(room or "").strip()
+    if building_text and room_text:
+        return f"{building_text}/{room_text}"
+    return building_text or room_text
+
+
 def _require_admin_for_route():
     user = current_user()
     role = str((user or {}).get("role") or "").strip().lower()
@@ -2784,7 +2787,7 @@ def _create_admin_asset_in_tx(
 
     now_iso = datetime.now(timezone.utc).isoformat()
     created_date = now_iso.split("T", 1)[0]
-    building_room = f"{building}/{room}"
+    building_room = _combine_building_room(building, room)
 
     home_slot_id = int(slot_row["id"]) if slot_row else None
     asset_columns = get_asset_table_columns(conn)
@@ -3014,7 +3017,7 @@ def _update_admin_asset_in_tx(
             raise ValueError("Selected slot is already occupied.")
 
     now_iso = datetime.now(timezone.utc).isoformat()
-    building_room = f"{building}/{room}"
+    building_room = _combine_building_room(building, room)
     asset_columns = get_asset_table_columns(conn)
 
     changed_fields: dict[str, object] = {}
@@ -8704,11 +8707,6 @@ def admin_edit_asset():
                     allow_current=asset_view["equipment_type"],
                 ):
                     errors.append(SUPPORTED_EQUIPMENT_TYPE_MESSAGE)
-                if not form_state["building"]:
-                    errors.append("building is required.")
-                if not form_state["room"]:
-                    errors.append("room is required.")
-
                 selected_slot, slot_errors = _resolve_slot_selection(
                     conn,
                     case_name=form_state["case_name"],

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -125,12 +125,12 @@
             </select>
           </div>
           <div class="row form-group">
-            <label class="form-label" for="building"><strong>building</strong> (required)</label>
-            <input class="form-input" type="text" id="building" name="building" value="{{ form.building or '' }}" required />
+            <label class="form-label" for="building"><strong>building</strong> (optional)</label>
+            <input class="form-input" type="text" id="building" name="building" value="{{ form.building or '' }}" />
           </div>
           <div class="row form-group">
-            <label class="form-label" for="room"><strong>room</strong> (required)</label>
-            <input class="form-input" type="text" id="room" name="room" value="{{ form.room or '' }}" required />
+            <label class="form-label" for="room"><strong>room</strong> (optional)</label>
+            <input class="form-input" type="text" id="room" name="room" value="{{ form.room or '' }}" />
           </div>
           <div class="row form-group">
             <label class="form-label" for="model"><strong>model</strong> (optional)</label>

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -57,12 +57,12 @@
           </select>
         </div>
         <div class="row">
-          <label for="building"><strong>Building</strong> (required)</label><br />
-          <input type="text" id="building" name="building" value="{{ form.building or '' }}" required />
+          <label for="building"><strong>Building</strong> (optional)</label><br />
+          <input type="text" id="building" name="building" value="{{ form.building or '' }}" />
         </div>
         <div class="row">
-          <label for="room"><strong>Room</strong> (required)</label><br />
-          <input type="text" id="room" name="room" value="{{ form.room or '' }}" required />
+          <label for="room"><strong>Room</strong> (optional)</label><br />
+          <input type="text" id="room" name="room" value="{{ form.room or '' }}" />
         </div>
         <div class="row">
           <label for="model"><strong>Model</strong> (optional)</label><br />

--- a/docs/issue-30-14-administrative-seed-data-policy.md
+++ b/docs/issue-30-14-administrative-seed-data-policy.md
@@ -11,7 +11,7 @@ Why it matters: asset creation and import depend on reference data, storage capa
 | Asset types | `assettrack/assets.py:APPROVED_NEW_EQUIPMENT_TYPES`, `validate_new_equipment_type`; UI defaults in `assettrack/intake/app.py` | Yes. New assets must be `laptop`, `switch`, or `router`. | System-provided enum in code. No admin UI for new types. | Trim/lowercase; unsupported new types rejected. Legacy labels can display but cannot be used for new asset creation. | Asset creation events include equipment type when the creating path records it. |
 | Organizations | `assettrack/db.py` schema and Ad Hoc bootstrap; `assettrack/reference_data.py:create_organization`; `assettrack/holder_import.py:_ensure_organization` | No for asset creation. Yes for holder creation/import. | Bootstrap/migration creates `Ad Hoc`; admin UI creates named organizations; holder CSV import creates missing organizations. | Trimmed name; case-insensitive unique table constraint and helper checks. | No asset event. Tests confirm reference changes do not rewrite asset events or receipt snapshots. |
 | Buildings | `assettrack/reference_data.py:create_building`, `update_building_name`, `set_building_active` | No for current asset creation; needed for operator issue-location choices and org-building mapping. | Admin reference-data UI only. | Trimmed name; case-insensitive unique table constraint and helper checks; active/inactive flag. | No asset event. Tests confirm corrections/deactivation do not rewrite asset events or receipt snapshots. |
-| Rooms | Asset fields and workflow form values; no `rooms` table found. | Current admin asset creation requires room text. No repository-level room seed table exists. | Entered as form/import text; unsupported as independent direct seed data. | Trimmed text in UI; not globally unique or centrally validated. | Room appears in asset creation, slot assignment, issue events, and receipt snapshots when those paths include it. |
+| Rooms | Asset fields and workflow form values; no `rooms` table found. | No for current individual asset creation. No repository-level room seed table exists. | Entered as form/import text; unsupported as independent direct seed data. | Trimmed text in UI; not globally unique or centrally validated. | Room appears in asset creation, slot assignment, issue events, and receipt snapshots when those paths include it. |
 | Cases | `slots.case_name`; dashboard/report code derives cases from slots. | Required only for slotted asset creation/import. | Admin slot provisioning creates slots for a case; XLSX importer can create case slots from workbook rows; network import requires existing slots when assignment is requested. | UI uppercases case numbers; slot table enforces unique `(case_name, slot_position)`. | Empty case/slot provisioning has no asset event. Slot assignment with an asset appends events in current asset/import paths. |
 | Slots | `assettrack/intake/app.py:admin_slot_provision`, `_resolve_slot_selection`; `assettrack/slots.py`; `scripts/import_inventory.py` | Required before slotted asset creation except the current documented XLSX import currently creates slots itself. Not required for unslotted asset creation. | Admin UI provisions empty slots; XLSX importer creates slots; network import and admin new asset select existing slots. | Case uppercased in UI/imports; slot count/position parsed as integer; occupied slots rejected by current create/import paths. | Empty slot provisioning has no audit event; asset-slot assignment appends `SLOT_ASSIGN` in admin new asset and current documented XLSX import, and via generic committer for ingest paths. |
 | Holders | `assettrack/holders.py:create_holder`, `update_holder`; `assettrack/holder_import.py:import_holders_csv` | No for first asset. Yes before Issue custody workflows. | Admin holder UI and holder CSV import. | Name trimmed; email normalized lowercase and unique by helper/import logic; organization required by current holder helpers. | Holder create/import/update does not append asset events. Custody events reference holder when assets are issued/returned. |
@@ -27,7 +27,7 @@ Before the first asset can be created or imported, AssetTrack must have:
 - An authenticated admin for UI creation paths, or a documented local CLI/import operating path where the relevant issue has defined support status.
 - A system-provided equipment type: Laptop, Switch, or Router.
 - A unique asset tag.
-- For UI single-asset creation: serial number, manufacturer, building text, room text, and optional model/model code/notes.
+- For UI single-asset creation: serial number, manufacturer, and optional building text, room text, model/model code/notes.
 - For slotted creation/import: an empty storage slot, unless the relevant import issue explicitly defines that path as the owner of slot creation.
 
 Not required before the first asset:
@@ -45,8 +45,8 @@ Not required before the first asset:
 | Asset tag | Required per asset | UI or import path whose support status is defined by its owning issue | Unsupported |
 | Serial number | Required by current admin new asset; optional in some imports | UI or import path whose support status is defined by its owning issue | Unsupported |
 | Manufacturer | Required by current admin new asset; optional in some imports | UI or import path whose support status is defined by its owning issue | Unsupported |
-| Building text | Required by current admin new asset; optional in some imports | UI/import field; reference building UI for controlled lists | Unsupported |
-| Room text | Required by current admin new asset; optional in some imports | UI/import field only; no room seed table | Unsupported |
+| Building text | Optional in current individual asset creation and some imports | UI/import field; reference building UI for controlled lists | Unsupported |
+| Room text | Optional in current individual asset creation and some imports | UI/import field only; no room seed table | Unsupported |
 | Organizations | Required for holders | Bootstrap creates `Ad Hoc`; admin UI; holder import may create missing organizations | Unsupported |
 | Buildings | Required for building mappings and controlled Issue location choices | Admin reference-data UI | Unsupported |
 | Organization-building mappings | Optional until Issue location needs them | Admin reference-data UI | Unsupported |
@@ -129,13 +129,13 @@ Minimum useful path for an unslotted first asset:
 2. Bootstrap the first admin user.
 3. Confirm system defaults are present, including the system-provided asset types and the `Ad Hoc` organization.
 4. Create or import an unslotted asset through a path whose owning issue allows unslotted asset creation/import.
-5. Provide the current required free-text asset fields for that path, such as asset tag, equipment type, serial number, manufacturer, building text, and room text where the current UI requires them.
+5. Provide the current required free-text asset fields for that path, such as asset tag, equipment type, serial number, and manufacturer. Building text and room text are optional for individual asset creation and should be supplied only when they are known.
 
 Reference-data setup is conditional, not mandatory before the first asset:
 
 - Prepare cases and slots only when creating or importing slotted assets.
 - Prepare organizations, buildings, organization-building mappings, and holders only when preparing Issue custody, holder import, or controlled location choices.
-- Keep free-text asset fields distinct from reference-data prerequisites. A current form may require building or room text even when no building reference row, room table, holder, case, or slot is required.
+- Keep free-text asset fields distinct from reference-data prerequisites. Individual asset creation may record building or room text when supplied, but it must not require a building reference row, room table, holder, case, or slot.
 - Use Issue/Return workflows only after the relevant holder, location context, and asset records exist.
 
 ## Constraints On Milestone 30 Issues

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -101,6 +101,18 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertNotIn(b'<option value="voip"', response.data)
         self.assertIn(b'name="case_name"', response.data)
         self.assertIn(b'name="slot_id"', response.data)
+        self.assertIn(b"<strong>Building</strong> (optional)", response.data)
+        self.assertIn(b"<strong>Room</strong> (optional)", response.data)
+        self.assertNotIn(b'id="building" name="building" value="" required', response.data)
+        self.assertNotIn(b'id="room" name="room" value="" required', response.data)
+
+    def test_admin_new_asset_route_rejects_non_admin(self) -> None:
+        operator_id = create_test_user(username="operator-new-asset", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.get("/admin/assets/new")
+
+        self.assertEqual(response.status_code, 403)
 
     def test_add_assets_queue_renders_scan_timestamps_from_queue_items(self) -> None:
         intake_app.SCAN_QUEUE.clear()
@@ -273,8 +285,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
                 "serial_number": "SER-500",
                 "manufacturer": "Lenovo",
                 "equipment_type": "laptop",
-                "building": "HQ",
-                "room": "120",
+                "building": "",
+                "room": "",
                 "model": "T14",
                 "model_code": "GEN5",
                 "notes": "new intake",
@@ -284,7 +296,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
 
         asset_row = self.conn.execute(
             """
-            SELECT asset_tag, serial_number, manufacturer, location_type, current_holder_id, home_slot_id
+            SELECT id, asset_tag, serial_number, manufacturer, building, room, building_room, location_type, current_holder_id, home_slot_id
             FROM assets
             WHERE asset_tag = ?;
             """,
@@ -293,9 +305,32 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIsNotNone(asset_row)
         self.assertEqual(asset_row["serial_number"], "SER-500")
         self.assertEqual(asset_row["manufacturer"], "Lenovo")
+        self.assertEqual(asset_row["building"], "")
+        self.assertEqual(asset_row["room"], "")
+        self.assertEqual(asset_row["building_room"], "")
         self.assertEqual(asset_row["location_type"], "STORAGE")
         self.assertIsNone(asset_row["current_holder_id"])
         self.assertIsNone(asset_row["home_slot_id"])
+
+        occ = self.conn.execute("SELECT 1 FROM slot_occupancy WHERE asset_id = ?;", (asset_row["id"],)).fetchone()
+        self.assertIsNone(occ)
+
+        events = self.conn.execute(
+            """
+            SELECT event_type, payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id ASC;
+            """,
+            ("AT-500",),
+        ).fetchall()
+        self.assertEqual([row["event_type"] for row in events], ["ASSET_CREATED"])
+        self.assertNotIn("SLOT_ASSIGN", [row["event_type"] for row in events])
+        created_payload = events[0]["payload"]
+        self.assertIsNotNone(created_payload)
+        self.assertNotIn("Unknown", created_payload)
+        self.assertNotIn("N/A", created_payload)
+        self.assertNotIn("Unassigned", created_payload)
 
         duplicate = self.client.post(
             "/admin/assets/new",
@@ -312,6 +347,33 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Serial number already exists.", duplicate.data)
         missing = self.conn.execute("SELECT 1 FROM assets WHERE asset_tag = ?;", ("AT-501",)).fetchone()
         self.assertIsNone(missing)
+
+    def test_post_accepts_building_without_room(self) -> None:
+        response = self.client.post(
+            "/admin/assets/new",
+            data={
+                "asset_tag": "AT-510",
+                "serial_number": "SER-510",
+                "manufacturer": "Lenovo",
+                "equipment_type": "laptop",
+                "building": "HQ",
+                "room": "",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            """
+            SELECT building, room, building_room
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            ("AT-510",),
+        ).fetchone()
+        self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["building"], "HQ")
+        self.assertEqual(asset_row["room"], "")
+        self.assertEqual(asset_row["building_room"], "HQ")
 
     def test_post_creates_slotted_asset_by_case_and_slot_and_writes_both_events(self) -> None:
         self._insert_slot(101, "CASE-A", 7)
@@ -332,10 +394,13 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
 
         asset_row = self.conn.execute(
-            "SELECT id, home_slot_id FROM assets WHERE asset_tag = ?;",
+            "SELECT id, building, room, building_room, home_slot_id FROM assets WHERE asset_tag = ?;",
             ("AT-600",),
         ).fetchone()
         self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["building"], "HQ")
+        self.assertEqual(asset_row["room"], "220")
+        self.assertEqual(asset_row["building_room"], "HQ/220")
         self.assertEqual(asset_row["home_slot_id"], 101)
 
         occ = self.conn.execute(
@@ -405,8 +470,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIn(b"Enter a serial number.", response.data)
         self.assertIn(b"Enter a manufacturer.", response.data)
         self.assertIn(b"Supported asset types are Laptop, Switch, and Router.", response.data)
-        self.assertIn(b"Enter the building.", response.data)
-        self.assertIn(b"Enter the room.", response.data)
+        self.assertNotIn(b"Enter the building.", response.data)
+        self.assertNotIn(b"Enter the room.", response.data)
         self.assertIn(b"Choose both a case and a slot, or leave both blank.", response.data)
         self.assertNotIn(b"asset_tag is required", response.data)
         self.assertNotIn(b"serial_number is required", response.data)

--- a/tests/test_admin_create_asset.py
+++ b/tests/test_admin_create_asset.py
@@ -21,6 +21,9 @@ class AdminCreateAssetTests(unittest.TestCase):
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 asset_tag TEXT NOT NULL UNIQUE,
                 equipment_type TEXT NOT NULL,
+                building TEXT NULL,
+                room TEXT NULL,
+                building_room TEXT NULL,
                 custody_state TEXT NOT NULL,
                 accountability_status TEXT NOT NULL,
                 condition TEXT NOT NULL,
@@ -87,7 +90,7 @@ class AdminCreateAssetTests(unittest.TestCase):
 
         asset_row = self.conn.execute(
             """
-            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id, equipment_type
+            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id, equipment_type, building, room, building_room
             FROM assets
             WHERE asset_tag = ?;
             """,
@@ -98,6 +101,9 @@ class AdminCreateAssetTests(unittest.TestCase):
         self.assertIsNone(asset_row["current_holder_id"])
         self.assertIsNone(asset_row["home_slot_id"])
         self.assertEqual(asset_row["equipment_type"], "laptop")
+        self.assertEqual(asset_row["building"], "")
+        self.assertEqual(asset_row["room"], "")
+        self.assertEqual(asset_row["building_room"], "")
 
         occ = self.conn.execute("SELECT 1 FROM slot_occupancy WHERE asset_id = ?;", (asset_row["id"],)).fetchone()
         self.assertIsNone(occ)
@@ -117,6 +123,64 @@ class AdminCreateAssetTests(unittest.TestCase):
         self.assertEqual(event["actor"], "admin-user")
         payload = json.loads(event["payload"])
         self.assertEqual(payload["equipment_type"], "laptop")
+        self.assertNotIn("building", payload)
+        self.assertNotIn("room", payload)
+
+    def test_create_asset_accepts_building_without_room(self) -> None:
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-110",
+                "actor": "admin-user",
+                "equipment_type": "router",
+                "building": "HQ",
+                "room": "",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json["ok"])
+
+        asset_row = self.conn.execute(
+            """
+            SELECT building, room, building_room
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            ("AT-110",),
+        ).fetchone()
+        self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["building"], "HQ")
+        self.assertEqual(asset_row["room"], "")
+        self.assertEqual(asset_row["building_room"], "HQ")
+
+        event = self.conn.execute(
+            """
+            SELECT payload
+            FROM asset_events
+            WHERE asset_tag = ?
+              AND event_type = 'ASSET_CREATED'
+            LIMIT 1;
+            """,
+            ("AT-110",),
+        ).fetchone()
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["building"], "HQ")
+        self.assertNotIn("room", payload)
+
+    def test_create_asset_api_rejects_non_admin(self) -> None:
+        operator_id = create_test_user(username="operator-create-asset", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-120",
+                "actor": "operator-user",
+                "equipment_type": "laptop",
+            },
+        )
+
+        self.assertEqual(response.status_code, 403)
 
     def test_create_asset_rejects_missing_equipment_type(self) -> None:
         response = self.client.post(

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -44,6 +44,9 @@ class AdminEditAssetUiTests(unittest.TestCase):
         home_slot_id: int | None,
         case_number: str | None = None,
         slot_number: str | None = None,
+        building: str = "HQ",
+        room: str = "110",
+        building_room: str = "HQ/110",
     ) -> int:
         cursor = self.conn.execute(
             """
@@ -69,9 +72,20 @@ class AdminEditAssetUiTests(unittest.TestCase):
                 case_number,
                 slot_number
             )
-            VALUES (?, ?, 'Dell', 'laptop', 'HQ', '110', 'Latitude', '5400', 'seed', 'HQ/110', 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, ?, ?);
+            VALUES (?, ?, 'Dell', 'laptop', ?, ?, 'Latitude', '5400', 'seed', ?, 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, ?, ?);
             """,
-            (asset_tag, serial_number, location_type, current_holder_id, home_slot_id, case_number, slot_number),
+            (
+                asset_tag,
+                serial_number,
+                building,
+                room,
+                building_room,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                case_number,
+                slot_number,
+            ),
         )
         self.conn.commit()
         return int(cursor.lastrowid)
@@ -103,6 +117,14 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertIn(b"Admin: Edit Asset", response.data)
         self.assertNotIn(b'<option value="tablet"', response.data)
 
+    def test_admin_edit_asset_route_rejects_non_admin(self) -> None:
+        operator_id = create_test_user(username="operator-edit-asset", password="op-pass", role="operator")
+        login_session(self.client, operator_id)
+
+        response = self.client.get("/admin/assets/edit")
+
+        self.assertEqual(response.status_code, 403)
+
     def test_exact_lookup_loads_edit_form_directly(self) -> None:
         self._insert_asset(
             "AT-EXACT-EDIT-1",
@@ -124,6 +146,10 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertIn(b"Edit Asset", response.data)
         self.assertIn(b"AT-EXACT-EDIT-1", response.data)
         self.assertIn(b"Save Asset", response.data)
+        self.assertIn(b"<strong>building</strong> (optional)", response.data)
+        self.assertIn(b"<strong>room</strong> (optional)", response.data)
+        self.assertNotIn(b'id="building" name="building" value="HQ" required', response.data)
+        self.assertNotIn(b'id="room" name="room" value="110" required', response.data)
         self.assertNotIn(b"Select Asset", response.data)
 
     def test_partial_lookup_requires_explicit_selection_before_edit(self) -> None:
@@ -277,6 +303,106 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertTrue(any(row["event_type"] == "ASSET_UPDATED" for row in events))
         payloads = [json.loads(row["payload"]) for row in events if row["payload"]]
         self.assertTrue(any(payload.get("home_slot_id") == 202 for payload in payloads))
+
+    def test_edit_allows_blank_building_and_room(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-EDIT-BLANK-LOCATION",
+            serial_number="SER-EDIT-BLANK-LOCATION",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-BLANK-LOCATION",
+                "asset_tag": "AT-EDIT-BLANK-LOCATION",
+                "serial_number": "SER-EDIT-BLANK-LOCATION-A",
+                "manufacturer": "Dell",
+                "equipment_type": "laptop",
+                "building": "",
+                "room": "",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "clear location text",
+                "case_name": "",
+                "slot_id": "",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            "SELECT building, room, building_room, home_slot_id FROM assets WHERE id = ?;",
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset_row["building"], "")
+        self.assertEqual(asset_row["room"], "")
+        self.assertEqual(asset_row["building_room"], "")
+        self.assertIsNone(asset_row["home_slot_id"])
+
+        occupancy = self.conn.execute("SELECT 1 FROM slot_occupancy WHERE asset_id = ?;", (asset_id,)).fetchone()
+        self.assertIsNone(occupancy)
+
+        event = self.conn.execute(
+            """
+            SELECT event_type, payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("AT-EDIT-BLANK-LOCATION",),
+        ).fetchone()
+        self.assertEqual(event["event_type"], "ASSET_UPDATED")
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["building"], "")
+        self.assertEqual(payload["room"], "")
+        self.assertEqual(payload["building_room"], "")
+        self.assertNotIn("Unknown", event["payload"])
+        self.assertNotIn("N/A", event["payload"])
+        self.assertNotIn("Unassigned", event["payload"])
+
+    def test_edit_allows_building_without_room(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-EDIT-BUILDING-ONLY",
+            serial_number="SER-EDIT-BUILDING-ONLY",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+            building="",
+            room="",
+            building_room="",
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-BUILDING-ONLY",
+                "asset_tag": "AT-EDIT-BUILDING-ONLY",
+                "serial_number": "SER-EDIT-BUILDING-ONLY-A",
+                "manufacturer": "Dell",
+                "equipment_type": "laptop",
+                "building": "HQ",
+                "room": "",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "building only",
+                "case_name": "",
+                "slot_id": "",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            "SELECT building, room, building_room FROM assets WHERE id = ?;",
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset_row["building"], "HQ")
+        self.assertEqual(asset_row["room"], "")
+        self.assertEqual(asset_row["building_room"], "HQ")
 
     def test_edit_form_preserves_existing_legacy_equipment_type(self) -> None:
         asset_id = self._insert_asset(

--- a/tests/test_import_inventory.py
+++ b/tests/test_import_inventory.py
@@ -126,6 +126,49 @@ def test_inventory_xlsx_import_appends_events_and_reconciles_current_state(
         persisted.close()
 
 
+def test_inventory_xlsx_import_keeps_blank_building_room_blank(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_path, excel_path = _configure_import(monkeypatch, tmp_path)
+    _write_inventory(excel_path, [_inventory_row(clean_asset_tag="IMPORT-BLANK-LOCATION", building_room="")])
+
+    rows = import_inventory.load_rows()
+    result = import_inventory.run_import(rows)
+
+    assert result == (1, 1, 1)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        asset = conn.execute(
+            """
+            SELECT building_room
+            FROM assets
+            WHERE asset_tag = 'IMPORT-BLANK-LOCATION';
+            """
+        ).fetchone()
+        assert asset is not None
+        assert asset["building_room"] is None
+
+        events = conn.execute(
+            """
+            SELECT event_type, payload
+            FROM asset_events
+            WHERE asset_tag = 'IMPORT-BLANK-LOCATION'
+            ORDER BY id;
+            """
+        ).fetchall()
+        created_payload = json.loads(events[0]["payload"])
+        assert "building_room" not in created_payload
+        slot_payload = json.loads(events[1]["payload"])
+        assert slot_payload["building_room"] == ""
+        assert "Unknown" not in events[0]["payload"]
+        assert "N/A" not in events[0]["payload"]
+        assert "Unassigned" not in events[0]["payload"]
+    finally:
+        conn.close()
+
+
 def test_inventory_xlsx_import_accepts_laptop_switch_and_router(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_network_asset_import.py
+++ b/tests/test_network_asset_import.py
@@ -75,14 +75,23 @@ class NetworkAssetImportTests(unittest.TestCase):
     def test_barcode_fills_blank_asset_tag(self) -> None:
         report = self._import(
             "asset_tag,barcode,serial_number,equipment_type,manufacturer,model,location_building,case_identifier,slot_identifier,notes_comments\n"
-            ",RTR-200,SER-200,router,Juniper,MX204,HQ,,,\n"
+            ",RTR-200,SER-200,router,Juniper,MX204,,,,\n"
         )
 
         self.assertEqual(report.summary(), {"processed": 1, "imported": 1, "errors": 0})
         conn = self._connection()
         try:
-            asset = conn.execute("SELECT asset_tag FROM assets WHERE asset_tag = 'RTR-200';").fetchone()
+            asset = conn.execute(
+                """
+                SELECT asset_tag, building, room, building_room
+                FROM assets
+                WHERE asset_tag = 'RTR-200';
+                """
+            ).fetchone()
             self.assertIsNotNone(asset)
+            self.assertEqual(asset["building"], "")
+            self.assertIsNone(asset["room"])
+            self.assertIsNone(asset["building_room"])
         finally:
             conn.close()
 


### PR DESCRIPTION
# Issue 30-4: Allow blank Building and Room values

## Summary

Make Building and Room optional during individual admin asset creation and editing.

Blank location values no longer block asset intake or create misleading combined location text.

## Related Issue

Closes #1021

## Changes

- Removed mandatory Building and Room validation from individual asset create and edit workflows.
- Allowed both fields to remain blank.
- Allowed Building without Room.
- Preserved supplied location values.
- Updated `building_room` composition:
  - blank when both fields are blank
  - Building only when Room is blank
  - `Building/Room` when both are supplied
- Updated the administrative seed-data policy.
- Preserved slot validation, events, occupancy, authentication, and roles.

## Verification

- [x] Focused tests passed: 64
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt
- [x] Incognito admin smoke test completed
- [x] Created asset with Building and Room blank
- [x] Created asset with Building present and Room blank
- [x] Cleared both fields during asset editing
- [x] Confirmed normal slotted creation
- [x] Confirmed occupied-slot rejection
- [x] Confirmed no placeholder location values were created
- [ ] Required GitHub CI checks pass

## Notes

No schema, migration, dependency, persistence, custody, or security-boundary changes were made.