### PR TITLE
Issue 30-25: Point deprecated network template to canonical asset imp…

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -8122,12 +8122,12 @@ def admin_network_asset_import():
 @require_login
 @require_role("admin")
 def admin_network_asset_import_template():
-    template_path = Path(__file__).resolve().parents[2] / "docs/fixtures/imports/network/network_switch_router_staging_template_v1.csv"
+    template_path = Path(__file__).resolve().parents[2] / "docs/fixtures/imports/asset_import_template.csv"
     return send_file(
         template_path,
         mimetype="text/csv",
         as_attachment=True,
-        download_name="network_switch_router_staging_template_v1.csv",
+        download_name="asset_import_template.csv",
     )
 
 

--- a/assettrack/intake/templates/admin_network_asset_import.html
+++ b/assettrack/intake/templates/admin_network_asset_import.html
@@ -27,7 +27,7 @@
       <a class="nav-link" href="{{ url_for('admin_asset_import') }}">Open Import Assets</a>
     </p>
     <p class="import-help">
-      <a class="nav-link" href="{{ url_for('admin_network_asset_import_template') }}">Download CSV template</a>
+      <a class="nav-link" href="{{ url_for('admin_network_asset_import_template') }}">Download Import Assets CSV template</a>
     </p>
   </div>
 

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
+from email.message import Message
 from io import BytesIO
 from pathlib import Path
 
@@ -9,6 +10,11 @@ import pytest
 import assettrack.db as db
 from assettrack.intake import app as intake_app
 from tests.auth_test_utils import create_test_user, login_session
+
+
+CANONICAL_ASSET_IMPORT_TEMPLATE = (
+    Path(__file__).resolve().parents[1] / "docs" / "fixtures" / "imports" / "asset_import_template.csv"
+)
 
 
 @pytest.fixture
@@ -280,6 +286,7 @@ def test_admin_network_asset_import_page_is_deprecated_and_points_to_import_asse
     assert b"deprecated for operator use" in response.data
     assert b'href="/admin/assets/import"' in response.data
     assert b"Import Assets supports CSV and XLSX files for Laptop, Switch, and Router" in response.data
+    assert b"Download Import Assets CSV template" in response.data
     assert b"python scripts/import_network_assets_csv.py" in response.data
     assert b"network_switch_router_staging_template_v1.csv" in response.data
     assert b'href="/admin/network-assets/import/template.csv"' in response.data
@@ -290,7 +297,7 @@ def test_admin_network_asset_import_page_is_deprecated_and_points_to_import_asse
     assert b"CMDB relationship" in response.data
 
 
-def test_admin_network_asset_import_template_downloads_existing_csv(client_with_temp_db) -> None:
+def test_admin_network_asset_import_template_downloads_canonical_import_assets_csv(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-network-template", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
 
@@ -298,8 +305,20 @@ def test_admin_network_asset_import_template_downloads_existing_csv(client_with_
 
     assert response.status_code == 200
     assert response.mimetype == "text/csv"
-    assert b"asset_tag,barcode,serial_number,equipment_type" in response.data
-    assert b"case_identifier,slot_identifier,notes_comments" in response.data
+    disposition = Message()
+    disposition["content-disposition"] = response.headers["Content-Disposition"]
+    assert disposition.get_filename() == "asset_import_template.csv"
+    assert response.data == CANONICAL_ASSET_IMPORT_TEMPLATE.read_bytes()
+    assert (
+        response.data
+        == b"equipment_type,asset_tag,barcode,serial_number,manufacturer,model,model_code,building_room,case_identifier,slot_identifier,notes_comments\n"
+    )
+
+
+def test_network_asset_import_template_requires_login(client_with_temp_db) -> None:
+    response = client_with_temp_db.get("/admin/network-assets/import/template.csv")
+
+    assert response.status_code == 403
 
 
 def test_admin_can_import_holders_from_csv(client_with_temp_db) -> None:


### PR DESCRIPTION
# Issue 30-25: Point deprecated network template route to canonical Import Assets template

## Summary

Updates the deprecated network template route to distribute the canonical Import Assets CSV template.

The route remains available and admin-protected while normal administrators continue to be directed to `Admin Tools → Import Assets`.

Closes #1070

## Changes

* Updated `/admin/network-assets/import/template.csv` to serve `docs/fixtures/imports/asset_import_template.csv`.
* Changed the downloaded filename to `asset_import_template.csv`.
* Updated the deprecated network import page to label the download as the Import Assets CSV template.
* Preserved the existing link to `/admin/assets/import`.
* Preserved the legacy network CSV fixture for later quarantine work.
* Updated focused route, authorization, content, and navigation tests.

## Verification

* [x] Ran `python -m pytest tests/test_admin_system_health.py -q`.
* [x] Confirmed 55 focused tests passed.
* [x] Ran the two canonical template contract tests.
* [x] Confirmed both template contract tests passed.
* [x] Ran `git diff --check`.
* [x] Ran `docker compose up -d --build`.
* [x] Confirmed the rebuilt container is healthy.
* [x] Confirmed the deprecated page returns `200` for an administrator.
* [x] Confirmed the page links to `/admin/assets/import`.
* [x] Confirmed the template route returns the canonical CSV.
* [x] Confirmed the response filename is `asset_import_template.csv`.
* [x] Confirmed the response body matches the canonical template file.
* [x] Confirmed unauthenticated access remains denied.
* [x] Confirmed operator access remains denied.
* [x] Confirmed import and authorization behavior did not change.

## Notes

Docker verification used a clean isolated-cookie HTTP session.

A real interactive incognito-browser smoke test was not performed because browser automation was unavailable in the execution environment.

No parser, validation, preview, commit, reconciliation, event, custody, role, authentication, schema, dependency, or persistence behavior changed.
