### PR TITLE
Issue 30-24: Add canonical asset import CSV template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ data/import/
 *.xlsx
 *.xls
 *.csv
+!docs/fixtures/imports/asset_import_template.csv
 
 # ----------------------------
 # Docker / runtime artifacts

--- a/docs/fixtures/imports/asset_import_template.csv
+++ b/docs/fixtures/imports/asset_import_template.csv
@@ -1,0 +1,1 @@
+equipment_type,asset_tag,barcode,serial_number,manufacturer,model,model_code,building_room,case_identifier,slot_identifier,notes_comments

--- a/docs/fixtures/imports/asset_import_template.md
+++ b/docs/fixtures/imports/asset_import_template.md
@@ -1,0 +1,53 @@
+# Canonical Asset Import CSV Template
+
+Use `asset_import_template.csv` with Admin Tools -> Import Assets for supported bulk asset imports.
+
+## Workflow
+
+1. Open Admin Tools.
+2. Open Import Assets.
+3. Choose a CSV or XLSX file.
+4. Select Analyze Import.
+5. Review the preview.
+6. Confirm the preview.
+7. Commit the approved rows.
+8. Review the results.
+
+Analyze Import creates a preview only. It does not write assets, events, slots, or occupancy. Commit requires explicit confirmation. Approved safe rows commit atomically, and blocked rows do not modify state.
+
+## Required Fields
+
+- `equipment_type` is required.
+- `asset_tag` or `barcode` is required.
+
+Supported `equipment_type` values:
+
+- Laptop
+- Switch
+- Router
+
+## Template Columns
+
+| Column | Use |
+| --- | --- |
+| `equipment_type` | Required asset type. Use Laptop, Switch, or Router. |
+| `asset_tag` | AssetTrack asset tag when assigned. Required when `barcode` is blank. |
+| `barcode` | Scannable custody barcode. Required when `asset_tag` is blank. |
+| `serial_number` | Manufacturer serial number when available. |
+| `manufacturer` | Equipment manufacturer. |
+| `model` | Equipment model. |
+| `model_code` | Model or catalog code when available. |
+| `building_room` | Free-text building or room detail when available. |
+| `case_identifier` | Optional storage case identifier. |
+| `slot_identifier` | Optional storage slot identifier. |
+| `notes_comments` | Short custody or storage note. |
+
+## Storage
+
+Storage fields are optional. Leave `case_identifier` and `slot_identifier` blank when storage is unknown or unavailable.
+
+Rows with missing or unavailable storage may continue as Unslotted only when the admin acknowledges that behavior during preview.
+
+## Unsupported Fields
+
+AssetTrack import is for custody and storage data. Do not add CMDB, IP address, MAC address, VLAN, topology, monitoring, configuration, switch port, patching, network relationship, running configuration, or device configuration fields.

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import csv
 import json
 
 import io
@@ -13,9 +14,25 @@ import pytest
 
 import assettrack.db as db
 from assettrack.intake import app as intake_app
-from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
+from assettrack.import_analysis import ALLOWED_COLUMNS, analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.import_reconciliation import build_asset_import_preview
 from tests.auth_test_utils import create_test_user, login_session
+
+
+ASSET_IMPORT_TEMPLATE_HEADERS = [
+    "equipment_type",
+    "asset_tag",
+    "barcode",
+    "serial_number",
+    "manufacturer",
+    "model",
+    "model_code",
+    "building_room",
+    "case_identifier",
+    "slot_identifier",
+    "notes_comments",
+]
+ASSET_IMPORT_TEMPLATE_PATH = Path(__file__).resolve().parents[1] / "docs" / "fixtures" / "imports" / "asset_import_template.csv"
 
 
 @pytest.fixture
@@ -30,6 +47,41 @@ def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 def _login_admin(client) -> None:
     admin_id = create_test_user(username="admin-asset-import", password="admin-pass", role="admin")
     login_session(client, admin_id)
