### PR TITLE
Issue 30-8: Add admin Case correction workflow

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -505,6 +505,55 @@ def _create_schema(conn: sqlite3.Connection):
 
     cursor.execute(
         """
+        CREATE TABLE IF NOT EXISTS case_correction_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL CHECK(event_type IN ('CASE_RENAME', 'CASE_REMOVE')),
+            created_at TEXT NOT NULL,
+            actor_user_id INTEGER NOT NULL,
+            actor_username TEXT NOT NULL CHECK(length(trim(actor_username)) > 0),
+            old_case_name TEXT NOT NULL CHECK(length(trim(old_case_name)) > 0),
+            new_case_name TEXT NULL,
+            affected_slot_count INTEGER NOT NULL CHECK(affected_slot_count > 0),
+            affected_asset_count INTEGER NOT NULL CHECK(affected_asset_count >= 0),
+            CHECK (
+                (
+                    event_type = 'CASE_RENAME'
+                    AND new_case_name IS NOT NULL
+                    AND length(trim(new_case_name)) > 0
+                    AND upper(trim(old_case_name)) <> upper(trim(new_case_name))
+                )
+                OR
+                (
+                    event_type = 'CASE_REMOVE'
+                    AND new_case_name IS NULL
+                )
+            )
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS case_correction_events_no_update
+        BEFORE UPDATE ON case_correction_events
+        BEGIN
+            SELECT RAISE(ABORT, 'case_correction_events is append-only');
+        END;
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS case_correction_events_no_delete
+        BEFORE DELETE ON case_correction_events
+        BEGIN
+            SELECT RAISE(ABORT, 'case_correction_events is append-only');
+        END;
+        """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS receipt_queue (
             id INTEGER PRIMARY KEY,
             receipt_key TEXT NOT NULL UNIQUE,

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2416,6 +2416,325 @@ def _validate_admin_slot_move_expected(
         raise ValueError("Destination slot changed. Preview the move again.")
 
 
+def _normalize_case_identifier(value: object) -> str:
+    return str(value or "").strip().upper()
+
+
+def _case_identifier_in_payload(value: object, case_name: str) -> bool:
+    normalized_case = _normalize_case_identifier(case_name)
+    if isinstance(value, dict):
+        return any(_case_identifier_in_payload(item, normalized_case) for item in value.values())
+    if isinstance(value, list):
+        return any(_case_identifier_in_payload(item, normalized_case) for item in value)
+    if isinstance(value, str):
+        return _normalize_case_identifier(value) == normalized_case
+    return False
+
+
+def _asset_event_payload_references_case(conn: sqlite3.Connection, case_name: str) -> bool:
+    normalized_case = _normalize_case_identifier(case_name)
+    if not normalized_case:
+        return False
+    rows = conn.execute(
+        """
+        SELECT payload
+        FROM asset_events
+        WHERE payload IS NOT NULL
+          AND TRIM(payload) <> ''
+          AND UPPER(payload) LIKE ?;
+        """,
+        (f"%{normalized_case}%",),
+    ).fetchall()
+    for row in rows:
+        payload_text = str(row["payload"] or "")
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError:
+            if normalized_case in payload_text.upper():
+                return True
+            continue
+        if _case_identifier_in_payload(payload, normalized_case):
+            return True
+    return False
+
+
+def _case_identifier_exists_in_slots(conn: sqlite3.Connection, case_name: str) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+        LIMIT 1;
+        """,
+        (case_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _case_identifier_exists_in_assets(conn: sqlite3.Connection, case_name: str) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+        FROM assets
+        WHERE UPPER(COALESCE(case_number, '')) = UPPER(?)
+        LIMIT 1;
+        """,
+        (case_name,),
+    ).fetchone()
+    return row is not None
+
+
+def _case_identifier_is_completely_unused(conn: sqlite3.Connection, case_name: str) -> bool:
+    return (
+        not _case_identifier_exists_in_slots(conn, case_name)
+        and not _case_identifier_exists_in_assets(conn, case_name)
+        and not _asset_event_payload_references_case(conn, case_name)
+    )
+
+
+def _case_correction_source_slots(conn: sqlite3.Connection, case_name: str) -> list[sqlite3.Row]:
+    return conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+        ORDER BY slot_position ASC;
+        """,
+        (case_name,),
+    ).fetchall()
+
+
+def _slot_id_placeholders(slot_ids: list[int]) -> str:
+    return ", ".join("?" for _ in slot_ids)
+
+
+def _count_assets_tied_to_slots(conn: sqlite3.Connection, slot_ids: list[int]) -> int:
+    if not slot_ids:
+        return 0
+    row = conn.execute(
+        f"""
+        SELECT COUNT(*) AS c
+        FROM assets
+        WHERE home_slot_id IN ({_slot_id_placeholders(slot_ids)});
+        """,
+        tuple(slot_ids),
+    ).fetchone()
+    return int(row["c"] or 0)
+
+
+def _case_has_occupancy(conn: sqlite3.Connection, slot_ids: list[int]) -> bool:
+    if not slot_ids:
+        return False
+    row = conn.execute(
+        f"""
+        SELECT 1
+        FROM slot_occupancy
+        WHERE slot_id IN ({_slot_id_placeholders(slot_ids)})
+        LIMIT 1;
+        """,
+        tuple(slot_ids),
+    ).fetchone()
+    return row is not None
+
+
+def _case_has_slot_marker(slots: list[sqlite3.Row]) -> bool:
+    return any(str(row["current_asset_tag"] or "").strip() for row in slots)
+
+
+def _build_case_correction_preview(
+    conn: sqlite3.Connection,
+    *,
+    event_type: str,
+    old_case_name: str,
+    new_case_name: str = "",
+) -> dict:
+    normalized_event_type = str(event_type or "").strip().upper()
+    old_case = _normalize_case_identifier(old_case_name)
+    new_case = _normalize_case_identifier(new_case_name)
+    if normalized_event_type not in {"CASE_RENAME", "CASE_REMOVE"}:
+        raise ValueError("Select rename or removal.")
+    if not old_case:
+        raise ValueError("Current Case is required.")
+
+    source_slots = _case_correction_source_slots(conn, old_case)
+    if not source_slots:
+        raise ValueError("Case not found.")
+    slot_ids = [int(row["id"]) for row in source_slots]
+    affected_slot_count = len(slot_ids)
+    affected_asset_count = _count_assets_tied_to_slots(conn, slot_ids)
+
+    if normalized_event_type == "CASE_RENAME":
+        if not new_case:
+            raise ValueError("New Case is required.")
+        if old_case == new_case:
+            raise ValueError("New Case must be different.")
+        if not _case_identifier_is_completely_unused(conn, new_case):
+            raise ValueError("New Case identifier is already used.")
+    else:
+        if new_case:
+            raise ValueError("Removal does not use a new Case.")
+        if affected_asset_count > 0:
+            raise ValueError("Cannot remove a Case referenced by assets.")
+        if _case_has_occupancy(conn, slot_ids):
+            raise ValueError("Cannot remove a Case with slot occupancy.")
+        if _case_has_slot_marker(source_slots):
+            raise ValueError("Cannot remove a Case with slot asset markers.")
+        if _case_identifier_exists_in_assets(conn, old_case):
+            raise ValueError("Cannot remove a Case referenced by assets.")
+        if _asset_event_payload_references_case(conn, old_case):
+            raise ValueError("Cannot remove a Case referenced by event history.")
+
+    return {
+        "event_type": normalized_event_type,
+        "old_case_name": old_case,
+        "new_case_name": new_case if normalized_event_type == "CASE_RENAME" else "",
+        "affected_slot_count": affected_slot_count,
+        "affected_asset_count": affected_asset_count,
+        "slots": [
+            {
+                "id": int(row["id"]),
+                "case_name": str(row["case_name"] or ""),
+                "slot_position": int(row["slot_position"]),
+                "current_asset_tag": str(row["current_asset_tag"] or ""),
+            }
+            for row in source_slots
+        ],
+    }
+
+
+def _validate_case_correction_expected(
+    preview: dict,
+    *,
+    expected_event_type: str,
+    expected_old_case_name: str,
+    expected_new_case_name: str,
+    expected_slot_count: str,
+    expected_asset_count: str,
+) -> None:
+    try:
+        slot_count = int(expected_slot_count)
+        asset_count = int(expected_asset_count)
+    except ValueError as exc:
+        raise ValueError("Case correction preview is stale. Preview again.") from exc
+    if preview["event_type"] != str(expected_event_type or "").strip().upper():
+        raise ValueError("Case correction action changed. Preview again.")
+    if preview["old_case_name"] != _normalize_case_identifier(expected_old_case_name):
+        raise ValueError("Case correction source changed. Preview again.")
+    if preview["new_case_name"] != _normalize_case_identifier(expected_new_case_name):
+        raise ValueError("Case correction target changed. Preview again.")
+    if int(preview["affected_slot_count"]) != slot_count:
+        raise ValueError("Case slot count changed. Preview again.")
+    if int(preview["affected_asset_count"]) != asset_count:
+        raise ValueError("Case asset count changed. Preview again.")
+
+
+def _commit_case_correction(
+    conn: sqlite3.Connection,
+    *,
+    preview: dict,
+    actor_user: dict,
+    created_at: str,
+) -> None:
+    event_type = str(preview["event_type"])
+    old_case = str(preview["old_case_name"])
+    new_case = str(preview["new_case_name"] or "")
+    slot_ids = [int(row["id"]) for row in preview["slots"]]
+
+    if event_type == "CASE_RENAME":
+        conn.execute(
+            """
+            UPDATE slots
+            SET case_name = ?
+            WHERE UPPER(case_name) = UPPER(?);
+            """,
+            (new_case, old_case),
+        )
+        conn.execute(
+            f"""
+            UPDATE assets
+            SET case_number = ?
+            WHERE home_slot_id IN ({_slot_id_placeholders(slot_ids)});
+            """,
+            (new_case, *slot_ids),
+        )
+    else:
+        conn.execute(
+            f"""
+            DELETE FROM slots
+            WHERE id IN ({_slot_id_placeholders(slot_ids)});
+            """,
+            tuple(slot_ids),
+        )
+
+    conn.execute(
+        """
+        INSERT INTO case_correction_events (
+            event_type,
+            created_at,
+            actor_user_id,
+            actor_username,
+            old_case_name,
+            new_case_name,
+            affected_slot_count,
+            affected_asset_count
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            event_type,
+            created_at,
+            int(actor_user["id"]),
+            str(actor_user.get("username") or ""),
+            old_case,
+            new_case if event_type == "CASE_RENAME" else None,
+            int(preview["affected_slot_count"]),
+            int(preview["affected_asset_count"]),
+        ),
+    )
+
+
+def _list_case_correction_history(conn: sqlite3.Connection) -> list[dict]:
+    rows = conn.execute(
+        """
+        SELECT
+            event_type,
+            created_at,
+            actor_username,
+            old_case_name,
+            new_case_name,
+            affected_slot_count,
+            affected_asset_count
+        FROM case_correction_events
+        ORDER BY id DESC;
+        """
+    ).fetchall()
+    return [
+        {
+            "event_type": str(row["event_type"] or ""),
+            "created_at": str(row["created_at"] or ""),
+            "actor_username": str(row["actor_username"] or ""),
+            "old_case_name": str(row["old_case_name"] or ""),
+            "new_case_name": str(row["new_case_name"] or ""),
+            "affected_slot_count": int(row["affected_slot_count"]),
+            "affected_asset_count": int(row["affected_asset_count"]),
+        }
+        for row in rows
+    ]
+
+
+def _list_case_correction_case_options(conn: sqlite3.Connection) -> list[str]:
+    rows = conn.execute(
+        """
+        SELECT case_name
+        FROM slots
+        WHERE TRIM(COALESCE(case_name, '')) <> ''
+        GROUP BY UPPER(case_name)
+        ORDER BY UPPER(case_name);
+        """
+    ).fetchall()
+    return [str(row["case_name"] or "") for row in rows]
+
+
 def _build_admin_retire_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     asset = _find_asset_for_scan_tag(conn, scan_tag)
     if not asset:
@@ -7463,6 +7782,106 @@ def admin_slot_provision():
         return redirect(url_for("admin_slot_provision"))
 
     return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count)
