### PR TITLE
Issue 30-21: Update operator asset import documentation

### DIFF
--- a/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
+++ b/docs/fixtures/imports/network/network_switch_router_staging_template_v1.md
@@ -2,9 +2,11 @@
 
 ## Purpose
 
-Use `network_switch_router_staging_template_v1.csv` to prepare switch and router custody records for administrator review and import.
+Use `network_switch_router_staging_template_v1.csv` only as a legacy network CSV reference for switch and router custody records.
 
-This template feeds the existing command-line importer. It does not create an admin upload page or add network-management behavior.
+Normal operators should use Admin Tools -> Import Assets for bulk imports. Import Assets supports CSV and XLSX files for Laptop, Switch, and Router records, with analysis, preview, explicit confirmation, atomic commit, and results.
+
+This template feeds the legacy command-line importer for internal or maintainer use. It does not create an admin upload page or add network-management behavior.
 
 AssetTrack tracks equipment custody and storage. It is not a CMDB or network configuration system.
 
@@ -70,6 +72,8 @@ Do not add or record CMDB-like or network configuration fields, including:
 - device configuration
 
 ## Import Command
+
+This command is not a normal operator workflow. It is retained as legacy internal guidance for maintainers who explicitly need the old Switch/Router-only CSV importer.
 
 Run from the AssetTrack project after reviewing the CSV:
 

--- a/docs/issue-30-15-legacy-import-tool-audit.md
+++ b/docs/issue-30-15-legacy-import-tool-audit.md
@@ -21,8 +21,8 @@ Why it matters: AssetTrack has several ways to create assets, holders, reference
 | --- | --- | --- |
 | Generic Add Assets UI workflow | Supported operational workflow | Admin-gated staged UI with queue, validation preview, confirmed commit, shared committer, append-only asset events, and queue clearing. |
 | Generic `assettrack.ingest` CLI | Internal utility | Approved internal commit adapter, but no Flask role gate, no enforced parser/validator, no preview command, free-text actor, and no direct CLI tests. |
-| Network Switch/Router CSV CLI | Supported operational workflow | Domain-specific CSV validation and shared committer for physical Switch/Router asset records. CLI bypasses Flask roles, so the canonical operator interface remains open for Issue 30-12. |
-| Network import admin template page | Supported operational support page | Admin-gated guidance/template download only; it performs no upload, validation, preview, transaction, or DB write. Final upload/interface ownership remains open for Issue 30-12. |
+| Network Switch/Router CSV CLI | Internal legacy utility | Domain-specific CSV validation and shared committer for physical Switch/Router asset records. It bypasses Flask roles and has no admin upload, preview, confirmation, or results workflow, so it is not the normal operator procedure. |
+| Network import admin template page | Deprecated operator guidance page | Admin-gated guidance/template download only; it performs no upload, validation, preview, transaction, or DB write. Import Assets is the canonical operator workflow. |
 | Holder CSV import UI | Supported operational workflow | Admin-gated UI with import report and transaction boundary. It writes holder/org reference state and lacks separate administrative audit, but does not bypass event-derived asset custody state. |
 | Holder CSV import CLI | Internal utility | Same holder importer as UI but no Flask role boundary. Useful for local/admin support only unless Issue 30-13 approves more. |
 | Admin reference-data UI | Supported operational workflow | Admin-gated creation/update of organizations, buildings, and mappings with helper validation. No asset events, because this is reference data. |
@@ -83,14 +83,14 @@ Why it matters: AssetTrack has several ways to create assets, holders, reference
 - Authentication or role boundary: bypasses Flask roles because it is a CLI; actor is required.
 - Actor attribution: free-form `--actor` string stored as ingest operator.
 - Direct derived-state writes: yes, through the committer; can create storage assets and slot occupancy when an existing empty slot is specified.
-- Tests and operator documentation: `tests/test_network_asset_import.py`, `docs/fixtures/imports/network/network_switch_router_staging_template_v1.md`, `docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv`, admin template page tests, and release user manual guidance.
-- Relationship to current workflows: supported current path, but Issue 30-12 owns the canonical Switch/Router interface and whether CLI, admin page, or another UI owns operator interaction.
+- Tests and maintainer documentation: `tests/test_network_asset_import.py`, `docs/fixtures/imports/network/network_switch_router_staging_template_v1.md`, `docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv`, and admin template page tests.
+- Relationship to current workflows: internal legacy utility. Normal operators should use Admin Tools -> Import Assets for bulk Switch/Router import.
 
 ### Network Import Admin Template Page
 
 - Name and location: `assettrack/intake/app.py:admin_network_asset_import`, `admin_network_asset_import_template`, `assettrack/intake/templates/admin_network_asset_import.html`.
 - Invocation method: admin browser page at `/admin/network-assets/import`; template download at `/admin/network-assets/import/template.csv`.