+
+
+def test_canonical_asset_import_template_headers_match_parser_contract() -> None:
+    with ASSET_IMPORT_TEMPLATE_PATH.open(newline="", encoding="utf-8") as handle:
+        headers = next(csv.reader(handle))
+
+    assert headers == ASSET_IMPORT_TEMPLATE_HEADERS
+    assert set(headers) <= ALLOWED_COLUMNS
+    analysis = analyze_asset_import_csv(ASSET_IMPORT_TEMPLATE_PATH, filename="asset_import_template.csv")
+    assert analysis.file_type == "CSV"
+    assert analysis.rows == ()
+    assert analysis.warnings == ()
+
+
+def test_canonical_asset_import_template_supports_laptop_switch_and_router_rows(tmp_path: Path) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        ",".join(ASSET_IMPORT_TEMPLATE_HEADERS)
+        + "\n"
+        + "Laptop,LAP-100,,SER-LAP-100,Dell,Latitude,7420,HQ 101,,,Ready for issue\n"
+        + "Switch,,SW-BC-100,SER-SW-100,Cisco,Catalyst,C9300,Network Lab,,,Barcode identity\n"
+        + "Router,RTR-100,,SER-RTR-100,Juniper,MX,MX204,Storage,CASE-CORE,4,Slotted intent\n",
+        encoding="utf-8",
+    )
+
+    analysis = analyze_asset_import_csv(csv_path, filename="assets.csv")
+
+    assert [row.equipment_type for row in analysis.rows] == ["laptop", "switch", "router"]
+    assert [row.asset_tag for row in analysis.rows] == ["LAP-100", "SW-BC-100", "RTR-100"]
+    assert analysis.rows[0].storage_intent == "unslotted"
+    assert analysis.rows[1].storage_intent == "unslotted"
+    assert analysis.rows[2].case_identifier == "CASE-CORE"
+    assert analysis.rows[2].slot_identifier == "4"
+    assert analysis.rows[2].storage_intent == "slotted"
+    assert analysis.warnings == ()
 
 
 def _table_counts() -> dict[str, int]:


### PR DESCRIPTION
# Issue 30-24: Add canonical Import Assets CSV template

## Summary

Adds a canonical CSV template for the supported Asset Import workflow.

The template reflects the existing parser contract for Laptop, Switch, and Router assets and documents required identity, optional storage, Unslotted handling, and unsupported CMDB-style fields.

Closes #1069

## Changes

* Added `docs/fixtures/imports/asset_import_template.csv`.
* Added operator guidance for the canonical template.
* Included supported fields for:

  * equipment type
  * asset identity
  * descriptive information
  * optional storage assignment
  * notes
* Documented that:

  * `equipment_type` is required
  * either `asset_tag` or `barcode` is required
  * Laptop, Switch, and Router are supported
  * storage fields are optional
  * rows may continue as Unslotted after preview acknowledgment
  * CMDB, IP address, MAC address, VLAN, topology, monitoring, and configuration fields are unsupported
* Added a focused test confirming every template header is accepted by the existing parser contract.
* Added a narrow `.gitignore` exception so the canonical CSV fixture can be tracked.

## Template Headers

```text
equipment_type
asset_tag
barcode
serial_number
manufacturer
model
model_code
building_room
case_identifier
slot_identifier
notes_comments
```

## Verification

* [x] Ran `python -m pytest tests/test_admin_asset_import.py -q`.
* [x] Confirmed 48 focused tests passed.
* [x] Confirmed every template header is accepted by `ALLOWED_COLUMNS`.
* [x] Confirmed the template does not promise unsupported fields or behavior.
* [x] Ran `git diff --check`.
* [x] Checked the new CSV and Markdown files directly for whitespace errors.
* [x] Confirmed no parser or runtime import behavior changed.

## Notes

The `.gitignore` change is limited to allowing this one canonical CSV fixture to be tracked.

No parsing, validation, preview, commit, reconciliation, schema, event, custody, authentication, dependency, or persistence behavior changed.