+
+
+@app.route("/admin/case-corrections", methods=["GET", "POST"])
+@require_login
+@require_role("admin")
+def admin_case_corrections():
+    guard_result = _require_admin_for_route()
+    if guard_result:
+        return guard_result
+
+    event_type = (request.form.get("event_type") or "CASE_RENAME").strip().upper()
+    old_case_name = _normalize_case_identifier(request.form.get("old_case_name"))
+    new_case_name = _normalize_case_identifier(request.form.get("new_case_name"))
+    confirmed = _is_truthy(request.form.get("confirm_correction"))
+    correction_preview: Optional[dict] = None
+
+    conn = get_connection()
+    try:
+        def render_case_corrections():
+            return render_template(
+                "admin_case_corrections.html",
+                event_type=event_type,
+                old_case_name=old_case_name,
+                new_case_name=new_case_name,
+                case_options=_list_case_correction_case_options(conn),
+                correction_preview=correction_preview,
+                correction_history=_list_case_correction_history(conn),
+                confirmed=confirmed,
+            )
+
+        if request.method == "POST":
+            action = (request.form.get("action") or "preview").strip().lower()
+
+            if action == "preview":
+                try:
+                    correction_preview = _build_case_correction_preview(
+                        conn,
+                        event_type=event_type,
+                        old_case_name=old_case_name,
+                        new_case_name=new_case_name,
+                    )
+                    event_type = str(correction_preview["event_type"])
+                    old_case_name = str(correction_preview["old_case_name"])
+                    new_case_name = str(correction_preview["new_case_name"] or "")
+                except ValueError as e:
+                    flash(str(e), "error")
+                return render_case_corrections()
+            if action != "commit":
+                flash("Unknown action.", "error")
+                return render_case_corrections()
+            if not confirmed:
+                flash("You must confirm the Case correction before commit.", "error")
+                return render_case_corrections()
+
+            actor_user = current_user()
+            if actor_user is None:
+                return _require_admin_for_route()
+
+            try:
+                conn.execute("BEGIN IMMEDIATE;")
+                correction_preview = _build_case_correction_preview(
+                    conn,
+                    event_type=event_type,
+                    old_case_name=old_case_name,
+                    new_case_name=new_case_name,
+                )
+                _validate_case_correction_expected(
+                    correction_preview,
+                    expected_event_type=request.form.get("expected_event_type") or "",
+                    expected_old_case_name=request.form.get("expected_old_case_name") or "",
+                    expected_new_case_name=request.form.get("expected_new_case_name") or "",
+                    expected_slot_count=request.form.get("expected_slot_count") or "",
+                    expected_asset_count=request.form.get("expected_asset_count") or "",
+                )
+                event_type = str(correction_preview["event_type"])
+                old_case_name = str(correction_preview["old_case_name"])
+                new_case_name = str(correction_preview["new_case_name"] or "")
+                _commit_case_correction(
+                    conn,
+                    preview=correction_preview,
+                    actor_user=actor_user,
+                    created_at=datetime.now(timezone.utc).isoformat(),
+                )
+                conn.commit()
+            except ValueError as e:
+                conn.rollback()
+                flash(str(e), "error")
+                return render_case_corrections()
+            except Exception:
+                conn.rollback()
+                raise
+
+            if event_type == "CASE_RENAME":
+                flash(f"Renamed Case {old_case_name} to {new_case_name}.", "success")
+            else:
+                flash(f"Removed never-used Case {old_case_name}.", "success")
+            return redirect(url_for("admin_case_corrections"))
+        return render_case_corrections()
+    finally:
+        conn.close()
 
 
 @app.post("/admin/recovery/acknowledge")

