### PR TITLE
Issue 30-13: Add Holder import preview

### DIFF
--- a/assettrack/holder_import.py
+++ b/assettrack/holder_import.py
@@ -39,6 +39,50 @@ class HolderImportReport:
         }
 
 
+@dataclass(frozen=True)
+class HolderImportPreviewRow:
+    row_number: int
+    category: str
+    organization: str
+    name: str
+    email: str
+    before: dict[str, object] | None = None
+    after: dict[str, object] | None = None
+    problem: str = ""
+
+
+@dataclass(frozen=True)
+class HolderImportPreview:
+    processed: int
+    rows: tuple[HolderImportPreviewRow, ...]
+    errors: tuple[str, ...] = ()
+
+    def summary(self) -> dict[str, int]:
+        totals = {
+            "processed": self.processed,
+            "new": 0,
+            "unchanged": 0,
+            "updated": 0,
+            "duplicate": 0,
+            "ambiguous": 0,
+            "invalid": 0,
+            "blocked": 0,
+        }
+        for row in self.rows:
+            if row.category in totals:
+                totals[row.category] += 1
+            if row.category in {"duplicate", "ambiguous", "invalid"}:
+                totals["blocked"] += 1
+        totals["invalid"] += len(self.errors)
+        totals["blocked"] += len(self.errors)
+        return totals
+
+    @property
+    def can_commit(self) -> bool:
+        summary = self.summary()
+        return self.processed > 0 and summary["blocked"] == 0
+
+
 def _normalize_header(name: str | None) -> str:
     return str(name or "").strip().lower()
 
