### PR TITLE
Issue 30 5d atomic import commit

### DIFF
--- a/assettrack/auth.py
+++ b/assettrack/auth.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from functools import wraps
+from pathlib import Path
 import time
 
 from flask import g, render_template, request, session
@@ -24,7 +25,17 @@ def begin_auth_session(user_id: int) -> None:
     session["session_started_at"] = started_at
 
 
+def _clear_pending_asset_import_session() -> None:
+    pending = session.pop("pending_asset_import", None)
+    if not isinstance(pending, dict):
+        return
+    temp_path_value = str(pending.get("temp_path") or "").strip()
+    if temp_path_value:
+        Path(temp_path_value).unlink(missing_ok=True)
+
+
 def clear_auth_session() -> None:
+    _clear_pending_asset_import_session()
     for key in AUTH_SESSION_KEYS:
         session.pop(key, None)
 

--- a/assettrack/import_analysis.py
+++ b/assettrack/import_analysis.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 
 import pandas as pd
@@ -109,6 +110,31 @@ def _normalize_text(value: object) -> str:
     return str(value or "").strip()
 
 
+def _normalize_slot_identifier(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    if isinstance(value, bool):
+        return str(value).strip()
+    if isinstance(value, int):
+        return str(value)
+
+    text = str(value or "").strip()
+    if not text:
+        return ""
+
+    try:
+        numeric_value = Decimal(text)
+    except InvalidOperation:
+        return text
+
+    # Spreadsheet readers commonly coerce whole-number cells to floats. Slot
+    # identifiers are logical integers, so normalize at the import boundary and
+    # give downstream reconciliation one canonical representation.
+    if numeric_value.is_finite() and numeric_value == numeric_value.to_integral_value():
+        return str(int(numeric_value))
+    return text
+
+
 def _first_line(value: object) -> str:
     text = str(value or "").strip()
     return text.splitlines()[0] if text else ""
@@ -143,7 +169,9 @@ def _validate_headers(headers: list[str], *, file_type: str) -> tuple[str, ...]:
 
 def _canonical_row(raw_row: dict[str, object], *, row_number: int) -> AssetImportAnalysisRow | None:
     row = {
-        normalized_key: _normalize_text(value)
+        normalized_key: _normalize_slot_identifier(value)
+        if normalized_key in {"slot_identifier", "slot_number"}
+        else _normalize_text(value)
         for key, value in raw_row.items()
         if (normalized_key := _normalize_header(key)) in ALLOWED_COLUMNS
     }
@@ -168,7 +196,7 @@ def _canonical_row(raw_row: dict[str, object], *, row_number: int) -> AssetImpor
     if not case_identifier:
         case_number = _normalize_text(row.get("case_number")).upper()
         case_identifier = f"CASE-{case_number}" if case_number else ""
-    slot_identifier = _normalize_text(row.get("slot_identifier")) or _normalize_text(row.get("slot_number"))
+    slot_identifier = _normalize_slot_identifier(row.get("slot_identifier")) or _normalize_slot_identifier(row.get("slot_number"))
 
     if bool(case_identifier) != bool(slot_identifier):
         raise ValueError(f"Row {row_number}: storage case and slot must both be present or both be blank.")

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -11,6 +11,7 @@ Feynman-brief:
 
 from __future__ import annotations
 
+import csv
 import hashlib
 import json
 import os
@@ -21,7 +22,7 @@ import tempfile
 import time
 from email.message import EmailMessage
 from email.utils import getaddresses
-from io import BytesIO
+from io import BytesIO, TextIOWrapper
 from pathlib import Path
 from typing import Optional
 from datetime import datetime, timezone, date, timedelta
@@ -81,6 +82,7 @@ from assettrack.reference_data import (
     set_building_active,
     update_building_name,
 )
+from assettrack.slots import move_asset_between_slots_in_tx
 from assettrack.settings import (
     active_receipt_cc_setting,
     read_receipt_cc_setting,
@@ -7547,26 +7549,507 @@ def _analyze_asset_import_upload(
     return preview.to_template_result()
 
 
+
+ASSET_IMPORT_PENDING_SESSION_KEY = "pending_asset_import"
+
+
+def _clear_pending_asset_import() -> None:
+    pending = session.pop(ASSET_IMPORT_PENDING_SESSION_KEY, None)
+    if not isinstance(pending, dict):
+        return
+    temp_path_value = str(pending.get("temp_path") or "").strip()
+    if temp_path_value:
+        Path(temp_path_value).unlink(missing_ok=True)
+
+
+def _asset_import_file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _asset_import_preview_token(*, result: dict, file_sha256: str, suffix: str, filename: str, unslotted_acknowledged: bool) -> str:
+    payload = {
+        "result": result,
+        "file_sha256": file_sha256,
+        "suffix": suffix,
+        "filename": filename,
+        "unslotted_acknowledged": unslotted_acknowledged,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _load_pending_asset_import() -> dict[str, object] | None:
+    pending = session.get(ASSET_IMPORT_PENDING_SESSION_KEY)
+    if not isinstance(pending, dict):
+        return None
+    temp_path_value = str(pending.get("temp_path") or "").strip()
+    if not temp_path_value:
+        _clear_pending_asset_import()
+        return None
+    temp_path = Path(temp_path_value)
+    if not temp_path.exists() or not temp_path.is_file():
+        _clear_pending_asset_import()
+        return None
+    return pending
+
+
+def _analyze_asset_import_to_preview(conn: sqlite3.Connection, temp_path: Path, *, filename: str, suffix: str, unslotted_acknowledged: bool):
+    if suffix == ".csv":
+        analysis = analyze_asset_import_csv(temp_path, filename=filename, collect_row_errors=True)
+    elif suffix == ".xlsx":
+        analysis = analyze_asset_import_xlsx(temp_path, filename=filename, collect_row_errors=True)
+    else:
+        raise ValueError("Unsupported file type. Upload a .csv or .xlsx file.")
+    return build_asset_import_preview(conn, analysis, unslotted_acknowledged=unslotted_acknowledged), analysis
+
+
+def _store_pending_asset_import(*, temp_path: Path, filename: str, suffix: str, result: dict, unslotted_acknowledged: bool) -> str:
+    _clear_pending_asset_import()
+    file_sha256 = _asset_import_file_sha256(temp_path)
+    token = _asset_import_preview_token(
+        result=result,
+        file_sha256=file_sha256,
+        suffix=suffix,
+        filename=filename,
+        unslotted_acknowledged=unslotted_acknowledged,
+    )
+    session[ASSET_IMPORT_PENDING_SESSION_KEY] = {
+        "temp_path": str(temp_path),
+        "filename": filename,
+        "suffix": suffix,
+        "file_sha256": file_sha256,
+        "preview_token": token,
+        "unslotted_acknowledged": unslotted_acknowledged,
+    }
+    return token
+
+
+def _asset_import_row_by_number(analysis) -> dict[int, object]:
+    return {int(row.row_number): row for row in analysis.rows}
+
+
+def _asset_import_existing_asset(conn: sqlite3.Connection, asset_tag: str) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT *
+        FROM assets
+        WHERE UPPER(asset_tag) = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_tag,),
+    ).fetchone()
+
+
+def _asset_import_slot_for_row(conn: sqlite3.Connection, row) -> sqlite3.Row | None:
+    if row.storage_intent != "slotted":
+        return None
+    return conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+          AND slot_position = ?
+        LIMIT 1;
+        """,
+        (row.case_identifier, int(row.slot_identifier)),
+    ).fetchone()
+
+
+def _asset_import_slot_is_available_for(conn: sqlite3.Connection, *, slot_id: int, asset_tag: str) -> bool:
+    occupant = conn.execute(
+        """
+        SELECT a.asset_tag
+        FROM slot_occupancy so
+        JOIN assets a ON a.id = so.asset_id
+        WHERE so.slot_id = ?
+        LIMIT 1;
+        """,
+        (slot_id,),
+    ).fetchone()
+    if occupant is not None and str(occupant["asset_tag"] or "").strip().upper() != asset_tag.upper():
+        return False
+    slot = conn.execute("SELECT current_asset_tag FROM slots WHERE id = ? LIMIT 1;", (slot_id,)).fetchone()
+    current_tag = str(slot["current_asset_tag"] or "").strip() if slot else ""
+    return not current_tag or current_tag.upper() == asset_tag.upper()
+
+
+def _asset_import_new_asset_values(conn: sqlite3.Connection, row, *, now_iso: str, slot: sqlite3.Row | None) -> dict[str, object]:
+    values: dict[str, object] = {
+        "asset_tag": row.asset_tag,
+        "equipment_type": row.equipment_type,
+        "custody_state": "in_stock",
+        "accountability_status": "accountable",
+        "condition": "serviceable",
+        "created_date": now_iso,
+        "location_type": "STORAGE",
+        "current_holder_id": None,
+    }
+    optional_fields = {
+        "serial_number": row.serial_number,
+        "manufacturer": row.manufacturer,
+        "model": row.model,
+        "model_code": row.model_code,
+        "building_room": row.building_room,
+        "building": row.location_building,
+        "notes": row.notes,
+    }
+    values.update({field: value for field, value in optional_fields.items() if value})
+    if slot is not None:
+        values.update(
+            {
+                "home_slot_id": int(slot["id"]),
+                "case_number": str(slot["case_name"]),
+                "slot_number": str(slot["slot_position"]),
+            }
+        )
+    return {field: value for field, value in values.items() if field in get_asset_table_columns(conn)}
+
+
+def _asset_import_insert_asset(conn: sqlite3.Connection, values: dict[str, object]) -> int:
+    column_names = list(values)
+    cursor = conn.execute(
+        f"INSERT INTO assets ({', '.join(column_names)}) VALUES ({', '.join('?' for _ in column_names)});",
+        [values[column] for column in column_names],
+    )
+    return int(cursor.lastrowid)
+
+
+def _asset_import_append_event(
+    conn: sqlite3.Connection,
+    *,
+    asset_tag: str,
+    event_type: str,
+    event_date: str,
+    actor: str,
+    payload: dict,
+    notes: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+        """,
+        (asset_tag, event_type, event_date, actor, notes, json.dumps(payload), None),
+    )
+
+
+def _asset_import_create_new_asset(conn: sqlite3.Connection, row, *, now_iso: str, actor: str, slot: sqlite3.Row | None) -> None:
+    values = _asset_import_new_asset_values(conn, row, now_iso=now_iso, slot=slot)
+    asset_id = _asset_import_insert_asset(conn, values)
+    _asset_import_append_event(
+        conn,
+        asset_tag=row.asset_tag,
+        event_type="ASSET_CREATED",
+        event_date=now_iso,
+        actor=actor,
+        payload={"asset": values, "row_number": row.row_number},
+    )
+    if slot is None:
+        return
+    slot_id = int(slot["id"])
+    if not _asset_import_slot_is_available_for(conn, slot_id=slot_id, asset_tag=row.asset_tag):
+        raise ValueError(f"Row {row.row_number}: requested slot is no longer available.")
+    conn.execute("INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at) VALUES (?, ?, ?);", (slot_id, asset_id, now_iso))
+    conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", (row.asset_tag, slot_id))
+    _asset_import_append_event(
+        conn,
+        asset_tag=row.asset_tag,
+        event_type="SLOT_ASSIGN",
+        event_date=now_iso,
+        actor=actor,
+        payload={
+            "slot": {
+                "slot_id": slot_id,
+                "case_number": str(slot["case_name"]),
+                "slot_number": int(slot["slot_position"]),
+            },
+            "row_number": row.row_number,
+        },
+    )
+
+
+def _asset_import_metadata_updates(row) -> dict[str, object]:
+    values: dict[str, object] = {}
+    for row_field, asset_field, source_field in (
+        ("serial_number", "serial_number", "serial_number"),
+        ("equipment_type", "equipment_type", "equipment_type"),
+        ("manufacturer", "manufacturer", "manufacturer"),
+        ("model", "model", "model"),
+        ("model_code", "model_code", "model_code"),
+        ("building_room", "building_room", "building_room"),
+        ("location_building", "building", "location_building"),
+        ("notes", "notes", "notes_comments"),
+    ):
+        if row.has_source_field(source_field):
+            value = str(getattr(row, row_field) or "").strip()
+            if value:
+                values[asset_field] = value
+    return values
+
+
+def _asset_import_apply_metadata_update(
+    conn: sqlite3.Connection,
+    *,
+    asset: sqlite3.Row,
+    row,
+    values: dict[str, object],
+    now_iso: str,
+    actor: str,
+) -> bool:
+    asset_columns = get_asset_table_columns(conn)
+    changed = {
+        field: value
+        for field, value in values.items()
+        if field in asset_columns and str((asset[field] if field in asset.keys() else "") or "").strip() != str(value).strip()
+    }
+    if not changed:
+        return False
+    if "updated_date" in asset_columns:
+        changed["updated_date"] = now_iso
+    conn.execute(
+        f"UPDATE assets SET {', '.join(f'{field} = ?' for field in changed)} WHERE id = ?;",
+        [changed[field] for field in changed] + [int(asset["id"])],
+    )
+    _asset_import_append_event(
+        conn,
+        asset_tag=str(asset["asset_tag"]),
+        event_type="ASSET_UPDATED",
+        event_date=now_iso,
+        actor=actor,
+        payload={"fields": changed, "row_number": row.row_number},
+    )
+    return True
+
+
+def _asset_import_apply_existing_update(conn: sqlite3.Connection, row, preview_row, *, now_iso: str, actor: str) -> tuple[bool, bool]:
+    asset = _asset_import_existing_asset(conn, row.asset_tag)
+    if asset is None:
+        raise ValueError(f"Row {row.row_number}: asset changed since preview.")
+    movement_change = any(change.field == "home_slot" for change in preview_row.changed_fields)
+    metadata_values = _asset_import_metadata_updates(row)
+    moved = False
+    if movement_change:
+        slot = _asset_import_slot_for_row(conn, row)
+        if slot is None:
+            raise ValueError(f"Row {row.row_number}: destination slot is unavailable.")
+        if not _asset_import_slot_is_available_for(conn, slot_id=int(slot["id"]), asset_tag=row.asset_tag):
+            raise ValueError(f"Row {row.row_number}: requested slot is no longer available.")
+        source_slot_id = asset["home_slot_id"]
+        if source_slot_id is None:
+            raise ValueError(f"Row {row.row_number}: asset is not currently slotted.")
+        building_room = row.building_room or str(asset["building_room"] or "")
+        move_preview = _build_admin_slot_move_preview(
+            conn,
+            source_slot_id=int(source_slot_id),
+            building_room=building_room,
+            case_number=str(slot["case_name"]),
+            slot_number=str(slot["slot_position"]),
+        )
+        move_asset_between_slots_in_tx(conn, move_preview=move_preview, notes="Asset import slot move", actor=actor, event_date=now_iso)
+        moved = True
+        asset = _asset_import_existing_asset(conn, row.asset_tag)
+        if asset is None:
+            raise ValueError(f"Row {row.row_number}: asset changed during update.")
+        metadata_values.pop("building_room", None)
+    metadata_updated = _asset_import_apply_metadata_update(
+        conn,
+        asset=asset,
+        row=row,
+        values=metadata_values,
+        now_iso=now_iso,
+        actor=actor,
+    )
+    return moved, metadata_updated
+
+
+def _commit_asset_import_pending(*, submitted_token: str) -> tuple[dict, dict]:
+    pending = _load_pending_asset_import()
+    if pending is None:
+        raise ValueError("Import preview expired. Upload and preview the file again.")
+    expected_token = str(pending.get("preview_token") or "")
+    if not submitted_token or submitted_token != expected_token:
+        _clear_pending_asset_import()
+        raise ValueError("Import confirmation is stale or tampered. Preview the file again.")
+
+    temp_path = Path(str(pending["temp_path"]))
+    filename = str(pending["filename"])
+    suffix = str(pending["suffix"])
+    unslotted_acknowledged = bool(pending.get("unslotted_acknowledged"))
+    file_sha256 = _asset_import_file_sha256(temp_path)
+    if file_sha256 != str(pending.get("file_sha256") or ""):
+        _clear_pending_asset_import()
+        raise ValueError("Uploaded file changed after preview. Upload and preview the file again.")
+
+    conn = get_connection()
+    try:
+        conn.execute("BEGIN IMMEDIATE;")
+        preview, analysis = _analyze_asset_import_to_preview(
+            conn,
+            temp_path,
+            filename=filename,
+            suffix=suffix,
+            unslotted_acknowledged=unslotted_acknowledged,
+        )
+        result = preview.to_template_result()
+        current_token = _asset_import_preview_token(
+            result=result,
+            file_sha256=file_sha256,
+            suffix=suffix,
+            filename=filename,
+            unslotted_acknowledged=unslotted_acknowledged,
+        )
+        if current_token != expected_token:
+            _clear_pending_asset_import()
+            raise ValueError("Import preview is stale. Upload and preview the file again.")
+        if preview.blocks_without_unslotted_acknowledgment:
+            _clear_pending_asset_import()
+            raise ValueError("Unslotted acknowledgment is required before commit.")
+
+        rows_by_number = _asset_import_row_by_number(analysis)
+        now_iso = datetime.now(timezone.utc).isoformat()
+        actor = "admin"
+        summary = {
+            "created": 0,
+            "updated": 0,
+            "slot_assigned": 0,
+            "slot_moved": 0,
+            "unchanged": 0,
+            "blocked": 0,
+            "committed_rows": 0,
+        }
+        safe_unslotted_categories = {"unslotted_import", "slot_conflict_unslotted"}
+        for preview_row in preview.rows:
+            row = rows_by_number.get(int(preview_row.row_number))
+            if row is None:
+                summary["blocked"] += 1
+                continue
+            if preview_row.category == "unchanged_exact_match":
+                summary["unchanged"] += 1
+                continue
+            if preview_row.category == "new_asset":
+                slot = _asset_import_slot_for_row(conn, row)
+                if slot is None:
+                    raise ValueError(f"Row {row.row_number}: requested slot is unavailable.")
+                _asset_import_create_new_asset(conn, row, now_iso=now_iso, actor=actor, slot=slot)
+                summary["created"] += 1
+                summary["slot_assigned"] += 1
+                summary["committed_rows"] += 1
+                continue
+            if preview_row.category in safe_unslotted_categories and preview.unslotted_acknowledged:
+                if _asset_import_existing_asset(conn, row.asset_tag) is None:
+                    _asset_import_create_new_asset(conn, row, now_iso=now_iso, actor=actor, slot=None)
+                    summary["created"] += 1
+                    summary["committed_rows"] += 1
+                else:
+                    summary["blocked"] += 1
+                continue
+            if preview_row.category == "proposed_update":
+                moved, metadata_updated = _asset_import_apply_existing_update(conn, row, preview_row, now_iso=now_iso, actor=actor)
+                if moved:
+                    summary["slot_moved"] += 1
+                if metadata_updated:
+                    summary["updated"] += 1
+                if moved or metadata_updated:
+                    summary["committed_rows"] += 1
+                continue
+            summary["blocked"] += 1
+
+        conn.commit()
+        _clear_pending_asset_import()
+        return result, summary
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _asset_import_reconciliation_csv_response() -> object:
+    pending = _load_pending_asset_import()
+    if pending is None:
+        flash("Import preview expired. Upload and preview the file again.", "error")
+        return redirect(url_for("admin_asset_import"))
+    temp_path = Path(str(pending["temp_path"]))
+    resolved_db_path = _resolved_runtime_db_path()
+    conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        preview, _analysis = _analyze_asset_import_to_preview(
+            conn,
+            temp_path,
+            filename=str(pending["filename"]),
+            suffix=str(pending["suffix"]),
+            unslotted_acknowledged=bool(pending.get("unslotted_acknowledged")),
+        )
+    finally:
+        conn.close()
+
+    output = BytesIO()
+    wrapper = TextIOWrapper(output, encoding="utf-8", newline="")
+    writer = csv.writer(wrapper)
+    writer.writerow(["row_number", "asset_tag", "category", "message", "changed_fields", "warnings"])
+    for row in preview.rows:
+        writer.writerow(
+            [
+                row.row_number,
+                row.asset_tag,
+                row.category,
+                row.message,
+                "; ".join(f"{change.field}: {change.current} -> {change.proposed}" for change in row.changed_fields),
+                "; ".join(row.warnings),
+            ]
+        )
+    wrapper.flush()
+    response = make_response(output.getvalue())
+    response.headers["Content-Type"] = "text/csv; charset=utf-8"
+    response.headers["Content-Disposition"] = "attachment; filename=asset-import-reconciliation.csv"
+    return response
+
+
 @app.route("/admin/assets/import", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
 def admin_asset_import():
     result: dict | None = None
+    commit_summary: dict | None = None
 
     if request.method == "POST":
+        action = (request.form.get("action") or "analyze").strip().lower()
+        if action == "commit":
+            if (request.form.get("confirm_import") or "").strip() != "1":
+                _clear_pending_asset_import()
+                flash("Confirm the preview before committing approved rows.", "error")
+                return render_template("admin_asset_import.html", result=None, commit_summary=None)
+            try:
+                result, commit_summary = _commit_asset_import_pending(
+                    submitted_token=(request.form.get("preview_token") or "").strip()
+                )
+                flash(
+                    "Asset import committed. Safe rows were written atomically; blocked rows were left unchanged.",
+                    "success",
+                )
+            except ValueError as exc:
+                flash(str(exc), "error")
+            return render_template("admin_asset_import.html", result=result, commit_summary=commit_summary)
+
         upload = request.files.get("asset_file")
         filename = str((upload.filename if upload is not None else "") or "").strip()
         if upload is None or not filename:
             flash("Choose a .csv or .xlsx file to analyze.", "error")
-            return render_template("admin_asset_import.html", result=None)
+            return render_template("admin_asset_import.html", result=None, commit_summary=None)
 
         suffix = Path(filename).suffix.lower()
         tempfile_suffix = ASSET_IMPORT_TEMPFILE_SUFFIXES.get(suffix)
         if tempfile_suffix is None:
             flash("Unsupported file type. Upload a .csv or .xlsx file.", "error")
-            return render_template("admin_asset_import.html", result=None)
+            return render_template("admin_asset_import.html", result=None, commit_summary=None)
 
         temp_path: Path | None = None
+        keep_temp_path = False
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix=tempfile_suffix) as handle:
                 upload.save(handle)
@@ -7579,15 +8062,30 @@ def admin_asset_import():
                 suffix=suffix,
                 unslotted_acknowledged=unslotted_acknowledged,
             )