--- a/assettrack/intake/templates/admin_case_corrections.html
+++ b/assettrack/intake/templates/admin_case_corrections.html
@@ -1,0 +1,166 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Case Corrections{% endblock %}
+{% block page_heading %}Admin: Case Corrections{% endblock %}
+{% block page_class %} admin-maintenance-standard-fields{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .case-correction-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(220px, 1fr));
+      gap: 0.75rem 1rem;
+    }
+    .case-correction-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      align-items: center;
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="workflow-local-nav" aria-label="Admin case correction navigation">
+    <a class="nav-link" href="{{ url_for('admin_system') }}">Back to Admin Tools</a>
+  </nav>
+
+  {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+      {% for category, message in messages %}
+        <div class="flash {{ category|e }}">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
+
+  <div class="card">
+    <h2>Prepare Correction</h2>
+    {% if case_options %}
+      <form method="post" action="{{ url_for('admin_case_corrections') }}">
+        <input type="hidden" name="action" value="preview" />
+        <input type="hidden" name="event_type" value="CASE_RENAME" />
+
+        <h3>Rename Case</h3>
+        <label for="rename_old_case_name">Current Case</label>
+        <select id="rename_old_case_name" name="old_case_name" required>
+          {% for case_name in case_options %}
+            <option value="{{ case_name }}"{% if old_case_name == case_name and event_type != "CASE_REMOVE" %} selected{% endif %}>{{ case_name }}</option>
+          {% endfor %}
+        </select>
+
+        <label for="new_case_name">New Case</label>
+        <input id="new_case_name" name="new_case_name" value="{{ new_case_name or '' }}" autocomplete="off" required />
+
+        <button type="submit">Preview Rename</button>
+      </form>
+
+      <form method="post" action="{{ url_for('admin_case_corrections') }}">
+        <input type="hidden" name="action" value="preview" />
+        <input type="hidden" name="event_type" value="CASE_REMOVE" />
+
+        <h3>Remove Never-Used Case</h3>
+        <label for="remove_old_case_name">Current Case</label>
+        <select id="remove_old_case_name" name="old_case_name" required>
+          {% for case_name in case_options %}
+            <option value="{{ case_name }}"{% if old_case_name == case_name and event_type == "CASE_REMOVE" %} selected{% endif %}>{{ case_name }}</option>
+          {% endfor %}
+        </select>
+
+        <button type="submit">Preview Removal</button>
+      </form>
+    {% else %}
+      <p>No Cases are available to correct. <a href="{{ url_for('admin_slot_provision') }}">Admin Tools → Provision Slots</a></p>
+    {% endif %}
+  </div>
+
+  {% if correction_preview %}
+    <div class="card" id="case-correction-preview">
+      <h2>Preview Correction</h2>
+      <div class="case-correction-grid">
+        <div><strong>action:</strong> <code>{{ correction_preview.event_type }}</code></div>
+        <div><strong>current Case:</strong> <code>{{ correction_preview.old_case_name }}</code></div>
+        <div><strong>new Case:</strong> {% if correction_preview.new_case_name %}<code>{{ correction_preview.new_case_name }}</code>{% else %}None{% endif %}</div>
+        <div><strong>affected Slots:</strong> <code>{{ correction_preview.affected_slot_count }}</code></div>
+        <div><strong>affected Assets:</strong> <code>{{ correction_preview.affected_asset_count }}</code></div>
+      </div>
+
+      <h3>Slots</h3>
+      <table>
+        <thead>
+          <tr>
+            <th>slot_id</th>
+            <th>Case</th>
+            <th>Slot</th>
+            <th>Marker</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for slot in correction_preview.slots %}
+            <tr>
+              <td><code>{{ slot.id }}</code></td>
+              <td><code>{{ slot.case_name }}</code></td>
+              <td><code>{{ slot.slot_position }}</code></td>
+              <td>{{ slot.current_asset_tag or "Empty" }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
+      <p><strong>Existing asset events will not be changed.</strong></p>
+      <p><strong>Slot IDs and occupancy links will be preserved for rename.</strong></p>
+
+      <form method="post" action="{{ url_for('admin_case_corrections') }}">
+        <input type="hidden" name="action" value="commit" />
+        <input type="hidden" name="event_type" value="{{ correction_preview.event_type }}" />
+        <input type="hidden" name="old_case_name" value="{{ correction_preview.old_case_name }}" />
+        <input type="hidden" name="new_case_name" value="{{ correction_preview.new_case_name or '' }}" />
+        <input type="hidden" name="expected_event_type" value="{{ correction_preview.event_type }}" />
+        <input type="hidden" name="expected_old_case_name" value="{{ correction_preview.old_case_name }}" />
+        <input type="hidden" name="expected_new_case_name" value="{{ correction_preview.new_case_name or '' }}" />
+        <input type="hidden" name="expected_slot_count" value="{{ correction_preview.affected_slot_count }}" />
+        <input type="hidden" name="expected_asset_count" value="{{ correction_preview.affected_asset_count }}" />
+        <label>
+          <input type="checkbox" name="confirm_correction" value="1"{% if confirmed %} checked{% endif %} />
+          Confirm Case correction
+        </label>
+        <div class="case-correction-actions">
+          <button type="submit">Commit Correction</button>
+        </div>
+      </form>
+    </div>
+  {% endif %}
+
+  <div class="card" id="case-correction-history">
+    <h2>Correction History</h2>
+    {% if correction_history %}
+      <table>
+        <thead>
+          <tr>
+            <th>Type</th>
+            <th>Date/time</th>
+            <th>Actor</th>
+            <th>Old Case</th>
+            <th>New Case</th>
+            <th>Slots</th>
+            <th>Assets</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in correction_history %}
+            <tr>
+              <td><code>{{ row.event_type }}</code></td>
+              <td>{{ row.created_at }}</td>
+              <td>{{ row.actor_username }}</td>
+              <td><code>{{ row.old_case_name }}</code></td>
+              <td>{% if row.new_case_name %}<code>{{ row.new_case_name }}</code>{% else %}None{% endif %}</td>
+              <td><code>{{ row.affected_slot_count }}</code></td>
+              <td><code>{{ row.affected_asset_count }}</code></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="muted">No Case corrections recorded.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -247,6 +247,9 @@
       <h3>Corrections</h3>
       <span class="admin-risk-marker">High Risk</span>
       <nav class="admin-tool-grid" aria-label="High-risk correction admin tools">
