### PR TITLE
Issue 29-31: Set Trivy artifact retention

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -66,6 +66,7 @@ jobs:
           name: trivy-filesystem-reports
           path: trivy-reports/
           if-no-files-found: error
+          retention-days: 30
 
   trivy-image:
     name: Trivy container image scan
@@ -132,3 +133,4 @@ jobs:
           name: trivy-image-reports
           path: trivy-reports/
           if-no-files-found: error
+          retention-days: 30


### PR DESCRIPTION
# Issue 29-31: Set Trivy artifact retention

## Summary

Set an explicit 30-day retention period for AssetTrack Trivy reports and SBOM artifacts.

Closes #996

## Changes

* Added `retention-days: 30` to the filesystem scan artifact upload.
* Added `retention-days: 30` to the image scan and SBOM artifact upload.
* Preserved `if: always()`.
* Preserved artifact names, paths, scan gates, action pins, permissions, and workflow behavior.

## Verification

* [x] Confirmed the workflow YAML parses successfully.
* [x] Confirmed both artifact upload steps use 30-day retention.
* [x] Confirmed `if: always()` remains in both upload steps.
* [x] Ran `git diff --check`.
* [x] Confirmed only `.github/workflows/security-baseline.yml` changed.

## Notes

No scanner thresholds, commands, dependencies, or runtime behavior changed.
