### PR TITLE
Issue 30-5A: Add unified asset import analyze page

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -11,6 +11,7 @@ Feynman-brief:
 
 from __future__ import annotations
 
+import csv
 import hashlib
 import json
 import os
@@ -119,6 +120,7 @@ from assettrack.users import (
     set_user_role,
     verify_password,
 )
+from scripts import import_inventory
 
 
 app = Flask(__name__)
@@ -136,6 +138,28 @@ TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
 ASSET_EQUIPMENT_TYPE_OPTIONS = APPROVED_NEW_EQUIPMENT_TYPES
 ASSET_EQUIPMENT_TYPE_LABELS = EQUIPMENT_TYPE_LABELS
+ASSET_IMPORT_ALLOWED_EXTENSIONS = {".csv", ".xlsx"}
+ASSET_IMPORT_CSV_IDENTITY_COLUMNS = {"asset_tag", "barcode", "clean_asset_tag"}
+ASSET_IMPORT_CSV_REQUIRED_COLUMNS = {"equipment_type"}
+ASSET_IMPORT_CSV_ALLOWED_COLUMNS = {
+    "asset_tag",
+    "barcode",
+    "clean_asset_tag",
+    "case_number",
+    "slot_helper",
+    "slot_number",
+    "serial_number",
+    "equipment_type",
+    "manufacturer",
+    "model",
+    "model_code",
+    "building_room",
+    "location_building",
+    "case_identifier",
+    "slot_identifier",
+    "mac_address",
+    "notes_comments",
+}
 DEMO_SUMMARY = {
     "assets_in_custody": 18,
     "pending_receipts": 2,
@@ -7503,6 +7527,151 @@ def admin_holder_import():
                 temp_path.unlink(missing_ok=True)
 
     return render_template("admin_holder_import.html", report=report)
+
+
+def _asset_import_header(value: object) -> str:
+    return str(value or "").strip().lower()
+
+
+def _asset_import_result(*, filename: str, file_type: str, equipment_types: set[str]) -> dict:
+    return {
+        "filename": filename,
+        "file_type": file_type,
+        "equipment_types": [equipment_type_label(value) for value in sorted(equipment_types)],
+    }
+
+
+def _first_line(value: object) -> str:
+    return str(value or "").strip().splitlines()[0] if str(value or "").strip() else ""
+
+
+def _analyze_asset_import_csv(temp_path: Path, *, filename: str) -> dict:
+    equipment_types: set[str] = set()
+
+    try:
+        with temp_path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None:
+                raise ValueError("Malformed CSV file. Include a header row.")
+
+            headers = [_asset_import_header(header) for header in reader.fieldnames]
+            if any(not header for header in headers):
+                raise ValueError("Malformed CSV file. Column headers cannot be blank.")
+            if len(headers) != len(set(headers)):
+                raise ValueError("Malformed CSV file. Column headers must be unique.")
+
+            unsupported_columns = sorted(set(headers) - ASSET_IMPORT_CSV_ALLOWED_COLUMNS)
+            if unsupported_columns:
+                raise ValueError(
+                    "Unsupported CSV column"
+                    f"{'' if len(unsupported_columns) == 1 else 's'}: {', '.join(unsupported_columns)}."
+                )
+
+            missing_columns = sorted(ASSET_IMPORT_CSV_REQUIRED_COLUMNS - set(headers))
+            if missing_columns:
+                raise ValueError(
+                    "Missing required CSV column"
+                    f"{'' if len(missing_columns) == 1 else 's'}: {', '.join(missing_columns)}."
+                )
+            if not ASSET_IMPORT_CSV_IDENTITY_COLUMNS.intersection(headers):
+                raise ValueError("Missing required CSV column: asset_tag or barcode.")
+
+            for row_number, raw_row in enumerate(reader, start=2):
+                if None in raw_row:
+                    raise ValueError(f"Malformed CSV file. Row {row_number} has extra columns.")
+
+                row = {
+                    _asset_import_header(key): str(value or "").strip()
+                    for key, value in raw_row.items()
+                    if key is not None
+                }
+                if not any(row.values()):
+                    continue
+
+                if not any(row.get(column, "") for column in ASSET_IMPORT_CSV_IDENTITY_COLUMNS):
+                    raise ValueError(f"Row {row_number}: asset_tag or barcode is required.")
+
+                try:
+                    equipment_types.add(validate_new_equipment_type(row.get("equipment_type", "")))
+                except ValueError as exc:
+                    message = _first_line(exc) or SUPPORTED_EQUIPMENT_TYPE_MESSAGE
+                    raise ValueError(f"Row {row_number}: {message}") from exc
+    except UnicodeDecodeError as exc:
+        raise ValueError("Malformed CSV file. Upload a UTF-8 CSV file.") from exc
+    except csv.Error as exc:
+        raise ValueError(f"Malformed CSV file. {exc}") from exc
+
+    return _asset_import_result(filename=filename, file_type="CSV", equipment_types=equipment_types)
+
+
+def _analyze_asset_import_xlsx(temp_path: Path, *, filename: str) -> dict:
+    try:
+        with temp_path.open("rb") as handle:
+            if handle.read(2) != b"PK":
+                raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.")
+
+        original_excel_path = import_inventory.EXCEL_PATH
+        original_db_path = import_inventory.DB_PATH
+        try:
+            import_inventory.EXCEL_PATH = temp_path
+            import_inventory.DB_PATH = _resolved_runtime_db_path()
+            rows = import_inventory.load_rows()
+        finally:
+            import_inventory.EXCEL_PATH = original_excel_path
+            import_inventory.DB_PATH = original_db_path
+    except import_inventory.ImportStopError as exc:
+        message = _first_line(exc) or "Could not analyze XLSX file."
+        raise ValueError(f"Malformed XLSX file. {message}") from exc
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.") from exc
+
+    equipment_types = {row.equipment_type for row in rows}
+    return _asset_import_result(filename=filename, file_type="XLSX", equipment_types=equipment_types)
+
+
+def _analyze_asset_import_upload(temp_path: Path, *, filename: str, suffix: str) -> dict:
+    if suffix == ".csv":
+        return _analyze_asset_import_csv(temp_path, filename=filename)
+    if suffix == ".xlsx":
+        return _analyze_asset_import_xlsx(temp_path, filename=filename)
+    raise ValueError("Unsupported file type. Upload a .csv or .xlsx file.")
+
+
+@app.route("/admin/assets/import", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_asset_import():
+    result: dict | None = None
+
+    if request.method == "POST":
+        upload = request.files.get("asset_file")
+        filename = str((upload.filename if upload is not None else "") or "").strip()
+        if upload is None or not filename:
+            flash("Choose a .csv or .xlsx file to analyze.", "error")
+            return render_template("admin_asset_import.html", result=None)
+
+        suffix = Path(filename).suffix.lower()
+        if suffix not in ASSET_IMPORT_ALLOWED_EXTENSIONS:
+            flash("Unsupported file type. Upload a .csv or .xlsx file.", "error")
+            return render_template("admin_asset_import.html", result=None)
+
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+                upload.save(handle)
+                temp_path = Path(handle.name)
+
+            result = _analyze_asset_import_upload(temp_path, filename=filename, suffix=suffix)
+            flash("Asset import analysis complete. No database changes were made.", "success")
+        except ValueError as exc:
+            flash(str(exc), "error")
+        finally:
+            if temp_path is not None:
+                temp_path.unlink(missing_ok=True)
+
+    return render_template("admin_asset_import.html", result=result)
 
 
 @app.get("/admin/network-assets/import")

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -138,7 +138,11 @@ TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
 RETIRE_FAILURE_TYPES = {"HARDWARE", "LOST", "STOLEN", "DESTROYED", "OTHER"}
 ASSET_EQUIPMENT_TYPE_OPTIONS = APPROVED_NEW_EQUIPMENT_TYPES
 ASSET_EQUIPMENT_TYPE_LABELS = EQUIPMENT_TYPE_LABELS
-ASSET_IMPORT_ALLOWED_EXTENSIONS = {".csv", ".xlsx"}
+ASSET_IMPORT_TEMPFILE_SUFFIXES = {
+    ".csv": ".csv",
+    ".xlsx": ".xlsx",
+}
+ASSET_IMPORT_ALLOWED_EXTENSIONS = set(ASSET_IMPORT_TEMPFILE_SUFFIXES)
 ASSET_IMPORT_CSV_IDENTITY_COLUMNS = {"asset_tag", "barcode", "clean_asset_tag"}
 ASSET_IMPORT_CSV_REQUIRED_COLUMNS = {"equipment_type"}
 ASSET_IMPORT_CSV_ALLOWED_COLUMNS = {
@@ -7653,13 +7657,14 @@ def admin_asset_import():
             return render_template("admin_asset_import.html", result=None)
 
         suffix = Path(filename).suffix.lower()
-        if suffix not in ASSET_IMPORT_ALLOWED_EXTENSIONS:
+        tempfile_suffix = ASSET_IMPORT_TEMPFILE_SUFFIXES.get(suffix)
+        if tempfile_suffix is None:
             flash("Unsupported file type. Upload a .csv or .xlsx file.", "error")
             return render_template("admin_asset_import.html", result=None)
 
         temp_path: Path | None = None
         try:
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=tempfile_suffix) as handle:
                 upload.save(handle)
                 temp_path = Path(handle.name)
 

--- a/assettrack/intake/templates/admin_asset_import.html
+++ b/assettrack/intake/templates/admin_asset_import.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+
+{% block title %}Import Assets{% endblock %}
+{% block page_heading %}Admin: Import Assets{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .import-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
+    .import-summary { margin: 0; }
+    .compact-list { margin: 0.5rem 0 0 1.25rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card">
+    <h2>Asset Import</h2>
+    <form method="post" enctype="multipart/form-data">
+      <div class="row">
+        <label for="asset_file"><strong>Asset file</strong></label><br />
+        <input
+          id="asset_file"
+          type="file"
+          name="asset_file"
+          accept=".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          required
+        />
+      </div>
+      <button type="submit">Analyze Import</button>
+    </form>
+  </div>
+
+  <details class="disclosure-section" open>
+    <summary>
+      <span class="disclosure-title">File requirements</span>
+      <span class="disclosure-hint">CSV and XLSX analysis only</span>
+    </summary>
+    <div class="disclosure-body">
+      <p class="import-help">Supported file types: <code>.csv</code> and <code>.xlsx</code>.</p>
+      <p class="import-help">Supported asset types: <code>laptop</code>, <code>switch</code>, and <code>router</code>.</p>
+      <p class="import-help">CSV files require <code>equipment_type</code> and one asset identifier: <code>asset_tag</code>, <code>barcode</code>, or <code>clean_asset_tag</code>.</p>
+      <p class="import-help">XLSX files use the current inventory workbook format.</p>
+      <p class="import-help">Analyze Import validates file structure only. It does not create assets, events, slots, or occupancy.</p>
+    </div>
+  </details>
+
+  {% if result is not none %}
+    <div class="card">
+      <h2>Analysis Result</h2>
+      <p class="import-summary">
+        <strong>File:</strong> {{ result.filename }}
+        &nbsp;|&nbsp;
+        <strong>Type:</strong> {{ result.file_type }}
+      </p>
+      <p class="import-help">File analyzed successfully. No database changes were made.</p>
+      {% if result.equipment_types %}
+        <p class="import-help">
+          <strong>Recognized asset types:</strong> {{ result.equipment_types|join(", ") }}
+        </p>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from scripts import import_inventory
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_admin(client) -> None:
+    admin_id = create_test_user(username="admin-asset-import", password="admin-pass", role="admin")
+    login_session(client, admin_id)
+
+
+def _table_counts() -> dict[str, int]:
+    conn = db.get_connection()
+    try:
+        return {
+            "assets": int(conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0]),
+            "asset_events": int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0]),
+            "slot_occupancy": int(conn.execute("SELECT COUNT(*) FROM slot_occupancy;").fetchone()[0]),
+        }
+    finally:
+        conn.close()
+
+
+def _post_file(client, content: bytes, filename: str):
+    before = _table_counts()
+    response = client.post(
+        "/admin/assets/import",
+        data={"asset_file": (io.BytesIO(content), filename)},
+        content_type="multipart/form-data",
+    )
+    after = _table_counts()
+    assert after == before
+    return response
+
+
+def _xlsx_bytes() -> bytes:
+    rows = [
+        {
+            "clean_asset_tag": "LAP-100",
+            "case_number": "LAPTOP",
+            "slot_helper": 1,
+            "serial_number": "SN-LAP-100",
+            "equipment_type": "laptop",
+            "manufacturer": "",
+            "model": "Latitude",
+            "model_code": "7420",
+            "building_room": "",
+            "slot_number": "1",
+            "mac_address": "",
+        },
+        {
+            "clean_asset_tag": "SW-100",
+            "case_number": "SWITCH",
+            "slot_helper": 1,
+            "serial_number": "SN-SW-100",
+            "equipment_type": "switch",
+            "manufacturer": "Cisco",
+            "model": "Catalyst",
+            "model_code": "9300",
+            "building_room": "",
+            "slot_number": "1",
+            "mac_address": "",
+        },
+        {
+            "clean_asset_tag": "RTR-100",
+            "case_number": "ROUTER",
+            "slot_helper": 1,
+            "serial_number": "SN-RTR-100",
+            "equipment_type": "router",
+            "manufacturer": "Juniper",
+            "model": "MX",
+            "model_code": "204",
+            "building_room": "",
+            "slot_number": "1",
+            "mac_address": "",
+        },
+    ]
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        pd.DataFrame(rows, columns=sorted(import_inventory.REQUIRED_COLUMNS)).to_excel(
+            writer,
+            sheet_name=import_inventory.SHEET_NAME,
+            index=False,
+        )
+    return buffer.getvalue()
+
+
+def test_admin_can_open_asset_import_upload_page(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = client_with_temp_db.get("/admin/assets/import")
+
+    assert response.status_code == 200
+    assert b"Admin: Import Assets" in response.data
+    assert b"Analyze Import" in response.data
+    assert b".csv" in response.data
+    assert b".xlsx" in response.data
+    assert b"python scripts/" not in response.data
+
+
+def test_csv_upload_analyzes_laptop_switch_and_router_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    csv_content = (
+        "asset_tag,barcode,serial_number,equipment_type,manufacturer,model,location_building,"
+        "case_identifier,slot_identifier,notes_comments\n"
+        "LAP-100,,SN-LAP-100,laptop,,Latitude,,,,\n"
+        "SW-100,,SN-SW-100,switch,Cisco,Catalyst,,,,\n"
+        "RTR-100,,SN-RTR-100,router,Juniper,MX,,,,\n"
+    ).encode()
+
+    response = _post_file(client_with_temp_db, csv_content, "assets.csv")
+
+    assert response.status_code == 200
+    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"File analyzed successfully. No database changes were made." in response.data
+    assert b"Laptop" in response.data
+    assert b"Switch" in response.data
+    assert b"Router" in response.data
+
+
+def test_xlsx_upload_analyzes_laptop_switch_and_router_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(client_with_temp_db, _xlsx_bytes(), "inventory.xlsx")
+
+    assert response.status_code == 200
+    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"XLSX" in response.data
+    assert b"Laptop" in response.data
+    assert b"Switch" in response.data
+    assert b"Router" in response.data
+
+
+def test_unsupported_asset_import_extension_is_rejected_clearly(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(client_with_temp_db, b"asset_tag,equipment_type\nAT-100,laptop\n", "assets.txt")
+
+    assert response.status_code == 200
+    assert b"Unsupported file type. Upload a .csv or .xlsx file." in response.data
+
+
+def test_malformed_csv_returns_useful_error_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,asset_tag,equipment_type\nAT-100,AT-101,laptop\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Malformed CSV file. Column headers must be unique." in response.data
+
+
+def test_malformed_xlsx_returns_useful_error_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(client_with_temp_db, b"not a workbook", "inventory.xlsx")
+
+    assert response.status_code == 200
+    assert b"Malformed XLSX file. Upload a valid .xlsx workbook." in response.data
+
+
+def test_operator_is_forbidden_from_asset_import_upload_page(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-asset-import", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+
+    get_response = client_with_temp_db.get("/admin/assets/import")
+    post_response = client_with_temp_db.post(
+        "/admin/assets/import",
+        data={"asset_file": (io.BytesIO(b"asset_tag,equipment_type\nAT-100,laptop\n"), "assets.csv")},
+        content_type="multipart/form-data",
+    )
+
+    assert get_response.status_code == 403
+    assert post_response.status_code == 403

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import tempfile
 from pathlib import Path
 
 import pandas as pd
@@ -146,6 +147,68 @@ def test_xlsx_upload_analyzes_laptop_switch_and_router_without_database_writes(c
     assert b"Laptop" in response.data
     assert b"Switch" in response.data
     assert b"Router" in response.data
+
+
+def test_traversal_style_csv_filename_uses_server_tempfile_suffix(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _login_admin(client_with_temp_db)
+    created_paths: list[Path] = []
+    original_named_temporary_file = intake_app.tempfile.NamedTemporaryFile
+
+    def recording_named_temporary_file(*args, **kwargs):
+        assert kwargs["suffix"] == ".csv"
+        handle = original_named_temporary_file(*args, **kwargs)
+        created_paths.append(Path(handle.name))
+        return handle
+
+    monkeypatch.setattr(intake_app.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nAT-100,SN-100,laptop\n",
+        "../../outside.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert created_paths
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    for created_path in created_paths:
+        assert created_path.parent.resolve() == temp_root
+        assert created_path.suffix == ".csv"
+        assert "outside" not in created_path.name
+        assert not created_path.exists()
+
+
+def test_traversal_style_xlsx_filename_uses_server_tempfile_suffix(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _login_admin(client_with_temp_db)
+    created_paths: list[Path] = []
+    original_named_temporary_file = intake_app.tempfile.NamedTemporaryFile
+
+    def recording_named_temporary_file(*args, **kwargs):
+        assert kwargs["suffix"] == ".xlsx"
+        handle = original_named_temporary_file(*args, **kwargs)
+        created_paths.append(Path(handle.name))
+        return handle
+
+    monkeypatch.setattr(intake_app.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
+
+    response = _post_file(client_with_temp_db, _xlsx_bytes(), "..\\..\\outside.xlsx")
+
+    assert response.status_code == 200
+    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert created_paths
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    for created_path in created_paths:
+        assert created_path.parent.resolve() == temp_root
+        assert created_path.suffix == ".xlsx"
+        assert "outside" not in created_path.name
+        assert not created_path.exists()
 
 
 def test_unsupported_asset_import_extension_is_rejected_clearly(client_with_temp_db) -> None:


### PR DESCRIPTION
# Issue 30-5A: Add unified Asset Import upload and analyze page

## Summary

Add one administrator-facing page for uploading and analyzing Asset Import files.

The page accepts CSV and XLSX files for Laptop, Switch, and Router records without writing to the database.

## Related Issue

Closes #1044

## Changes

- Added the admin-only `/admin/assets/import` upload page.
- Added CSV and XLSX structural analysis.
- Added clear file requirements and plain-language errors.
- Reused the existing XLSX reader without invoking its import path.
- Used temporary files that are removed after analysis.
- Added focused access, format, validation, and no-write tests.

## Verification

- [x] Focused tests passed: 7
- [x] `python3 -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt
- [x] Incognito administrator smoke test passed
- [x] Valid XLSX analyzed successfully
- [x] Valid CSV analyzed successfully
- [x] Laptop, Switch, and Router values accepted
- [x] Unsupported or malformed files rejected clearly
- [x] Confirmed analysis created no assets, events, or slot occupancy
- [x] Confirmed non-admin access remains denied
- [x] Required GitHub CI checks pass

## Notes

This issue provides analysis only. Preview, reconciliation, defaults, commit, and results belong to Issues 30-5B through 30-5D.

No schema, migration, dependency, persistence, custody, event, occupancy, or authorization-boundary changes were made.