+        <a class="admin-tool-link" href="{{ url_for('admin_case_corrections') }}">
+          <strong>Case Corrections</strong>
+        </a>
         <a class="admin-tool-link" href="{{ url_for('admin_force_vacate') }}">
           <strong>Force Vacate Slot</strong>
         </a>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -219,7 +219,33 @@ Holder is stored for the Issue workflow.
 
 ---
 
-## 11. Admin Users
+## 11. Case Corrections
+
+**What this does**
+Renames one Case to an unused identifier or removes one strictly never-used Case.
+
+**Do this**
+1. Click **Admin**
+2. Click **Admin Tools**
+3. Click **Case Corrections**
+4. Enter the current Case
+5. Enter a new Case only for rename
+6. Click **Preview Correction**
+7. Confirm and commit only if the preview is correct
+
+**What happens next**
+- Rename preserves Slot IDs and asset event history
+- Removal deletes only never-used empty Slots
+- One correction row is recorded
+
+**Watch for**
+- Existing asset events are not changed
+- Used Cases cannot be removed
+- Rename cannot use an existing identifier
+
+---
+
+## 12. Admin Users
 
 **What this does**  
 Manage system users.
@@ -241,7 +267,7 @@ Changes apply immediately.
 
 ---
 
-## 12. Common Fixes
+## 13. Common Fixes
 
 **What this does**  
 Quick answers when something doesn’t work.