+            preview_token = _store_pending_asset_import(
+                temp_path=temp_path,
+                filename=filename,
+                suffix=suffix,
+                result=result,
+                unslotted_acknowledged=unslotted_acknowledged,
+            )
+            result["preview_token"] = preview_token
+            keep_temp_path = True
             flash("Asset import preview complete. No database changes were made.", "success")
         except ValueError as exc:
             flash(str(exc), "error")
         finally:
-            if temp_path is not None:
+            if temp_path is not None and not keep_temp_path:
                 temp_path.unlink(missing_ok=True)
 
-    return render_template("admin_asset_import.html", result=result)
+    return render_template("admin_asset_import.html", result=result, commit_summary=commit_summary)
 
+
+@app.get("/admin/assets/import/reconciliation.csv")
+@require_login
+@require_role("admin")
+def admin_asset_import_reconciliation_csv():
+    return _asset_import_reconciliation_csv_response()
 
 @app.get("/admin/network-assets/import")
 @require_login
@@ -10071,113 +10569,13 @@ def admin_slot_move():
                     expected_asset_id_raw=expected_asset_id_raw,
                     expected_destination_slot_id_raw=expected_destination_slot_id_raw,
                 )
-                asset_id = int(move_preview["asset"]["asset_id"])
                 asset_tag = str(move_preview["asset"]["asset_tag"])
                 destination_slot_id = int(move_preview["destination"]["slot_id"])
