### PR TITLE
Issue 30-7: Add Import Assets admin action

### DIFF
--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -38,6 +38,12 @@
       color: var(--color-primary);
       font-weight: 800;
     }
+    .admin-tool-link span {
+      display: block;
+      margin-top: 0.15rem;
+      color: var(--color-text-muted);
+      font-size: 0.85rem;
+    }
     .admin-tool-link:hover {
       text-decoration: none;
       background: color-mix(in srgb, var(--color-primary-soft) 36%, var(--color-surface-bg));
@@ -191,6 +197,10 @@
         </a>
         <a class="admin-tool-link" href="{{ url_for('admin_replace_asset') }}">
           <strong>Replace Asset</strong>
+        </a>
+        <a class="admin-tool-link" href="{{ url_for('admin_asset_import') }}">
+          <strong>Import Assets</strong>
+          <span>CSV/XLSX; Laptop, Switch, Router</span>
         </a>
         <a class="admin-tool-link" href="{{ url_for('admin_network_asset_import') }}">
           <strong>Import Switch/Router CSV</strong>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -129,6 +129,8 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Edit Asset" in response.data
     assert b"Retire Asset" in response.data
     assert b"Replace Asset" in response.data
+    assert b"Import Assets" in response.data
+    assert b"CSV/XLSX; Laptop, Switch, Router" in response.data
     assert b"Import Switch/Router CSV" in response.data
     assert b"Provision Slots" in response.data
     assert b"Assign Slot" in response.data
@@ -159,6 +161,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
         b'href="/admin/assets/edit"',
         b'href="/admin/assets/retire"',
         b'href="/admin/assets/replace"',
+        b'href="/admin/assets/import"',
         b'href="/admin/network-assets/import"',
         b'href="/admin/slots/provision"',
         b'href="/admin/assign-slot"',
@@ -187,6 +190,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
         "/admin/assets/edit",
         "/admin/assets/retire",
         "/admin/assets/replace",
+        "/admin/assets/import",
         "/admin/network-assets/import",
         "/admin/slots/provision",
         "/admin/assign-slot",
@@ -218,6 +222,7 @@ def test_admin_tools_link_destinations_remain_reachable_for_admin(client_with_te
         "/admin/assets/edit",
         "/admin/assets/retire",
         "/admin/assets/replace",
+        "/admin/assets/import",
         "/admin/network-assets/import",
         "/admin/network-assets/import/template.csv",
         "/admin/slots/provision",


### PR DESCRIPTION
# Issue 30-7: Add Import Assets admin action

## Summary

Adds the unified **Import Assets** action to the Assets section of Admin Tools.

Closes #1024

## Changes

* Added an **Import Assets** action linking directly to `/admin/assets/import`.
* Identified CSV and XLSX as supported formats.
* Identified Laptop, Switch, and Router as supported asset types.
* Preserved the existing specialized Switch/Router import action.
* Added focused UI coverage.

## Verification

* [x] `python -m pytest tests/test_admin_system_health.py`
* [x] 55 focused tests passed
* [x] `git diff --check`
* [x] Docker rebuilt with `docker compose up -d --build`
* [x] Verified in an incognito browser session
* [x] Confirmed the action appears under Admin Tools → Assets
* [x] Confirmed the action opens `/admin/assets/import`
* [x] Confirmed CSV, XLSX, Laptop, Switch, and Router support text
* [x] Confirmed the existing Switch/Router CSV action remains available
* [x] Confirmed admin-only access remains unchanged

## Notes

This is a presentation-only change. It does not modify import behavior, parsing, preview, commit, authorization, schema, or persistence.