-- Purpose: guidance and template download for the current network CSV import process.
+- Purpose: deprecated guidance and template download for the legacy network CSV import process.
 - Input format: none uploaded to the app; template CSV download only.
 - Validation and preview: static guidance only; no upload, uploaded-data validation, or preview.
 - Transaction behavior: none; no transaction or DB write.
@@ -98,8 +98,8 @@ Why it matters: AssetTrack has several ways to create assets, holders, reference
 - Authentication or role boundary: Flask login and admin role required.
 - Actor attribution: none.
 - Direct derived-state writes: no.
-- Tests and operator documentation: `tests/test_admin_system_health.py` coverage plus release user manual instructions.
-- Relationship to current workflows: supported operational support page. It does not decide Issue 30-12's canonical import interface.
+- Tests and maintainer documentation: `tests/test_admin_system_health.py` coverage plus legacy fixture documentation.
+- Relationship to current workflows: deprecated operator guidance page. Normal operators should use Admin Tools -> Import Assets.
 
 ### Holder CSV Import UI And CLI
 

--- a/docs/release/user-manual.md
+++ b/docs/release/user-manual.md
@@ -290,7 +290,7 @@ Admin Tools can include:
 - manage reference data
 - import holders
 - create or edit assets
-- import switch and router CSV data
+- import assets from CSV or XLSX
 - provision, assign, or move slots
 - receipt search
 - receipt CC settings
@@ -340,20 +340,43 @@ Use Import Holders when you need to load holder records from an approved file.
 
 Fix the file if AssetTrack reports errors.
 
-## Import Switch And Router CSV Data
+## Import Assets
 
 **Admin only**
 
-Use this page for switch and router CSV imports.
+Use Import Assets for supported bulk asset imports.
+
+Supported files:
+
+- CSV
+- XLSX
+
+Supported asset types:
+
+- Laptop
+- Switch
+- Router
 
 1. Select `Admin`.
 2. Select `Admin Tools`.
-3. Select `Import Switch/Router CSV`.
-4. Download the CSV template if needed.
-5. Review the page instructions.
-6. Run the approved local import command from the operational computer.
+3. Select `Import Assets`.
+4. Choose the CSV or XLSX file.
+5. Select `Analyze Import`.
+6. Review the preview.
+7. Fix blocked rows before import, or leave them blocked.
+8. Confirm the preview.
+9. Commit the approved rows.
+10. Review the results.
 
-This import path is for switches and routers only.
+Expected result:
+
+- Analyze Import creates a preview only. It does not write assets, events, slots, or occupancy.
+- Commit requires explicit confirmation.
+- Approved safe rows commit atomically.
+- Blocked rows do not modify state.
+- The results show category totals and committed row counts.
+
+Legacy network CSV command-line utilities are not normal operator procedures. They are retained for internal or maintainer use only.
 
 ## Backup The Database
 


### PR DESCRIPTION
# Issue 30-21: Update operator asset import documentation

## Summary

Updates operator-facing documentation to identify `Import Assets` as the supported bulk import workflow for Laptop, Switch, and Router assets.

Older network CSV CLI guidance remains available for maintainers but is no longer presented as a normal operator workflow.

Closes #1063

## Changes

* Replaced the outdated Switch/Router CSV operator procedure in the release user manual.
* Documented the canonical workflow:

  * Admin Tools
  * Import Assets
  * choose CSV or XLSX
  * analyze
  * preview
  * confirm
  * results
* Documented Laptop, Switch, and Router support.
* Documented preview without writes, explicit confirmation, atomic commit, blocked rows, and results.
* Marked the older network CSV template and CLI instructions as legacy internal or maintainer guidance.
* Updated the legacy import-tool audit so the network CSV CLI is not described as a normal operator workflow.

## Verification

* [x] Re-searched documentation for stale operator workflow language.
* [x] Confirmed the release user manual points administrators to `Import Assets`.
* [x] Confirmed internal tools are identified as legacy or maintainer-only.
* [x] Ran `git diff --check`.
* [x] Confirmed only documentation files changed.

## Notes

No application code, templates, routes, tests, scripts, fixtures, schema, authentication, events, custody behavior, dependencies, or persistence behavior changed.

Tests, Docker verification, and operator smoke testing were not run because this change is documentation-only.
