### PR TITLE
Issue 30-16: Add first-run deployment guide

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -4951,6 +4951,17 @@ def account_change_password_submit():
     return redirect(url_for("account_change_password"))
 
 
+FIRST_RUN_OPERATIONAL_TABLES = ("assets", "holders", "slots", "asset_events")
+
+
+def _database_has_operational_data(conn: sqlite3.Connection) -> bool:
+    for table_name in FIRST_RUN_OPERATIONAL_TABLES:
+        row = conn.execute(f"SELECT 1 FROM {table_name} LIMIT 1;").fetchone()
+        if row is not None:
+            return True
+    return False
+
+
 @app.get("/dashboard")
 @require_login
 def dashboard():
@@ -4965,6 +4976,9 @@ def dashboard():
             conn,
             custody_days_threshold=threshold_days,
         )
+        user = current_user()
+        user_role = str((user or {}).get("role") or "").strip().lower()
+        show_first_run_guide = user_role == "admin" and not _database_has_operational_data(conn)
     finally:
         conn.close()
 
@@ -4972,6 +4986,7 @@ def dashboard():
         "dashboard.html",
         dashboard=dashboard_data,
         custody_days_threshold=threshold_days,
+        show_first_run_guide=show_first_run_guide,
     )
 
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -94,6 +94,57 @@
       grid-column: span 2;
     }
 
+    .first-run-guide {
+      margin-bottom: 1rem;
+      border: 1px solid color-mix(in srgb, var(--color-primary) 32%, var(--color-surface));
+      background: var(--color-panel-bg);
+    }
+    .first-run-guide-header {
+      display: grid;
+      gap: 0.35rem;
+      margin-bottom: 1rem;
+    }
+    .first-run-guide-header p {
+      margin: 0;
+      color: var(--color-text-muted);
+      line-height: 1.45;
+    }
+    .first-run-actions {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 0.75rem;
+    }
+    .first-run-action {
+      display: grid;
+      gap: 0.35rem;
+      min-width: 0;
+      padding: 0.85rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 8px;
+      background: var(--color-surface-bg);
+      text-decoration: none;
+    }
+    .first-run-action:hover {
+      text-decoration: none;
+      border-color: color-mix(in srgb, var(--color-primary) 42%, var(--color-surface));
+    }
+    .first-run-label {
+      color: var(--color-text-muted);
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+    }
+    .first-run-title {
+      color: var(--color-primary);
+      font-weight: 800;
+      line-height: 1.25;
+    }
+    .first-run-copy {
+      color: var(--color-text-muted);
+      font-size: 0.9rem;
+      line-height: 1.35;
+    }
     .dashboard-map-card {
       margin-bottom: 1rem;
     }
