### PR TITLE
Issue 30-19: Update pypdf security baseline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==2.4.1
 openpyxl==3.1.5
 pandas==3.0.0
 pillow==12.3.0
-pypdf==6.13.3
+pypdf==6.14.2
 python-dateutil==2.9.0.post0
 reportlab==4.4.9
 six==1.17.0


### PR DESCRIPTION
Title: Issue 30-19: Update pypdf security baseline

## Summary

Updates `pypdf` to the minimum safe version that resolves the four vulnerabilities reported by the Security Baseline.

Closes #1052

## Changes

- Updated `pypdf` from `6.13.3` to `6.14.2`.
- Changed no other dependency declarations.
- Changed no application or PDF-processing behavior.
- Changed no security thresholds, exclusions, workflows, or scanner configuration.

## Verification

- [x] Confirmed local virtual environment uses `pypdf 6.14.2`
- [x] Confirmed rebuilt Docker container uses `pypdf 6.14.2`
- [x] `python -m pytest tests/test_receipt_detail.py tests/test_basic_auth_guard.py tests/test_dashboard_drilldowns.py -q`
- [x] 112 focused PDF and receipt tests passed
- [x] `python -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt without cache
- [x] Docker application started successfully
- [x] HTTP startup check returned `200 OK`
- [x] Local Trivy scan reported zero vulnerabilities for `pypdf 6.14.2`
- [x] No Security Baseline protection was weakened

## Notes

The local Trivy scan used the vulnerability database cached on July 22, 2026. GitHub CI will perform the authoritative Security Baseline verification.