### PR TITLE
Issue 29-32: Correct CI security threshold documentation

### DIFF
--- a/docs/ci-cd-security-audit.md
+++ b/docs/ci-cd-security-audit.md
@@ -180,8 +180,6 @@ The active `security-baseline.yml` fails on:
 
 for both filesystem and image findings.
 
-Note: `docs/security/ci-baseline.md` still says only `CRITICAL` findings fail. The workflow and `docs/security-ci-baseline.md` show the effective current gate is `MEDIUM,HIGH,CRITICAL`.
-
 ### Secrets Handling
 
 No workflow passes AssetTrack runtime secrets through `env`.
@@ -230,7 +228,7 @@ No workflow step uses repository secrets.
 | F-08 | Medium | Docker base image is pinned by tag but not by digest. | `Dockerfile` uses `FROM python:3.12.13-alpine3.23`. | Rebuilding later can consume different base image contents under the same tag. |
 | F-09 | Low | Artifact retention is implicit. | `upload-artifact` steps do not set `retention-days`; GitHub API showed current artifacts expiring about 90 days after creation. | Retention behavior depends on repository/org defaults and may drift. |
 | F-10 | Low | CI upgrades pip without pinning the installed pip version. | `.github/workflows/ci.yml` runs `python -m pip install --upgrade pip`; Dockerfile pins `pip==26.1.2`. | CI dependency resolution can drift independently from the Docker build path. |
-| F-11 | Low | Existing CI security docs disagree about the Trivy severity gate. | `docs/security/ci-baseline.md` says only `CRITICAL` fails; `security-baseline.yml` fails on `MEDIUM,HIGH,CRITICAL`; `docs/security-ci-baseline.md` matches the workflow. | Operators may misunderstand which findings block CI. |
+| F-11 | Low | CI security docs now agree about the Trivy severity gate. | `docs/security/ci-baseline.md`, `docs/security-ci-baseline.md`, and `security-baseline.yml` all describe the active `MEDIUM,HIGH,CRITICAL` fail gate. | Operators can see which findings block CI. |
 | F-12 | Low | Trivy uses `--ignore-unfixed`. | Both filesystem and image scan commands include `--ignore-unfixed`. | Vulnerabilities without an upstream fix do not fail the gate and need human review through report artifacts. |
 
 ## Coverage Assessment
@@ -277,7 +275,7 @@ Ordered by risk first, then effort.
 | 7 | Medium | Low | Enable Dependabot security updates and add a minimal `.github/dependabot.yml` for `pip` and GitHub Actions. |
 | 8 | Medium | Medium | Evaluate digest pinning for the Docker base image and define a reviewed update process that preserves offline deployment needs. |
 | 9 | Low | Low | Set explicit `retention-days` for Trivy artifacts and SBOMs. |
-| 10 | Low | Low | Align `docs/security/ci-baseline.md` with the active `MEDIUM,HIGH,CRITICAL` Trivy gate. |
+| 10 | Low | Low | Keep CI security documentation aligned with the active `MEDIUM,HIGH,CRITICAL` Trivy gate. |
 | 11 | Low | Low | Pin CI pip version or remove the CI pip upgrade so CI dependency installation tracks the Docker path more closely. |
 | 12 | Low | Low | Decide whether to enable GitHub secret scanning non-provider patterns and validity checks. |
 

--- a/docs/security/ci-baseline.md
+++ b/docs/security/ci-baseline.md
@@ -15,13 +15,13 @@ This repository uses a minimal GitHub Actions security baseline for pull request
 
 ## Failure Thresholds
 
-- `CRITICAL` findings fail the workflow
-- `HIGH`, `MEDIUM`, `LOW`, and `UNKNOWN` findings are advisory and uploaded as workflow artifacts
+- `MEDIUM`, `HIGH`, and `CRITICAL` findings fail the workflow
+- `LOW` and `UNKNOWN` findings are advisory and uploaded as workflow artifacts
 - `--ignore-unfixed` is enabled so the baseline does not fail on issues without an upstream fix
 
 Why it matters:
-- the current baseline reports every severity for visibility while blocking only `CRITICAL` findings
-- this keeps the pipeline usable while still surfacing lower-severity issues for review
+- the current baseline reports every severity for visibility while blocking known findings above Low
+- this keeps lower-severity and unknown findings visible for review without treating them as clean
 
 ## Trivy Reference and Update Path
 
@@ -48,7 +48,7 @@ Why it matters:
 
 ## Triage Guidance
 
-- treat `CRITICAL` findings as merge blockers until fixed or explicitly risk-accepted
+- treat `MEDIUM`, `HIGH`, and `CRITICAL` findings as merge blockers until fixed or explicitly risk-accepted
 - review advisory findings from uploaded artifacts during the normal patch cadence process and convert real issues into scoped remediation work
 - if a finding is a false positive, document the suppression in a separate change instead of weakening the baseline broadly
 

--- a/docs/security/patch-cadence.md
+++ b/docs/security/patch-cadence.md
@@ -119,7 +119,7 @@ Why it matters:
 - track during routine cadence unless more concrete risk information appears
 
 Why it matters:
-- the workflow provides full visibility across severities, but only `CRITICAL` findings block the pipeline
+- the workflow provides full visibility across severities, and `MEDIUM`, `HIGH`, and `CRITICAL` findings block the pipeline
 
 ## Advisory Finding Triage
 


### PR DESCRIPTION
# Issue 29-32: Correct CI security threshold documentation

## Summary

Correct the CI security documentation so it matches the active Trivy failure threshold.

Closes #997

## Changes

* Updated outdated statements that said only Critical findings fail.
* Documented that Medium, High, and Critical findings block the Security Baseline workflow.
* Clarified that Low and Unknown findings remain advisory.
* Made the CI security documents consistent with `.github/workflows/security-baseline.yml`.
* Made no workflow, scanner, dependency, or runtime changes.

## Verification

* [x] Confirmed filesystem and image scans use `MEDIUM,HIGH,CRITICAL` with exit code 1.
* [x] Confirmed the edited documentation agrees with the active workflow.
* [x] Ran `git diff --check`.
* [x] Confirmed only documentation files changed.

## Notes

No Docker or manual operator testing was required because this is a documentation-only correction.