@@ -123,14 +167,8 @@ def _load_csv_rows(csv_path: str | Path) -> HolderImportReport | list[HolderImpo
                 errors.append(f"Row {line_number}: {exc}")
                 continue
 
-            previous_row = seen_emails.get(normalized_email)
-            if previous_row is not None:
-                errors.append(
-                    f"Row {line_number}: duplicate email in CSV matches row {previous_row}: {normalized_email}"
-                )
-                continue
-
-            seen_emails[normalized_email] = line_number
+            if normalized_email not in seen_emails:
+                seen_emails[normalized_email] = line_number
             rows.append(
                 HolderImportRow(
                     row_number=line_number,
@@ -197,7 +235,207 @@ def _ensure_organization(conn: sqlite3.Connection, organization_name: str, organ
     return int(row["id"])
 
 
+def _row_after(row: HolderImportRow, organization_id: int | None) -> dict[str, object]:
+    return {
+        "name": row.name,
+        "organization": row.organization,
+        "organization_id": organization_id,
+        "email": row.email,
+    }
+
+
+def _row_before(holder: sqlite3.Row) -> dict[str, object]:
+    return {
+        "id": int(holder["id"]),
+        "name": holder["name"],
+        "organization": holder["organization"],
+        "organization_id": holder["organization_id"],
+        "email": holder["email"],
+    }
+
+
+def _holder_matches_import(holder: sqlite3.Row, row: HolderImportRow, organization_id: int | None) -> bool:
+    return (
+        str(holder["name"] or "") == row.name
+        and str(holder["organization"] or "") == row.organization
+        and (None if holder["organization_id"] is None else int(holder["organization_id"])) == organization_id
+        and str(holder["email"] or "").strip().lower() == row.email
+    )
+
+
+def _invalid_preview_row(row_number: int, problem: str, *, organization: str = "", name: str = "", email: str = "") -> HolderImportPreviewRow:
+    return HolderImportPreviewRow(
+        row_number=row_number,
+        category="invalid",
+        organization="",
+        name="",
+        email="",
+        problem=problem,
+    )
+
+
+
+def _load_csv_rows_for_preview(csv_path: str | Path) -> tuple[int, list[HolderImportRow], list[HolderImportPreviewRow]]:
+    path = Path(csv_path)
+    if not path.exists():
+        return 0, [], [_invalid_preview_row(0, f"CSV not found: {path}")]
+
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return 0, [], [_invalid_preview_row(1, "CSV header row is required.")]
+
+        normalized_headers = [_normalize_header(field_name) for field_name in reader.fieldnames]
+        if any(not header for header in normalized_headers):
+            return 0, [], [_invalid_preview_row(1, "CSV headers must not be blank.")]
+        if len(set(normalized_headers)) != len(normalized_headers):
+            return 0, [], [_invalid_preview_row(1, "CSV headers must be unique.")]
+
+        missing_columns = [column for column in REQUIRED_COLUMNS if column not in normalized_headers]
+        if missing_columns:
+            return 0, [], [_invalid_preview_row(1, f"Missing required CSV columns: {', '.join(missing_columns)}")]
+
+        rows: list[HolderImportRow] = []
+        invalid_rows: list[HolderImportPreviewRow] = []
+        processed = 0
+
+        for line_number, raw_row in enumerate(reader, start=2):
+            normalized_row = {_normalize_header(key): value for key, value in raw_row.items() if key is not None}
+            if None in raw_row:
+                invalid_rows.append(_invalid_preview_row(line_number, "malformed CSV row has extra columns."))
+                continue
+            if any(value is None for value in normalized_row.values()):
+                invalid_rows.append(_invalid_preview_row(line_number, "malformed CSV row has missing columns."))
+                continue
+
+            if all(not str(value or "").strip() for value in normalized_row.values()):
+                continue
+
+            processed += 1
+            organization = str(normalized_row.get("organization") or "").strip()
+            name = str(normalized_row.get("name") or "").strip()
+            email = str(normalized_row.get("email") or "").strip()
+
+            try:
+                organization = _normalize_required_text(organization, field_name="organization")
+                name = _normalize_required_text(name, field_name="name")
+                email = _normalize_required_text(email, field_name="email")
+                normalized_email = _normalize_email(email)
+                assert normalized_email is not None
+            except ValueError as exc:
+                invalid_rows.append(
+                    _invalid_preview_row(
+                        line_number,
+                        str(exc),
+                        organization=organization,
+                        name=name,
+                        email=email,
+                    )
+                )
+                continue
+
+            rows.append(
+                HolderImportRow(
+                    row_number=line_number,
+                    organization=organization,
+                    name=name,
+                    email=normalized_email,
+                )
+            )
+
+        return processed, rows, invalid_rows
+
+def preview_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderImportPreview:
+    processed, parsed, invalid_rows = _load_csv_rows_for_preview(csv_path)
+
+    bootstrap_db(Path(db_path))
+    conn = sqlite3.connect(Path(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        organizations = _organizations_by_name(conn)
+        rows_by_email = _holder_rows_by_email(conn, {row.email for row in parsed})
+        email_rows: dict[str, list[int]] = {}
+        for row in parsed:
+            email_rows.setdefault(row.email, []).append(row.row_number)
+
+        preview_rows: list[HolderImportPreviewRow] = list(invalid_rows)
+        for row in parsed:
+            organization_match = organizations.get(row.organization.lower())
+            organization_id = int(organization_match["id"]) if organization_match is not None else None
+            after = _row_after(row, organization_id)
+
+            duplicate_rows = email_rows.get(row.email, [])
+            if len(duplicate_rows) > 1:
+                row_list = ", ".join(str(row_number) for row_number in duplicate_rows)
+                preview_rows.append(
+                    HolderImportPreviewRow(
+                        row_number=row.row_number,
+                        category="duplicate",
+                        organization=row.organization,
+                        name=row.name,
+                        email=row.email,
+                        after=after,
+                        problem=f"Duplicate email in uploaded CSV: {row.email} appears on rows {row_list}.",
+                    )
+                )
+                continue
+
+            matches = rows_by_email.get(row.email, [])
+            if len(matches) > 1:
+                preview_rows.append(
+                    HolderImportPreviewRow(
+                        row_number=row.row_number,
+                        category="ambiguous",
+                        organization=row.organization,
+                        name=row.name,
+                        email=row.email,
+                        after=after,
+                        problem=f"Multiple existing holders already use email {row.email}.",
+                    )
+                )
+                continue
+
+            if not matches:
+                preview_rows.append(
+                    HolderImportPreviewRow(
+                        row_number=row.row_number,
+                        category="new",
+                        organization=row.organization,
+                        name=row.name,
+                        email=row.email,
+                        after=after,
+                    )
+                )
+                continue
+
+            before = _row_before(matches[0])
+            category = "unchanged" if _holder_matches_import(matches[0], row, organization_id) else "updated"
+            preview_rows.append(
+                HolderImportPreviewRow(
+                    row_number=row.row_number,
+                    category=category,
+                    organization=row.organization,
+                    name=row.name,
+                    email=row.email,
+                    before=before,
+                    after=after,
+                )
+            )
+
+        return HolderImportPreview(processed=processed, rows=tuple(sorted(preview_rows, key=lambda row: row.row_number)))
+    finally:
+        conn.close()
+
+
 def import_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderImportReport:
+    preview = preview_holders_csv(csv_path, db_path=db_path)
+    if not preview.can_commit:
+        errors = [f"Row {row.row_number}: {row.problem}" for row in preview.rows if row.problem]
+        errors.extend(preview.errors)
+        if not errors:
+            errors.append("No holder rows found.")
+        return HolderImportReport(processed=preview.processed, created=0, updated=0, errors=tuple(errors))
+
     parsed = _load_csv_rows(csv_path)
     if isinstance(parsed, HolderImportReport):
         return parsed
@@ -246,6 +484,9 @@ def import_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderIm
                         ("PERSON", row.name, row.organization, organization_id, row.email, now_iso, now_iso),
                     )
                     created += 1
+                    continue
+
+                if _holder_matches_import(matches[0], row, organization_id):
                     continue
 
                 holder_id = int(matches[0]["id"])

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -7578,8 +7578,7 @@ def admin_holder_import():
             flash("Choose a CSV file to preview.", "error")
             return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
 
-        suffix = Path(filename).suffix or ".csv"
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as handle:
             upload.save(handle)
             temp_path = Path(handle.name)
 

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -69,7 +69,7 @@ from assettrack.auth import (
     require_role,
 )
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, set_holder_active, update_holder
-from assettrack.holder_import import HolderImportReport, import_holders_csv
+from assettrack.holder_import import HolderImportPreview, HolderImportReport, import_holders_csv, preview_holders_csv
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.import_reconciliation import build_asset_import_preview
 from assettrack.reference_data import (
@@ -7481,52 +7481,122 @@ def admin_recovery_acknowledge():
     return redirect(url_for("admin_system"))
 
 
+HOLDER_IMPORT_PENDING_SESSION_KEY = "pending_holder_import"
+
+
+def _clear_pending_holder_import() -> None:
+    pending = session.pop(HOLDER_IMPORT_PENDING_SESSION_KEY, None)
+    if not isinstance(pending, dict):
+        return
+    pending_path = pending.get("path")
+    if not pending_path:
+        return
+    try:
+        Path(str(pending_path)).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def _pending_holder_import_path() -> Path | None:
+    pending = session.get(HOLDER_IMPORT_PENDING_SESSION_KEY)
+    if not isinstance(pending, dict):
+        return None
+    pending_path = pending.get("path")
+    if not pending_path:
+        return None
+    path = Path(str(pending_path))
+    if not path.exists():
+        session.pop(HOLDER_IMPORT_PENDING_SESSION_KEY, None)
+        return None
+    return path
+
+
+def _holder_import_flash(report: HolderImportReport) -> None:
+    summary = report.summary()
+    if report.errors:
+        flash(
+            (
+                f"Holder import failed. Processed {summary['processed']} row"
+                f"{'' if summary['processed'] == 1 else 's'} with {summary['errors']} error"
+                f"{'' if summary['errors'] == 1 else 's'}."
+            ),
+            "error",
+        )
+    else:
+        flash(
+            (
+                f"Holder import complete. Processed {summary['processed']} row"
+                f"{'' if summary['processed'] == 1 else 's'}: created {summary['created']}, "
+                f"updated {summary['updated']}."
+            ),
+            "success",
+        )
+
 @app.route("/admin/holders/import", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
 def admin_holder_import():
+    preview: HolderImportPreview | None = None
     report: HolderImportReport | None = None
+    pending_filename = ""
 
     if request.method == "POST":
+        action = (request.form.get("action") or "preview").strip().lower()
+
+        if action == "cancel":
+            _clear_pending_holder_import()
+            flash("Holder import preview cleared.", "success")
+            return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
+
+        if action == "commit":
+            temp_path = _pending_holder_import_path()
+            if temp_path is None:
+                flash("Upload and preview a Holder CSV before confirming import.", "error")
+                return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
+
+            preview = preview_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
+            pending = session.get(HOLDER_IMPORT_PENDING_SESSION_KEY)
+            pending_filename = str((pending or {}).get("filename") or "") if isinstance(pending, dict) else ""
+            if not preview.can_commit:
+                flash("Holder import preview has blocked rows. Fix the CSV and upload again.", "error")
+                return render_template(
+                    "admin_holder_import.html",
+                    preview=preview,
+                    report=None,
+                    pending_filename=pending_filename,
+                )
+
+            report = import_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
+            _holder_import_flash(report)
+            _clear_pending_holder_import()
+            return render_template("admin_holder_import.html", preview=None, report=report, pending_filename="")
+
+        _clear_pending_holder_import()
         upload = request.files.get("csv_file")
         filename = str((upload.filename if upload is not None else "") or "").strip()
         if upload is None or not filename:
-            flash("Choose a CSV file to import.", "error")
-            return render_template("admin_holder_import.html", report=None)
+            flash("Choose a CSV file to preview.", "error")
+            return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
 
         suffix = Path(filename).suffix or ".csv"
-        temp_path: Path | None = None
-        try:
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
-                upload.save(handle)
-                temp_path = Path(handle.name)
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as handle:
+            upload.save(handle)
+            temp_path = Path(handle.name)
 
-            report = import_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
-            summary = report.summary()
-            if report.errors:
-                flash(
-                    (
-                        f"Holder import failed. Processed {summary['processed']} row"
-                        f"{'' if summary['processed'] == 1 else 's'} with {summary['errors']} error"
-                        f"{'' if summary['errors'] == 1 else 's'}."
-                    ),
-                    "error",
-                )
-            else:
-                flash(
-                    (
-                        f"Holder import complete. Processed {summary['processed']} row"
-                        f"{'' if summary['processed'] == 1 else 's'}: created {summary['created']}, "
-                        f"updated {summary['updated']}."
-                    ),
-                    "success",
-                )
-        finally:
-            if temp_path is not None:
-                temp_path.unlink(missing_ok=True)
+        session[HOLDER_IMPORT_PENDING_SESSION_KEY] = {"path": str(temp_path), "filename": filename}
+        preview = preview_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
+        pending_filename = filename
+        if preview.can_commit:
+            flash("Holder import preview ready. Review and confirm one batch to commit.", "success")
+        else:
+            flash("Holder import preview found blocked rows. Fix the CSV and upload again.", "error")
 
-    return render_template("admin_holder_import.html", report=report)
-
+    return render_template(
+        "admin_holder_import.html",
+        preview=preview,
+        report=report,
+        pending_filename=pending_filename,
+    )
 
 def _analyze_asset_import_csv(temp_path: Path, *, filename: str) -> dict:
     return analyze_asset_import_csv(temp_path, filename=filename, collect_row_errors=True).to_template_result()

--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -8,6 +8,42 @@
     .import-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
     .import-summary { margin: 0; }
     .import-errors { margin: 0.75rem 0 0 1.25rem; }
+    .import-actions { display: flex; flex-wrap: wrap; gap: 0.65rem; align-items: center; margin-top: 1rem; }
+    .holder-preview-grid {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0.75rem;
+      margin: 0 0 1rem 0;
+    }
+    .holder-preview-metric {
+      padding: 0.75rem;
+      border: 1px solid var(--color-surface);
+      border-radius: 8px;
+      background: var(--color-panel-bg);
+    }
+    .holder-preview-metric span {
+      display: block;
+      color: var(--color-text-muted);
+      font-size: 0.82rem;
+      font-weight: 800;
+      text-transform: uppercase;
+    }
+    .holder-preview-metric strong { display: block; margin-top: 0.25rem; font-size: 1.35rem; }
+    .holder-preview-table { overflow-x: auto; }
+    .holder-preview-table table { width: 100%; border-collapse: collapse; }
+    .holder-preview-table th,
+    .holder-preview-table td {
+      padding: 0.65rem;
+      border-bottom: 1px solid var(--color-surface);
+      text-align: left;
+      vertical-align: top;
+    }
+    .holder-preview-table th { background: var(--color-primary-soft); }
+    .holder-preview-category { font-weight: 800; text-transform: capitalize; }
+    .holder-preview-change { margin: 0; color: var(--color-text-muted); line-height: 1.35; }
+    @media (max-width: 780px) {
+      .holder-preview-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
   </style>
 {% endblock %}
 
@@ -22,12 +58,14 @@
 
   <div class="card">
     <h2>Holder CSV Import</h2>
+    <p class="import-help">Upload, validate, preview, confirm, then commit one batch. Preview does not create or update Holders or Organizations.</p>
     <form method="post" enctype="multipart/form-data">
+      <input type="hidden" name="action" value="preview" />
       <div class="row">
         <label for="csv_file"><strong>CSV file</strong></label><br />
         <input id="csv_file" type="file" name="csv_file" accept=".csv,text/csv" required />
       </div>
-      <button type="submit">Import Holders</button>
+      <button type="submit">Preview Holders</button>
     </form>
   </div>
 
@@ -39,8 +77,87 @@
     <div class="disclosure-body">
       <p class="import-help">Required columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
       <p class="import-help">Matching email addresses update existing holder records. New email addresses create new holders.</p>
+      <p class="import-help">Organizations are reused by case-insensitive name; missing Organizations are proposed in preview and created only after confirmation.</p>
+      <p class="import-help">Holder imports change Holder and Organization reference data. Holder imports do not create asset custody events. A separate persistent import audit record is not currently created.</p>
     </div>
   </details>
+
+  {% if preview is not none %}
+    {% set summary = preview.summary() %}
+    <div class="card">
+      <h2>Import Preview</h2>
+      {% if pending_filename %}<p class="import-help">File: <code>{{ pending_filename }}</code></p>{% endif %}
+      <div class="holder-preview-grid" aria-label="Holder import preview totals">
+        <div class="holder-preview-metric"><span>Processed</span><strong>{{ summary.processed }}</strong></div>
+        <div class="holder-preview-metric"><span>New</span><strong>{{ summary.new }}</strong></div>
+        <div class="holder-preview-metric"><span>Updated</span><strong>{{ summary.updated }}</strong></div>
+        <div class="holder-preview-metric"><span>Unchanged</span><strong>{{ summary.unchanged }}</strong></div>
+        <div class="holder-preview-metric"><span>Duplicate</span><strong>{{ summary.duplicate }}</strong></div>
+        <div class="holder-preview-metric"><span>Ambiguous</span><strong>{{ summary.ambiguous }}</strong></div>
+        <div class="holder-preview-metric"><span>Invalid</span><strong>{{ summary.invalid }}</strong></div>
+        <div class="holder-preview-metric"><span>Blocked</span><strong>{{ summary.blocked }}</strong></div>
+      </div>
+
+      <div class="holder-preview-table">
+        <table>
+          <thead>
+            <tr>
+              <th>Row</th>
+              <th>Status</th>
+              <th>Email</th>
+              <th>Before</th>
+              <th>After</th>
+              <th>Problem</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in preview.rows %}
+              <tr>
+                <td>{{ row.row_number }}</td>
+                <td class="holder-preview-category">{{ row.category }}</td>
+                <td>{% if row.email %}<code>{{ row.email }}</code>{% endif %}</td>
+                <td>
+                  {% if row.before %}
+                    <p class="holder-preview-change"><strong>Name:</strong> {{ row.before.name }}</p>
+                    <p class="holder-preview-change"><strong>Organization:</strong> {{ row.before.organization }}</p>
+                  {% else %}
+                    <span class="muted">None</span>
+                  {% endif %}
+                </td>
+                <td>
+                  {% if row.after %}
+                    <p class="holder-preview-change"><strong>Name:</strong> {{ row.after.name }}</p>
+                    <p class="holder-preview-change"><strong>Organization:</strong> {{ row.after.organization }}</p>
+                    {% if row.after.organization_id is none %}
+                      <p class="holder-preview-change"><strong>Organization action:</strong> Create</p>
+                    {% else %}
+                      <p class="holder-preview-change"><strong>Organization action:</strong> Reuse</p>
+                    {% endif %}
+                  {% else %}
+                    <span class="muted">None</span>
+                  {% endif %}
+                </td>
+                <td>{{ row.problem }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <div class="import-actions">
+        {% if preview.can_commit %}
+          <form method="post">
+            <input type="hidden" name="action" value="commit" />
+            <button type="submit">Confirm and Commit Holder Import</button>
+          </form>
+        {% endif %}
+        <form method="post">
+          <input type="hidden" name="action" value="cancel" />
+          <button type="submit" class="button-secondary">Clear Preview</button>
+        </form>
+      </div>
+    </div>
+  {% endif %}
 
   {% if report is not none %}
     <div class="card">

--- a/docs/issue-30-15-legacy-import-tool-audit.md
+++ b/docs/issue-30-15-legacy-import-tool-audit.md
@@ -319,7 +319,7 @@ Why it matters: AssetTrack has several ways to create assets, holders, reference
 
 - Generic `assettrack.ingest` CLI: lacks enforced validation, preview, Flask roles, app-user attribution, direct tests, operator docs, and in-file collision checks.
 - Network CSV CLI: lacks Flask role enforcement and interactive preview; validation/commit are separate phases.
-- Holder import: lacks separate preview/confirmation, actor attribution, and reference-data audit.
+- Holder import: Issue 30-13 adds preview/confirmation and documents the current policy that Holder imports change reference data without custody events or a separate persistent audit record; persistent reference-data import auditing is deferred to Issue 30-27 / #1078.
 - Admin reference-data UI: lacks preview and actor/audit trail.
 - Admin slot provisioning UI: lacks preview and actor/audit trail.
 - Standard XLSX inventory importer: lacks Flask role enforcement, interactive preview, app-user attribution, and shared-committer behavior; collision reporting relies partly on DB integrity.
@@ -342,7 +342,7 @@ Why it matters: AssetTrack has several ways to create assets, holders, reference
 - Add a small docs/control issue for `assettrack.ingest` that documents internal-only status and prevents accidental operator exposure, without changing `commit_batch`.
 - Add direct CLI tests for `assettrack.ingest` only if Greg wants it retained as more than private plumbing.
 - In Issue 30-12, decide whether Switch/Router import remains CLI-backed, becomes an admin upload workflow, or keeps the current admin template page as guidance only.
-- In Issue 30-13, add Holder import preview and audit policy without deciding schema changes in this audit.
+- In Issue 30-13, add Holder import preview and document the current audit policy without schema changes; persistent reference-data import auditing is deferred to Issue 30-27 / #1078.
 - In Issue 30-5, repair XLSX inventory import scaling and deterministic reconciliation while preserving first-asset prerequisites and avoiding silent reference-data creation.
 - In Issue 30-16, document first-run operator guidance without exposing internal or legacy tools as supported workflows.
 - Add a future reference-data audit design only with explicit approval if it requires schema or persistence changes.

--- a/docs/release/user-manual.md
+++ b/docs/release/user-manual.md
@@ -335,11 +335,12 @@ Use Import Holders when you need to load holder records from an approved file.
 1. Select `Admin`.
 2. Select `Import Holders`.
 3. Choose the holder import file.
-4. Select `Import Holders`.
-5. Review the result.
+4. Select `Preview Holders`.
+5. Review the totals, blocked rows, and proposed before/after changes.
+6. Select `Confirm and Commit Holder Import` only after the preview is correct.
+7. Review the result.
 
-Fix the file if AssetTrack reports errors.
-
+Fix the file if AssetTrack reports duplicate, ambiguous, invalid, or blocked rows. Preview does not create or update Holders or Organizations. Confirmed imports currently change Holder and Organization reference data only; they do not create custody events or a separate persistent audit record. Persistent reference-data import auditing is deferred to Issue 30-27 / #1078.
 ## Import Assets
 
 **Admin only**

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -378,6 +378,42 @@ def test_admin_can_preview_and_confirm_holders_from_csv(client_with_temp_db) -> 
     assert holder is not None
     assert dict(holder) == {"name": "Jane Doe", "organization": "Ops Alpha", "email": "jane@example.org"}
 
+def test_admin_holder_import_temp_path_ignores_uploaded_filename(client_with_temp_db, monkeypatch) -> None:
+    admin_id = create_test_user(username="admin-import-hostile-name", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    original_named_temporary_file = intake_app.tempfile.NamedTemporaryFile
+    captured_calls: list[dict[str, object]] = []
+
+    def spy_named_temporary_file(*args, **kwargs):
+        handle = original_named_temporary_file(*args, **kwargs)
+        captured_calls.append({"kwargs": dict(kwargs), "name": handle.name})
+        return handle
+
+    monkeypatch.setattr(intake_app.tempfile, "NamedTemporaryFile", spy_named_temporary_file)
+
+    response = client_with_temp_db.post(
+        "/admin/holders/import",
+        data={
+            "csv_file": (
+                BytesIO(b"organization,name,email\nOps Alpha,Jane Doe,jane@example.org\n"),
+                "..\\..\\hostile-holder-import.pwn",
+            ),
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Holder import preview ready. Review and confirm one batch to commit." in response.data
+    assert captured_calls
+    assert captured_calls[0]["kwargs"]["suffix"] == ".csv"
+    temp_name = Path(str(captured_calls[0]["name"])).name.lower()
+    assert temp_name.endswith(".csv")
+    assert "hostile" not in temp_name
+    assert "pwn" not in temp_name
+
+    client_with_temp_db.post("/admin/holders/import", data={"action": "cancel"}, follow_redirects=True)
+
 def test_admin_holder_import_page_exposes_collapsible_csv_requirements(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-import-page", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -320,28 +320,51 @@ def test_network_asset_import_template_requires_login(client_with_temp_db) -> No
     assert response.status_code == 403
 
 
-def test_admin_can_import_holders_from_csv(client_with_temp_db) -> None:
+def test_admin_can_preview_and_confirm_holders_from_csv(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-import", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
 
-    response = client_with_temp_db.post(
+    preview_response = client_with_temp_db.post(
         "/admin/holders/import",
         data={
+            "action": "preview",
             "csv_file": (
                 BytesIO(b"organization,name,email\nOps Alpha,Jane Doe,jane@example.org\n"),
                 "holders.csv",
-            )
+            ),
         },
         content_type="multipart/form-data",
         follow_redirects=True,
     )
 
-    assert response.status_code == 200
-    assert b"Holder import complete. Processed 1 row: created 1, updated 0." in response.data
-    assert b"Processed:</strong> 1" in response.data
-    assert b"Created:</strong> 1" in response.data
-    assert b"Updated:</strong> 0" in response.data
-    assert b"Errors:</strong> 0" in response.data
+    assert preview_response.status_code == 200
+    assert b"Holder import preview ready. Review and confirm one batch to commit." in preview_response.data
+    assert b"Import Preview" in preview_response.data
+    assert b"Confirm and Commit Holder Import" in preview_response.data
+    assert b"New</span><strong>1" in preview_response.data
+
+    conn = db.get_connection()
+    try:
+        holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        org = conn.execute("SELECT id FROM organizations WHERE name = ?;", ("Ops Alpha",)).fetchone()
+    finally:
+        conn.close()
+
+    assert holder_count == 0
+    assert org is None
+
+    commit_response = client_with_temp_db.post(
+        "/admin/holders/import",
+        data={"action": "commit"},
+        follow_redirects=True,
+    )
+
+    assert commit_response.status_code == 200
+    assert b"Holder import complete. Processed 1 row: created 1, updated 0." in commit_response.data
+    assert b"Processed:</strong> 1" in commit_response.data
+    assert b"Created:</strong> 1" in commit_response.data
+    assert b"Updated:</strong> 0" in commit_response.data
+    assert b"Errors:</strong> 0" in commit_response.data
 
     conn = db.get_connection()
     try:
@@ -355,7 +378,6 @@ def test_admin_can_import_holders_from_csv(client_with_temp_db) -> None:
     assert holder is not None
     assert dict(holder) == {"name": "Jane Doe", "organization": "Ops Alpha", "email": "jane@example.org"}
 
-
 def test_admin_holder_import_page_exposes_collapsible_csv_requirements(client_with_temp_db) -> None:
     admin_id = create_test_user(username="admin-import-page", password="admin-pass", role="admin")
     login_session(client_with_temp_db, admin_id)
@@ -364,8 +386,13 @@ def test_admin_holder_import_page_exposes_collapsible_csv_requirements(client_wi
 
     assert response.status_code == 200
     assert b"Holder CSV Import" in response.data
+    assert b"Preview Holders" in response.data
     assert b"CSV requirements" in response.data
     assert b"Columns and import behavior" in response.data
+    assert b"Holder imports change Holder and Organization reference data." in response.data
+    assert b"Holder imports do not create asset custody events." in response.data
+    assert b"A separate persistent import audit record is not currently created." in response.data
+    assert b"Issue 30-27" not in response.data
     assert b'<details class="disclosure-section">' in response.data
 
 
@@ -386,8 +413,11 @@ def test_admin_holder_import_surfaces_existing_validation_errors(client_with_tem
     )
 
     assert response.status_code == 200
-    assert b"Holder import failed. Processed 1 row with 1 error." in response.data
-    assert b"Row 2: name is required" in response.data
+    assert b"Holder import preview found blocked rows. Fix the CSV and upload again." in response.data
+    assert b"<td>2</td>" in response.data
+    assert b"name is required" in response.data
+    assert b"<td>-</td>" not in response.data
+    assert b"Confirm and Commit Holder Import" not in response.data
 
     conn = db.get_connection()
     try:
@@ -397,6 +427,46 @@ def test_admin_holder_import_surfaces_existing_validation_errors(client_with_tem
 
     assert holder_count == 0
 
+
+def test_admin_holder_import_preview_shows_duplicate_and_invalid_rows(client_with_temp_db) -> None:
+    admin_id = create_test_user(username="admin-import-mixed-blocked", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+
+    response = client_with_temp_db.post(
+        "/admin/holders/import",
+        data={
+            "csv_file": (
+                BytesIO(
+                    b"organization,name,email\n"
+                    b"Ops Alpha,Duplicate One,dup@example.org\n"
+                    b"Ops Alpha,Duplicate Two,dup@example.org\n"
+                    b"Ops Alpha,,invalid@example.org\n"
+                ),
+                "holders.csv",
+            )
+        },
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Holder import preview found blocked rows. Fix the CSV and upload again." in response.data
+    assert b"Duplicate email in uploaded CSV: dup@example.org appears on rows 2, 3." in response.data
+    assert response.data.count(b"Duplicate email in uploaded CSV: dup@example.org appears on rows 2, 3.") == 2
+    assert b"name is required" in response.data
+    assert b"<td>2</td>" in response.data
+    assert b"<td>3</td>" in response.data
+    assert b"<td>4</td>" in response.data
+    assert b"<td>-</td>" not in response.data
+    assert b"Confirm and Commit Holder Import" not in response.data
+
+    conn = db.get_connection()
+    try:
+        holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+    finally:
+        conn.close()
+
+    assert holder_count == 0
 
 def test_operator_is_forbidden_for_human_readable_report(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-report", password="op-pass", role="operator")

--- a/tests/test_holder_import.py
+++ b/tests/test_holder_import.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -66,6 +67,113 @@ class HolderImportTests(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_preview_classifies_rows_and_performs_no_writes(self) -> None:
+        original_org_id = self._insert_organization("Ops Alpha")
+        self._insert_holder(
+            name="Existing Holder",
+            organization="Ops Alpha",
+            organization_id=original_org_id,
+            email="existing@example.org",
+        )
+        self._insert_holder(
+            name="Same Holder",
+            organization="Ops Alpha",
+            organization_id=original_org_id,
+            email="same@example.org",
+        )
+        csv_path = self._write_csv(
+            "holders.csv",
+            (
+                "organization,name,email\n"
+                "Ops Bravo,New Holder,new@example.org\n"
+                "Ops Alpha,Existing Holder Updated,existing@example.org\n"
+                "Ops Alpha,Same Holder,same@example.org\n"
+            ),
+        )
+
+        preview = holder_import.preview_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertTrue(preview.can_commit)
+        self.assertEqual(
+            preview.summary(),
+            {
+                "processed": 3,
+                "new": 1,
+                "unchanged": 1,
+                "updated": 1,
+                "duplicate": 0,
+                "ambiguous": 0,
+                "invalid": 0,
+                "blocked": 0,
+            },
+        )
+        self.assertEqual([row.category for row in preview.rows], ["new", "updated", "unchanged"])
+        conn = self._connection()
+        try:
+            holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+            org = conn.execute("SELECT id FROM organizations WHERE name = ?;", ("Ops Bravo",)).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(holder_count, 2)
+        self.assertIsNone(org)
+
+    def test_preview_blocks_duplicate_and_ambiguous_rows_without_writes(self) -> None:
+        org_id = self._insert_organization("Ops Alpha")
+        self._insert_holder(name="First", organization="Ops Alpha", organization_id=org_id, email="shared@example.org")
+        self._insert_holder(name="Second", organization="Ops Alpha", organization_id=org_id, email="shared@example.org")
+        csv_path = self._write_csv(
+            "holders.csv",
+            (
+                "organization,name,email\n"
+                "Ops Alpha,Ambiguous,shared@example.org\n"
+                "Ops Alpha,Duplicate One,dup@example.org\n"
+                "Ops Alpha,Duplicate Two,dup@example.org\n"
+            ),
+        )
+
+        preview = holder_import.preview_holders_csv(csv_path, db_path=self.db_path)
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertFalse(preview.can_commit)
+        self.assertEqual(preview.summary()["ambiguous"], 1)
+        self.assertEqual(preview.summary()["duplicate"], 2)
+        self.assertEqual(preview.summary()["blocked"], 3)
+        self.assertEqual(report.summary(), {"processed": 3, "created": 0, "updated": 0, "errors": 3})
+        conn = self._connection()
+        try:
+            holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        finally:
+            conn.close()
+        self.assertEqual(holder_count, 2)
+    def test_preview_shows_duplicate_and_invalid_rows_together(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            (
+                "organization,name,email\n"
+                "Ops Alpha,Duplicate One,dup@example.org\n"
+                "Ops Alpha,Duplicate Two,dup@example.org\n"
+                "Ops Alpha,,invalid@example.org\n"
+            ),
+        )
+
+        preview = holder_import.preview_holders_csv(csv_path, db_path=self.db_path)
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertFalse(preview.can_commit)
+        self.assertEqual(preview.summary()["duplicate"], 2)
+        self.assertEqual(preview.summary()["invalid"], 1)
+        self.assertEqual(preview.summary()["blocked"], 3)
+        self.assertEqual([(row.row_number, row.category) for row in preview.rows], [(2, "duplicate"), (3, "duplicate"), (4, "invalid")])
+        duplicate_problems = [row.problem for row in preview.rows if row.category == "duplicate"]
+        self.assertEqual(
+            duplicate_problems,
+            [
+                "Duplicate email in uploaded CSV: dup@example.org appears on rows 2, 3.",
+                "Duplicate email in uploaded CSV: dup@example.org appears on rows 2, 3.",
+            ],
+        )
+        self.assertEqual(preview.rows[2].problem, "name is required")
+        self.assertEqual(report.summary(), {"processed": 3, "created": 0, "updated": 0, "errors": 3})
     def test_import_creates_new_holder_for_new_email(self) -> None:
         csv_path = self._write_csv(
             "holders.csv",
@@ -160,6 +268,27 @@ class HolderImportTests(unittest.TestCase):
         self.assertEqual(report.summary(), {"processed": 0, "created": 0, "updated": 0, "errors": 1})
         self.assertEqual(report.errors, ("Row 2: malformed CSV row has extra columns.",))
 
+    def test_import_rolls_back_approved_batch_on_commit_failure(self) -> None:
+        org_id = self._insert_organization("Ops Alpha")
+        csv_path = self._write_csv(
+            "holders.csv",
+            (
+                "organization,name,email\n"
+                "Ops Alpha,First,first@example.org\n"
+                "Ops Alpha,Second,second@example.org\n"
+            ),
+        )
+
+        with patch.object(holder_import, "_ensure_organization", side_effect=[org_id, RuntimeError("forced failure")]):
+            with self.assertRaises(RuntimeError):
+                holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        conn = self._connection()
+        try:
+            holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        finally:
+            conn.close()
+        self.assertEqual(holder_count, 0)
     def test_cli_returns_summary_and_nonzero_exit_on_invalid_csv(self) -> None:
         csv_path = self._write_csv(
             "holders.csv",


### PR DESCRIPTION
# Issue 30-13: Add Holder import preview and confirmation

## Summary

Adds a safe preview and confirmation workflow for Holder imports before any Holder or Organization records are changed.

Closes #1031

## Changes

- Added the Holder import workflow:
  - upload
  - validate
  - preview
  - confirm
  - commit
  - results
- Preview performs no Holder or Organization writes.
- Classifies rows as:
  - new
  - unchanged
  - updated
  - duplicate
  - ambiguous
  - invalid
- Shows proposed before-and-after values.
- Displays all blocked rows together, including duplicates and invalid rows.
- Shows the actual spreadsheet row number for every preview result.
- Blocks commit when duplicate, ambiguous, or invalid rows exist.
- Preserves one-transaction commit behavior.
- Preserves existing email identity and case-insensitive Organization reuse.
- Documents that Holder imports change reference data only and do not create custody events.
- Defers persistent reference-data import auditing to Issue 30-27 / #1078.

## Verification

- [x] Python compilation passed for changed runtime files
- [x] `pytest tests/test_holder_import.py` — 12 passed
- [x] `pytest tests/test_admin_system_health.py` — 56 passed
- [x] `pytest tests/test_admin_reference_data.py` — 15 passed
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Container reported healthy
- [x] Valid Holder CSV preview showed 2 new Holders
- [x] Preview caused no Holder or Organization writes
- [x] Valid batch committed successfully
- [x] Jordan Ellis and Morgan Price were created
- [x] Blocked CSV showed 2 duplicate rows and 1 invalid row
- [x] Duplicate rows displayed spreadsheet rows 2 and 3
- [x] Invalid row displayed spreadsheet row 4
- [x] Commit action was hidden while blocked rows existed

## Notes

Persistent reference-data import auditing requires the separately approved Class 3 work in Issue 30-27 / #1078.

No schema, custody-event, asset-import, Holder identity, authentication, role, dependency, or persistence behavior changed.