### PR TITLE
Issue 29-33: Pin CI pip version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade "pip==26.1.2"
           pip install -r requirements.txt
           pip install -r requirements-test.txt
 


### PR DESCRIPTION
# Issue 29-33: Pin CI pip version

## Summary

Pin the pip version used by CI so dependency installation remains reproducible and matches the Docker build.

Closes #998

## Changes

* Replaced the unbounded CI pip upgrade with `pip==26.1.2`.
* Matched the pip version already pinned in the Dockerfile.
* Preserved the existing requirements installation, pytest, and compileall steps.
* Made no other dependency, workflow, permission, or runtime changes.

## Verification

* [x] Confirmed CI installs pip `26.1.2` on Python 3.12.
* [x] Installed `requirements.txt`.
* [x] Installed `requirements-test.txt`.
* [x] Ran pytest: 643 passed, 2 subtests passed.
* [x] Ran compileall.
* [x] Ran `git diff --check`.
* [x] Confirmed only `.github/workflows/ci.yml` changed.

## Notes

The initial sandboxed package-install attempts failed because network access was unavailable. Verification succeeded once approved network access was used.