@@ -259,4 +285,4 @@ Fix the condition, then retry the action.
 
 **Watch for**
 - Queue is staging only  
-- Commit is the actual change  
+- Commit is the actual change

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import sqlite3
 
 import pytest
 
@@ -221,6 +222,105 @@ def _slot_move_commit_data(
     return data
 
 
+def _insert_case_correction_fixture(*, case_name: str = "CASE-OLD", used: bool = True, with_event: bool = True) -> int:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES
+                (1901, ?, 1, ?),
+                (1902, ?, 2, NULL);
+            """,
+            (case_name, "CASE-ASSET-1" if used else None, case_name),
+        )
+        asset_id = 0
+        if used:
+            cursor = conn.execute(
+                """
+                INSERT INTO assets (
+                    asset_tag,
+                    location_type,
+                    home_slot_id,
+                    case_number,
+                    slot_number,
+                    building_room
+                )
+                VALUES ('CASE-ASSET-1', 'STORAGE', 1901, ?, '1', 'HQ/101');
+                """,
+                (case_name,),
+            )
+            asset_id = int(cursor.lastrowid)
+            conn.execute(
+                """
+                INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                VALUES (1901, ?, '2026-01-01T00:00:00+00:00');
+                """,
+                (asset_id,),
+            )
+            if with_event:
+                conn.execute(
+                    """
+                    INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+                    VALUES ('CASE-ASSET-1', 'SLOT_ASSIGN', '2026-01-01T00:00:00+00:00', 'admin', NULL, ?, NULL);
+                    """,
+                    (json.dumps({"slot": {"case_number": case_name, "slot_number": 1}}),),
+                )
+        conn.commit()
+        return asset_id
+    finally:
+        conn.close()
+
+
+def _case_correction_state() -> dict[str, object]:
+    conn = db.get_connection()
+    try:
+        slots = conn.execute(
+            """
+            SELECT id, case_name, slot_position, current_asset_tag
+            FROM slots
+            ORDER BY id ASC;
+            """
+        ).fetchall()
+        assets = conn.execute(
+            """
+            SELECT asset_tag, home_slot_id, case_number, slot_number
+            FROM assets
+            ORDER BY asset_tag ASC;
+            """
+        ).fetchall()
+        occupancy = conn.execute(
+            """
+            SELECT slot_id, asset_id
+            FROM slot_occupancy
+            ORDER BY slot_id ASC;
+            """
+        ).fetchall()
+        events = conn.execute(
+            """
+            SELECT event_type, payload
+            FROM asset_events
+            ORDER BY id ASC;
+            """
+        ).fetchall()
+        corrections = conn.execute(
+            """
+            SELECT event_type, actor_user_id, actor_username, old_case_name, new_case_name, affected_slot_count, affected_asset_count
+            FROM case_correction_events
+            ORDER BY id ASC;
+            """
+        ).fetchall()
+        return {
+            "slots": [dict(row) for row in slots],
+            "assets": [dict(row) for row in assets],
+            "occupancy": [dict(row) for row in occupancy],
+            "events": [dict(row) for row in events],
+            "corrections": [dict(row) for row in corrections],
+        }
+    finally:
+        conn.close()
+
+
 def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
 
@@ -280,6 +380,342 @@ def test_admin_slot_provision_appends_slots_for_existing_case(client_with_temp_d
     finally:
         verify_conn.close()
     assert [int(row["slot_position"]) for row in rows] == [1, 2, 3, 4]
+
+
+def test_case_correction_schema_is_append_only(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO case_correction_events (
+                event_type,
+                created_at,
+                actor_user_id,
+                actor_username,
+                old_case_name,
+                new_case_name,
+                affected_slot_count,
+                affected_asset_count
+            )
+            VALUES ('CASE_REMOVE', '2026-01-01T00:00:00+00:00', 1, 'admin', 'CASE-X', NULL, 1, 0);
+            """
+        )
+        conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("UPDATE case_correction_events SET old_case_name = 'CASE-Y' WHERE id = 1;")
+        conn.rollback()
+
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute("DELETE FROM case_correction_events WHERE id = 1;")
+    finally:
+        conn.close()
+
+
+def test_operator_denied_case_correction_preview_and_commit(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-case-correct", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    _insert_case_correction_fixture(used=False)
+
+    entry_response = client_with_temp_db.get("/admin/case-corrections")
+    preview_response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={"action": "preview", "event_type": "CASE_REMOVE", "old_case_name": "CASE-OLD"},
+    )
+    commit_response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={
+            "action": "commit",
+            "event_type": "CASE_REMOVE",
+            "old_case_name": "CASE-OLD",
+            "expected_event_type": "CASE_REMOVE",
+            "expected_old_case_name": "CASE-OLD",
+            "expected_new_case_name": "",
+            "expected_slot_count": "2",
+            "expected_asset_count": "0",
+            "confirm_correction": "1",
+        },
+    )
+
+    assert entry_response.status_code == 403
+    assert preview_response.status_code == 403
+    assert commit_response.status_code == 403
+    assert _case_correction_state()["corrections"] == []
+
+
+def test_case_correction_page_shows_empty_case_message(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = client_with_temp_db.get("/admin/case-corrections")
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "No Cases are available to correct." in html
+    assert "Admin Tools → Provision Slots" in html
+    assert "/admin/slots/provision" in html
+    assert 'name="old_case_name"' not in html
+    assert 'name="new_case_name"' not in html
+
+
+def test_case_correction_page_uses_case_dropdowns_and_rename_only_new_case(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_case_correction_fixture(used=False)
+
+    response = client_with_temp_db.get("/admin/case-corrections")
+    html = response.get_data(as_text=True)
+    remove_section = html[html.index("Remove Never-Used Case") : html.index("Correction History")]
+
+    assert response.status_code == 200
+    assert 'id="old_case_name"' not in html
+    assert 'id="rename_old_case_name" name="old_case_name" required' in html
+    assert 'id="remove_old_case_name" name="old_case_name" required' in html
+    assert '<option value="CASE-OLD"' in html
+    assert 'id="new_case_name" name="new_case_name"' in html
+    assert 'id="new_case_name" name="new_case_name" value="" autocomplete="off" required' in html
+    assert 'name="new_case_name"' not in remove_section
+
+
+def test_case_rename_preview_does_not_write(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_case_correction_fixture()
+    before = _case_correction_state()
+
+    response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={
+            "action": "preview",
+            "event_type": "CASE_RENAME",
+            "old_case_name": "CASE-OLD",
+            "new_case_name": "CASE-NEW",
+        },
+    )
+
+    assert response.status_code == 200
+    assert b"Preview Correction" in response.data
+    assert b'name="expected_slot_count" value="2"' in response.data
+    assert b'name="expected_asset_count" value="1"' in response.data
+    assert _case_correction_state() == before
+
+
+def test_case_correction_page_shows_successful_history(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO case_correction_events (
+                event_type,
+                created_at,
+                actor_user_id,
+                actor_username,
+                old_case_name,
+                new_case_name,
+                affected_slot_count,
+                affected_asset_count
+            )
+            VALUES (
+                'CASE_RENAME',
+                '2026-07-29T14:03:00+00:00',
+                1,
+                'admin-slots',
+                'CASE-OLD',
+                'CASE-NEW',
+                2,
+                1
+            );
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/admin/case-corrections")
+
+    assert response.status_code == 200
+    assert b"Correction History" in response.data
+    assert b"CASE_RENAME" in response.data
+    assert b"2026-07-29T14:03:00+00:00" in response.data
+    assert b"admin-slots" in response.data
+    assert b"CASE-OLD" in response.data
+    assert b"CASE-NEW" in response.data
+    assert b"<code>2</code>" in response.data
+    assert b"<code>1</code>" in response.data
+
+
+def test_case_rename_commit_updates_current_state_and_preserves_events(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    asset_id = _insert_case_correction_fixture()
+    before = _case_correction_state()
+
+    response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={
+            "action": "commit",
+            "event_type": "CASE_RENAME",
+            "old_case_name": "CASE-OLD",
+            "new_case_name": "CASE-NEW",
+            "expected_event_type": "CASE_RENAME",
+            "expected_old_case_name": "CASE-OLD",
+            "expected_new_case_name": "CASE-NEW",
+            "expected_slot_count": "2",
+            "expected_asset_count": "1",
+            "confirm_correction": "1",
+        },
+        follow_redirects=True,
+    )
+    after = _case_correction_state()
+
+    assert response.status_code == 200
+    assert b"Renamed Case CASE-OLD to CASE-NEW." in response.data
+    assert [(row["id"], row["case_name"]) for row in after["slots"]] == [(1901, "CASE-NEW"), (1902, "CASE-NEW")]
+    assert after["assets"] == [
+        {"asset_tag": "CASE-ASSET-1", "home_slot_id": 1901, "case_number": "CASE-NEW", "slot_number": "1"}
+    ]
+    assert after["occupancy"] == [{"slot_id": 1901, "asset_id": asset_id}]
+    assert after["events"] == before["events"]
+    assert after["corrections"] == [
+        {
+            "event_type": "CASE_RENAME",
+            "actor_user_id": 1,
+            "actor_username": "admin-slots",
+            "old_case_name": "CASE-OLD",
+            "new_case_name": "CASE-NEW",
+            "affected_slot_count": 2,
+            "affected_asset_count": 1,
+        }
+    ]
+
+
+def test_case_rename_blocks_used_target_identifier(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_case_correction_fixture()
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (1910, 'CASE-USED', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={
+            "action": "preview",
+            "event_type": "CASE_RENAME",
+            "old_case_name": "CASE-OLD",
+            "new_case_name": "CASE-USED",
+        },
+    )
+
+    assert b"New Case identifier is already used." in response.data
+    assert _case_correction_state()["corrections"] == []
+
+
+def test_case_rename_blocks_stale_confirmation(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_case_correction_fixture(used=True, with_event=False)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO assets (asset_tag, location_type, home_slot_id, case_number, slot_number)
+            VALUES ('CASE-ASSET-2', 'STORAGE', 1902, 'CASE-OLD', '2');
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={
+            "action": "commit",
+            "event_type": "CASE_RENAME",
+            "old_case_name": "CASE-OLD",
+            "new_case_name": "CASE-NEW",
+            "expected_event_type": "CASE_RENAME",
+            "expected_old_case_name": "CASE-OLD",
+            "expected_new_case_name": "CASE-NEW",
+            "expected_slot_count": "2",
+            "expected_asset_count": "1",
+            "confirm_correction": "1",
+        },
+    )
+
+    assert b"Case asset count changed. Preview again." in response.data
+    state = _case_correction_state()
+    assert {row["case_name"] for row in state["slots"]} == {"CASE-OLD"}
+    assert state["corrections"] == []
+
+
+def test_case_remove_commit_deletes_strictly_never_used_case(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_case_correction_fixture(used=False)
+
+    response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={
+            "action": "commit",
+            "event_type": "CASE_REMOVE",
+            "old_case_name": "CASE-OLD",
+            "expected_event_type": "CASE_REMOVE",
+            "expected_old_case_name": "CASE-OLD",
+            "expected_new_case_name": "",
+            "expected_slot_count": "2",
+            "expected_asset_count": "0",
+            "confirm_correction": "1",
+        },
+        follow_redirects=True,
+    )
+    state = _case_correction_state()
+
+    assert response.status_code == 200
+    assert b"Removed never-used Case CASE-OLD." in response.data
+    assert state["slots"] == []
+    assert state["corrections"] == [
+        {
+            "event_type": "CASE_REMOVE",
+            "actor_user_id": 1,
+            "actor_username": "admin-slots",
+            "old_case_name": "CASE-OLD",
+            "new_case_name": None,
+            "affected_slot_count": 2,
+            "affected_asset_count": 0,
+        }
+    ]
+
+
+def test_case_remove_blocks_event_history_reference(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_case_correction_fixture(used=False)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES ('OLD-EVENT-ASSET', 'SLOT_ASSIGN', '2026-01-01T00:00:00+00:00', 'admin', NULL, ?, NULL);
+            """,
+            (json.dumps({"slot": {"case_number": "CASE-OLD", "slot_number": 1}}),),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/case-corrections",
+        data={"action": "preview", "event_type": "CASE_REMOVE", "old_case_name": "CASE-OLD"},
+    )
+
+    assert b"Cannot remove a Case referenced by event history." in response.data
+    state = _case_correction_state()
+    assert len(state["slots"]) == 2
+    assert state["corrections"] == []
 
 
 def test_unslotted_storage_asset_can_be_assigned_after_slot_provision(client_with_temp_db) -> None:


### PR DESCRIPTION
# Issue 30-8: Add safe administrative Case correction workflow

## Summary

Adds an admin-only workflow for safely renaming a Case or removing a strictly never-used Case.

Corrections use preview and explicit confirmation, revalidate inside a single transaction, and create an immutable administrative correction record.

## Related Issue

Closes #1025

## Changes

- Added the append-only `case_correction_events` table.
- Added database triggers that prevent correction records from being updated or deleted.
- Added an admin-only Case Corrections page.
- Added separate preview and confirmation workflows for:
  - renaming one Case to a completely unused identifier;
  - removing one strictly never-used Case.
- Preserved Slot IDs, occupancy links, Asset home-slot references, and historical Asset events during rename.
- Blocked removal when a Case has current or historical Asset references.
- Added dropdown selection for existing Cases.
- Added a clear empty state linking to Provision Slots.
- Added read-only correction history for administrators.
- Added focused regression tests and operator documentation.

## Verification

- [x] Focused Case correction tests passed: 11 passed.
- [x] Full `tests/test_admin_slot_provision.py` passed: 44 passed.
- [x] `tests/test_admin_system_health.py` passed: 57 passed.
- [x] Python compile check passed.
- [x] `git diff --check` passed.
- [x] Docker image rebuilt successfully.
- [x] Admin rename workflow manually verified.
- [x] Never-used Case removal manually verified.
- [x] Used Case removal protection manually verified.
- [x] Duplicate Case rename protection manually verified.
- [x] Correction history manually verified.
- [x] Non-admin role protection manually verified.
- [x] Container restart persistence manually verified.
- [x] Existing Asset custody history remained intact.

## Notes

The workflow does not modify or delete existing Asset events. Case correction records are append-only and are separate from custody events.