### PR TITLE
Issue 29-30: Pin Docker base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-FROM python:3.12.13-alpine3.23
+FROM python:3.12.13-alpine3.23@sha256:601d3d3797e90e2534782e69c85fafb7971b43f24c7b1b079b7e48dd435e458d
 
 RUN python -m pip install --upgrade "pip==26.1.2"
 

--- a/docs/security/patch-cadence.md
+++ b/docs/security/patch-cadence.md
@@ -172,6 +172,30 @@ After any dependency update or base-image update:
 Why it matters:
 - AssetTrack runs in Docker, so dependency changes are not complete until the image is rebuilt and verified
 
+## Docker Base Image Digest Review
+
+The Dockerfile keeps the readable Python base-image tag and pins it to the reviewed multi-platform manifest digest:
+
+```text
+python:3.12.13-alpine3.23@sha256:<digest>
+```
+
+Before changing the base-image tag or digest:
+
+1. Inspect the official Docker Hub image tag:
+   `docker buildx imagetools inspect python:<tag>`
+2. Confirm the image name is `docker.io/library/python:<tag>`.
+3. Confirm the reported top-level digest is an OCI image index or Docker manifest list, not a single-architecture child manifest.
+4. Confirm the manifests include the deployment architecture and annotate `org.opencontainers.image.version` with the exact tag.
+5. Record the reviewed tag, digest, source revision, and review date in the related issue.
+6. Update the Dockerfile only after review, keeping the tag and digest together.
+7. Rebuild the image, confirm Python and Alpine versions, confirm container health, and confirm SQLite persistence survives restart.
+
+Why it matters:
+- the readable tag explains operator intent
+- the digest prevents a future rebuild from silently consuming different base-image contents
+- reviewing the manifest list keeps multi-platform builds aligned instead of pinning one local architecture by accident
+
 ## Required Verification Before Deployment
 
 Before deploying an update based on scan findings:


### PR DESCRIPTION
# Issue 29-30: Pin Docker base image digest

## Summary

Pin the AssetTrack Docker base image to a reviewed manifest digest for reproducible builds while preserving the readable image tag.

Closes #995

## Changes

* Pinned `python:3.12.13-alpine3.23` to the reviewed multi-platform OCI manifest digest.
* Preserved the readable Python and Alpine tag beside the digest.
* Documented how to review and update the digest safely.
* Made no application, schema, dependency, workflow, event, custody, or persistence behavior changes.

## Verification

* [x] Verified the tag resolves to the official `docker.io/library/python` image.
* [x] Verified the selected digest is the multi-platform image index, not a single-architecture child manifest.
* [x] Built the Docker image successfully.
* [x] Confirmed the AssetTrack container became healthy.
* [x] Confirmed runtime Python version `3.12.13`.
* [x] Confirmed runtime Alpine version `3.23.5`.
* [x] Verified SQLite data survived container restart:

  * 32 schema entries before and after
  * 29 assets before and after
  * 34 asset events before and after
* [x] Ran `git diff --check`.
* [x] Confirmed only `Dockerfile` and `docs/security/patch-cadence.md` changed.

## Notes

The SQLite file hash changed during normal container startup, but the database schema and operational record counts remained stable across restart.
