### PR TITLE
Issue 30-19: Simplify import results and errors

### DIFF
--- a/assettrack/import_analysis.py
+++ b/assettrack/import_analysis.py
@@ -75,6 +75,7 @@ class AssetImportAnalysisIssue:
     category: str
     message: str
     fields: tuple[str, ...] = ()
+    asset_identifier: str = ""
 
 
 @dataclass(frozen=True)
@@ -167,6 +168,19 @@ def _validate_headers(headers: list[str], *, file_type: str) -> tuple[str, ...]:
     return tuple(warnings)
 
 
+def _raw_asset_identifier(raw_row: dict[str, object]) -> str:
+    row = {
+        normalized_key: _normalize_text(value)
+        for key, value in raw_row.items()
+        if (normalized_key := _normalize_header(key)) in ALLOWED_COLUMNS
+    }
+    for column in IDENTITY_COLUMNS:
+        identifier = _normalize_text(row.get(column)).upper()
+        if identifier:
+            return identifier
+    return ""
+
+
 def _canonical_row(raw_row: dict[str, object], *, row_number: int) -> AssetImportAnalysisRow | None:
     row = {
         normalized_key: _normalize_slot_identifier(value)
@@ -231,6 +245,7 @@ def _duplicate_issues(rows: list[AssetImportAnalysisRow]) -> tuple[AssetImportAn
                     category="duplicate_upload_row",
                     message=f"duplicate asset_tag matches row {previous_asset_row}: {row.asset_tag}.",
                     fields=("asset_tag",),
+                    asset_identifier=row.asset_tag,
                 )
             )
         else:
@@ -247,6 +262,7 @@ def _duplicate_issues(rows: list[AssetImportAnalysisRow]) -> tuple[AssetImportAn
                     category="duplicate_upload_row",
                     message=f"duplicate serial_number matches row {previous_serial_row}: {row.serial_number}.",
                     fields=("serial_number",),
+                    asset_identifier=row.asset_tag,
                 )
             )
         else:
@@ -285,6 +301,7 @@ def _analyze_rows(
                     row_number=offset,
                     category="invalid_upload_row",
                     message=str(exc).removeprefix(f"Row {offset}: "),
+                    asset_identifier=_raw_asset_identifier(raw_row),
                 )
             )
             continue

--- a/assettrack/import_reconciliation.py
+++ b/assettrack/import_reconciliation.py
@@ -55,6 +55,7 @@ class AssetImportFieldChange:
 class AssetImportPreviewRow:
     row_number: int
     asset_tag: str
+    asset_identifier: str
     category: str
     category_label: str
     message: str
