### PR TITLE
Issue 30-20: Remove deprecated network import from Admin Tools

### DIFF
--- a/assettrack/intake/templates/admin_network_asset_import.html
+++ b/assettrack/intake/templates/admin_network_asset_import.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Import Switch/Router CSV{% endblock %}
-{% block page_heading %}Admin: Import Switch/Router CSV{% endblock %}
+{% block title %}Deprecated Switch/Router CSV Import{% endblock %}
+{% block page_heading %}Admin: Deprecated Switch/Router CSV Import{% endblock %}
 
 {% block extra_head %}
   <style>
@@ -17,12 +17,16 @@
   </nav>
 
   <div class="card">
-    <h2>Switch/Router Import</h2>
+    <h2>Use Import Assets</h2>
     <p class="import-help">
-      Use the existing command-line CSV importer for custody-only switch and router records.
-      AssetTrack supports Laptop, Switch, and Router; this CSV path imports Switch and Router only.
+      This Switch/Router CSV guidance is deprecated for operator use. Use Import Assets for bulk asset imports.
+      Import Assets supports CSV and XLSX files for Laptop, Switch, and Router records with analysis, preview,
+      explicit confirmation, atomic commit, and results.
     </p>
     <p>
+      <a class="nav-link" href="{{ url_for('admin_asset_import') }}">Open Import Assets</a>
+    </p>
+    <p class="import-help">
       <a class="nav-link" href="{{ url_for('admin_network_asset_import_template') }}">Download CSV template</a>
     </p>
   </div>

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -202,9 +202,6 @@
           <strong>Import Assets</strong>
           <span>CSV/XLSX; Laptop, Switch, Router</span>
         </a>
-        <a class="admin-tool-link" href="{{ url_for('admin_network_asset_import') }}">
-          <strong>Import Switch/Router CSV</strong>
-        </a>
       </nav>
     </div>
     <div class="admin-tool-section">

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -131,7 +131,9 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert b"Replace Asset" in response.data
     assert b"Import Assets" in response.data
     assert b"CSV/XLSX; Laptop, Switch, Router" in response.data
-    assert b"Import Switch/Router CSV" in response.data
+    assert response.data.count(b'href="/admin/assets/import"') == 1
+    assert b"Import Switch/Router CSV" not in response.data
+    assert b'href="/admin/network-assets/import"' not in response.data
     assert b"Provision Slots" in response.data
     assert b"Assign Slot" in response.data
     assert b"Move Slot" in response.data
@@ -162,7 +164,6 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
         b'href="/admin/assets/retire"',
         b'href="/admin/assets/replace"',
         b'href="/admin/assets/import"',
-        b'href="/admin/network-assets/import"',
         b'href="/admin/slots/provision"',
         b'href="/admin/assign-slot"',
         b'href="/admin/slot-move"',
@@ -191,7 +192,6 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
         "/admin/assets/retire",
         "/admin/assets/replace",
         "/admin/assets/import",
-        "/admin/network-assets/import",
         "/admin/slots/provision",
         "/admin/assign-slot",
         "/admin/slot-move",
@@ -269,15 +269,17 @@ def test_operator_is_forbidden_for_holder_import_page(client_with_temp_db) -> No
     assert response.status_code == 403
 
 
-def test_admin_network_asset_import_page_exposes_existing_cli_process(client_with_temp_db) -> None:
+def test_admin_network_asset_import_page_is_deprecated_and_points_to_import_assets(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-network-import", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
 
     response = client_with_temp_db.get("/admin/network-assets/import")
 
     assert response.status_code == 200
-    assert b"Import Switch/Router CSV" in response.data
-    assert b"AssetTrack supports Laptop, Switch, and Router" in response.data
+    assert b"Deprecated Switch/Router CSV Import" in response.data
+    assert b"deprecated for operator use" in response.data
+    assert b'href="/admin/assets/import"' in response.data
+    assert b"Import Assets supports CSV and XLSX files for Laptop, Switch, and Router" in response.data
     assert b"python scripts/import_network_assets_csv.py" in response.data
     assert b"network_switch_router_staging_template_v1.csv" in response.data
     assert b'href="/admin/network-assets/import/template.csv"' in response.data


### PR DESCRIPTION
# Issue 30-20: Remove deprecated network import from Admin Tools

## Summary

Removes the deprecated Switch/Router CSV guidance from normal Admin Tools navigation so administrators see one clear bulk import workflow.

The deprecated page remains available to administrators by direct URL and now points to the canonical Import Assets workflow.

Closes #1062

## Changes

- Removed the visible `Import Switch/Router CSV` action from Admin Tools.
- Kept the canonical `Import Assets` action unchanged.
- Marked `/admin/network-assets/import` as deprecated for operator use.
- Added a direct link from the deprecated page to `/admin/assets/import`.
- Updated focused presentation and navigation tests.
- Preserved the legacy route, CLI guidance, and template download.

## Verification

- [x] Ran `python -m pytest tests/test_admin_system_health.py -q`.
- [x] Confirmed 54 focused tests passed.
- [x] Ran `git diff --check`.
- [x] Built and started the Docker application.
- [x] Verified Admin Tools shows only `Import Assets`.
- [x] Verified `/admin/network-assets/import` remains admin-protected.
- [x] Verified the deprecated page links to `/admin/assets/import`.
- [x] Confirmed no import, parsing, preview, commit, reconciliation, authentication, schema, event, custody, dependency, or persistence behavior changed.

## Notes

The deprecated network import route and supporting utilities remain intact. Their final disposition is tracked separately under Issue 30-22.