@@ -217,7 +268,11 @@
     .status-dot.low { background: #f59e0b; }
     .status-dot.open { background: #16a34a; }
 
-    @media (max-width: 1180px) {
+    @media (max-width: 980px) {
+      .first-run-actions {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }    @media (max-width: 1180px) {
       .dashboard-primary-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
@@ -227,7 +282,8 @@
       }
     }
     @media (max-width: 760px) {
-      .dashboard-primary-grid {
+      .dashboard-primary-grid,
+      .first-run-actions {
         grid-template-columns: 1fr;
       }
     }
@@ -242,7 +298,49 @@
     <p class="dashboard-note">Custody map is read-only.</p>
   </div>
 
-  <div class="dashboard-primary-grid" aria-label="Primary dashboard cards">
+  {% if show_first_run_guide %}
+    <section class="dashboard-primary-card first-run-guide" aria-label="First-run deployment guide">
+      <div class="first-run-guide-header">
+        <h2>First-run deployment guide</h2>
+        <p>No assets, holders, storage, or asset events exist yet. These steps are available now and do not block dashboard access.</p>
+        <p>Assets may remain Unslotted. Storage can be created and assigned later.</p>
+      </div>
+      <div class="first-run-actions">
+        <a class="first-run-action" href="{{ url_for('admin_asset_import') }}">
+          <span class="first-run-label">Recommended</span>
+          <span class="first-run-title">Import inventory</span>
+          <span class="first-run-copy">Load the canonical asset inventory CSV or XLSX.</span>
+        </a>
+        <a class="first-run-action" href="{{ url_for('admin_holder_import') }}">
+          <span class="first-run-label">Recommended</span>
+          <span class="first-run-title">Import Holders</span>
+          <span class="first-run-copy">Load holder records before custody operations.</span>
+        </a>
+        <a class="first-run-action" href="{{ url_for('holders_new', return_to=url_for('dashboard')) }}">
+          <span class="first-run-label">Recommended</span>
+          <span class="first-run-title">Add one Holder</span>
+          <span class="first-run-copy">Create a holder before issuing assets.</span>
+        </a>
+        <a class="first-run-action" href="{{ url_for('admin_slot_provision') }}">
+          <span class="first-run-label">Optional</span>
+          <span class="first-run-title">Create storage</span>
+          <span class="first-run-copy">Add empty case slots when storage is ready.</span>
+        </a>
+        <a class="first-run-action" href="{{ url_for('admin_new_asset') }}">
+          <span class="first-run-label">Optional</span>
+          <span class="first-run-title">Add one asset</span>
+          <span class="first-run-copy">Create a single asset without requiring a slot.</span>
+        </a>
+        <a class="first-run-action" href="#dashboard-main">
+          <span class="first-run-label">Deferrable</span>
+          <span class="first-run-title">Continue to Dashboard</span>
+          <span class="first-run-copy">Skip setup guidance and view current empty state.</span>
+        </a>
+      </div>
+    </section>
+  {% endif %}
+
+  <div id="dashboard-main" class="dashboard-primary-grid" aria-label="Primary dashboard cards">
     <section class="dashboard-primary-card dashboard-metric-card">
       <p class="dashboard-primary-label">Assets Out</p>
       <strong>{{ overview.issued_assets }}</strong>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -52,6 +52,10 @@ class DashboardTests(unittest.TestCase):
         operator_user_id = create_test_user(username="operator", password="op-pass", role="operator")
         login_session(self.client, operator_user_id)
 
+    def _login_admin(self) -> None:
+        admin_user_id = create_test_user(username="admin", password="admin-pass", role="admin")
+        login_session(self.client, admin_user_id)
+
     def tearDown(self) -> None:
         self.conn.close()
         self.temp_dir.cleanup()
@@ -244,10 +248,69 @@ class DashboardTests(unittest.TestCase):
         self.assertNotIn(b"Workflow Shortcuts", response.data)
         self.assertNotIn(b'href="/issue/preview">Issue</a>', response.data)
 
+    def test_first_run_guide_shows_for_admin_when_no_operational_data(self) -> None:
+        self._login_admin()
+
+        response = self.client.get("/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"First-run deployment guide", response.data)
+        self.assertIn(b"No assets, holders, storage, or asset events exist yet.", response.data)
+        self.assertIn(b"Assets may remain Unslotted. Storage can be created and assigned later.", response.data)
+        self.assertIn(b"Recommended", response.data)
+        self.assertIn(b"Optional", response.data)
+        self.assertIn(b"Deferrable", response.data)
+        self.assertIn(b'href="/admin/assets/import"', response.data)
+        self.assertIn(b"Import inventory", response.data)
+        self.assertIn(b'href="/admin/holders/import"', response.data)
+        self.assertIn(b"Import Holders", response.data)
+        self.assertIn(b'href="/holders/new?return_to=/dashboard"', response.data)
+        self.assertIn(b"Add one Holder", response.data)
+        self.assertIn(b"Create a holder before issuing assets.", response.data)
+        self.assertIn(b'href="/admin/slots/provision"', response.data)
+        self.assertIn(b"Create storage", response.data)
+        self.assertIn(b'href="/admin/assets/new"', response.data)
+        self.assertIn(b"Add one asset", response.data)
+        self.assertIn(b'href="#dashboard-main"', response.data)
+        self.assertIn(b"Continue to Dashboard", response.data)
+        self.assertIn(b"Assets Out", response.data)
+        self.assertIn(b"No active assets in the custody map.", response.data)
+        for table_name in ("assets", "holders", "slots", "asset_events"):
+            row_count = int(self.conn.execute(f"SELECT COUNT(*) FROM {table_name};").fetchone()[0])
+            self.assertEqual(row_count, 0)
+
+    def test_first_run_guide_hides_after_creating_one_holder(self) -> None:
+        self._login_admin()
+
+        holder_form = self.client.get("/holders/new?return_to=/dashboard")
+        self.assertEqual(holder_form.status_code, 200)
+        self.assertIn(b"Create Holder", holder_form.data)
+        self.assertIn(b'name="return_to" value="/dashboard"', holder_form.data)
+
+        response = self.client.post(
+            "/holders/new",
+            data={
+                "name": "First Holder",
+                "organization_id": "1",
+                "email": "first@example.org",
+                "return_to": "/dashboard",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b"First-run deployment guide", response.data)
+        self.assertNotIn(b"Import inventory", response.data)
+        self.assertIn(b"Assets Out", response.data)
+        holder_count = int(self.conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        self.assertEqual(holder_count, 1)
     def test_dashboard_empty_states_are_operator_facing(self) -> None:
         response = self.client.get("/dashboard")
 
         self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b"First-run deployment guide", response.data)
+        self.assertNotIn(b"Import inventory", response.data)
+        self.assertNotIn(b'href="/admin/assets/import"', response.data)
         self.assertNotIn(b"At a Glance", response.data)
         self.assertIn(b"Assets Out", response.data)
         self.assertNotIn(b"Issue Assets", response.data)


### PR DESCRIPTION
# Issue 30-16: Add a first-run deployment guide workflow

## Summary

Adds clear, non-blocking setup guidance for administrators starting with an empty AssetTrack deployment.

Closes #1034

## Changes

- Added an administrator-only first-run guide to the Dashboard.
- Shows the guide only when assets, Holders, slots, and asset events are empty.
- Added direct choices to:
  - Import inventory
  - Import Holders
  - Add one Holder
  - Create storage
  - Add one asset
  - Continue to Dashboard
- Explained that assets may remain Unslotted and storage can be assigned later.
- Linked `Add one Holder` directly to the existing Holder form with return to Dashboard.
- Preserved normal Dashboard access and the existing operator empty state.
- Created no placeholder operational data.

## Verification

- [x] `pytest tests/test_dashboard.py` — 18 passed
- [x] `pytest tests/test_basic_auth_guard.py` — 36 passed
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Container reported healthy
- [x] Fresh administrator bootstrap completed using an isolated database
- [x] First-run guide appeared on the Dashboard
- [x] `Import Holders` and `Add one Holder` were visible
- [x] `Add one Holder` opened the existing form directly
- [x] Creating a Holder returned to the Dashboard
- [x] The guide disappeared after the Holder was created
- [x] No placeholder assets, Cases, or Slots were created

## Notes

No schema, persistence, import, event, custody, authentication, role, or Holder workflow behavior changed.