@@ -105,6 +106,7 @@ class AssetImportPreview:
             {
                 "row_number": row.row_number,
                 "asset_tag": row.asset_tag,
+                "asset_identifier": row.asset_identifier,
                 "category": row.category,
                 "category_label": row.category_label,
                 "message": row.message,
@@ -132,6 +134,7 @@ class AssetImportPreview:
             "attention_categories": ATTENTION_CATEGORIES,
             "rows": row_dicts,
             "rows_by_category": rows_by_category,
+            "total_rows": self.total_rows,
             "unslotted_acknowledged": self.unslotted_acknowledged,
             "requires_unslotted_acknowledgment": self.requires_unslotted_acknowledgment,
             "blocks_without_unslotted_acknowledgment": self.blocks_without_unslotted_acknowledgment,
@@ -289,6 +292,7 @@ def _preview_row(
         return AssetImportPreviewRow(
             row_number=row.row_number,
             asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
             category="identity_conflict",
             category_label=CATEGORY_LABELS["identity_conflict"],
             message=f"serial_number matches existing asset {serial_match['asset_tag']}",
@@ -300,6 +304,7 @@ def _preview_row(
         return AssetImportPreviewRow(
             row_number=row.row_number,
             asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
             category="unslotted_import",
             category_label=CATEGORY_LABELS["unslotted_import"],
             message="No storage case and slot supplied; row can continue as Unslotted after acknowledgment.",
@@ -313,6 +318,7 @@ def _preview_row(
             return AssetImportPreviewRow(
                 row_number=row.row_number,
                 asset_tag=row.asset_tag,
+                asset_identifier=row.asset_tag,
                 category="slot_conflict_unslotted",
                 category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
                 message=f"{slot_error}; row can continue as Unslotted after acknowledgment.",
@@ -330,6 +336,7 @@ def _preview_row(
             return AssetImportPreviewRow(
                 row_number=row.row_number,
                 asset_tag=row.asset_tag,
+                asset_identifier=row.asset_tag,
                 category="slot_conflict_unslotted",
                 category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
                 message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",
@@ -341,6 +348,7 @@ def _preview_row(
         return AssetImportPreviewRow(
             row_number=row.row_number,
             asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
             category="new_asset",
             category_label=CATEGORY_LABELS["new_asset"],
             message=f"New {equipment_type_label(row.equipment_type)} asset with available storage.",
@@ -363,6 +371,7 @@ def _preview_row(
         return AssetImportPreviewRow(
             row_number=row.row_number,
             asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
             category="proposed_update",
             category_label=CATEGORY_LABELS["proposed_update"],
             message=message,
@@ -372,11 +381,11 @@ def _preview_row(
     return AssetImportPreviewRow(
         row_number=row.row_number,
         asset_tag=row.asset_tag,
+        asset_identifier=row.asset_tag,
         category="unchanged_exact_match",
         category_label=CATEGORY_LABELS["unchanged_exact_match"],
         message="Upload row matches current asset data exactly.",
     )
-
 
 def _build_preview_context(conn: sqlite3.Connection, rows: tuple[AssetImportAnalysisRow, ...]) -> AssetImportPreviewContext:
     asset_tags = {row.asset_tag.upper() for row in rows if row.asset_tag}
@@ -490,6 +499,7 @@ def build_asset_import_preview(
         AssetImportPreviewRow(
             row_number=issue.row_number,
             asset_tag="",
+            asset_identifier=issue.asset_identifier,
             category="invalid_duplicate_upload_row",
             category_label=CATEGORY_LABELS["invalid_duplicate_upload_row"],
             message=issue.message,

--- a/assettrack/intake/templates/admin_asset_import.html
+++ b/assettrack/intake/templates/admin_asset_import.html
@@ -8,6 +8,23 @@
     .import-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
     .import-summary { margin: 0; }
     .compact-list { margin: 0.5rem 0 0 1.25rem; }
+    .import-result-metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+    }
+    .import-result-metric {
+      border: 1px solid var(--color-surface);
+      padding: 0.75rem;
+      background: var(--color-surface-bg);
+    }
+    .import-result-metric strong {
+      display: block;
+      font-size: 1.75rem;
+      line-height: 1;
+    }
+    .blocked-row-list { margin-top: 1rem; }
     .import-row-section { margin-top: 1rem; border-top: 1px solid var(--color-surface); padding-top: 0.75rem; }
     .import-row-section summary { cursor: pointer; font-weight: 700; }
     .import-row-count { color: var(--color-text-muted); font-weight: 400; margin-left: 0.5rem; }
@@ -68,6 +85,7 @@
   </details>
 
   {% if result is not none %}
+    {% set blocked_rows = result.rows_by_category["identity_conflict"] + result.rows_by_category["invalid_duplicate_upload_row"] %}
     <div class="card">
       <h2>Analysis Result</h2>
       <p class="import-summary">
@@ -91,27 +109,52 @@
           <p class="flash error">Unslotted acknowledgment is required before these rows can continue.</p>
         {% endif %}
       {% endif %}
-      <h3>Category Totals</h3>
-      <ul class="compact-list">
-        {% for category in result.category_order %}
-          <li>{{ result.category_labels[category] }}: {{ result.totals[category] }}</li>
-        {% endfor %}
-      </ul>
+      <div class="import-result-metrics" aria-label="Import result counts">
+        <div class="import-result-metric">
+          <strong>{{ commit_summary.committed_rows if commit_summary else result.total_rows - blocked_rows|length }}</strong>
+          <span>{{ "Committed rows" if commit_summary else "Ready to commit" }}</span>
+        </div>
+        <div class="import-result-metric">
+          <strong>{{ commit_summary.blocked if commit_summary else blocked_rows|length }}</strong>
+          <span>Blocked rows</span>
+        </div>
+      </div>
       {% if commit_summary %}
-        <h3>Commit Result</h3>
-        <ul class="compact-list">
-          <li>Committed rows: {{ commit_summary.committed_rows }}</li>
-          <li>Created assets: {{ commit_summary.created }}</li>
-          <li>Updated assets: {{ commit_summary.updated }}</li>
-          <li>Slot assignments: {{ commit_summary.slot_assigned }}</li>
-          <li>Slot moves: {{ commit_summary.slot_moved }}</li>
-          <li>Unchanged rows: {{ commit_summary.unchanged }}</li>
-          <li>Blocked rows: {{ commit_summary.blocked }}</li>
-        </ul>
+        <p class="import-help">
+          {{ commit_summary.committed_rows }} row{% if commit_summary.committed_rows != 1 %}s{% endif %} committed. {{ commit_summary.blocked }} blocked row{% if commit_summary.blocked != 1 %}s{% endif %} left unchanged.
+        </p>
       {% endif %}
-      <p class="import-help">
-        <a href="{{ url_for('admin_asset_import_reconciliation_csv') }}">Download reconciliation CSV</a>
-      </p>
+      {% if blocked_rows %}
+        <div class="blocked-row-list" aria-label="Blocked rows requiring correction">
+          <h3>Blocked Rows To Fix</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Row</th>
+                <th>Asset</th>
+                <th>Problem</th>
+                <th>Required correction</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for row in blocked_rows %}
+                <tr>
+                  <td>{{ row.row_number }}</td>
+                  <td><code>{{ row.asset_identifier or "missing asset_tag or barcode" }}</code></td>
+                  <td>{{ row.message }}</td>
+                  <td>
+                    {% if row.category == "identity_conflict" %}
+                      Use a unique asset tag and serial number, or update the existing asset outside this import.
+                    {% else %}
+                      Correct the upload row, then analyze the file again.
+                    {% endif %}
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      {% endif %}
       {% if result.preview_token and not commit_summary %}
         <form method="post" class="row">
           <input type="hidden" name="action" value="commit" />
@@ -123,69 +166,98 @@
           <button type="submit">Commit Approved Rows</button>
         </form>
       {% endif %}
-      <h3>System Defaults Before Commit</h3>
-      <ul class="compact-list">
-        {% for default in result.defaults %}
-          <li><code>{{ default.field }}</code>: {{ default.value }}</li>
-        {% endfor %}
-      </ul>
-      <h3>Rows</h3>
-      {% for category in result.category_order %}
-        {% set category_rows = result.rows_by_category[category] %}
-        <details
-          id="asset-import-{{ category|replace('_', '-') }}"
-          class="import-row-section"
-          {% if category in result.attention_categories %}open{% endif %}
-        >
-          <summary>
-            {{ result.category_labels[category] }}
-            <span class="import-row-count">{{ category_rows|length }} row{% if category_rows|length != 1 %}s{% endif %}</span>
-          </summary>
-          <div class="import-row-table-wrap" tabindex="0" aria-label="{{ result.category_labels[category] }} rows">
-            <table>
-              <thead>
-                <tr>
-                  <th>Row</th>
-                  <th>Asset</th>
-                  <th>Details</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for row in category_rows %}
-                  <tr>
-                    <td>{{ row.row_number }}</td>
-                    <td><code>{{ row.asset_tag or "n/a" }}</code></td>
-                    <td>
-                      <p class="import-summary">{{ row.message }}</p>
-                      {% if row.fields %}
-                        <p class="import-help"><strong>Fields:</strong> {{ row.fields|join(", ") }}</p>
-                      {% endif %}
-                      {% if row.warnings %}
-                        <ul class="compact-list">
-                          {% for warning in row.warnings %}
-                            <li>{{ warning }}</li>
-                          {% endfor %}
-                        </ul>
-                      {% endif %}
-                      {% if row.changed_fields %}
-                        <ul class="compact-list">
-                          {% for change in row.changed_fields %}
-                            <li><code>{{ change.field }}</code>: {{ change.current or "blank" }} -> {{ change.proposed or "blank" }}</li>
-                          {% endfor %}
-                        </ul>
-                      {% endif %}
-                    </td>
-                  </tr>
-                {% else %}
-                  <tr>
-                    <td colspan="3">No rows in this category.</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        </details>
-      {% endfor %}
+      <details class="disclosure-section">
+        <summary>
+          <span class="disclosure-title">Technical Details</span>
+          <span class="disclosure-hint">Totals, defaults, reconciliation, and row diagnostics</span>
+        </summary>
+        <div class="disclosure-body">
+          <p class="import-help">
+            <a href="{{ url_for('admin_asset_import_reconciliation_csv') }}">Download reconciliation CSV</a>
+          </p>
+          {% if commit_summary %}
+            <h3>Commit Result</h3>
+            <ul class="compact-list">
+              <li>Committed rows: {{ commit_summary.committed_rows }}</li>
+              <li>Created assets: {{ commit_summary.created }}</li>
+              <li>Updated assets: {{ commit_summary.updated }}</li>
+              <li>Slot assignments: {{ commit_summary.slot_assigned }}</li>
+              <li>Slot moves: {{ commit_summary.slot_moved }}</li>
+              <li>Unchanged rows: {{ commit_summary.unchanged }}</li>
+              <li>Blocked rows: {{ commit_summary.blocked }}</li>
+            </ul>
+          {% endif %}
+          <h3>Category Totals</h3>
+          <ul class="compact-list">
+            {% for category in result.category_order %}
+              <li>{{ result.category_labels[category] }}: {{ result.totals[category] }}</li>
+            {% endfor %}
+          </ul>
+          <h3>System Defaults Before Commit</h3>
+          <ul class="compact-list">
+            {% for default in result.defaults %}
+              <li><code>{{ default.field }}</code>: {{ default.value }}</li>
+            {% endfor %}
+          </ul>
+          <h3>Rows</h3>
+          {% for category in result.category_order %}
+            {% set category_rows = result.rows_by_category[category] %}
+            <details
+              id="asset-import-{{ category|replace('_', '-') }}"
+              class="import-row-section"
+              {% if category in result.attention_categories %}open{% endif %}
+            >
+              <summary>
+                {{ result.category_labels[category] }}
+                <span class="import-row-count">{{ category_rows|length }} row{% if category_rows|length != 1 %}s{% endif %}</span>
+              </summary>
+              <div class="import-row-table-wrap" tabindex="0" aria-label="{{ result.category_labels[category] }} rows">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Row</th>
+                      <th>Asset</th>
+                      <th>Details</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for row in category_rows %}
+                      <tr>
+                        <td>{{ row.row_number }}</td>
+                        <td><code>{{ row.asset_tag or "n/a" }}</code></td>
+                        <td>
+                          <p class="import-summary">{{ row.message }}</p>
+                          {% if row.fields %}
+                            <p class="import-help"><strong>Fields:</strong> {{ row.fields|join(", ") }}</p>
+                          {% endif %}
+                          {% if row.warnings %}
+                            <ul class="compact-list">
+                              {% for warning in row.warnings %}
+                                <li>{{ warning }}</li>
+                              {% endfor %}
+                            </ul>
+                          {% endif %}
+                          {% if row.changed_fields %}
+                            <ul class="compact-list">
+                              {% for change in row.changed_fields %}
+                                <li><code>{{ change.field }}</code>: {{ change.current or "blank" }} -> {{ change.proposed or "blank" }}</li>
+                              {% endfor %}
+                            </ul>
+                          {% endif %}
+                        </td>
+                      </tr>
+                    {% else %}
+                      <tr>
+                        <td colspan="3">No rows in this category.</td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          {% endfor %}
+        </div>
+      </details>
     </div>
   {% endif %}
 {% endblock %}

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -471,6 +471,8 @@ def test_asset_import_preview_classifies_new_asset_with_available_slot(client_wi
     )
 
     assert response.status_code == 200
+    assert b"Ready to commit" in response.data
+    assert b"Committed rows" not in response.data
     assert b"New Asset: 1" in response.data
     assert b"New Laptop asset with available storage." in response.data
     assert b"location_type</code>: STORAGE" in response.data
@@ -852,7 +854,9 @@ def test_asset_import_preview_classifies_identity_conflict(client_with_temp_db) 
 
     assert response.status_code == 200
     assert b"Identity Conflict: 1" in response.data
+    assert b"Blocked Rows To Fix" in response.data
     assert b"serial_number matches existing asset SERIAL-OWNER" in response.data
+    assert b"Use a unique asset tag and serial number" in response.data
     assert b"serial_number" in response.data
 
 
@@ -872,8 +876,29 @@ def test_asset_import_preview_classifies_invalid_and_duplicate_upload_rows(
 
     assert response.status_code == 200
     assert b"Invalid Or Duplicate Upload Row: 2" in response.data
+    assert b"Blocked Rows To Fix" in response.data
+    assert b"<code>DUP-100</code>" in response.data
+    assert b"missing asset_tag or barcode" in response.data
     assert b"asset_tag or barcode is required." in response.data
     assert b"duplicate asset_tag matches row 2: DUP-100." in response.data
+    assert b"Correct the upload row, then analyze the file again." in response.data
+
+def test_asset_import_blocked_row_uses_barcode_identifier_when_asset_tag_blank(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,barcode,equipment_type,case_identifier,slot_identifier\n,BC-BAD,laptop,CASE-ONLY,\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Blocked Rows To Fix" in response.data
+    assert b"<code>BC-BAD</code>" in response.data
+    assert b"missing asset_tag or barcode" not in response.data
+    assert b"Correct the upload row, then analyze the file again." in response.data
 
 
 def test_asset_import_preview_groups_rows_by_category_with_expected_disclosure_defaults(
@@ -939,6 +964,9 @@ def test_asset_import_preview_groups_rows_by_category_with_expected_disclosure_d
     assert "Slot Conflict Eligible For Unslotted Import: 1" in html
     assert "Identity Conflict: 1" in html
     assert "Invalid Or Duplicate Upload Row: 1" in html
+    assert "Technical Details" in html
+    assert "Blocked Rows To Fix" in html
+    assert "Required correction" in html
 
     for section_id in (
         "asset-import-new-asset",
@@ -1446,8 +1474,13 @@ def test_asset_import_commit_writes_approved_safe_rows_atomically_and_leaves_blo
 
     assert commit_response.status_code == 200
     assert b"Asset import committed." in commit_response.data
+    assert b"Committed rows" in commit_response.data
+    assert b"Blocked rows" in commit_response.data
+    assert b"6 rows committed. 2 blocked rows left unchanged." in commit_response.data
     assert b"Committed rows: 6" in commit_response.data
     assert b"Blocked rows: 2" in commit_response.data
+    assert b"Blocked Rows To Fix" in commit_response.data
+    assert b"Required correction" in commit_response.data
     assert _asset_record("CONFLICT-TAG") is None
     assert _asset_record("SER-MISSING") is None
 


### PR DESCRIPTION
# Issue 30-19: Simplify Asset Import results and actionable errors

## Summary

Makes Asset Import results shorter, clearer, and immediately actionable for field operators.

Closes #1060

## Changes

- Shows safe rows as `Ready to commit` during preview.
- Shows actual `Committed rows` after confirmation.
- Prominently displays blocked-row counts.
- Gives each blocked row a plain-language problem and required correction.
- Displays the available asset tag or barcode for blocked rows.
- Uses `missing asset_tag or barcode` only when both identifiers are blank.
- Moves detailed reconciliation, defaults, diagnostics, and full row information under `Technical Details`.
- Preserves all existing import and reconciliation information.

## Verification

- [x] Python compilation passed for changed runtime modules
- [x] `pytest tests/test_admin_asset_import.py` — 49 passed
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Container reported healthy
- [x] Clean-browser preview smoke test passed
- [x] Preview showed 1 row ready to commit and 2 blocked rows
- [x] Blocked rows displayed the correct identifiers and corrections
- [x] Confirmed commit smoke test passed
- [x] Final result showed 1 committed row and 2 blocked rows
- [x] Technical Details retained the full diagnostic information

## Notes

This issue was reclassified from Class 1 to Class 2 because display-only identifier data was passed through two runtime Python modules.

No parsing decisions, reconciliation categories, commit behavior, atomicity, schema, events, custody state, authentication, roles, dependencies, or persistence behavior changed.