### PR TITLE
Issue 30-5C: Add asset import preview and reconciliation

### DIFF
--- a/assettrack/import_analysis.py
+++ b/assettrack/import_analysis.py
@@ -58,10 +58,22 @@ class AssetImportAnalysisRow:
     case_identifier: str
     slot_identifier: str
     notes: str
+    source_fields: frozenset[str] = frozenset()
 
     @property
     def storage_intent(self) -> str:
         return "slotted" if self.case_identifier and self.slot_identifier else "unslotted"
+
+    def has_source_field(self, field: str) -> bool:
+        return field in self.source_fields
+
+
+@dataclass(frozen=True)
+class AssetImportAnalysisIssue:
+    row_number: int
+    category: str
+    message: str
+    fields: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -70,6 +82,7 @@ class AssetImportAnalysis:
     file_type: str
     rows: tuple[AssetImportAnalysisRow, ...]
     warnings: tuple[str, ...] = ()
+    issues: tuple[AssetImportAnalysisIssue, ...] = ()
 
     @property
     def equipment_types(self) -> list[str]:
@@ -82,6 +95,7 @@ class AssetImportAnalysis:
             "file_type": self.file_type,
             "equipment_types": self.equipment_types,
             "warnings": list(self.warnings),
+            "issues": [issue.__dict__ for issue in self.issues],
         }
 
 
@@ -172,29 +186,52 @@ def _canonical_row(raw_row: dict[str, object], *, row_number: int) -> AssetImpor
         case_identifier=case_identifier,
         slot_identifier=slot_identifier,
         notes=_normalize_text(row.get("notes_comments")),
+        source_fields=frozenset(row),
     )
 
 
-def _validate_duplicates(rows: list[AssetImportAnalysisRow]) -> None:
+def _duplicate_issues(rows: list[AssetImportAnalysisRow]) -> tuple[AssetImportAnalysisIssue, ...]:
+    issues: list[AssetImportAnalysisIssue] = []
     seen_asset_tags: dict[str, int] = {}
     seen_serial_numbers: dict[str, int] = {}
     for row in rows:
         previous_asset_row = seen_asset_tags.get(row.asset_tag)
         if previous_asset_row is not None:
