### PR TITLE
Issue 30-17: Make manufacturer optional

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1303,8 +1303,6 @@ def _validate_admin_new_asset_form(
         errors.append("Enter an asset tag.")
     if not form_state["serial_number"]:
         errors.append("Enter a serial number.")
-    if not form_state["manufacturer"]:
-        errors.append("Enter a manufacturer.")
     if not form_state["equipment_type"]:
         errors.append("Choose an asset type.")
     else:
@@ -8698,8 +8696,6 @@ def admin_edit_asset():
                 errors: list[str] = []
                 if not form_state["serial_number"]:
                     errors.append("serial_number is required.")
-                if not form_state["manufacturer"]:
-                    errors.append("manufacturer is required.")
                 if not form_state["equipment_type"]:
                     errors.append("equipment_type is required.")
                 elif not _equipment_type_is_allowed(
@@ -9061,8 +9057,6 @@ def admin_replace_asset():
                     errors.append("replacement asset_tag is required.")
                 if not form_state["replacement_serial_number"]:
                     errors.append("replacement serial_number is required.")
-                if not form_state["replacement_manufacturer"]:
-                    errors.append("replacement manufacturer is required.")
                 if not form_state["replacement_equipment_type"]:
                     errors.append("replacement equipment_type is required.")
                 elif not is_approved_new_equipment_type(form_state["replacement_equipment_type"]):

--- a/assettrack/intake/templates/admin_edit_asset.html
+++ b/assettrack/intake/templates/admin_edit_asset.html
@@ -111,8 +111,8 @@
             <input class="form-input" type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" required />
           </div>
           <div class="row form-group">
-            <label class="form-label" for="manufacturer"><strong>manufacturer</strong> (required)</label>
-            <input class="form-input" type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" required />
+            <label class="form-label" for="manufacturer"><strong>manufacturer</strong> (optional)</label>
+            <input class="form-input" type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" />
           </div>
           <div class="row form-group">
             <label class="form-label" for="equipment_type"><strong>equipment_type</strong> (required)</label>

--- a/assettrack/intake/templates/admin_new_asset.html
+++ b/assettrack/intake/templates/admin_new_asset.html
@@ -43,8 +43,8 @@
           <input type="text" id="serial_number" name="serial_number" value="{{ form.serial_number or '' }}" required />
         </div>
         <div class="row">
-          <label for="manufacturer"><strong>Manufacturer</strong> (required)</label><br />
-          <input type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" required />
+          <label for="manufacturer"><strong>Manufacturer</strong> (optional)</label><br />
+          <input type="text" id="manufacturer" name="manufacturer" value="{{ form.manufacturer or '' }}" />
         </div>
         <div class="row">
           <label for="equipment_type"><strong>Asset type</strong> (required)</label><br />

--- a/assettrack/intake/templates/admin_replace_asset.html
+++ b/assettrack/intake/templates/admin_replace_asset.html
@@ -95,8 +95,8 @@
             <input type="text" id="replacement_serial_number" name="replacement_serial_number" value="{{ form.replacement_serial_number or '' }}" required />
           </div>
           <div class="row">
-            <label for="replacement_manufacturer"><strong>manufacturer</strong> (required)</label><br />
-            <input type="text" id="replacement_manufacturer" name="replacement_manufacturer" value="{{ form.replacement_manufacturer or '' }}" required />
+            <label for="replacement_manufacturer"><strong>manufacturer</strong> (optional)</label><br />
+            <input type="text" id="replacement_manufacturer" name="replacement_manufacturer" value="{{ form.replacement_manufacturer or '' }}" />
           </div>
           <div class="row">
             <label for="replacement_equipment_type"><strong>equipment_type</strong> (required)</label><br />

--- a/docs/issue-30-14-administrative-seed-data-policy.md
+++ b/docs/issue-30-14-administrative-seed-data-policy.md
@@ -27,7 +27,7 @@ Before the first asset can be created or imported, AssetTrack must have:
 - An authenticated admin for UI creation paths, or a documented local CLI/import operating path where the relevant issue has defined support status.
 - A system-provided equipment type: Laptop, Switch, or Router.
 - A unique asset tag.
-- For UI single-asset creation: serial number, manufacturer, and optional building text, room text, model/model code/notes.
+- For UI single-asset creation: serial number, and optional manufacturer, building text, room text, model/model code/notes.
 - For slotted creation/import: an empty storage slot, unless the relevant import issue explicitly defines that path as the owner of slot creation.
 
 Not required before the first asset:
@@ -44,7 +44,7 @@ Not required before the first asset:
 | Asset types | Required for new assets; system-provided | Code-defined allowlist only | Unsupported |
 | Asset tag | Required per asset | UI or import path whose support status is defined by its owning issue | Unsupported |
 | Serial number | Required by current admin new asset; optional in some imports | UI or import path whose support status is defined by its owning issue | Unsupported |
-| Manufacturer | Required by current admin new asset; optional in some imports | UI or import path whose support status is defined by its owning issue | Unsupported |
+| Manufacturer | Optional in current individual asset creation and supported imports | UI or import path whose support status is defined by its owning issue | Unsupported |
 | Building text | Optional in current individual asset creation and some imports | UI/import field; reference building UI for controlled lists | Unsupported |
 | Room text | Optional in current individual asset creation and some imports | UI/import field only; no room seed table | Unsupported |
 | Organizations | Required for holders | Bootstrap creates `Ad Hoc`; admin UI; holder import may create missing organizations | Unsupported |
@@ -129,7 +129,7 @@ Minimum useful path for an unslotted first asset:
 2. Bootstrap the first admin user.
 3. Confirm system defaults are present, including the system-provided asset types and the `Ad Hoc` organization.
 4. Create or import an unslotted asset through a path whose owning issue allows unslotted asset creation/import.
-5. Provide the current required free-text asset fields for that path, such as asset tag, equipment type, serial number, and manufacturer. Building text and room text are optional for individual asset creation and should be supplied only when they are known.
+5. Provide the current required free-text asset fields for that path, such as asset tag, equipment type, and serial number. Manufacturer, building text, and room text are optional for individual asset creation and should be supplied only when they are known.
 
 Reference-data setup is conditional, not mandatory before the first asset:
 

--- a/docs/release/smoke-test.md
+++ b/docs/release/smoke-test.md
@@ -13,7 +13,7 @@ Use sample values like these so the test is easy to repeat:
 - Holder name: `Smoke Holder`
 - Asset tag: `SMOKE-0001`
 - Serial number: `SER-SMOKE-0001`
-- Manufacturer: `SmokeTech`
+- Manufacturer (optional): `SmokeTech`
 - Equipment type: `laptop`
 - Building: `HQ`
 - Room: `101`

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -101,6 +101,8 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertNotIn(b'<option value="voip"', response.data)
         self.assertIn(b'name="case_name"', response.data)
         self.assertIn(b'name="slot_id"', response.data)
+        self.assertIn(b"<strong>Manufacturer</strong> (optional)", response.data)
+        self.assertNotIn(b'id="manufacturer" name="manufacturer" value="" required', response.data)
         self.assertIn(b"<strong>Building</strong> (optional)", response.data)
         self.assertIn(b"<strong>Room</strong> (optional)", response.data)
         self.assertNotIn(b'id="building" name="building" value="" required', response.data)
@@ -283,7 +285,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
             data={
                 "asset_tag": "AT-500",
                 "serial_number": "SER-500",
-                "manufacturer": "Lenovo",
+                "manufacturer": "",
                 "equipment_type": "laptop",
                 "building": "",
                 "room": "",
@@ -304,7 +306,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         ).fetchone()
         self.assertIsNotNone(asset_row)
         self.assertEqual(asset_row["serial_number"], "SER-500")
-        self.assertEqual(asset_row["manufacturer"], "Lenovo")
+        self.assertEqual(asset_row["manufacturer"], "")
         self.assertEqual(asset_row["building"], "")
         self.assertEqual(asset_row["room"], "")
         self.assertEqual(asset_row["building_room"], "")
@@ -330,7 +332,10 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertIsNotNone(created_payload)
         self.assertNotIn("Unknown", created_payload)
         self.assertNotIn("N/A", created_payload)
+        self.assertNotIn("None", created_payload)
+        self.assertNotIn("Not Provided", created_payload)
         self.assertNotIn("Unassigned", created_payload)
+        self.assertNotIn("manufacturer", created_payload)
 
         duplicate = self.client.post(
             "/admin/assets/new",
@@ -394,10 +399,11 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 302)
 
         asset_row = self.conn.execute(
-            "SELECT id, building, room, building_room, home_slot_id FROM assets WHERE asset_tag = ?;",
+            "SELECT id, manufacturer, building, room, building_room, home_slot_id FROM assets WHERE asset_tag = ?;",
             ("AT-600",),
         ).fetchone()
         self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["manufacturer"], "HP")
         self.assertEqual(asset_row["building"], "HQ")
         self.assertEqual(asset_row["room"], "220")
         self.assertEqual(asset_row["building_room"], "HQ/220")
@@ -468,7 +474,7 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b"Enter an asset tag.", response.data)
         self.assertIn(b"Enter a serial number.", response.data)