-
-                delete_source = conn.execute(
-                    """
-                    DELETE FROM slot_occupancy
-                    WHERE slot_id = ? AND asset_id = ?;
-                    """,
-                    (source_slot_id, asset_id),
-                )
-                if delete_source.rowcount != 1:
-                    raise ValueError("Source slot is missing or empty.")
-
-                now_iso = datetime.now(timezone.utc).isoformat()
-                conn.execute(
-                    """
-                    INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
-                    VALUES (?, ?, ?);
-                    """,
-                    (destination_slot_id, asset_id, now_iso),
-                )
-
-                conn.execute(
-                    """
-                    UPDATE slots
-                    SET current_asset_tag = NULL
-                    WHERE id = ?;
-                    """,
-                    (source_slot_id,),
-                )
-                conn.execute(
-                    """
-                    UPDATE slots
-                    SET current_asset_tag = ?
-                    WHERE id = ?;
-                    """,
-                    (asset_tag, destination_slot_id),
-                )
-
-                asset_columns = get_asset_table_columns(conn)
-                update_clauses: list[str] = []
-                update_values: list[object] = []
-                if "home_slot_id" in asset_columns:
-                    update_clauses.append("home_slot_id = ?")
-                    update_values.append(destination_slot_id)
-                if "building" in asset_columns:
-                    update_clauses.append("building = ?")
-                    update_values.append(str(move_preview["destination"]["building"]))
-                if "room" in asset_columns:
-                    update_clauses.append("room = ?")
-                    update_values.append(str(move_preview["destination"]["room"]))
-                if "building_room" in asset_columns:
-                    update_clauses.append("building_room = ?")
-                    update_values.append(building_room)
-                if "case_number" in asset_columns:
-                    update_clauses.append("case_number = ?")
-                    update_values.append(str(move_preview["destination"]["case_number"]))
-                if "slot_number" in asset_columns:
-                    update_clauses.append("slot_number = ?")
-                    update_values.append(str(move_preview["destination"]["slot_number"]))
-                if "updated_date" in asset_columns:
-                    update_clauses.append("updated_date = ?")
-                    update_values.append(now_iso)
-                if update_clauses:
-                    update_values.append(asset_id)
-                    conn.execute(
-                        f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
-                        tuple(update_values),
-                    )
-
-                payload = {
-                    "from_slot": {
-                        "slot_id": int(move_preview["source"]["slot_id"]),
-                        "building_room": str(move_preview["source"]["building_room"]),
-                        "case_number": str(move_preview["source"]["case_number"]),
-                        "slot_number": int(move_preview["source"]["slot_number"]),
-                    },
-                    "to_slot": {
-                        "slot_id": destination_slot_id,
-                        "building_room": building_room,
-                        "case_number": str(move_preview["destination"]["case_number"]),
-                        "slot_number": int(move_preview["destination"]["slot_number"]),
-                    },
-                }
-                conn.execute(
-                    """
-                    INSERT INTO asset_events (
-                        asset_tag,
-                        event_type,
-                        event_date,
-                        actor,
-                        notes,
-                        payload,
-                        holder_id
-                    )
-                    VALUES (?, ?, ?, ?, ?, ?, ?);
-                    """,
-                    (
-                        asset_tag,
-                        "SLOT_MOVE",
-                        now_iso,
-                        "admin",
-                        notes or None,
-                        json.dumps(payload),
-                        None,
-                    ),
+                move_asset_between_slots_in_tx(
+                    conn,
+                    move_preview=move_preview,
+                    notes=notes,
+                    actor="admin",
                 )
 
                 conn.commit()

--- a/assettrack/intake/templates/admin_asset_import.html
+++ b/assettrack/intake/templates/admin_asset_import.html
@@ -48,7 +48,7 @@
         <input type="checkbox" name="acknowledge_unslotted" value="1" />
         Acknowledge rows with missing or unavailable storage may continue as Unslotted.
       </label>
-      <button type="submit">Analyze Import</button>
+      <button type="submit" name="action" value="analyze">Analyze Import</button>
     </form>
   </div>
 
@@ -97,6 +97,32 @@
           <li>{{ result.category_labels[category] }}: {{ result.totals[category] }}</li>
         {% endfor %}
       </ul>
+      {% if commit_summary %}
+        <h3>Commit Result</h3>
+        <ul class="compact-list">
+          <li>Committed rows: {{ commit_summary.committed_rows }}</li>
+          <li>Created assets: {{ commit_summary.created }}</li>
+          <li>Updated assets: {{ commit_summary.updated }}</li>
+          <li>Slot assignments: {{ commit_summary.slot_assigned }}</li>
+          <li>Slot moves: {{ commit_summary.slot_moved }}</li>
+          <li>Unchanged rows: {{ commit_summary.unchanged }}</li>
+          <li>Blocked rows: {{ commit_summary.blocked }}</li>
+        </ul>
+      {% endif %}
+      <p class="import-help">
+        <a href="{{ url_for('admin_asset_import_reconciliation_csv') }}">Download reconciliation CSV</a>
+      </p>
+      {% if result.preview_token and not commit_summary %}
+        <form method="post" class="row">
+          <input type="hidden" name="action" value="commit" />
+          <input type="hidden" name="preview_token" value="{{ result.preview_token }}" />
+          <label class="row">
+            <input type="checkbox" name="confirm_import" value="1" required />
+            Confirm this preview and commit the approved safe rows.
+          </label>
+          <button type="submit">Commit Approved Rows</button>
+        </form>
+      {% endif %}
       <h3>System Defaults Before Commit</h3>
       <ul class="compact-list">
         {% for default in result.defaults %}

--- a/assettrack/slots.py
+++ b/assettrack/slots.py
@@ -1,9 +1,12 @@
 # assettrack/slots.py
 from __future__ import annotations
 
+import json
 import sqlite3
+from datetime import datetime, timezone
 from typing import Optional
 
+from assettrack.assets import get_asset_table_columns
 from assettrack.db import get_connection
 
 
@@ -329,6 +332,124 @@ def move_asset_to_slot(
             _set_asset_home_slot_in_tx(conn, normalized_tag, destination_slot_id)
     finally:
         conn.close()
+
+def move_asset_between_slots_in_tx(
+    conn: sqlite3.Connection,
+    *,
+    move_preview: dict,
+    notes: str = "",
+    actor: str = "admin",
+    event_date: str | None = None,
+) -> None:
+    asset_id = int(move_preview["asset"]["asset_id"])
+    asset_tag = str(move_preview["asset"]["asset_tag"])
+    source_slot_id = int(move_preview["source"]["slot_id"])
+    destination_slot_id = int(move_preview["destination"]["slot_id"])
+    now_iso = event_date or datetime.now(timezone.utc).isoformat()
+
+    delete_source = conn.execute(
+        """
+        DELETE FROM slot_occupancy
+        WHERE slot_id = ? AND asset_id = ?;
+        """,
+        (source_slot_id, asset_id),
+    )
+    if delete_source.rowcount != 1:
+        raise ValueError("Source slot is missing or empty.")
+
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (?, ?, ?);
+        """,
+        (destination_slot_id, asset_id, now_iso),
+    )
+
+    conn.execute(
+        """
+        UPDATE slots
+        SET current_asset_tag = NULL
+        WHERE id = ?;
+        """,
+        (source_slot_id,),
+    )
+    conn.execute(
+        """
+        UPDATE slots
+        SET current_asset_tag = ?
+        WHERE id = ?;
+        """,
+        (asset_tag, destination_slot_id),
+    )
+
+    asset_columns = get_asset_table_columns(conn)
+    update_clauses: list[str] = []
+    update_values: list[object] = []
+    if "home_slot_id" in asset_columns:
+        update_clauses.append("home_slot_id = ?")
+        update_values.append(destination_slot_id)
+    if "building" in asset_columns:
+        update_clauses.append("building = ?")
+        update_values.append(str(move_preview["destination"]["building"]))
+    if "room" in asset_columns:
+        update_clauses.append("room = ?")
+        update_values.append(str(move_preview["destination"]["room"]))
+    if "building_room" in asset_columns:
+        update_clauses.append("building_room = ?")
+        update_values.append(str(move_preview["destination"]["building_room"]))
+    if "case_number" in asset_columns:
+        update_clauses.append("case_number = ?")
+        update_values.append(str(move_preview["destination"]["case_number"]))
+    if "slot_number" in asset_columns:
+        update_clauses.append("slot_number = ?")
+        update_values.append(str(move_preview["destination"]["slot_number"]))
+    if "updated_date" in asset_columns:
+        update_clauses.append("updated_date = ?")
+        update_values.append(now_iso)
+    if update_clauses:
+        update_values.append(asset_id)
+        conn.execute(
+            f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+            tuple(update_values),
+        )
+
+    payload = {
+        "from_slot": {
+            "slot_id": source_slot_id,
+            "building_room": str(move_preview["source"]["building_room"]),
+            "case_number": str(move_preview["source"]["case_number"]),
+            "slot_number": int(move_preview["source"]["slot_number"]),
+        },
+        "to_slot": {
+            "slot_id": destination_slot_id,
+            "building_room": str(move_preview["destination"]["building_room"]),
+            "case_number": str(move_preview["destination"]["case_number"]),
+            "slot_number": int(move_preview["destination"]["slot_number"]),
+        },
+    }
+    conn.execute(
+        """
+        INSERT INTO asset_events (
+            asset_tag,
+            event_type,
+            event_date,
+            actor,
+            notes,
+            payload,
+            holder_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            asset_tag,
+            "SLOT_MOVE",
+            now_iso,
+            actor,
+            notes or None,
+            json.dumps(payload),
+            None,
+        ),
+    )
 
 
 def _set_asset_home_slot_in_tx(conn: sqlite3.Connection, asset_tag: str, slot_id: Optional[int]) -> None:

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -250,6 +250,112 @@ def test_csv_and_xlsx_use_equivalent_canonical_analysis_rows(tmp_path: Path) -> 
     assert csv_analysis.equipment_types == xlsx_analysis.equipment_types == ["Laptop", "Switch"]
 
 
+def test_slot_identifiers_normalize_integer_like_csv_and_xlsx_values(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,equipment_type,case_identifier,slot_identifier\n"
+        "CSV-INT,laptop,CASE-CSV,4\n"
+        "CSV-DECIMAL,switch,CASE-CSV,4.0\n",
+        encoding="utf-8",
+    )
+    xlsx_path = tmp_path / "assets.xlsx"
+    xlsx_path.write_bytes(
+        _xlsx_bytes(
+            [
+                {
+                    "clean_asset_tag": "XLSX-FOUR",
+                    "equipment_type": "laptop",
+                    "case_identifier": "CASE-2912-SMOKE",
+                    "slot_identifier": 4.0,
+                },
+                {
+                    "clean_asset_tag": "XLSX-NINES",
+                    "equipment_type": "router",
+                    "case_identifier": "CASE-999",
+                    "slot_identifier": 999.0,
+                },
+                {
+                    "clean_asset_tag": "XLSX-FRACTION",
+                    "equipment_type": "switch",
+                    "case_identifier": "CASE-FRACTION",
+                    "slot_identifier": 4.5,
+                },
+            ]
+        )
+    )
+
+    csv_rows = analyze_asset_import_csv(csv_path, filename="assets.csv").rows
+    xlsx_rows = analyze_asset_import_xlsx(xlsx_path, filename="assets.xlsx").rows
+
+    assert [row.slot_identifier for row in csv_rows] == ["4", "4"]
+    assert [row.slot_identifier for row in xlsx_rows] == ["4", "999", "4.5"]
+    assert xlsx_rows[0].case_identifier == "CASE-2912-SMOKE"
+
+
+def test_fractional_slot_identifier_is_rejected_without_rounding(
+    client_with_temp_db,
+    tmp_path: Path,
+) -> None:
+    xlsx_path = tmp_path / "assets.xlsx"
+    xlsx_path.write_bytes(
+        _xlsx_bytes(
+            [
+                {
+                    "clean_asset_tag": "XLSX-FRACTION",
+                    "equipment_type": "laptop",
+                    "case_identifier": "CASE-FRACTION",
+                    "slot_identifier": 4.5,
+                }
+            ]
+        )
+    )
+
+    analysis = analyze_asset_import_xlsx(xlsx_path, filename="assets.xlsx", collect_row_errors=True)
+    assert analysis.rows[0].slot_identifier == "4.5"
+
+    conn = sqlite3.connect(f"file:{db.DB_PATH.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        preview = build_asset_import_preview(conn, analysis)
+    finally:
+        conn.close()
+
+    assert preview.rows[0].category == "slot_conflict_unslotted"
+    assert preview.rows[0].message == "slot_identifier must be numeric; row can continue as Unslotted after acknowledgment."
+
+
+def test_xlsx_numeric_slot_identifier_reaches_available_slot_classification(
+    client_with_temp_db,
+    tmp_path: Path,
+) -> None:
+    _insert_slot(slot_id=560, case_name="CASE-2912-SMOKE", slot_position=4)
+    xlsx_path = tmp_path / "assets.xlsx"
+    xlsx_path.write_bytes(
+        _xlsx_bytes(
+            [
+                {
+                    "clean_asset_tag": "XLSX-SLOT-4",
+                    "equipment_type": "laptop",
+                    "case_identifier": "CASE-2912-SMOKE",
+                    "slot_identifier": 4.0,
+                }
+            ]
+        )
+    )
+
+    analysis = analyze_asset_import_xlsx(xlsx_path, filename="assets.xlsx", collect_row_errors=True)
+    conn = sqlite3.connect(f"file:{db.DB_PATH.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        preview = build_asset_import_preview(conn, analysis)
+    finally:
+        conn.close()
+
+    assert analysis.rows[0].case_identifier == "CASE-2912-SMOKE"
+    assert analysis.rows[0].slot_identifier == "4"
+    assert preview.rows[0].category == "new_asset"
+
+
 def test_admin_can_open_asset_import_upload_page(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
 

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -44,11 +44,13 @@ def _table_counts() -> dict[str, int]:
         conn.close()
 
 
-def _post_file(client, content: bytes, filename: str):
+def _post_file(client, content: bytes, filename: str, *, form: dict[str, str] | None = None):
     before = _table_counts()
+    data = dict(form or {})
+    data["asset_file"] = (io.BytesIO(content), filename)
     response = client.post(
         "/admin/assets/import",
-        data={"asset_file": (io.BytesIO(content), filename)},
+        data=data,
         content_type="multipart/form-data",
     )
     after = _table_counts()
@@ -842,6 +844,13 @@ def test_traversal_style_csv_filename_uses_server_tempfile_suffix(
         assert created_path.parent.resolve() == temp_root
         assert created_path.suffix == ".csv"
         assert "outside" not in created_path.name
+        assert created_path.exists()
+    assert _pending_temp_path(client_with_temp_db) == created_paths[-1]
+
+    logout_response = client_with_temp_db.get("/logout")
+
+    assert logout_response.status_code == 302
+    for created_path in created_paths:
         assert not created_path.exists()
 
 
@@ -850,10 +859,13 @@ def test_traversal_style_xlsx_filename_uses_server_tempfile_suffix(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _login_admin(client_with_temp_db)
+    xlsx_content = _xlsx_bytes()
     created_paths: list[Path] = []
     original_named_temporary_file = intake_app.tempfile.NamedTemporaryFile
 
     def recording_named_temporary_file(*args, **kwargs):
+        if kwargs.get("prefix") == "openpyxl.":
+            return original_named_temporary_file(*args, **kwargs)
         assert kwargs["suffix"] == ".xlsx"
         handle = original_named_temporary_file(*args, **kwargs)
         created_paths.append(Path(handle.name))
@@ -861,7 +873,7 @@ def test_traversal_style_xlsx_filename_uses_server_tempfile_suffix(
 
     monkeypatch.setattr(intake_app.tempfile, "NamedTemporaryFile", recording_named_temporary_file)
 
-    response = _post_file(client_with_temp_db, _xlsx_bytes(), "..\\..\\outside.xlsx")
+    response = _post_file(client_with_temp_db, xlsx_content, "..\\..\\outside.xlsx")
 
     assert response.status_code == 200
     assert b"Asset import preview complete. No database changes were made." in response.data
@@ -871,6 +883,13 @@ def test_traversal_style_xlsx_filename_uses_server_tempfile_suffix(
         assert created_path.parent.resolve() == temp_root
         assert created_path.suffix == ".xlsx"
         assert "outside" not in created_path.name
+        assert created_path.exists()
+    assert _pending_temp_path(client_with_temp_db) == created_paths[-1]
+
+    logout_response = client_with_temp_db.get("/logout")
+
+    assert logout_response.status_code == 302
+    for created_path in created_paths:
         assert not created_path.exists()
 
 
@@ -1252,6 +1271,7 @@ def test_asset_import_commit_writes_approved_safe_rows_atomically_and_leaves_blo
         b"CONFLICT-TAG,SER-CONFLICT,laptop,Dell,Latitude,,\n"
         b",SER-MISSING,laptop,Dell,Latitude,,\n",
         "assets.csv",
+        form={"acknowledge_unslotted": "1"},
     )
     assert response.status_code == 200
     token = _preview_token(response)

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import io
 import re
 import sqlite3
@@ -1093,3 +1095,388 @@ def test_operator_is_forbidden_from_asset_import_upload_page(client_with_temp_db
 
     assert get_response.status_code == 403
     assert post_response.status_code == 403
+
+
+def _preview_token(response) -> str:
+    match = re.search(rb'name="preview_token" value="([a-f0-9]{64})"', response.data)
+    assert match is not None
+    return match.group(1).decode("ascii")
+
+
+def _post_commit(client, token: str):
+    return client.post(
+        "/admin/assets/import",
+        data={"action": "commit", "preview_token": token, "confirm_import": "1"},
+    )
+
+
+
+
+def _pending_asset_import(client) -> dict:
+    with client.session_transaction() as sess:
+        pending = sess.get("pending_asset_import")
+        return dict(pending) if isinstance(pending, dict) else {}
+
+
+def _pending_temp_path(client) -> Path:
+    pending = _pending_asset_import(client)
+    temp_path = str(pending.get("temp_path") or "").strip()
+    assert temp_path
+    return Path(temp_path)
+
+
+def _asset_events(asset_tag: str) -> list[sqlite3.Row]:
+    conn = db.get_connection()
+    try:
+        return list(
+            conn.execute(
+                """
+                SELECT event_type, payload
+                FROM asset_events
+                WHERE asset_tag = ?
+                ORDER BY id;
+                """,
+                (asset_tag,),
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+
+def _asset_record(asset_tag: str) -> sqlite3.Row | None:
+    conn = db.get_connection()
+    try:
+        return conn.execute("SELECT * FROM assets WHERE asset_tag = ? LIMIT 1;", (asset_tag,)).fetchone()
+    finally:
+        conn.close()
+
+
+def _slot_record(slot_id: int) -> sqlite3.Row:
+    conn = db.get_connection()
+    try:
+        row = conn.execute("SELECT * FROM slots WHERE id = ?;", (slot_id,)).fetchone()
+        assert row is not None
+        return row
+    finally:
+        conn.close()
+
+
+def _occupancy_asset_tags() -> dict[int, str]:
+    conn = db.get_connection()
+    try:
+        return {
+            int(row["slot_id"]): str(row["asset_tag"])
+            for row in conn.execute(
+                """
+                SELECT so.slot_id, a.asset_tag
+                FROM slot_occupancy so
+                JOIN assets a ON a.id = so.asset_id;
+                """
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+
+def test_asset_import_commit_writes_approved_safe_rows_atomically_and_leaves_blocked_rows(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=901, case_name="CASE-NEW", slot_position=1)
+    _insert_slot(slot_id=902, case_name="CASE-BUSY", slot_position=2, current_asset_tag="BUSY-OTHER")
+    _insert_slot(slot_id=903, case_name="CASE-EXACT", slot_position=3, current_asset_tag="EXACT-300")
+    _insert_slot(slot_id=904, case_name="CASE-UPD", slot_position=4, current_asset_tag="UPD-300")
+    _insert_slot(slot_id=905, case_name="CASE-MOVE-OLD", slot_position=5, current_asset_tag="MOVE-ONLY")
+    _insert_slot(slot_id=906, case_name="CASE-MOVE-NEW", slot_position=6)
+    _insert_slot(slot_id=907, case_name="CASE-METAMOVE-OLD", slot_position=7, current_asset_tag="MOVE-META")
+    _insert_slot(slot_id=908, case_name="CASE-METAMOVE-NEW", slot_position=8)
+    _insert_asset(asset_tag="BUSY-OTHER", home_slot_id=902, case_number="CASE-BUSY", slot_number="2", slotted=True)
+    _insert_asset(
+        asset_tag="EXACT-300",
+        serial_number="SER-EXACT-300",
+        equipment_type="switch",
+        manufacturer="Cisco",
+        model="Catalyst",
+        case_number="CASE-EXACT",
+        slot_number="3",
+        home_slot_id=903,
+        slotted=True,
+    )
+    _insert_asset(
+        asset_tag="UPD-300",
+        serial_number="SER-UPD-300",
+        equipment_type="router",
+        manufacturer="Old Maker",
+        model="Old Model",
+        case_number="CASE-UPD",
+        slot_number="4",
+        home_slot_id=904,
+        slotted=True,
+    )
+    _insert_asset(
+        asset_tag="MOVE-ONLY",
+        serial_number="SER-MOVE-ONLY",
+        equipment_type="laptop",
+        manufacturer="Dell",
+        model="Latitude",
+        building_room="HQ/105",
+        case_number="CASE-MOVE-OLD",
+        slot_number="5",
+        home_slot_id=905,
+        slotted=True,
+    )
+    _insert_asset(
+        asset_tag="MOVE-META",
+        serial_number="SER-MOVE-META",
+        equipment_type="laptop",
+        manufacturer="Old Maker",
+        model="Latitude",
+        building_room="HQ/107",
+        case_number="CASE-METAMOVE-OLD",
+        slot_number="7",
+        home_slot_id=907,
+        slotted=True,
+    )
+    _insert_asset(asset_tag="SERIAL-OWNER", serial_number="SER-CONFLICT")
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"NEW-SLOT,SER-NEW-SLOT,laptop,Dell,Latitude,CASE-NEW,1\n"
+        b"NEW-UNSLOT,SER-NEW-UNSLOT,router,Juniper,MX,,\n"
+        b"BUSY-NEW,SER-BUSY-NEW,switch,Cisco,Catalyst,CASE-BUSY,2\n"
+        b"EXACT-300,SER-EXACT-300,switch,Cisco,Catalyst,CASE-EXACT,3\n"
+        b"UPD-300,SER-UPD-300,router,New Maker,New Model,CASE-UPD,4\n"
+        b"MOVE-ONLY,SER-MOVE-ONLY,laptop,Dell,Latitude,CASE-MOVE-NEW,6\n"
+        b"MOVE-META,SER-MOVE-META,laptop,New Maker,Latitude,CASE-METAMOVE-NEW,8\n"
+        b"CONFLICT-TAG,SER-CONFLICT,laptop,Dell,Latitude,,\n"
+        b",SER-MISSING,laptop,Dell,Latitude,,\n",
+        "assets.csv",
+    )
+    assert response.status_code == 200
+    token = _preview_token(response)
+
+    pending_path = _pending_temp_path(client_with_temp_db)
+    assert pending_path.exists()
+    csv_response = client_with_temp_db.get("/admin/assets/import/reconciliation.csv")
+    assert csv_response.status_code == 200
+    assert csv_response.headers["Content-Type"].startswith("text/csv")
+    assert b"row_number,asset_tag,category,message" in csv_response.data
+    assert b"CONFLICT-TAG" in csv_response.data
+
+    commit_response = _post_commit(client_with_temp_db, token)
+
+    assert commit_response.status_code == 200
+    assert b"Asset import committed." in commit_response.data
+    assert b"Committed rows: 6" in commit_response.data
+    assert b"Blocked rows: 2" in commit_response.data
+    assert _asset_record("CONFLICT-TAG") is None
+    assert _asset_record("SER-MISSING") is None
+
+    assert [row["event_type"] for row in _asset_events("NEW-SLOT")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+    assert [row["event_type"] for row in _asset_events("NEW-UNSLOT")] == ["ASSET_CREATED"]
+    assert [row["event_type"] for row in _asset_events("BUSY-NEW")] == ["ASSET_CREATED"]
+    assert _asset_record("BUSY-NEW")["home_slot_id"] is None
+    assert _slot_record(902)["current_asset_tag"] == "BUSY-OTHER"
+
+    assert _asset_events("EXACT-300") == []
+    assert [row["event_type"] for row in _asset_events("UPD-300")] == ["ASSET_UPDATED"]
+    assert _asset_record("UPD-300")["manufacturer"] == "New Maker"
+    assert _asset_record("UPD-300")["model"] == "New Model"
+
+    move_only_events = _asset_events("MOVE-ONLY")
+    assert [row["event_type"] for row in move_only_events] == ["SLOT_MOVE"]
+    move_payload = json.loads(move_only_events[0]["payload"])
+    assert move_payload["from_slot"]["slot_id"] == 905
+    assert move_payload["to_slot"]["slot_id"] == 906
+
+    move_meta_events = _asset_events("MOVE-META")
+    assert [row["event_type"] for row in move_meta_events] == ["SLOT_MOVE", "ASSET_UPDATED"]
+    assert _asset_record("MOVE-META")["manufacturer"] == "New Maker"
+    assert _occupancy_asset_tags()[901] == "NEW-SLOT"
+    assert _occupancy_asset_tags()[906] == "MOVE-ONLY"
+    assert _occupancy_asset_tags()[908] == "MOVE-META"
+    assert not pending_path.exists()
+    assert _pending_asset_import(client_with_temp_db) == {}
+
+
+
+
+def test_asset_import_commit_rejected_without_confirmation_removes_pending_file_and_state(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nNO-CONFIRM,SER-NO-CONFIRM,laptop\n",
+        "no-confirm.csv",
+    )
+    assert response.status_code == 200
+    token = _preview_token(response)
+    pending_path = _pending_temp_path(client_with_temp_db)
+    assert pending_path.exists()
+
+    commit_response = client_with_temp_db.post(
+        "/admin/assets/import",
+        data={"action": "commit", "preview_token": token},
+    )
+
+    assert commit_response.status_code == 200
+    assert b"Confirm the preview" in commit_response.data
+    assert not pending_path.exists()
+    assert _pending_asset_import(client_with_temp_db) == {}
+    assert _asset_record("NO-CONFIRM") is None
+
+
+def test_asset_import_commit_rejects_tampered_confirmation_before_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=921, case_name="CASE-TAMPER", slot_position=1)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"TAMPER-100,SER-TAMPER-100,laptop,CASE-TAMPER,1\n",
+        "assets.csv",
+    )
+
+    pending_path = _pending_temp_path(client_with_temp_db)
+    assert pending_path.exists()
+
+    commit_response = _post_commit(client_with_temp_db, "0" * 64)
+
+    assert commit_response.status_code == 200
+    assert b"stale or tampered" in commit_response.data
+    assert not pending_path.exists()
+    assert _pending_asset_import(client_with_temp_db) == {}
+    assert _asset_record("TAMPER-100") is None
+    assert _asset_events("TAMPER-100") == []
+
+
+def test_asset_import_commit_rejects_stale_preview_before_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=931, case_name="CASE-STALE", slot_position=1)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"STALE-100,SER-STALE-100,laptop,CASE-STALE,1\n",
+        "assets.csv",
+    )
+    token = _preview_token(response)
+    pending_path = _pending_temp_path(client_with_temp_db)
+    assert pending_path.exists()
+    _insert_asset(asset_tag="STALE-OCCUPANT", home_slot_id=931, case_number="CASE-STALE", slot_number="1", slotted=True)
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", ("STALE-OCCUPANT", 931))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+
+    commit_response = _post_commit(client_with_temp_db, token)
+
+    assert commit_response.status_code == 200
+    assert b"preview is stale" in commit_response.data.lower()
+    assert not pending_path.exists()
+    assert _pending_asset_import(client_with_temp_db) == {}
+    assert _asset_record("STALE-100") is None
+    assert _asset_events("STALE-100") == []
+
+
+def test_asset_import_commit_rolls_back_complete_batch_on_mid_batch_failure(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=941, case_name="CASE-ROLL", slot_position=1)
+    _insert_slot(slot_id=942, case_name="CASE-ROLL", slot_position=2)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"ROLL-OK,SER-ROLL-OK,laptop,CASE-ROLL,1\n"
+        b"ROLL-FAIL,SER-ROLL-FAIL,laptop,CASE-ROLL,2\n",
+        "assets.csv",
+    )
+    token = _preview_token(response)
+    original_append_event = intake_app._asset_import_append_event
+
+    def fail_second_created(*args, **kwargs):
+        if kwargs.get("asset_tag") == "ROLL-FAIL" and kwargs.get("event_type") == "ASSET_CREATED":
+            raise RuntimeError("forced import failure")
+        return original_append_event(*args, **kwargs)
+
+    monkeypatch.setattr(intake_app, "_asset_import_append_event", fail_second_created)
+
+    with pytest.raises(RuntimeError, match="forced import failure"):
+        _post_commit(client_with_temp_db, token)
+
+    assert _asset_record("ROLL-OK") is None
+    assert _asset_record("ROLL-FAIL") is None
+    assert _asset_events("ROLL-OK") == []
+    assert _asset_events("ROLL-FAIL") == []
+    assert _occupancy_asset_tags() == {}
+    assert _slot_record(941)["current_asset_tag"] is None
+    assert _slot_record(942)["current_asset_tag"] is None
+
+
+def test_asset_import_replacing_preview_removes_previous_pending_file(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    first = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nREPLACE-ONE,SER-REPLACE-ONE,laptop\n",
+        "first.csv",
+    )
+    assert first.status_code == 200
+    first_path = _pending_temp_path(client_with_temp_db)
+    assert first_path.exists()
+
+    second = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nREPLACE-TWO,SER-REPLACE-TWO,laptop\n",
+        "second.csv",
+    )
+
+    assert second.status_code == 200
+    second_path = _pending_temp_path(client_with_temp_db)
+    assert second_path.exists()
+    assert second_path != first_path
+    assert not first_path.exists()
+
+
+def test_asset_import_logout_removes_pending_file_and_session_state(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nLOGOUT-100,SER-LOGOUT-100,laptop\n",
+        "logout.csv",
+    )
+    assert response.status_code == 200
+    pending_path = _pending_temp_path(client_with_temp_db)
+    assert pending_path.exists()
+
+    logout_response = client_with_temp_db.get("/logout")
+
+    assert logout_response.status_code == 302
+    assert not pending_path.exists()
+    with client_with_temp_db.session_transaction() as sess:
+        assert "pending_asset_import" not in sess
+        assert "user_id" not in sess
+
+
+def test_asset_import_logout_cleanup_tolerates_missing_pending_file(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type\nMISSING-100,SER-MISSING-100,laptop\n",
+        "missing.csv",
+    )
+    assert response.status_code == 200
+    pending_path = _pending_temp_path(client_with_temp_db)
+    pending_path.unlink(missing_ok=True)
+
+    logout_response = client_with_temp_db.get("/logout")
+
+    assert logout_response.status_code == 302
+    with client_with_temp_db.session_transaction() as sess:
+        assert "pending_asset_import" not in sess
+        assert "user_id" not in sess


### PR DESCRIPTION
# PR Title

Issue 30-5D: Add confirmed atomic asset import commits

# PR Description

## Summary

Adds an explicit preview and confirmed commit workflow for asset imports.

Approved safe rows commit in one transaction. Blocked rows remain unchanged, existing slot occupants are protected, and successful commits clear the pending preview.

The issue also includes durable slot-identifier normalization so whole-number XLSX values such as `4.0` are consistently treated as Slot `4`.

Closes #1047

## Changes

- Added explicit confirmation before imported rows are written.
- Added atomic commit handling for safe rows.
- Added new asset creation with append-only `ASSET_CREATED` events.
- Added slot assignment with `SLOT_ASSIGN` events.
- Added existing asset metadata updates with `ASSET_UPDATED` events.
- Added existing asset slot movement through the established slot-move path.
- Prevented blocked rows from writing.
- Prevented existing slot occupants from being displaced.
- Added reconciliation CSV output.
- Added pending-preview cleanup after commit and logout.
- Added durable CSV and XLSX slot-identifier normalization.
- Added focused regression coverage for whole-number and fractional slot values.

## Verification

- [x] 79 focused tests passed before smoke testing
- [x] Full asset-import test file passed: 46 tests
- [x] `python -m compileall assettrack`
- [x] `git diff --check`
- [x] Docker rebuilt with `docker compose up -d --build`
- [x] File 01 created three Unslotted assets
- [x] File 02 moved `MANUAL-SW-2912` from Slot 2 to Slot 4
- [x] File 02 committed safe mixed rows while leaving blocked rows unchanged
- [x] File 03 created `AT-ONE-006` in the freed Slot 2
- [x] Final case occupancy matched asset records
- [x] Successful commit cleared the pending preview
- [x] Existing occupants were not displaced

## Notes

The detailed import preview remains operator-heavy. Simplifying that presentation and adding an Asset Import chip under Admin Tools should be handled as separate Class 1 issues.