### PR TITLE
Issue 30-5B: Normalize CSV and XLSX asset import rows

### DIFF
--- a/assettrack/import_analysis.py
+++ b/assettrack/import_analysis.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from assettrack.assets import (
+    SUPPORTED_EQUIPMENT_TYPE_MESSAGE,
+    equipment_type_label,
+    validate_new_equipment_type,
+)
+
+IDENTITY_COLUMNS = ("asset_tag", "barcode", "clean_asset_tag")
+REQUIRED_COLUMNS = {"equipment_type"}
+ALLOWED_COLUMNS = {
+    "asset_tag",
+    "barcode",
+    "clean_asset_tag",
+    "serial_number",
+    "equipment_type",
+    "manufacturer",
+    "model",
+    "model_code",
+    "building_room",
+    "location_building",
+    "case_identifier",
+    "slot_identifier",
+    "case_number",
+    "slot_number",
+    "notes_comments",
+}
+REJECTED_CMDB_COLUMNS = {
+    "ip_address",
+    "mac_address",
+    "vlan",
+    "switch_port",
+    "topology",
+    "patching",
+    "network_relationships",
+    "running_configuration",
+    "device_configuration",
+}
+
+
+@dataclass(frozen=True)
+class AssetImportAnalysisRow:
+    row_number: int
+    asset_tag: str
+    serial_number: str
+    equipment_type: str
+    manufacturer: str
+    model: str
+    model_code: str
+    building_room: str
+    location_building: str
+    case_identifier: str
+    slot_identifier: str
+    notes: str
+
+    @property
+    def storage_intent(self) -> str:
+        return "slotted" if self.case_identifier and self.slot_identifier else "unslotted"
+
+
+@dataclass(frozen=True)
+class AssetImportAnalysis:
+    filename: str
+    file_type: str
+    rows: tuple[AssetImportAnalysisRow, ...]
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def equipment_types(self) -> list[str]:
+        values = {row.equipment_type for row in self.rows}
+        return [equipment_type_label(value) for value in sorted(values)]
+
+    def to_template_result(self) -> dict:
+        return {
+            "filename": self.filename,
+            "file_type": self.file_type,
+            "equipment_types": self.equipment_types,
+            "warnings": list(self.warnings),
+        }
+
+
+def _normalize_header(value: object) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _normalize_text(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    return str(value or "").strip()
+
+
+def _first_line(value: object) -> str:
+    text = str(value or "").strip()
+    return text.splitlines()[0] if text else ""
+
+
+def _validate_headers(headers: list[str], *, file_type: str) -> tuple[str, ...]:
+    if any(not header for header in headers):
+        raise ValueError(f"Malformed {file_type} file. Column headers cannot be blank.")
+    if len(headers) != len(set(headers)):
+        raise ValueError(f"Malformed {file_type} file. Column headers must be unique.")
+
+    unsupported = sorted((set(headers) - ALLOWED_COLUMNS) | (set(headers) & REJECTED_CMDB_COLUMNS))
+    warnings: list[str] = []
+    if unsupported:
+        warnings.append(
+            f"Ignored unsupported {file_type} column"
+            f"{'' if len(unsupported) == 1 else 's'}: {', '.join(unsupported)}."
+        )
+
+    missing = sorted(REQUIRED_COLUMNS - set(headers))
+    if missing:
+        raise ValueError(
+            f"Missing required {file_type} column"
+            f"{'' if len(missing) == 1 else 's'}: {', '.join(missing)}."
+        )
+    if not set(IDENTITY_COLUMNS).intersection(headers):
+        raise ValueError(
+            f"Missing required {file_type} column: asset_tag or barcode."
+        )
+    return tuple(warnings)
+
+
+def _canonical_row(raw_row: dict[str, object], *, row_number: int) -> AssetImportAnalysisRow | None:
+    row = {
+        normalized_key: _normalize_text(value)
+        for key, value in raw_row.items()
+        if (normalized_key := _normalize_header(key)) in ALLOWED_COLUMNS
+    }
+    if not any(row.values()):
+        return None
+
+    asset_tag = ""
+    for column in IDENTITY_COLUMNS:
+        asset_tag = _normalize_text(row.get(column)).upper()
+        if asset_tag:
+            break
+    if not asset_tag:
+        raise ValueError(f"Row {row_number}: asset_tag or barcode is required.")
+
+    try:
+        equipment_type = validate_new_equipment_type(row.get("equipment_type", ""))
+    except ValueError as exc:
+        message = _first_line(exc) or SUPPORTED_EQUIPMENT_TYPE_MESSAGE
+        raise ValueError(f"Row {row_number}: {message}") from exc
+
+    case_identifier = _normalize_text(row.get("case_identifier")).upper()
+    if not case_identifier:
+        case_number = _normalize_text(row.get("case_number")).upper()
+        case_identifier = f"CASE-{case_number}" if case_number else ""
+    slot_identifier = _normalize_text(row.get("slot_identifier")) or _normalize_text(row.get("slot_number"))
+
+    if bool(case_identifier) != bool(slot_identifier):
+        raise ValueError(f"Row {row_number}: storage case and slot must both be present or both be blank.")
+
+    return AssetImportAnalysisRow(
+        row_number=row_number,
+        asset_tag=asset_tag,
+        serial_number=_normalize_text(row.get("serial_number")),
+        equipment_type=equipment_type,
+        manufacturer=_normalize_text(row.get("manufacturer")),
+        model=_normalize_text(row.get("model")),
+        model_code=_normalize_text(row.get("model_code")),
+        building_room=_normalize_text(row.get("building_room")),
+        location_building=_normalize_text(row.get("location_building")),
+        case_identifier=case_identifier,
+        slot_identifier=slot_identifier,
+        notes=_normalize_text(row.get("notes_comments")),
+    )
+
+
+def _validate_duplicates(rows: list[AssetImportAnalysisRow]) -> None:
+    seen_asset_tags: dict[str, int] = {}
+    seen_serial_numbers: dict[str, int] = {}
+    for row in rows:
+        previous_asset_row = seen_asset_tags.get(row.asset_tag)
+        if previous_asset_row is not None:
+            raise ValueError(
+                f"Row {row.row_number}: duplicate asset_tag matches row {previous_asset_row}: {row.asset_tag}."
+            )
+        seen_asset_tags[row.asset_tag] = row.row_number
+
+        normalized_serial = row.serial_number.upper()
+        if not normalized_serial:
+            continue
+        previous_serial_row = seen_serial_numbers.get(normalized_serial)
+        if previous_serial_row is not None:
+            raise ValueError(
+                f"Row {row.row_number}: duplicate serial_number matches row {previous_serial_row}: {row.serial_number}."
+            )
+        seen_serial_numbers[normalized_serial] = row.row_number
+
+
+def _analyze_rows(
+    raw_rows: list[dict[str, object]],
+    *,
+    headers: list[str],
+    filename: str,
+    file_type: str,
+) -> AssetImportAnalysis:
+    warnings = _validate_headers(headers, file_type=file_type)
+
+    rows: list[AssetImportAnalysisRow] = []
+    for offset, raw_row in enumerate(raw_rows, start=2):
+        row = _canonical_row(raw_row, row_number=offset)
+        if row is not None:
+            rows.append(row)
+
+    _validate_duplicates(rows)
+    return AssetImportAnalysis(filename=filename, file_type=file_type.upper(), rows=tuple(rows), warnings=warnings)
+
+
+def analyze_asset_import_csv(csv_path: str | Path, *, filename: str) -> AssetImportAnalysis:
+    path = Path(csv_path)
+    try:
+        with path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            if reader.fieldnames is None:
+                raise ValueError("Malformed CSV file. Include a header row.")
+
+            headers = [_normalize_header(header) for header in reader.fieldnames]
+            raw_rows: list[dict[str, object]] = []
+            for row_number, raw_row in enumerate(reader, start=2):
+                if None in raw_row:
+                    raise ValueError(f"Malformed CSV file. Row {row_number} has extra columns.")
+                if any(value is None for value in raw_row.values()):
+                    raise ValueError(f"Malformed CSV file. Row {row_number} has missing columns.")
+                raw_rows.append({str(key): value for key, value in raw_row.items() if key is not None})
+    except UnicodeDecodeError as exc:
+        raise ValueError("Malformed CSV file. Upload a UTF-8 CSV file.") from exc
+    except csv.Error as exc:
+        raise ValueError(f"Malformed CSV file. {exc}") from exc
+
+    return _analyze_rows(raw_rows, headers=headers, filename=filename, file_type="CSV")
+
+
+def analyze_asset_import_xlsx(xlsx_path: str | Path, *, filename: str) -> AssetImportAnalysis:
+    path = Path(xlsx_path)
+    try:
+        with path.open("rb") as handle:
+            if handle.read(2) != b"PK":
+                raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.")
+        dataframe = pd.read_excel(path, engine="openpyxl")
+    except ValueError:
+        raise
+    except Exception as exc:
+        raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.") from exc
+
+    headers = [_normalize_header(header) for header in dataframe.columns]
+    raw_rows = [
+        {str(column): row[column] for column in dataframe.columns}
+        for _, row in dataframe.iterrows()
+    ]
+    return _analyze_rows(raw_rows, headers=headers, filename=filename, file_type="XLSX")

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -11,7 +11,6 @@ Feynman-brief:
 
 from __future__ import annotations
 
-import csv
 import hashlib
 import json
 import os
@@ -70,6 +69,7 @@ from assettrack.auth import (
 )
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, set_holder_active, update_holder
 from assettrack.holder_import import HolderImportReport, import_holders_csv
+from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.reference_data import (
     create_building,
     create_organization,
@@ -120,8 +120,6 @@ from assettrack.users import (
     set_user_role,
     verify_password,
 )
-from scripts import import_inventory
-
 
 app = Flask(__name__)
 app.secret_key = os.getenv("ASSETTRACK_SECRET_KEY", "dev-not-secret")
@@ -143,27 +141,6 @@ ASSET_IMPORT_TEMPFILE_SUFFIXES = {
     ".xlsx": ".xlsx",
 }
 ASSET_IMPORT_ALLOWED_EXTENSIONS = set(ASSET_IMPORT_TEMPFILE_SUFFIXES)
-ASSET_IMPORT_CSV_IDENTITY_COLUMNS = {"asset_tag", "barcode", "clean_asset_tag"}
-ASSET_IMPORT_CSV_REQUIRED_COLUMNS = {"equipment_type"}
-ASSET_IMPORT_CSV_ALLOWED_COLUMNS = {
-    "asset_tag",
-    "barcode",
-    "clean_asset_tag",
-    "case_number",
-    "slot_helper",
-    "slot_number",
-    "serial_number",
-    "equipment_type",
-    "manufacturer",
-    "model",
-    "model_code",
-    "building_room",
-    "location_building",
-    "case_identifier",
-    "slot_identifier",
-    "mac_address",
-    "notes_comments",
-}
 DEMO_SUMMARY = {
     "assets_in_custody": 18,
     "pending_receipts": 2,
@@ -7533,106 +7510,12 @@ def admin_holder_import():
     return render_template("admin_holder_import.html", report=report)
 
 
-def _asset_import_header(value: object) -> str:
-    return str(value or "").strip().lower()
-
-
-def _asset_import_result(*, filename: str, file_type: str, equipment_types: set[str]) -> dict:
-    return {
-        "filename": filename,
-        "file_type": file_type,
-        "equipment_types": [equipment_type_label(value) for value in sorted(equipment_types)],
-    }
-
-
-def _first_line(value: object) -> str:
-    return str(value or "").strip().splitlines()[0] if str(value or "").strip() else ""
-
-
 def _analyze_asset_import_csv(temp_path: Path, *, filename: str) -> dict:
-    equipment_types: set[str] = set()
-
-    try:
-        with temp_path.open("r", encoding="utf-8-sig", newline="") as handle:
-            reader = csv.DictReader(handle)
-            if reader.fieldnames is None:
-                raise ValueError("Malformed CSV file. Include a header row.")
-
-            headers = [_asset_import_header(header) for header in reader.fieldnames]
-            if any(not header for header in headers):
-                raise ValueError("Malformed CSV file. Column headers cannot be blank.")
-            if len(headers) != len(set(headers)):
-                raise ValueError("Malformed CSV file. Column headers must be unique.")
-
-            unsupported_columns = sorted(set(headers) - ASSET_IMPORT_CSV_ALLOWED_COLUMNS)
-            if unsupported_columns:
-                raise ValueError(
-                    "Unsupported CSV column"
-                    f"{'' if len(unsupported_columns) == 1 else 's'}: {', '.join(unsupported_columns)}."
-                )
-
-            missing_columns = sorted(ASSET_IMPORT_CSV_REQUIRED_COLUMNS - set(headers))
-            if missing_columns:
-                raise ValueError(
-                    "Missing required CSV column"
-                    f"{'' if len(missing_columns) == 1 else 's'}: {', '.join(missing_columns)}."
-                )
-            if not ASSET_IMPORT_CSV_IDENTITY_COLUMNS.intersection(headers):
-                raise ValueError("Missing required CSV column: asset_tag or barcode.")
-
-            for row_number, raw_row in enumerate(reader, start=2):
-                if None in raw_row:
-                    raise ValueError(f"Malformed CSV file. Row {row_number} has extra columns.")
-
-                row = {
-                    _asset_import_header(key): str(value or "").strip()
-                    for key, value in raw_row.items()
-                    if key is not None
-                }
-                if not any(row.values()):
-                    continue
-
-                if not any(row.get(column, "") for column in ASSET_IMPORT_CSV_IDENTITY_COLUMNS):
-                    raise ValueError(f"Row {row_number}: asset_tag or barcode is required.")
-
-                try:
-                    equipment_types.add(validate_new_equipment_type(row.get("equipment_type", "")))
-                except ValueError as exc:
-                    message = _first_line(exc) or SUPPORTED_EQUIPMENT_TYPE_MESSAGE
-                    raise ValueError(f"Row {row_number}: {message}") from exc
-    except UnicodeDecodeError as exc:
-        raise ValueError("Malformed CSV file. Upload a UTF-8 CSV file.") from exc
-    except csv.Error as exc:
-        raise ValueError(f"Malformed CSV file. {exc}") from exc
-
-    return _asset_import_result(filename=filename, file_type="CSV", equipment_types=equipment_types)
+    return analyze_asset_import_csv(temp_path, filename=filename).to_template_result()
 
 
 def _analyze_asset_import_xlsx(temp_path: Path, *, filename: str) -> dict:
-    try:
-        with temp_path.open("rb") as handle:
-            if handle.read(2) != b"PK":
-                raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.")
-
-        original_excel_path = import_inventory.EXCEL_PATH
-        original_db_path = import_inventory.DB_PATH
-        try:
-            import_inventory.EXCEL_PATH = temp_path
-            import_inventory.DB_PATH = _resolved_runtime_db_path()
-            rows = import_inventory.load_rows()
-        finally:
-            import_inventory.EXCEL_PATH = original_excel_path
-            import_inventory.DB_PATH = original_db_path
-    except import_inventory.ImportStopError as exc:
-        message = _first_line(exc) or "Could not analyze XLSX file."
-        raise ValueError(f"Malformed XLSX file. {message}") from exc
-    except ValueError:
-        raise
-    except Exception as exc:
-        raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.") from exc
-
-    equipment_types = {row.equipment_type for row in rows}
-    return _asset_import_result(filename=filename, file_type="XLSX", equipment_types=equipment_types)
+    return analyze_asset_import_xlsx(temp_path, filename=filename).to_template_result()
 
 
 def _analyze_asset_import_upload(temp_path: Path, *, filename: str, suffix: str) -> dict:

--- a/assettrack/intake/templates/admin_asset_import.html
+++ b/assettrack/intake/templates/admin_asset_import.html
@@ -44,9 +44,10 @@
     </summary>
     <div class="disclosure-body">
       <p class="import-help">Supported file types: <code>.csv</code> and <code>.xlsx</code>.</p>
-      <p class="import-help">Supported asset types: <code>laptop</code>, <code>switch</code>, and <code>router</code>.</p>
-      <p class="import-help">CSV files require <code>equipment_type</code> and one asset identifier: <code>asset_tag</code>, <code>barcode</code>, or <code>clean_asset_tag</code>.</p>
-      <p class="import-help">XLSX files use the current inventory workbook format.</p>
+      <p class="import-help">Required column: <code>equipment_type</code>.</p>
+      <p class="import-help">Required identity: <code>asset_tag</code> or <code>barcode</code>.</p>
+      <p class="import-help">Supported equipment types: Laptop, Switch, Router.</p>
+      <p class="import-help">Extra columns are ignored and reported.</p>
       <p class="import-help">Analyze Import validates file structure only. It does not create assets, events, slots, or occupancy.</p>
     </div>
   </details>
@@ -64,6 +65,14 @@
         <p class="import-help">
           <strong>Recognized asset types:</strong> {{ result.equipment_types|join(", ") }}
         </p>
+      {% endif %}
+      {% if result.warnings %}
+        <p class="import-help"><strong>Warnings:</strong></p>
+        <ul class="compact-list">
+          {% for warning in result.warnings %}
+            <li>{{ warning }}</li>
+          {% endfor %}
+        </ul>
       {% endif %}
     </div>
   {% endif %}

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -9,7 +9,7 @@ import pytest
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from scripts import import_inventory
+from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from tests.auth_test_utils import create_test_user, login_session
 
 
@@ -51,56 +51,98 @@ def _post_file(client, content: bytes, filename: str):
     return response
 
 
-def _xlsx_bytes() -> bytes:
-    rows = [
-        {
-            "clean_asset_tag": "LAP-100",
-            "case_number": "LAPTOP",
-            "slot_helper": 1,
-            "serial_number": "SN-LAP-100",
-            "equipment_type": "laptop",
-            "manufacturer": "",
-            "model": "Latitude",
-            "model_code": "7420",
-            "building_room": "",
-            "slot_number": "1",
-            "mac_address": "",
-        },
-        {
-            "clean_asset_tag": "SW-100",
-            "case_number": "SWITCH",
-            "slot_helper": 1,
-            "serial_number": "SN-SW-100",
-            "equipment_type": "switch",
-            "manufacturer": "Cisco",
-            "model": "Catalyst",
-            "model_code": "9300",
-            "building_room": "",
-            "slot_number": "1",
-            "mac_address": "",
-        },
-        {
-            "clean_asset_tag": "RTR-100",
-            "case_number": "ROUTER",
-            "slot_helper": 1,
-            "serial_number": "SN-RTR-100",
-            "equipment_type": "router",
-            "manufacturer": "Juniper",
-            "model": "MX",
-            "model_code": "204",
-            "building_room": "",
-            "slot_number": "1",
-            "mac_address": "",
-        },
+def _xlsx_bytes(rows: list[dict[str, object]] | None = None) -> bytes:
+    if rows is None:
+        rows = [
+            {
+                "clean_asset_tag": "LAP-100",
+                "serial_number": "SN-LAP-100",
+                "equipment_type": "laptop",
+                "manufacturer": "",
+                "model": "Latitude",
+            },
+            {
+                "clean_asset_tag": "SW-100",
+                "serial_number": "SN-SW-100",
+                "equipment_type": "switch",
+                "manufacturer": "Cisco",
+                "model": "Catalyst",
+            },
+            {
+                "clean_asset_tag": "RTR-100",
+                "serial_number": "SN-RTR-100",
+                "equipment_type": "router",
+                "manufacturer": "Juniper",
+                "model": "MX",
+            },
+        ]
+    columns = [
+        "clean_asset_tag",
+        "serial_number",
+        "equipment_type",
+        "manufacturer",
+        "model",
+        "model_code",
+        "building_room",
+        "location_building",
+        "case_identifier",
+        "slot_identifier",
+        "notes_comments",
     ]
     buffer = io.BytesIO()
     with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
-        pd.DataFrame(rows, columns=sorted(import_inventory.REQUIRED_COLUMNS)).to_excel(
+        pd.DataFrame(rows, columns=columns).to_excel(
             writer,
-            sheet_name=import_inventory.SHEET_NAME,
             index=False,
         )
     return buffer.getvalue()
+
+
+def test_csv_and_xlsx_use_equivalent_canonical_analysis_rows(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        " Asset Tag ,Serial Number,Equipment Type,Manufacturer,Model,Location Building,Case Identifier,Slot Identifier,Notes Comments\n"
+        " lap-100 , SN-LAP-100 , Laptop , , Latitude , , , ,\n"
+        " sw-100 , SN-SW-100 , Switch , Cisco , Catalyst , HQ , Case-Net , 2 , Reviewed\n",
+        encoding="utf-8",
+    )
+    xlsx_path = tmp_path / "assets.xlsx"
+    rows = [
+        {
+            "clean_asset_tag": " lap-100 ",
+            "serial_number": "SN-LAP-100",
+            "equipment_type": " Laptop ",
+            "manufacturer": "",
+            "model": "Latitude",
+        },
+        {
+            "clean_asset_tag": "SW-100",
+            "serial_number": "SN-SW-100",
+            "equipment_type": "Switch",
+            "manufacturer": "Cisco",
+            "model": "Catalyst",
+            "location_building": "HQ",
+            "case_identifier": "Case-Net",
+            "slot_identifier": "2",
+            "notes_comments": "Reviewed",
+        },
+    ]
+    xlsx_path.write_bytes(_xlsx_bytes(rows))
+
+    csv_analysis = analyze_asset_import_csv(csv_path, filename="assets.csv")
+    xlsx_analysis = analyze_asset_import_xlsx(xlsx_path, filename="assets.xlsx")
+
+    csv_rows = csv_analysis.rows
+    xlsx_rows = xlsx_analysis.rows
+    assert [row.asset_tag for row in csv_rows] == [row.asset_tag for row in xlsx_rows] == ["LAP-100", "SW-100"]
+    assert [row.equipment_type for row in csv_rows] == [row.equipment_type for row in xlsx_rows] == ["laptop", "switch"]
+    assert [row.storage_intent for row in csv_rows] == [row.storage_intent for row in xlsx_rows] == [
+        "unslotted",
+        "slotted",
+    ]
+    assert csv_rows[0].manufacturer == xlsx_rows[0].manufacturer == ""
+    assert csv_rows[0].building_room == xlsx_rows[0].building_room == ""
+    assert csv_analysis.equipment_types == xlsx_analysis.equipment_types == ["Laptop", "Switch"]
 
 
 def test_admin_can_open_asset_import_upload_page(client_with_temp_db) -> None:
@@ -113,6 +155,11 @@ def test_admin_can_open_asset_import_upload_page(client_with_temp_db) -> None:
     assert b"Analyze Import" in response.data
     assert b".csv" in response.data
     assert b".xlsx" in response.data
+    assert b"Required column: <code>equipment_type</code>" in response.data
+    assert b"Required identity: <code>asset_tag</code> or <code>barcode</code>" in response.data
+    assert b"Supported equipment types: Laptop, Switch, Router." in response.data
+    assert b"Extra columns are ignored and reported." in response.data
+    assert b"clean_asset_tag" not in response.data
     assert b"python scripts/" not in response.data
 
 
@@ -240,6 +287,183 @@ def test_malformed_xlsx_returns_useful_error_without_database_writes(client_with
 
     assert response.status_code == 200
     assert b"Malformed XLSX file. Upload a valid .xlsx workbook." in response.data
+
+
+def test_missing_identity_is_rejected_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,barcode,clean_asset_tag,equipment_type\n,,,laptop\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Row 2: asset_tag or barcode is required." in response.data
+
+
+def test_unsupported_equipment_type_is_rejected_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,equipment_type\nMON-100,monitor\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Supported asset types are Laptop, Switch, and Router." in response.data
+
+
+def test_csv_upload_ignores_unknown_and_cmdb_style_columns_with_warning_without_database_writes(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,equipment_type,mac_address,owner\nSW-MAC,switch,00:11:22:33:44:55,Alice\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"File analyzed successfully. No database changes were made." in response.data
+    assert b"Warnings:" in response.data
+    assert b"Ignored unsupported CSV columns: mac_address, owner." in response.data
+
+
+def test_xlsx_upload_ignores_unknown_and_cmdb_style_columns_with_warning_without_database_writes(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        pd.DataFrame(
+            [
+                {
+                    "clean_asset_tag": "SW-MAC",
+                    "equipment_type": "switch",
+                    "mac_address": "00:11:22:33:44:55",
+                    "owner": "Alice",
+                }
+            ]
+        ).to_excel(writer, index=False)
+
+    response = _post_file(client_with_temp_db, buffer.getvalue(), "assets.xlsx")
+
+    assert response.status_code == 200
+    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"Warnings:" in response.data
+    assert b"Ignored unsupported XLSX columns: mac_address, owner." in response.data
+
+
+def test_ignored_columns_do_not_enter_canonical_analysis_rows(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,equipment_type,mac_address,owner\n"
+        "SW-MAC,switch,00:11:22:33:44:55,Alice\n",
+        encoding="utf-8",
+    )
+
+    analysis = analyze_asset_import_csv(csv_path, filename="assets.csv")
+
+    assert analysis.warnings == ("Ignored unsupported CSV columns: mac_address, owner.",)
+    assert len(analysis.rows) == 1
+    row = analysis.rows[0]
+    assert row.asset_tag == "SW-MAC"
+    assert row.equipment_type == "switch"
+    assert "mac_address" not in row.__dataclass_fields__
+    assert "owner" not in row.__dataclass_fields__
+    assert "00:11:22:33:44:55" not in str(row)
+    assert "Alice" not in str(row)
+
+
+def test_supported_optional_columns_are_mapped_to_canonical_analysis_row(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,barcode,clean_asset_tag,serial_number,equipment_type,manufacturer,model,model_code,"
+        "building_room,location_building,case_number,slot_number,notes_comments\n"
+        ",BAR-100,CLEAN-100,SN-100,laptop,Dell,Latitude,7420,HQ/101,HQ,alpha,7,Ready\n",
+        encoding="utf-8",
+    )
+
+    analysis = analyze_asset_import_csv(csv_path, filename="assets.csv")
+
+    assert analysis.warnings == ()
+    assert len(analysis.rows) == 1
+    row = analysis.rows[0]
+    assert row.asset_tag == "BAR-100"
+    assert row.serial_number == "SN-100"
+    assert row.equipment_type == "laptop"
+    assert row.manufacturer == "Dell"
+    assert row.model == "Latitude"
+    assert row.model_code == "7420"
+    assert row.building_room == "HQ/101"
+    assert row.location_building == "HQ"
+    assert row.case_identifier == "CASE-ALPHA"
+    assert row.slot_identifier == "7"
+    assert row.notes == "Ready"
+    assert row.storage_intent == "slotted"
+
+
+def test_direct_storage_columns_override_legacy_storage_aliases(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,equipment_type,case_identifier,slot_identifier,case_number,slot_number\n"
+        "SW-100,switch,CASE-DIRECT,3,legacy,8\n",
+        encoding="utf-8",
+    )
+
+    row = analyze_asset_import_csv(csv_path, filename="assets.csv").rows[0]
+
+    assert row.case_identifier == "CASE-DIRECT"
+    assert row.slot_identifier == "3"
+
+
+def test_slot_helper_is_ignored_with_visible_warning(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,equipment_type,slot_helper\n"
+        "SW-HELPER,switch,4\n",
+        encoding="utf-8",
+    )
+
+    analysis = analyze_asset_import_csv(csv_path, filename="assets.csv")
+
+    assert analysis.warnings == ("Ignored unsupported CSV column: slot_helper.",)
+    assert len(analysis.rows) == 1
+    row = analysis.rows[0]
+    assert row.asset_tag == "SW-HELPER"
+    assert row.storage_intent == "unslotted"
+    assert "slot_helper" not in row.__dataclass_fields__
+    assert "4" not in str(row)
+
+
+def test_duplicate_asset_rows_are_rejected_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,barcode,equipment_type\nDUP-100,,laptop\n,dup-100,switch\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Row 3: duplicate asset_tag matches row 2: DUP-100." in response.data
+
+
+def test_duplicate_serial_rows_are_rejected_without_database_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nLAP-100,SN-DUP,laptop\nSW-100,sn-dup,switch\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Row 3: duplicate serial_number matches row 2: sn-dup." in response.data
 
 
 def test_operator_is_forbidden_from_asset_import_upload_page(client_with_temp_db) -> None:


### PR DESCRIPTION
Title: Issue 30-5B: Normalize CSV and XLSX asset import rows

## Summary

Creates one canonical analyze-only row format for CSV and XLSX asset uploads.

Equivalent Laptop, Switch, and Router records now follow the same identity, storage, validation, and duplicate-detection rules.

Extra spreadsheet columns are ignored and reported to the operator instead of causing the complete upload to fail.

Closes #1045

## Changes

- Added shared CSV and XLSX row normalization.
- Requires `equipment_type` and an identity column such as `asset_tag` or `barcode`.
- Accepts `clean_asset_tag` for compatibility without presenting it as the normal operator format.
- Leaves missing optional descriptive values blank.
- Represents missing storage information as Unslotted intent.
- Blocks missing identity, unsupported equipment types, duplicate headers, and duplicate rows.
- Ignores unsupported columns and displays a warning listing them.
- Prevents accepted columns from being silently discarded.
- Keeps analysis isolated from assets, events, and slot occupancy.

## Verification

- [x] `python -m pytest tests/test_admin_asset_import.py -q`
- [x] 20 focused tests passed
- [x] `python -m pytest tests/test_network_asset_import.py tests/test_import_inventory.py -q`
- [x] 17 related importer tests passed
- [x] `python -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt successfully
- [x] Incognito administrator smoke test completed
- [x] Equivalent CSV and XLSX analysis verified
- [x] Ignored-column warnings verified
- [x] No asset, event, or occupancy writes observed

## Notes

No schema changes, migrations, dependencies, preview behavior, reconciliation behavior, or commit behavior were added.