-        self.assertIn(b"Enter a manufacturer.", response.data)
+        self.assertNotIn(b"Enter a manufacturer.", response.data)
         self.assertIn(b"Supported asset types are Laptop, Switch, and Router.", response.data)
         self.assertNotIn(b"Enter the building.", response.data)
         self.assertNotIn(b"Enter the room.", response.data)

--- a/tests/test_admin_create_asset.py
+++ b/tests/test_admin_create_asset.py
@@ -21,6 +21,7 @@ class AdminCreateAssetTests(unittest.TestCase):
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 asset_tag TEXT NOT NULL UNIQUE,
                 equipment_type TEXT NOT NULL,
+                manufacturer TEXT NULL,
                 building TEXT NULL,
                 room TEXT NULL,
                 building_room TEXT NULL,
@@ -90,7 +91,7 @@ class AdminCreateAssetTests(unittest.TestCase):
 
         asset_row = self.conn.execute(
             """
-            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id, equipment_type, building, room, building_room
+            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id, equipment_type, manufacturer, building, room, building_room
             FROM assets
             WHERE asset_tag = ?;
             """,
@@ -101,6 +102,7 @@ class AdminCreateAssetTests(unittest.TestCase):
         self.assertIsNone(asset_row["current_holder_id"])
         self.assertIsNone(asset_row["home_slot_id"])
         self.assertEqual(asset_row["equipment_type"], "laptop")
+        self.assertEqual(asset_row["manufacturer"], "")
         self.assertEqual(asset_row["building"], "")
         self.assertEqual(asset_row["room"], "")
         self.assertEqual(asset_row["building_room"], "")
@@ -123,8 +125,46 @@ class AdminCreateAssetTests(unittest.TestCase):
         self.assertEqual(event["actor"], "admin-user")
         payload = json.loads(event["payload"])
         self.assertEqual(payload["equipment_type"], "laptop")
+        self.assertNotIn("manufacturer", payload)
         self.assertNotIn("building", payload)
         self.assertNotIn("room", payload)
+        self.assertNotIn("Unknown", event["payload"])
+        self.assertNotIn("N/A", event["payload"])
+        self.assertNotIn("None", event["payload"])
+        self.assertNotIn("Not Provided", event["payload"])
+
+    def test_create_asset_preserves_supplied_manufacturer(self) -> None:
+        response = self.client.post(
+            "/admin/assets/create",
+            json={
+                "asset_tag": "AT-105",
+                "actor": "admin-user",
+                "equipment_type": "switch",
+                "manufacturer": "Cisco",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json["ok"])
+
+        asset_row = self.conn.execute(
+            "SELECT manufacturer FROM assets WHERE asset_tag = ?;",
+            ("AT-105",),
+        ).fetchone()
+        self.assertIsNotNone(asset_row)
+        self.assertEqual(asset_row["manufacturer"], "Cisco")
+
+        event = self.conn.execute(
+            """
+            SELECT payload
+            FROM asset_events
+            WHERE asset_tag = ?
+              AND event_type = 'ASSET_CREATED'
+            LIMIT 1;
+            """,
+            ("AT-105",),
+        ).fetchone()
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["manufacturer"], "Cisco")
 
     def test_create_asset_accepts_building_without_room(self) -> None:
         response = self.client.post(

--- a/tests/test_admin_edit_asset_ui.py
+++ b/tests/test_admin_edit_asset_ui.py
@@ -44,6 +44,7 @@ class AdminEditAssetUiTests(unittest.TestCase):
         home_slot_id: int | None,
         case_number: str | None = None,
         slot_number: str | None = None,
+        manufacturer: str = "Dell",
         building: str = "HQ",
         room: str = "110",
         building_room: str = "HQ/110",
@@ -72,11 +73,12 @@ class AdminEditAssetUiTests(unittest.TestCase):
                 case_number,
                 slot_number
             )
-            VALUES (?, ?, 'Dell', 'laptop', ?, ?, 'Latitude', '5400', 'seed', ?, 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, ?, ?);
+            VALUES (?, ?, ?, 'laptop', ?, ?, 'Latitude', '5400', 'seed', ?, 'in_stock', 'accountable', 'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, ?, ?, ?, ?);
             """,
             (
                 asset_tag,
                 serial_number,
+                manufacturer,
                 building,
                 room,
                 building_room,
@@ -146,6 +148,8 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertIn(b"Edit Asset", response.data)
         self.assertIn(b"AT-EXACT-EDIT-1", response.data)
         self.assertIn(b"Save Asset", response.data)
+        self.assertIn(b"<strong>manufacturer</strong> (optional)", response.data)
+        self.assertNotIn(b'id="manufacturer" name="manufacturer" value="Dell" required', response.data)
         self.assertIn(b"<strong>building</strong> (optional)", response.data)
         self.assertIn(b"<strong>room</strong> (optional)", response.data)
         self.assertNotIn(b'id="building" name="building" value="HQ" required', response.data)
@@ -303,6 +307,60 @@ class AdminEditAssetUiTests(unittest.TestCase):
         self.assertTrue(any(row["event_type"] == "ASSET_UPDATED" for row in events))
         payloads = [json.loads(row["payload"]) for row in events if row["payload"]]
         self.assertTrue(any(payload.get("home_slot_id") == 202 for payload in payloads))
+
+    def test_edit_allows_blank_manufacturer(self) -> None:
+        asset_id = self._insert_asset(
+            "AT-EDIT-BLANK-MANUFACTURER",
+            serial_number="SER-EDIT-BLANK-MANUFACTURER",
+            location_type="STORAGE",
+            current_holder_id=None,
+            home_slot_id=None,
+            manufacturer="Dell",
+        )
+
+        response = self.client.post(
+            "/admin/assets/edit",
+            data={
+                "action": "update",
+                "lookup_asset_tag": "AT-EDIT-BLANK-MANUFACTURER",
+                "asset_tag": "AT-EDIT-BLANK-MANUFACTURER",
+                "serial_number": "SER-EDIT-BLANK-MANUFACTURER-A",
+                "manufacturer": "",
+                "equipment_type": "laptop",
+                "building": "HQ",
+                "room": "110",
+                "model": "Latitude",
+                "model_code": "5400",
+                "notes": "clear manufacturer",
+                "case_name": "",
+                "slot_id": "",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+
+        asset_row = self.conn.execute(
+            "SELECT manufacturer, home_slot_id FROM assets WHERE id = ?;",
+            (asset_id,),
+        ).fetchone()
+        self.assertEqual(asset_row["manufacturer"], "")
+        self.assertIsNone(asset_row["home_slot_id"])
+
+        event = self.conn.execute(
+            """
+            SELECT payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id DESC
+            LIMIT 1;
+            """,
+            ("AT-EDIT-BLANK-MANUFACTURER",),
+        ).fetchone()
+        payload = json.loads(event["payload"])
+        self.assertEqual(payload["manufacturer"], "")
+        self.assertNotIn("Unknown", event["payload"])
+        self.assertNotIn("N/A", event["payload"])
+        self.assertNotIn("None", event["payload"])
+        self.assertNotIn("Not Provided", event["payload"])
 
     def test_edit_allows_blank_building_and_room(self) -> None:
         asset_id = self._insert_asset(

--- a/tests/test_admin_replace_asset.py
+++ b/tests/test_admin_replace_asset.py
@@ -135,6 +135,8 @@ class AdminReplaceAssetTests(unittest.TestCase):
         self.assertIn(b'<option value="switch"', response.data)
         self.assertIn(b'<option value="router"', response.data)
         self.assertNotIn(b'<option value="monitor"', response.data)
+        self.assertIn(b"<strong>manufacturer</strong> (optional)", response.data)
+        self.assertNotIn(b'id="replacement_manufacturer" name="replacement_manufacturer" value="" required', response.data)
 
     def test_swap_from_storage_success(self) -> None:
         self._insert_slot(10, "CASE-A", 1, None)
@@ -179,13 +181,14 @@ class AdminReplaceAssetTests(unittest.TestCase):
 
         replacement = self.conn.execute(
             """
-            SELECT id, location_type, current_holder_id, home_slot_id
+            SELECT id, manufacturer, location_type, current_holder_id, home_slot_id
             FROM assets
             WHERE asset_tag = ?;
             """,
             ("NEW-100",),
         ).fetchone()
         self.assertIsNotNone(replacement)
+        self.assertEqual(replacement["manufacturer"], "Lenovo")
         self.assertEqual(replacement["location_type"], "STORAGE")
         self.assertIsNone(replacement["current_holder_id"])
         self.assertEqual(replacement["home_slot_id"], 10)
@@ -219,6 +222,66 @@ class AdminReplaceAssetTests(unittest.TestCase):
             ("NEW-100",),
         ).fetchall()
         self.assertEqual([row["event_type"] for row in replacement_events], ["ASSET_CREATED", "SLOT_ASSIGN"])
+
+    def test_swap_allows_blank_replacement_manufacturer(self) -> None:
+        self._insert_slot(15, "CASE-F", 6, None)
+        failed_id = self._insert_asset(
+            "FAIL-BLANK-MFR",
+            serial_number="SER-FAIL-BLANK-MFR",
+            location_type="STORAGE",
+            holder_id=None,
+            home_slot_id=15,
+        )
+        self._assign_slot(15, failed_id, "FAIL-BLANK-MFR")
+
+        response = self.client.post(
+            "/admin/assets/replace",
+            data={
+                "action": "replace",
+                "failed_asset_tag": "FAIL-BLANK-MFR",
+                "failure_type": "HARDWARE",
+                "failure_notes": "Power rail damage.",
+                "replacement_asset_tag": "NEW-BLANK-MFR",
+                "replacement_serial_number": "SER-NEW-BLANK-MFR",
+                "replacement_manufacturer": "",
+                "replacement_equipment_type": "laptop",
+                "confirm_retire": "yes",
+                "confirm_slot": "yes",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Replaced FAIL-BLANK-MFR with NEW-BLANK-MFR", response.data)
+
+        replacement = self.conn.execute(
+            """
+            SELECT id, manufacturer, location_type, home_slot_id
+            FROM assets
+            WHERE asset_tag = ?;
+            """,
+            ("NEW-BLANK-MFR",),
+        ).fetchone()
+        self.assertIsNotNone(replacement)
+        self.assertEqual(replacement["manufacturer"], "")
+        self.assertEqual(replacement["location_type"], "STORAGE")
+        self.assertEqual(replacement["home_slot_id"], 15)
+
+        replacement_events = self.conn.execute(
+            """
+            SELECT event_type, payload
+            FROM asset_events
+            WHERE asset_tag = ?
+            ORDER BY id ASC;
+            """,
+            ("NEW-BLANK-MFR",),
+        ).fetchall()
+        self.assertEqual([row["event_type"] for row in replacement_events], ["ASSET_CREATED", "SLOT_ASSIGN"])
+        created_payload = replacement_events[0]["payload"]
+        self.assertNotIn("manufacturer", created_payload)
+        self.assertNotIn("Unknown", created_payload)
+        self.assertNotIn("N/A", created_payload)
+        self.assertNotIn("None", created_payload)
+        self.assertNotIn("Not Provided", created_payload)
 
     def test_swap_from_in_custody_success(self) -> None:
         self._insert_slot(11, "CASE-B", 2, None)

--- a/tests/test_import_inventory.py
+++ b/tests/test_import_inventory.py
@@ -126,12 +126,12 @@ def test_inventory_xlsx_import_appends_events_and_reconciles_current_state(
         persisted.close()
 
 
-def test_inventory_xlsx_import_keeps_blank_building_room_blank(
+def test_inventory_xlsx_import_keeps_blank_manufacturer_and_building_room_blank(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     db_path, excel_path = _configure_import(monkeypatch, tmp_path)
-    _write_inventory(excel_path, [_inventory_row(clean_asset_tag="IMPORT-BLANK-LOCATION", building_room="")])
+    _write_inventory(excel_path, [_inventory_row(clean_asset_tag="IMPORT-BLANK-LOCATION", manufacturer="", building_room="")])
 
     rows = import_inventory.load_rows()
     result = import_inventory.run_import(rows)
@@ -142,12 +142,13 @@ def test_inventory_xlsx_import_keeps_blank_building_room_blank(
     try:
         asset = conn.execute(
             """
-            SELECT building_room
+            SELECT manufacturer, building_room
             FROM assets
             WHERE asset_tag = 'IMPORT-BLANK-LOCATION';
             """
         ).fetchone()
         assert asset is not None
+        assert asset["manufacturer"] is None
         assert asset["building_room"] is None
 
         events = conn.execute(
@@ -159,11 +160,14 @@ def test_inventory_xlsx_import_keeps_blank_building_room_blank(
             """
         ).fetchall()
         created_payload = json.loads(events[0]["payload"])
+        assert "manufacturer" not in created_payload
         assert "building_room" not in created_payload
         slot_payload = json.loads(events[1]["payload"])
         assert slot_payload["building_room"] == ""
         assert "Unknown" not in events[0]["payload"]
         assert "N/A" not in events[0]["payload"]
+        assert "None" not in events[0]["payload"]
+        assert "Not Provided" not in events[0]["payload"]
         assert "Unassigned" not in events[0]["payload"]
     finally:
         conn.close()

--- a/tests/test_network_asset_import.py
+++ b/tests/test_network_asset_import.py
@@ -61,6 +61,7 @@ class NetworkAssetImportTests(unittest.TestCase):
                 """
             ).fetchone()
             self.assertIsNotNone(asset)
+            self.assertEqual(asset["manufacturer"], "Cisco")
             self.assertEqual(asset["building"], "HQ")
             self.assertIsNone(asset["room"])
             self.assertEqual(asset["location_type"], "STORAGE")
@@ -75,7 +76,7 @@ class NetworkAssetImportTests(unittest.TestCase):
     def test_barcode_fills_blank_asset_tag(self) -> None:
         report = self._import(
             "asset_tag,barcode,serial_number,equipment_type,manufacturer,model,location_building,case_identifier,slot_identifier,notes_comments\n"
-            ",RTR-200,SER-200,router,Juniper,MX204,,,,\n"
+            ",RTR-200,SER-200,router,,MX204,,,,\n"
         )
 
         self.assertEqual(report.summary(), {"processed": 1, "imported": 1, "errors": 0})
@@ -83,15 +84,30 @@ class NetworkAssetImportTests(unittest.TestCase):
         try:
             asset = conn.execute(
                 """
-                SELECT asset_tag, building, room, building_room
+                SELECT asset_tag, manufacturer, building, room, building_room
                 FROM assets
                 WHERE asset_tag = 'RTR-200';
                 """
             ).fetchone()
             self.assertIsNotNone(asset)
+            self.assertEqual(asset["manufacturer"], "")
             self.assertEqual(asset["building"], "")
             self.assertIsNone(asset["room"])
             self.assertIsNone(asset["building_room"])
+            event = conn.execute(
+                """
+                SELECT payload
+                FROM asset_events
+                WHERE asset_tag = 'RTR-200'
+                  AND event_type = 'SCAN'
+                LIMIT 1;
+                """
+            ).fetchone()
+            self.assertIsNotNone(event)
+            self.assertNotIn("Unknown", event["payload"])
+            self.assertNotIn("N/A", event["payload"])
+            self.assertNotIn("None", event["payload"])
+            self.assertNotIn("Not Provided", event["payload"])
         finally:
             conn.close()
 


### PR DESCRIPTION
# Issue 30-17: Make Manufacturer optional throughout AssetTrack

## Summary

Make Manufacturer optional across supported asset creation, editing, replacement, and import workflows.

Blank Manufacturer values no longer block asset intake or require misleading placeholder data.

## Related Issue

Closes #1039

## Changes

* Removed mandatory Manufacturer validation from individual admin asset creation.
* Removed mandatory Manufacturer validation from admin asset editing.
* Removed mandatory Manufacturer validation from the replacement-asset workflow.
* Updated affected forms to identify Manufacturer as optional.
* Preserved legitimate Manufacturer values when supplied.
* Allowed blank values to remain blank or `NULL` according to existing workflow behavior.
* Added focused regression coverage for:

  * admin form presentation
  * individual asset creation
  * asset editing and clearing Manufacturer
  * replacement assets
  * XLSX inventory import
  * network asset import
* Updated the administrative seed-data policy and release smoke-test documentation.

## Verification

* [x] Focused tests passed: 75
* [x] `python3 -m compileall assettrack tests`
* [x] `git diff --check`
* [x] Docker image rebuilt successfully
* [x] Fresh-cookie Docker HTTP smoke test passed
* [x] Incognito administrator smoke test completed
* [x] Created an asset with Manufacturer blank
* [x] Confirmed no placeholder Manufacturer was stored or displayed
* [x] Created an asset with Manufacturer supplied
* [x] Confirmed the supplied Manufacturer was preserved
* [x] Cleared Manufacturer during asset editing
* [x] Confirmed Manufacturer is optional during asset replacement
* [x] Confirmed the operator role cannot access protected admin functionality
* [x] Required GitHub CI checks pass

## Notes

No schema, migration, dependency, persistence, custody, event-history, slot-occupancy, Docker configuration, or security-boundary changes were made.