-            raise ValueError(
-                f"Row {row.row_number}: duplicate asset_tag matches row {previous_asset_row}: {row.asset_tag}."
+            issues.append(
+                AssetImportAnalysisIssue(
+                    row_number=row.row_number,
+                    category="duplicate_upload_row",
+                    message=f"duplicate asset_tag matches row {previous_asset_row}: {row.asset_tag}.",
+                    fields=("asset_tag",),
+                )
             )
-        seen_asset_tags[row.asset_tag] = row.row_number
+        else:
+            seen_asset_tags[row.asset_tag] = row.row_number
 
         normalized_serial = row.serial_number.upper()
         if not normalized_serial:
             continue
         previous_serial_row = seen_serial_numbers.get(normalized_serial)
         if previous_serial_row is not None:
-            raise ValueError(
-                f"Row {row.row_number}: duplicate serial_number matches row {previous_serial_row}: {row.serial_number}."
+            issues.append(
+                AssetImportAnalysisIssue(
+                    row_number=row.row_number,
+                    category="duplicate_upload_row",
+                    message=f"duplicate serial_number matches row {previous_serial_row}: {row.serial_number}.",
+                    fields=("serial_number",),
+                )
             )
-        seen_serial_numbers[normalized_serial] = row.row_number
+        else:
+            seen_serial_numbers[normalized_serial] = row.row_number
+    return tuple(issues)
+
+
+def _validate_duplicates(rows: list[AssetImportAnalysisRow]) -> None:
+    issues = _duplicate_issues(rows)
+    if not issues:
+        return
+    first = issues[0]
+    raise ValueError(f"Row {first.row_number}: {first.message}")
 
 
 def _analyze_rows(
@@ -203,20 +240,55 @@ def _analyze_rows(
     headers: list[str],
     filename: str,
     file_type: str,
+    collect_row_errors: bool = False,
 ) -> AssetImportAnalysis:
     warnings = _validate_headers(headers, file_type=file_type)
 
     rows: list[AssetImportAnalysisRow] = []
+    issues: list[AssetImportAnalysisIssue] = []
     for offset, raw_row in enumerate(raw_rows, start=2):
-        row = _canonical_row(raw_row, row_number=offset)
+        try:
+            row = _canonical_row(raw_row, row_number=offset)
+        except ValueError as exc:
+            if not collect_row_errors:
+                raise
+            issues.append(
+                AssetImportAnalysisIssue(
+                    row_number=offset,
+                    category="invalid_upload_row",
+                    message=str(exc).removeprefix(f"Row {offset}: "),
+                )
+            )
+            continue
         if row is not None:
             rows.append(row)
 
-    _validate_duplicates(rows)
-    return AssetImportAnalysis(filename=filename, file_type=file_type.upper(), rows=tuple(rows), warnings=warnings)
+    duplicate_issues = _duplicate_issues(rows)
+    if duplicate_issues:
+        if not collect_row_errors:
+            first = duplicate_issues[0]
+            raise ValueError(f"Row {first.row_number}: {first.message}")
+        issues.extend(duplicate_issues)
+
+    duplicate_row_numbers = {issue.row_number for issue in duplicate_issues}
+    if duplicate_row_numbers:
+        rows = [row for row in rows if row.row_number not in duplicate_row_numbers]
+
+    return AssetImportAnalysis(
+        filename=filename,
+        file_type=file_type.upper(),
+        rows=tuple(rows),
+        warnings=warnings,
+        issues=tuple(issues),
+    )
 
 
-def analyze_asset_import_csv(csv_path: str | Path, *, filename: str) -> AssetImportAnalysis:
+def analyze_asset_import_csv(
+    csv_path: str | Path,
+    *,
+    filename: str,
+    collect_row_errors: bool = False,
+) -> AssetImportAnalysis:
     path = Path(csv_path)
     try:
         with path.open("r", encoding="utf-8-sig", newline="") as handle:
@@ -237,10 +309,21 @@ def analyze_asset_import_csv(csv_path: str | Path, *, filename: str) -> AssetImp
     except csv.Error as exc:
         raise ValueError(f"Malformed CSV file. {exc}") from exc
 
-    return _analyze_rows(raw_rows, headers=headers, filename=filename, file_type="CSV")
+    return _analyze_rows(
+        raw_rows,
+        headers=headers,
+        filename=filename,
+        file_type="CSV",
+        collect_row_errors=collect_row_errors,
+    )
 
 
-def analyze_asset_import_xlsx(xlsx_path: str | Path, *, filename: str) -> AssetImportAnalysis:
+def analyze_asset_import_xlsx(
+    xlsx_path: str | Path,
+    *,
+    filename: str,
+    collect_row_errors: bool = False,
+) -> AssetImportAnalysis:
     path = Path(xlsx_path)
     try:
         with path.open("rb") as handle:
@@ -257,4 +340,10 @@ def analyze_asset_import_xlsx(xlsx_path: str | Path, *, filename: str) -> AssetI
         {str(column): row[column] for column in dataframe.columns}
         for _, row in dataframe.iterrows()
     ]
-    return _analyze_rows(raw_rows, headers=headers, filename=filename, file_type="XLSX")
+    return _analyze_rows(
+        raw_rows,
+        headers=headers,
+        filename=filename,
+        file_type="XLSX",
+        collect_row_errors=collect_row_errors,
+    )

--- a/assettrack/import_reconciliation.py
+++ b/assettrack/import_reconciliation.py
@@ -1,0 +1,369 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+
+from assettrack.assets import equipment_type_label
+from assettrack.import_analysis import AssetImportAnalysis, AssetImportAnalysisRow
+
+DEFAULTS_BEFORE_COMMIT = (
+    ("location_type", "STORAGE"),
+    ("current_holder", "Unassigned"),
+    ("custody_state", "in_stock"),
+    ("accountability_status", "accountable"),
+    ("condition", "serviceable"),
+    ("storage", "Unslotted when no available slot is provided"),
+)
+
+CHANGE_FIELDS = (
+    ("serial_number", "serial_number", "serial_number"),
+    ("equipment_type", "equipment_type", "equipment_type"),
+    ("manufacturer", "manufacturer", "manufacturer"),
+    ("model", "model", "model"),
+    ("model_code", "model_code", "model_code"),
+    ("building_room", "building_room", "building_room"),
+    ("location_building", "building", "location_building"),
+    ("notes", "notes", "notes_comments"),
+)
+
+CATEGORY_LABELS = {
+    "new_asset": "New Asset",
+    "unchanged_exact_match": "Unchanged Exact Match",
+    "proposed_update": "Proposed Update",
+    "unslotted_import": "Unslotted Import",
+    "slot_conflict_unslotted": "Slot Conflict Eligible For Unslotted Import",
+    "identity_conflict": "Identity Conflict",
+    "invalid_duplicate_upload_row": "Invalid Or Duplicate Upload Row",
+}
+CATEGORY_ORDER = tuple(CATEGORY_LABELS)
+ATTENTION_CATEGORIES = (
+    "proposed_update",
+    "slot_conflict_unslotted",
+    "identity_conflict",
+    "invalid_duplicate_upload_row",
+)
+
+
+@dataclass(frozen=True)
+class AssetImportFieldChange:
+    field: str
+    current: str
+    proposed: str
+
+
+@dataclass(frozen=True)
+class AssetImportPreviewRow:
+    row_number: int
+    asset_tag: str
+    category: str
+    category_label: str
+    message: str
+    changed_fields: tuple[AssetImportFieldChange, ...] = ()
+    warnings: tuple[str, ...] = ()
+    fields: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AssetImportPreview:
+    filename: str
+    file_type: str
+    rows: tuple[AssetImportPreviewRow, ...]
+    warnings: tuple[str, ...]
+    defaults: tuple[tuple[str, str], ...]
+    unslotted_acknowledged: bool
+
+    @property
+    def totals(self) -> dict[str, int]:
+        totals = {category: 0 for category in CATEGORY_ORDER}
+        for row in self.rows:
+            totals[row.category] = totals.get(row.category, 0) + 1
+        return totals
+
+    @property
+    def total_rows(self) -> int:
+        return len(self.rows)
+
+    @property
+    def requires_unslotted_acknowledgment(self) -> bool:
+        return any(row.category in {"unslotted_import", "slot_conflict_unslotted"} for row in self.rows)
+
+    @property
+    def blocks_without_unslotted_acknowledgment(self) -> bool:
+        return self.requires_unslotted_acknowledgment and not self.unslotted_acknowledged
+
+    def to_template_result(self) -> dict[str, object]:
+        row_dicts = [
+            {
+                "row_number": row.row_number,
+                "asset_tag": row.asset_tag,
+                "category": row.category,
+                "category_label": row.category_label,
+                "message": row.message,
+                "warnings": list(row.warnings),
+                "fields": list(row.fields),
+                "changed_fields": [
+                    {"field": change.field, "current": change.current, "proposed": change.proposed}
+                    for change in row.changed_fields
+                ],
+            }
+            for row in self.rows
+        ]
+        rows_by_category = {
+            category: [row for row in row_dicts if row["category"] == category]
+            for category in CATEGORY_ORDER
+        }
+        return {
+            "filename": self.filename,
+            "file_type": self.file_type,
+            "warnings": list(self.warnings),
+            "defaults": [{"field": field, "value": value} for field, value in self.defaults],
+            "totals": self.totals,
+            "category_labels": CATEGORY_LABELS,
+            "category_order": CATEGORY_ORDER,
+            "attention_categories": ATTENTION_CATEGORIES,
+            "rows": row_dicts,
+            "rows_by_category": rows_by_category,
+            "unslotted_acknowledged": self.unslotted_acknowledged,
+            "requires_unslotted_acknowledgment": self.requires_unslotted_acknowledgment,
+            "blocks_without_unslotted_acknowledgment": self.blocks_without_unslotted_acknowledgment,
+        }
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _asset_by_tag(conn: sqlite3.Connection, asset_tag: str) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT *
+        FROM assets
+        WHERE UPPER(asset_tag) = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_tag,),
+    ).fetchone()
+
+
+def _asset_by_serial(conn: sqlite3.Connection, serial_number: str) -> sqlite3.Row | None:
+    if not serial_number:
+        return None
+    return conn.execute(
+        """
+        SELECT *
+        FROM assets
+        WHERE TRIM(COALESCE(serial_number, '')) <> ''
+          AND UPPER(serial_number) = UPPER(?)
+        LIMIT 1;
+        """,
+        (serial_number,),
+    ).fetchone()
+
+
+def _slot_for_row(conn: sqlite3.Connection, row: AssetImportAnalysisRow) -> tuple[sqlite3.Row | None, str | None]:
+    if not row.case_identifier or not row.slot_identifier:
+        return None, None
+    try:
+        slot_position = int(row.slot_identifier)
+    except ValueError:
+        return None, "slot_identifier must be numeric"
+
+    slot = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+          AND slot_position = ?
+        LIMIT 1;
+        """,
+        (row.case_identifier, slot_position),
+    ).fetchone()
+    if slot is None:
+        return None, "slot does not exist"
+    return slot, None
+
+
+def _slot_occupant(conn: sqlite3.Connection, slot_id: int) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT a.asset_tag
+        FROM slot_occupancy so
+        JOIN assets a ON a.id = so.asset_id
+        WHERE so.slot_id = ?
+        LIMIT 1;
+        """,
+        (slot_id,),
+    ).fetchone()
+
+
+def _same_slot(asset: sqlite3.Row | None, slot: sqlite3.Row | None) -> bool:
+    if asset is None or slot is None or asset["home_slot_id"] is None:
+        return False
+    return int(asset["home_slot_id"]) == int(slot["id"])
+
+
+def _slot_label(slot: sqlite3.Row) -> str:
+    return f"{_text(slot['case_name'])} / {_text(slot['slot_position'])}"
+
+
+def _asset_home_slot_label(conn: sqlite3.Connection, asset: sqlite3.Row) -> str:
+    if asset["home_slot_id"] is None:
+        return "Unslotted"
+    slot = conn.execute(
+        """
+        SELECT case_name, slot_position
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (asset["home_slot_id"],),
+    ).fetchone()
+    if slot is not None:
+        return _slot_label(slot)
+    fallback_case = _text(asset["case_number"])
+    fallback_slot = _text(asset["slot_number"])
+    if fallback_case or fallback_slot:
+        return f"{fallback_case or 'Unknown case'} / {fallback_slot or 'Unknown slot'}"
+    return f"home_slot_id {asset['home_slot_id']}"
+
+
+def _field_changes(asset: sqlite3.Row, row: AssetImportAnalysisRow) -> tuple[AssetImportFieldChange, ...]:
+    changes: list[AssetImportFieldChange] = []
+    for row_field, asset_field, source_field in CHANGE_FIELDS:
+        if not row.has_source_field(source_field):
+            continue
+        proposed = _text(getattr(row, row_field))
+        if not proposed:
+            continue
+        current = _text(asset[asset_field]) if asset_field in asset.keys() else ""
+        if current != proposed:
+            changes.append(AssetImportFieldChange(field=asset_field, current=current, proposed=proposed))
+    return tuple(changes)
+
+
+def _preview_row(
+    conn: sqlite3.Connection,
+    row: AssetImportAnalysisRow,
+) -> AssetImportPreviewRow:
+    existing = _asset_by_tag(conn, row.asset_tag)
+    serial_match = _asset_by_serial(conn, row.serial_number)
+    if serial_match is not None and _text(serial_match["asset_tag"]).upper() != row.asset_tag.upper():
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            category="identity_conflict",
+            category_label=CATEGORY_LABELS["identity_conflict"],
+            message=f"serial_number matches existing asset {serial_match['asset_tag']}",
+            fields=("serial_number",),
+        )
+
+    storage_requested = row.storage_intent == "slotted"
+    if existing is None and not storage_requested:
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            category="unslotted_import",
+            category_label=CATEGORY_LABELS["unslotted_import"],
+            message="No storage case and slot supplied; row can continue as Unslotted after acknowledgment.",
+            warnings=("Storage will remain Unslotted.",),
+        )
+
+    slot = None
+    if storage_requested:
+        slot, slot_error = _slot_for_row(conn, row)
+        if slot_error is not None:
+            return AssetImportPreviewRow(
+                row_number=row.row_number,
+                asset_tag=row.asset_tag,
+                category="slot_conflict_unslotted",
+                category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
+                message=f"{slot_error}; row can continue as Unslotted after acknowledgment.",
+                warnings=("Requested storage is unavailable.",),
+                fields=("case_identifier", "slot_identifier"),
+            )
+
+        assert slot is not None
+        occupant = _slot_occupant(conn, int(slot["id"]))
+        legacy_current_asset_tag = _text(slot["current_asset_tag"])
+        occupied_by_other = occupant is not None and _text(occupant["asset_tag"]).upper() != row.asset_tag.upper()
+        legacy_occupied_by_other = legacy_current_asset_tag and legacy_current_asset_tag.upper() != row.asset_tag.upper()
+        if occupied_by_other or legacy_occupied_by_other:
+            occupant_tag = _text(occupant["asset_tag"]) if occupant is not None else legacy_current_asset_tag
+            return AssetImportPreviewRow(
+                row_number=row.row_number,
+                asset_tag=row.asset_tag,
+                category="slot_conflict_unslotted",
+                category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
+                message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",
+                warnings=("Existing slot occupants are never displaced.",),
+                fields=("case_identifier", "slot_identifier"),
+            )
+
+    if existing is None:
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            category="new_asset",
+            category_label=CATEGORY_LABELS["new_asset"],
+            message=f"New {equipment_type_label(row.equipment_type)} asset with available storage.",
+        )
+
+    changes = list(_field_changes(existing, row))
+    if storage_requested and not _same_slot(existing, slot):
+        assert slot is not None
+        changes.append(
+            AssetImportFieldChange(
+                field="home_slot",
+                current=_asset_home_slot_label(conn, existing),
+                proposed=_slot_label(slot),
+            )
+        )
+    if changes:
+        message = "Existing asset has proposed field updates."
+        if len(changes) == 1 and changes[0].field == "home_slot":
+            message = "Existing asset would move to a different available home slot."
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            category="proposed_update",
+            category_label=CATEGORY_LABELS["proposed_update"],
+            message=message,
+            changed_fields=tuple(changes),
+        )
+
+    return AssetImportPreviewRow(
+        row_number=row.row_number,
+        asset_tag=row.asset_tag,
+        category="unchanged_exact_match",
+        category_label=CATEGORY_LABELS["unchanged_exact_match"],
+        message="Upload row matches current asset data exactly.",
+    )
+
+
+def build_asset_import_preview(
+    conn: sqlite3.Connection,
+    analysis: AssetImportAnalysis,
+    *,
+    unslotted_acknowledged: bool = False,
+) -> AssetImportPreview:
+    rows: list[AssetImportPreviewRow] = [
+        AssetImportPreviewRow(
+            row_number=issue.row_number,
+            asset_tag="",
+            category="invalid_duplicate_upload_row",
+            category_label=CATEGORY_LABELS["invalid_duplicate_upload_row"],
+            message=issue.message,
+            fields=issue.fields,
+        )
+        for issue in analysis.issues
+    ]
+    rows.extend(_preview_row(conn, row) for row in analysis.rows)
+    rows.sort(key=lambda row: row.row_number)
+    return AssetImportPreview(
+        filename=analysis.filename,
+        file_type=analysis.file_type,
+        rows=tuple(rows),
+        warnings=analysis.warnings,
+        defaults=DEFAULTS_BEFORE_COMMIT,
+        unslotted_acknowledged=unslotted_acknowledged,
+    )

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -70,6 +70,7 @@ from assettrack.auth import (
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, set_holder_active, update_holder
 from assettrack.holder_import import HolderImportReport, import_holders_csv
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
+from assettrack.import_reconciliation import build_asset_import_preview
 from assettrack.reference_data import (
     create_building,
     create_organization,
@@ -7511,19 +7512,39 @@ def admin_holder_import():
 
 
 def _analyze_asset_import_csv(temp_path: Path, *, filename: str) -> dict:
-    return analyze_asset_import_csv(temp_path, filename=filename).to_template_result()
+    return analyze_asset_import_csv(temp_path, filename=filename, collect_row_errors=True).to_template_result()
 
 
 def _analyze_asset_import_xlsx(temp_path: Path, *, filename: str) -> dict:
-    return analyze_asset_import_xlsx(temp_path, filename=filename).to_template_result()
+    return analyze_asset_import_xlsx(temp_path, filename=filename, collect_row_errors=True).to_template_result()
 
 
-def _analyze_asset_import_upload(temp_path: Path, *, filename: str, suffix: str) -> dict:
+def _analyze_asset_import_upload(
+    temp_path: Path,
+    *,
+    filename: str,
+    suffix: str,
+    unslotted_acknowledged: bool = False,
+) -> dict:
     if suffix == ".csv":
-        return _analyze_asset_import_csv(temp_path, filename=filename)
-    if suffix == ".xlsx":
-        return _analyze_asset_import_xlsx(temp_path, filename=filename)
-    raise ValueError("Unsupported file type. Upload a .csv or .xlsx file.")
+        analysis = analyze_asset_import_csv(temp_path, filename=filename, collect_row_errors=True)
+    elif suffix == ".xlsx":
+        analysis = analyze_asset_import_xlsx(temp_path, filename=filename, collect_row_errors=True)
+    else:
+        raise ValueError("Unsupported file type. Upload a .csv or .xlsx file.")
+
+    resolved_db_path = _resolved_runtime_db_path()
+    conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        preview = build_asset_import_preview(
+            conn,
+            analysis,
+            unslotted_acknowledged=unslotted_acknowledged,
+        )
+    finally:
+        conn.close()
+    return preview.to_template_result()
 
 
 @app.route("/admin/assets/import", methods=["GET", "POST"])
@@ -7551,8 +7572,14 @@ def admin_asset_import():
                 upload.save(handle)
                 temp_path = Path(handle.name)
 
-            result = _analyze_asset_import_upload(temp_path, filename=filename, suffix=suffix)
-            flash("Asset import analysis complete. No database changes were made.", "success")
+            unslotted_acknowledged = (request.form.get("acknowledge_unslotted") or "").strip() == "1"
+            result = _analyze_asset_import_upload(
+                temp_path,
+                filename=filename,
+                suffix=suffix,
+                unslotted_acknowledged=unslotted_acknowledged,
+            )
+            flash("Asset import preview complete. No database changes were made.", "success")
         except ValueError as exc:
             flash(str(exc), "error")
         finally:

--- a/assettrack/intake/templates/admin_asset_import.html
+++ b/assettrack/intake/templates/admin_asset_import.html
@@ -8,6 +8,17 @@
     .import-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
     .import-summary { margin: 0; }
     .compact-list { margin: 0.5rem 0 0 1.25rem; }
+    .import-row-section { margin-top: 1rem; border-top: 1px solid var(--color-surface); padding-top: 0.75rem; }
+    .import-row-section summary { cursor: pointer; font-weight: 700; }
+    .import-row-count { color: var(--color-text-muted); font-weight: 400; margin-left: 0.5rem; }
+    .import-row-table-wrap { max-height: 28rem; overflow: auto; margin-top: 0.75rem; border: 1px solid var(--color-surface); }
+    .import-row-table-wrap table { margin: 0; }
+    .import-row-table-wrap thead th {
+      position: sticky;
+      top: 0;
+      background: var(--color-surface-bg);
+      z-index: 1;
+    }
   </style>
 {% endblock %}
 
@@ -33,6 +44,10 @@
           required
         />
       </div>
+      <label class="row">
+        <input type="checkbox" name="acknowledge_unslotted" value="1" />
+        Acknowledge rows with missing or unavailable storage may continue as Unslotted.
+      </label>
       <button type="submit">Analyze Import</button>
     </form>
   </div>
@@ -60,12 +75,7 @@
         &nbsp;|&nbsp;
         <strong>Type:</strong> {{ result.file_type }}
       </p>
-      <p class="import-help">File analyzed successfully. No database changes were made.</p>
-      {% if result.equipment_types %}
-        <p class="import-help">
-          <strong>Recognized asset types:</strong> {{ result.equipment_types|join(", ") }}
-        </p>
-      {% endif %}
+      <p class="import-help">Preview generated successfully. No database changes were made.</p>
       {% if result.warnings %}
         <p class="import-help"><strong>Warnings:</strong></p>
         <ul class="compact-list">
@@ -74,6 +84,82 @@
           {% endfor %}
         </ul>
       {% endif %}
+      {% if result.requires_unslotted_acknowledgment %}
+        {% if result.unslotted_acknowledged %}
+          <p class="flash success">Unslotted import acknowledged for rows with missing or unavailable storage.</p>
+        {% else %}
+          <p class="flash error">Unslotted acknowledgment is required before these rows can continue.</p>
+        {% endif %}
+      {% endif %}
+      <h3>Category Totals</h3>
+      <ul class="compact-list">
+        {% for category in result.category_order %}
+          <li>{{ result.category_labels[category] }}: {{ result.totals[category] }}</li>
+        {% endfor %}
+      </ul>
+      <h3>System Defaults Before Commit</h3>
+      <ul class="compact-list">
+        {% for default in result.defaults %}
+          <li><code>{{ default.field }}</code>: {{ default.value }}</li>
+        {% endfor %}
+      </ul>
+      <h3>Rows</h3>
+      {% for category in result.category_order %}
+        {% set category_rows = result.rows_by_category[category] %}
+        <details
+          id="asset-import-{{ category|replace('_', '-') }}"
+          class="import-row-section"
+          {% if category in result.attention_categories %}open{% endif %}
+        >
+          <summary>
+            {{ result.category_labels[category] }}
+            <span class="import-row-count">{{ category_rows|length }} row{% if category_rows|length != 1 %}s{% endif %}</span>
+          </summary>
+          <div class="import-row-table-wrap" tabindex="0" aria-label="{{ result.category_labels[category] }} rows">
+            <table>
+              <thead>
+                <tr>
+                  <th>Row</th>
+                  <th>Asset</th>
+                  <th>Details</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in category_rows %}
+                  <tr>
+                    <td>{{ row.row_number }}</td>
+                    <td><code>{{ row.asset_tag or "n/a" }}</code></td>
+                    <td>
+                      <p class="import-summary">{{ row.message }}</p>
+                      {% if row.fields %}
+                        <p class="import-help"><strong>Fields:</strong> {{ row.fields|join(", ") }}</p>
+                      {% endif %}
+                      {% if row.warnings %}
+                        <ul class="compact-list">
+                          {% for warning in row.warnings %}
+                            <li>{{ warning }}</li>
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
+                      {% if row.changed_fields %}
+                        <ul class="compact-list">
+                          {% for change in row.changed_fields %}
+                            <li><code>{{ change.field }}</code>: {{ change.current or "blank" }} -> {{ change.proposed or "blank" }}</li>
+                          {% endfor %}
+                        </ul>
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% else %}
+                  <tr>
+                    <td colspan="3">No rows in this category.</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </details>
+      {% endfor %}
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import io
+import re
+import sqlite3
 import tempfile
 from pathlib import Path
 
@@ -10,6 +12,7 @@ import pytest
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
+from assettrack.import_reconciliation import build_asset_import_preview
 from tests.auth_test_utils import create_test_user, login_session
 
 
@@ -49,6 +52,104 @@ def _post_file(client, content: bytes, filename: str):
     after = _table_counts()
     assert after == before
     return response
+
+
+def _details_tag(html: str, section_id: str) -> str:
+    match = re.search(rf'<details[^>]+id="{re.escape(section_id)}"[^>]*>', html)
+    assert match is not None
+    return match.group(0)
+
+
+def _insert_slot(
+    *,
+    slot_id: int,
+    case_name: str,
+    slot_position: int,
+    current_asset_tag: str | None = None,
+) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            (slot_id, case_name, slot_position, current_asset_tag),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_asset(
+    *,
+    asset_tag: str,
+    serial_number: str = "",
+    equipment_type: str = "laptop",
+    manufacturer: str = "",
+    model: str = "",
+    model_code: str = "",
+    building: str = "",
+    building_room: str = "",
+    case_number: str = "",
+    slot_number: str = "",
+    notes: str = "",
+    home_slot_id: int | None = None,
+    slotted: bool = False,
+) -> None:
+    conn = db.get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag,
+                serial_number,
+                equipment_type,
+                manufacturer,
+                model,
+                model_code,
+                building,
+                building_room,
+                custody_state,
+                accountability_status,
+                condition,
+                created_date,
+                location_type,
+                current_holder_id,
+                home_slot_id,
+                case_number,
+                slot_number,
+                notes
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'in_stock', 'accountable', 'serviceable',
+                    '2026-01-01', 'STORAGE', NULL, ?, ?, ?, ?);
+            """,
+            (
+                asset_tag,
+                serial_number,
+                equipment_type,
+                manufacturer,
+                model,
+                model_code,
+                building,
+                building_room,
+                home_slot_id,
+                case_number,
+                slot_number,
+                notes,
+            ),
+        )
+        if slotted and home_slot_id is not None:
+            conn.execute(
+                """
+                INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                VALUES (?, ?, '2026-01-01T00:00:00Z');
+                """,
+                (home_slot_id, int(cursor.lastrowid)),
+            )
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def _xlsx_bytes(rows: list[dict[str, object]] | None = None) -> bytes:
@@ -176,8 +277,8 @@ def test_csv_upload_analyzes_laptop_switch_and_router_without_database_writes(cl
     response = _post_file(client_with_temp_db, csv_content, "assets.csv")
 
     assert response.status_code == 200
-    assert b"Asset import analysis complete. No database changes were made." in response.data
-    assert b"File analyzed successfully. No database changes were made." in response.data
+    assert b"Asset import preview complete. No database changes were made." in response.data
+    assert b"Preview generated successfully. No database changes were made." in response.data
     assert b"Laptop" in response.data
     assert b"Switch" in response.data
     assert b"Router" in response.data
@@ -189,11 +290,524 @@ def test_xlsx_upload_analyzes_laptop_switch_and_router_without_database_writes(c
     response = _post_file(client_with_temp_db, _xlsx_bytes(), "inventory.xlsx")
 
     assert response.status_code == 200
-    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"Asset import preview complete. No database changes were made." in response.data
     assert b"XLSX" in response.data
     assert b"Laptop" in response.data
     assert b"Switch" in response.data
     assert b"Router" in response.data
+
+
+def test_asset_import_preview_classifies_new_asset_with_available_slot(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=501, case_name="CASE-NEW", slot_position=1)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"NEW-100,SER-NEW-100,laptop,Dell,Latitude,CASE-NEW,1\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"New Asset: 1" in response.data
+    assert b"New Laptop asset with available storage." in response.data
+    assert b"location_type</code>: STORAGE" in response.data
+    assert b"condition</code>: serviceable" in response.data
+
+
+def test_asset_import_preview_classifies_unchanged_exact_match_without_changes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=502, case_name="CASE-EXACT", slot_position=2, current_asset_tag="EXACT-100")
+    _insert_asset(
+        asset_tag="EXACT-100",
+        serial_number="SER-EXACT-100",
+        equipment_type="switch",
+        manufacturer="Cisco",
+        model="Catalyst",
+        model_code="9300",
+        building="HQ",
+        building_room="HQ/101",
+        case_number="CASE-EXACT",
+        slot_number="2",
+        home_slot_id=502,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,model_code,location_building,"
+        b"building_room,case_identifier,slot_identifier\n"
+        b"EXACT-100,SER-EXACT-100,switch,Cisco,Catalyst,9300,HQ,HQ/101,CASE-EXACT,2\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in response.data
+    assert b"Upload row matches current asset data exactly." in response.data
+    assert b"Proposed Update: 0" in response.data
+    assert b"Existing asset has proposed field updates." not in response.data
+
+
+def test_existing_slotted_asset_with_omitted_storage_preserves_current_slot(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=520, case_name="CASE-KEEP", slot_position=1, current_asset_tag="KEEP-100")
+    _insert_asset(
+        asset_tag="KEEP-100",
+        serial_number="SER-KEEP-100",
+        equipment_type="laptop",
+        manufacturer="Dell",
+        model="Latitude",
+        building="HQ",
+        building_room="HQ/101",
+        case_number="CASE-KEEP",
+        slot_number="1",
+        home_slot_id=520,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,equipment_type\nKEEP-100,laptop\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in response.data
+    assert b"Unslotted Import: 0" in response.data
+    assert b"home_slot" not in response.data
+    assert b"Storage will remain Unslotted." not in response.data
+
+
+def test_existing_slotted_asset_with_blank_storage_preserves_current_slot(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=521, case_name="CASE-BLANK", slot_position=2, current_asset_tag="BLANK-100")
+    _insert_asset(
+        asset_tag="BLANK-100",
+        serial_number="SER-BLANK-100",
+        equipment_type="switch",
+        manufacturer="Cisco",
+        model="Catalyst",
+        case_number="CASE-BLANK",
+        slot_number="2",
+        home_slot_id=521,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"BLANK-100,SER-BLANK-100,switch,Cisco,Catalyst,,\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in response.data
+    assert b"Unslotted Import: 0" in response.data
+    assert b"Storage will remain Unslotted." not in response.data
+
+
+def test_existing_unslotted_asset_with_blank_storage_is_unchanged_exact_match(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_asset(
+        asset_tag="UNSLOTTED-EXACT",
+        serial_number="SER-UNSLOTTED-EXACT",
+        equipment_type="router",
+        manufacturer="Juniper",
+        model="MX",
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"UNSLOTTED-EXACT,SER-UNSLOTTED-EXACT,router,Juniper,MX,,\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in response.data
+    assert b"Unslotted Import: 0" in response.data
+
+
+def test_existing_asset_omitted_optional_fields_preserve_current_values(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=522, case_name="CASE-OPTIONAL", slot_position=3, current_asset_tag="OPTIONAL-100")
+    _insert_asset(
+        asset_tag="OPTIONAL-100",
+        serial_number="SER-OPTIONAL-100",
+        equipment_type="laptop",
+        manufacturer="Dell",
+        model="Latitude",
+        model_code="7420",
+        building="HQ",
+        building_room="HQ/101",
+        notes="Ready",
+        case_number="CASE-OPTIONAL",
+        slot_number="3",
+        home_slot_id=522,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,equipment_type,case_identifier,slot_identifier\n"
+        b"OPTIONAL-100,laptop,CASE-OPTIONAL,3\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in response.data
+    assert b"Proposed Update: 0" in response.data
+    assert b"manufacturer</code>" not in response.data
+    assert b"serial_number</code>" not in response.data
+    assert b"notes</code>" not in response.data
+
+
+def test_existing_asset_present_blank_optional_fields_preserve_current_values(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=523, case_name="CASE-BLANKOPT", slot_position=4, current_asset_tag="BLANKOPT-100")
+    _insert_asset(
+        asset_tag="BLANKOPT-100",
+        serial_number="SER-BLANKOPT-100",
+        equipment_type="switch",
+        manufacturer="Cisco",
+        model="Catalyst",
+        model_code="9300",
+        building="HQ",
+        building_room="HQ/201",
+        notes="Existing note",
+        case_number="CASE-BLANKOPT",
+        slot_number="4",
+        home_slot_id=523,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,model_code,building_room,"
+        b"location_building,notes_comments,case_identifier,slot_identifier\n"
+        b"BLANKOPT-100,,switch,,,,,,,CASE-BLANKOPT,4\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in response.data
+    assert b"Proposed Update: 0" in response.data
+    assert b"manufacturer</code>" not in response.data
+    assert b"serial_number</code>" not in response.data
+    assert b"notes</code>" not in response.data
+
+
+def test_asset_import_preview_shows_proposed_update_changed_fields(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=503, case_name="CASE-UPD", slot_position=3, current_asset_tag="UPD-100")
+    _insert_asset(
+        asset_tag="UPD-100",
+        serial_number="SER-UPD-100",
+        equipment_type="router",
+        manufacturer="Old Maker",
+        model="Old Model",
+        case_number="CASE-UPD",
+        slot_number="3",
+        home_slot_id=503,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"UPD-100,SER-UPD-100,router,New Maker,New Model,CASE-UPD,3\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Proposed Update: 1" in response.data
+    assert b"Existing asset has proposed field updates." in response.data
+    assert b"manufacturer</code>: Old Maker -> New Maker" in response.data
+    assert b"model</code>: Old Model -> New Model" in response.data
+
+
+def test_existing_asset_different_available_slot_shows_readable_labels(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=524, case_name="CASE-OLD", slot_position=5, current_asset_tag="MOVE-100")
+    _insert_slot(slot_id=525, case_name="CASE-NEW", slot_position=6)
+    _insert_asset(
+        asset_tag="MOVE-100",
+        serial_number="SER-MOVE-100",
+        equipment_type="router",
+        manufacturer="Juniper",
+        model="MX",
+        case_number="CASE-OLD",
+        slot_number="5",
+        home_slot_id=524,
+        slotted=True,
+    )
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"MOVE-100,SER-MOVE-100,router,Juniper,MX,CASE-NEW,6\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Proposed Update: 1" in response.data
+    assert b"Existing asset would move to a different available home slot." in response.data
+    assert b"home_slot</code>: CASE-OLD / 5 -> CASE-NEW / 6" in response.data
+    assert b"home_slot_id" not in response.data
+
+
+def test_asset_import_preview_classifies_unslotted_missing_storage_and_acknowledgment(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nUNSLOT-100,SER-UNSLOT-100,laptop\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Unslotted Import: 1" in response.data
+    assert b"No storage case and slot supplied" in response.data
+    assert b"Unslotted acknowledgment is required before these rows can continue." in response.data
+
+    before = _table_counts()
+    acknowledged_response = client_with_temp_db.post(
+        "/admin/assets/import",
+        data={
+            "acknowledge_unslotted": "1",
+            "asset_file": (
+                io.BytesIO(b"asset_tag,serial_number,equipment_type\nUNSLOT-100,SER-UNSLOT-100,laptop\n"),
+                "assets.csv",
+            ),
+        },
+        content_type="multipart/form-data",
+    )
+    after = _table_counts()
+
+    assert acknowledged_response.status_code == 200
+    assert after == before
+    assert b"Unslotted import acknowledged for rows with missing or unavailable storage." in acknowledged_response.data
+
+
+def test_csv_and_xlsx_preview_preserve_blank_existing_fields_equivalently(
+    client_with_temp_db,
+    tmp_path: Path,
+) -> None:
+    _insert_asset(
+        asset_tag="PARITY-100",
+        serial_number="SER-PARITY-100",
+        equipment_type="laptop",
+        manufacturer="Dell",
+        model="Latitude",
+    )
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        "PARITY-100,,laptop,,,,\n",
+        encoding="utf-8",
+    )
+    xlsx_path = tmp_path / "assets.xlsx"
+    xlsx_path.write_bytes(
+        _xlsx_bytes(
+            [
+                {
+                    "clean_asset_tag": "PARITY-100",
+                    "serial_number": "",
+                    "equipment_type": "laptop",
+                    "manufacturer": "",
+                    "model": "",
+                    "case_identifier": "",
+                    "slot_identifier": "",
+                }
+            ]
+        )
+    )
+
+    conn = sqlite3.connect(f"file:{db.DB_PATH.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        csv_preview = build_asset_import_preview(
+            conn,
+            analyze_asset_import_csv(csv_path, filename="assets.csv", collect_row_errors=True),
+        )
+        xlsx_preview = build_asset_import_preview(
+            conn,
+            analyze_asset_import_xlsx(xlsx_path, filename="assets.xlsx", collect_row_errors=True),
+        )
+    finally:
+        conn.close()
+
+    assert [(row.category, row.changed_fields) for row in csv_preview.rows] == [
+        (row.category, row.changed_fields) for row in xlsx_preview.rows
+    ]
+    assert csv_preview.rows[0].category == xlsx_preview.rows[0].category == "unchanged_exact_match"
+
+
+def test_asset_import_preview_classifies_slot_conflict_as_unslotted_eligible(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=504, case_name="CASE-BUSY", slot_position=4, current_asset_tag="BUSY-OTHER")
+    _insert_asset(asset_tag="BUSY-OTHER", home_slot_id=504, case_number="CASE-BUSY", slot_number="4", slotted=True)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"BUSY-100,SER-BUSY-100,switch,CASE-BUSY,4\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Slot Conflict Eligible For Unslotted Import: 1" in response.data
+    assert b"Requested slot is occupied by BUSY-OTHER" in response.data
+    assert b"Existing slot occupants are never displaced." in response.data
+    assert b"Unslotted acknowledgment is required before these rows can continue." in response.data
+
+
+def test_asset_import_preview_classifies_identity_conflict(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_asset(asset_tag="SERIAL-OWNER", serial_number="SER-CONFLICT")
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nOTHER-TAG,SER-CONFLICT,laptop\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Identity Conflict: 1" in response.data
+    assert b"serial_number matches existing asset SERIAL-OWNER" in response.data
+    assert b"serial_number" in response.data
+
+
+def test_asset_import_preview_classifies_invalid_and_duplicate_upload_rows(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\n"
+        b"DUP-100,SER-DUP-100,laptop\n"
+        b",SER-MISSING,switch\n"
+        b"DUP-100,SER-DUP-200,router\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Invalid Or Duplicate Upload Row: 2" in response.data
+    assert b"asset_tag or barcode is required." in response.data
+    assert b"duplicate asset_tag matches row 2: DUP-100." in response.data
+
+
+def test_asset_import_preview_groups_rows_by_category_with_expected_disclosure_defaults(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=530, case_name="CASE-GROUP-NEW", slot_position=1)
+    _insert_slot(slot_id=531, case_name="CASE-GROUP-EXACT", slot_position=2, current_asset_tag="GROUP-EXACT")
+    _insert_slot(slot_id=532, case_name="CASE-GROUP-UPD", slot_position=3, current_asset_tag="GROUP-UPD")
+    _insert_slot(slot_id=533, case_name="CASE-GROUP-BUSY", slot_position=4, current_asset_tag="GROUP-BUSY-OTHER")
+    _insert_asset(
+        asset_tag="GROUP-EXACT",
+        serial_number="SER-GROUP-EXACT",
+        equipment_type="switch",
+        manufacturer="Cisco",
+        model="Catalyst",
+        case_number="CASE-GROUP-EXACT",
+        slot_number="2",
+        home_slot_id=531,
+        slotted=True,
+    )
+    _insert_asset(
+        asset_tag="GROUP-UPD",
+        serial_number="SER-GROUP-UPD",
+        equipment_type="laptop",
+        manufacturer="Old Maker",
+        model="Latitude",
+        case_number="CASE-GROUP-UPD",
+        slot_number="3",
+        home_slot_id=532,
+        slotted=True,
+    )
+    _insert_asset(
+        asset_tag="GROUP-BUSY-OTHER",
+        equipment_type="router",
+        case_number="CASE-GROUP-BUSY",
+        slot_number="4",
+        home_slot_id=533,
+        slotted=True,
+    )
+    _insert_asset(asset_tag="GROUP-SERIAL-OWNER", serial_number="SER-GROUP-CONFLICT")
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"GROUP-NEW,SER-GROUP-NEW,laptop,Dell,Latitude,CASE-GROUP-NEW,1\n"
+        b"GROUP-EXACT,SER-GROUP-EXACT,switch,Cisco,Catalyst,CASE-GROUP-EXACT,2\n"
+        b"GROUP-UNSLOT,SER-GROUP-UNSLOT,router,Juniper,MX,,\n"
+        b"GROUP-UPD,SER-GROUP-UPD,laptop,New Maker,Latitude,CASE-GROUP-UPD,3\n"
+        b"GROUP-BUSY,SER-GROUP-BUSY,switch,,,CASE-GROUP-BUSY,4\n"
+        b"GROUP-CONFLICT,SER-GROUP-CONFLICT,laptop,,,,\n"
+        b",SER-GROUP-MISSING,router,,,,\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    html = response.data.decode("utf-8")
+
+    assert "New Asset: 1" in html
+    assert "Unchanged Exact Match: 1" in html
+    assert "Proposed Update: 1" in html
+    assert "Unslotted Import: 1" in html
+    assert "Slot Conflict Eligible For Unslotted Import: 1" in html
+    assert "Identity Conflict: 1" in html
+    assert "Invalid Or Duplicate Upload Row: 1" in html
+
+    for section_id in (
+        "asset-import-new-asset",
+        "asset-import-unchanged-exact-match",
+        "asset-import-unslotted-import",
+    ):
+        assert "open" not in _details_tag(html, section_id)
+
+    for section_id in (
+        "asset-import-proposed-update",
+        "asset-import-slot-conflict-unslotted",
+        "asset-import-identity-conflict",
+        "asset-import-invalid-duplicate-upload-row",
+    ):
+        assert "open" in _details_tag(html, section_id)
+
+    assert html.count("1 row") >= 7
+    assert 'class="import-row-table-wrap"' in html
+    assert "<th>Row</th>" in html
+    assert "Unslotted acknowledgment is required before these rows can continue." in html
+
+    for asset_tag in (
+        "GROUP-NEW",
+        "GROUP-EXACT",
+        "GROUP-UNSLOT",
+        "GROUP-UPD",
+        "GROUP-BUSY",
+        "GROUP-CONFLICT",
+    ):
+        assert asset_tag in html
+    assert "asset_tag or barcode is required." in html
 
 
 def test_traversal_style_csv_filename_uses_server_tempfile_suffix(
@@ -219,7 +833,7 @@ def test_traversal_style_csv_filename_uses_server_tempfile_suffix(
     )
 
     assert response.status_code == 200
-    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"Asset import preview complete. No database changes were made." in response.data
     assert created_paths
     temp_root = Path(tempfile.gettempdir()).resolve()
     for created_path in created_paths:
@@ -248,7 +862,7 @@ def test_traversal_style_xlsx_filename_uses_server_tempfile_suffix(
     response = _post_file(client_with_temp_db, _xlsx_bytes(), "..\\..\\outside.xlsx")
 
     assert response.status_code == 200
-    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"Asset import preview complete. No database changes were made." in response.data
     assert created_paths
     temp_root = Path(tempfile.gettempdir()).resolve()
     for created_path in created_paths:
@@ -299,7 +913,7 @@ def test_missing_identity_is_rejected_without_database_writes(client_with_temp_d
     )
 
     assert response.status_code == 200
-    assert b"Row 2: asset_tag or barcode is required." in response.data
+    assert b"asset_tag or barcode is required." in response.data
 
 
 def test_unsupported_equipment_type_is_rejected_without_database_writes(client_with_temp_db) -> None:
@@ -327,8 +941,8 @@ def test_csv_upload_ignores_unknown_and_cmdb_style_columns_with_warning_without_
     )
 
     assert response.status_code == 200
-    assert b"Asset import analysis complete. No database changes were made." in response.data
-    assert b"File analyzed successfully. No database changes were made." in response.data
+    assert b"Asset import preview complete. No database changes were made." in response.data
+    assert b"Preview generated successfully. No database changes were made." in response.data
     assert b"Warnings:" in response.data
     assert b"Ignored unsupported CSV columns: mac_address, owner." in response.data
 
@@ -353,7 +967,7 @@ def test_xlsx_upload_ignores_unknown_and_cmdb_style_columns_with_warning_without
     response = _post_file(client_with_temp_db, buffer.getvalue(), "assets.xlsx")
 
     assert response.status_code == 200
-    assert b"Asset import analysis complete. No database changes were made." in response.data
+    assert b"Asset import preview complete. No database changes were made." in response.data
     assert b"Warnings:" in response.data
     assert b"Ignored unsupported XLSX columns: mac_address, owner." in response.data
 
@@ -450,7 +1064,7 @@ def test_duplicate_asset_rows_are_rejected_without_database_writes(client_with_t
     )
 
     assert response.status_code == 200
-    assert b"Row 3: duplicate asset_tag matches row 2: DUP-100." in response.data
+    assert b"duplicate asset_tag matches row 2: DUP-100." in response.data
 
 
 def test_duplicate_serial_rows_are_rejected_without_database_writes(client_with_temp_db) -> None:
@@ -463,7 +1077,7 @@ def test_duplicate_serial_rows_are_rejected_without_database_writes(client_with_
     )
 
     assert response.status_code == 200
-    assert b"Row 3: duplicate serial_number matches row 2: sn-dup." in response.data
+    assert b"duplicate serial_number matches row 2: sn-dup." in response.data
 
 
 def test_operator_is_forbidden_from_asset_import_upload_page(client_with_temp_db) -> None:


### PR DESCRIPTION
Title: Issue 30-5C: Add asset import preview and reconciliation

## Summary

Adds a read-only preview that reconciles normalized CSV and XLSX asset rows against current AssetTrack data before commit.

The preview is summary-first, preserves existing data when uploads are incomplete, and identifies rows requiring operator attention.

Closes #1046

## Changes

- Classifies rows as new, unchanged, proposed update, Unslotted, slot conflict, identity conflict, or invalid/duplicate.
- Shows category totals, row details, proposed field changes, warnings, and documented defaults.
- Preserves existing optional values when upload fields are omitted or blank.
- Preserves existing slot assignments unless a complete, valid, available replacement slot is supplied.
- Displays readable current and proposed case and slot labels.
- Requires acknowledgment for safe Unslotted handling.
- Groups rows into collapsible category sections.
- Keeps routine categories collapsed and attention categories expanded by default.
- Uses bounded scrolling and sticky table headers for large uploads.
- Performs no asset, event, custody, or occupancy writes.
- Adds no confirmed commit behavior.

## Verification

- [x] `python -m pytest tests/test_admin_asset_import.py -q`
- [x] 35 focused tests passed
- [x] `python -m pytest tests/test_network_asset_import.py tests/test_import_inventory.py -q`
- [x] 17 related importer tests passed
- [x] `python -m compileall assettrack tests`
- [x] `git diff --check`
- [x] Docker image rebuilt successfully
- [x] Incognito administrator preview smoke test completed
- [x] Existing values and slot assignments remain preserved for incomplete uploads
- [x] New Unslotted assets and slot conflicts display correctly
- [x] Large mixed upload presentation verified
- [x] No commit action or database writes observed

## Notes

No schema changes, migrations, dependencies, confirmed commit behavior, or security changes were added.