### PR TITLE
Issue 30-23: Add legacy network CSV CLI warning

### DIFF
--- a/assettrack/network_asset_import.py
+++ b/assettrack/network_asset_import.py
@@ -36,6 +36,11 @@ REJECTED_CMDB_COLUMNS = {
     "device_configuration",
 }
 ALLOWED_EQUIPMENT_TYPES = {"switch", "router"}
+LEGACY_NETWORK_CSV_CLI_WARNING = (
+    "Warning: assettrack.network_asset_import is a legacy internal maintenance utility. "
+    "It is not the supported operator workflow. Normal administrators must use "
+    "Admin Tools -> Import Assets."
+)
 
 
 @dataclass(frozen=True)
@@ -276,6 +281,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--actor", required=True, help="Operator performing the import")
     args = parser.parse_args(argv)
 
+    print(LEGACY_NETWORK_CSV_CLI_WARNING, file=sys.stderr)
     report = import_network_assets_csv(args.csv_path, db_path=args.db, actor=args.actor)
     print(json.dumps(report.summary(), sort_keys=True))
     if report.errors:

--- a/tests/test_network_asset_import.py
+++ b/tests/test_network_asset_import.py
@@ -8,7 +8,7 @@ import unittest
 from pathlib import Path
 
 from assettrack.db import bootstrap_db
-from assettrack.network_asset_import import import_network_assets_csv
+from assettrack.network_asset_import import LEGACY_NETWORK_CSV_CLI_WARNING, import_network_assets_csv
 
 
 class NetworkAssetImportTests(unittest.TestCase):
@@ -216,6 +216,26 @@ class NetworkAssetImportTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0)
         self.assertEqual(result.stdout.strip(), '{"errors": 0, "imported": 1, "processed": 1}')
+        self.assertEqual(result.stderr.count(LEGACY_NETWORK_CSV_CLI_WARNING), 1)
+
+    def test_script_entrypoint_warns_once_and_preserves_failure_exit_code(self) -> None:
+        csv_path = self._write_csv(
+            "asset_tag,equipment_type,ip_address\n"
+            "SW-IP,switch,192.0.2.10\n"
+        )
+        script_path = Path(__file__).resolve().parents[1] / "scripts" / "import_network_assets_csv.py"
+
+        result = subprocess.run(
+            [sys.executable, str(script_path), str(csv_path), "--db", str(self.db_path), "--actor", "admin-import"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(result.stdout.strip(), '{"errors": 1, "imported": 0, "processed": 0}')
+        self.assertEqual(result.stderr.count(LEGACY_NETWORK_CSV_CLI_WARNING), 1)
+        self.assertIn("Rejected CMDB-like CSV columns: ip_address", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Issue 30-23: Add legacy network CSV CLI warning

## Summary

Adds a clear deprecation warning to the legacy Switch/Router CSV command.

The warning identifies the command as an internal maintenance utility and directs normal administrators to the supported `Admin Tools → Import Assets` workflow.

Closes #1068

## Changes

* Added one shared deprecation warning in `assettrack/network_asset_import.py`.
* Printed the warning to standard error before validation and import processing.
* Preserved the wrapper’s use of the same shared `main()` entry point.
* Ensured the warning appears exactly once per invocation.
* Added focused tests for module and wrapper warning behavior.
* Preserved existing standard output and JSON summaries.

## Verification

* [x] Ran `python -m pytest tests/test_network_asset_import.py -q`.
* [x] Confirmed 13 focused tests passed.
* [x] Confirmed the warning appears on standard error exactly once.
* [x] Confirmed successful execution still returns exit code `0`.
* [x] Confirmed failed validation still returns exit code `2`.
* [x] Confirmed existing failure details remain on standard error.
* [x] Confirmed standard output remains unchanged.
* [x] Ran `git diff --check`.

## Notes

No command arguments, parsing, validation, commit behavior, event handling, slot behavior, reconciliation, schema, authentication, roles, dependencies, persistence, or canonical Import Assets behavior changed.
