### PR TITLE
Issue 30-27: Add Holder import audit records

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -554,6 +554,41 @@ def _create_schema(conn: sqlite3.Connection):
 
     cursor.execute(
         """
+        CREATE TABLE IF NOT EXISTS holder_import_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT NOT NULL,
+            actor_user_id INTEGER NOT NULL,
+            actor_username TEXT NOT NULL CHECK(length(trim(actor_username)) > 0),
+            source_filename TEXT NOT NULL CHECK(length(trim(source_filename)) > 0),
+            processed_count INTEGER NOT NULL CHECK(processed_count >= 0),
+            created_count INTEGER NOT NULL CHECK(created_count >= 0),
+            updated_count INTEGER NOT NULL CHECK(updated_count >= 0)
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS holder_import_events_no_update
+        BEFORE UPDATE ON holder_import_events
+        BEGIN
+            SELECT RAISE(ABORT, 'holder_import_events is append-only');
+        END;
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS holder_import_events_no_delete
+        BEFORE DELETE ON holder_import_events
+        BEGIN
+            SELECT RAISE(ABORT, 'holder_import_events is append-only');
+        END;
+        """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS receipt_queue (
             id INTEGER PRIMARY KEY,
             receipt_key TEXT NOT NULL UNIQUE,

--- a/assettrack/holder_import.py
+++ b/assettrack/holder_import.py
@@ -40,6 +40,13 @@ class HolderImportReport:
 
 
 @dataclass(frozen=True)
+class HolderImportAuditContext:
+    actor_user_id: int
+    actor_username: str
+    source_filename: str
+
+
+@dataclass(frozen=True)
 class HolderImportPreviewRow:
     row_number: int
     category: str
@@ -263,6 +270,40 @@ def _holder_matches_import(holder: sqlite3.Row, row: HolderImportRow, organizati
     )
 
 
+def _insert_holder_import_event(
+    conn: sqlite3.Connection,
+    *,
+    audit_context: HolderImportAuditContext,
+    created_at: str,
+    processed_count: int,
+    created_count: int,
+    updated_count: int,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO holder_import_events (
+            created_at,
+            actor_user_id,
+            actor_username,
+            source_filename,
+            processed_count,
+            created_count,
+            updated_count
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            created_at,
+            int(audit_context.actor_user_id),
+            str(audit_context.actor_username or "").strip(),
+            str(audit_context.source_filename or "").strip(),
+            int(processed_count),
+            int(created_count),
+            int(updated_count),
+        ),
+    )
+
+
 def _invalid_preview_row(row_number: int, problem: str, *, organization: str = "", name: str = "", email: str = "") -> HolderImportPreviewRow:
     return HolderImportPreviewRow(
         row_number=row_number,
@@ -427,7 +468,12 @@ def preview_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderI
         conn.close()
 
 
-def import_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderImportReport:
+def import_holders_csv(
+    csv_path: str | Path,
+    *,
+    db_path: str | Path,
+    audit_context: HolderImportAuditContext | None = None,
+) -> HolderImportReport:
     preview = preview_holders_csv(csv_path, db_path=db_path)
     if not preview.can_commit:
         errors = [f"Row {row.row_number}: {row.problem}" for row in preview.rows if row.problem]
@@ -499,6 +545,16 @@ def import_holders_csv(csv_path: str | Path, *, db_path: str | Path) -> HolderIm
                     (row.name, row.organization, organization_id, row.email, now_iso, holder_id),
                 )
                 updated += 1
+
+            if audit_context is not None:
+                _insert_holder_import_event(
+                    conn,
+                    audit_context=audit_context,
+                    created_at=_utc_now_iso(),
+                    processed_count=len(parsed),
+                    created_count=created,
+                    updated_count=updated,
+                )
 
         return HolderImportReport(processed=len(parsed), created=created, updated=updated, errors=())
     finally:

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -69,7 +69,13 @@ from assettrack.auth import (
     require_role,
 )
 from assettrack.holders import create_holder, get_holder, list_holders, search_holders, set_holder_active, update_holder
-from assettrack.holder_import import HolderImportPreview, HolderImportReport, import_holders_csv, preview_holders_csv
+from assettrack.holder_import import (
+    HolderImportAuditContext,
+    HolderImportPreview,
+    HolderImportReport,
+    import_holders_csv,
+    preview_holders_csv,
+)
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.import_reconciliation import build_asset_import_preview
 from assettrack.reference_data import (
@@ -7951,6 +7957,44 @@ def _holder_import_flash(report: HolderImportReport) -> None:
             "success",
         )
 
+
+def _list_holder_import_history() -> list[dict]:
+    conn = get_connection()
+    try:
+        rows = conn.execute(
+            """
+            SELECT
+                created_at,
+                actor_username,
+                source_filename,
+                processed_count,
+                created_count,
+                updated_count
+            FROM holder_import_events
+            ORDER BY id DESC;
+            """
+        ).fetchall()
+        history = []
+        for row in rows:
+            processed_count = int(row["processed_count"])
+            created_count = int(row["created_count"])
+            updated_count = int(row["updated_count"])
+            history.append(
+                {
+                    "created_at": str(row["created_at"] or ""),
+                    "actor_username": str(row["actor_username"] or ""),
+                    "source_filename": str(row["source_filename"] or ""),
+                    "processed_count": processed_count,
+                    "created_count": created_count,
+                    "updated_count": updated_count,
+                    "unchanged_count": max(0, processed_count - created_count - updated_count),
+                }
+            )
+        return history
+    finally:
+        conn.close()
+
+
 @app.route("/admin/holders/import", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
@@ -7959,43 +8003,60 @@ def admin_holder_import():
     report: HolderImportReport | None = None
     pending_filename = ""
 
+    def render_holder_import():
+        return render_template(
+            "admin_holder_import.html",
+            preview=preview,
+            report=report,
+            pending_filename=pending_filename,
+            holder_import_history=_list_holder_import_history(),
+        )
+
     if request.method == "POST":
         action = (request.form.get("action") or "preview").strip().lower()
 
         if action == "cancel":
             _clear_pending_holder_import()
             flash("Holder import preview cleared.", "success")
-            return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
+            return render_holder_import()
 
         if action == "commit":
             temp_path = _pending_holder_import_path()
             if temp_path is None:
                 flash("Upload and preview a Holder CSV before confirming import.", "error")
-                return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
+                return render_holder_import()
 
             preview = preview_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
             pending = session.get(HOLDER_IMPORT_PENDING_SESSION_KEY)
             pending_filename = str((pending or {}).get("filename") or "") if isinstance(pending, dict) else ""
             if not preview.can_commit:
                 flash("Holder import preview has blocked rows. Fix the CSV and upload again.", "error")
-                return render_template(
-                    "admin_holder_import.html",
-                    preview=preview,
-                    report=None,
-                    pending_filename=pending_filename,
-                )
+                return render_holder_import()
 
-            report = import_holders_csv(temp_path, db_path=_resolved_runtime_db_path())
+            user = current_user()
+            if user is None:
+                return _require_admin_for_route()
+            report = import_holders_csv(
+                temp_path,
+                db_path=_resolved_runtime_db_path(),
+                audit_context=HolderImportAuditContext(
+                    actor_user_id=int(user["id"]),
+                    actor_username=str(user.get("username") or ""),
+                    source_filename=pending_filename,
+                ),
+            )
             _holder_import_flash(report)
             _clear_pending_holder_import()
-            return render_template("admin_holder_import.html", preview=None, report=report, pending_filename="")
+            preview = None
+            pending_filename = ""
+            return render_holder_import()
 
         _clear_pending_holder_import()
         upload = request.files.get("csv_file")
         filename = str((upload.filename if upload is not None else "") or "").strip()
         if upload is None or not filename:
             flash("Choose a CSV file to preview.", "error")
-            return render_template("admin_holder_import.html", preview=None, report=None, pending_filename="")
+            return render_holder_import()
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as handle:
             upload.save(handle)
@@ -8009,12 +8070,7 @@ def admin_holder_import():
         else:
             flash("Holder import preview found blocked rows. Fix the CSV and upload again.", "error")
 
-    return render_template(
-        "admin_holder_import.html",
-        preview=preview,
-        report=report,
-        pending_filename=pending_filename,
-    )
+    return render_holder_import()
 
 def _analyze_asset_import_csv(temp_path: Path, *, filename: str) -> dict:
     return analyze_asset_import_csv(temp_path, filename=filename, collect_row_errors=True).to_template_result()

--- a/assettrack/intake/templates/admin_holder_import.html
+++ b/assettrack/intake/templates/admin_holder_import.html
@@ -78,7 +78,7 @@
       <p class="import-help">Required columns: <code>organization</code>, <code>name</code>, <code>email</code>.</p>
       <p class="import-help">Matching email addresses update existing holder records. New email addresses create new holders.</p>
       <p class="import-help">Organizations are reused by case-insensitive name; missing Organizations are proposed in preview and created only after confirmation.</p>
-      <p class="import-help">Holder imports change Holder and Organization reference data. Holder imports do not create asset custody events. A separate persistent import audit record is not currently created.</p>
+      <p class="import-help">Successful admin UI Holder imports create a persistent import audit record retained indefinitely. Holder imports do not create asset custody events.</p>
     </div>
   </details>
 
@@ -180,4 +180,40 @@
       {% endif %}
     </div>
   {% endif %}
+
+  <div class="card">
+    <h2>Import History</h2>
+    {% if holder_import_history %}
+      <div class="holder-preview-table">
+        <table>
+          <thead>
+            <tr>
+              <th>Timestamp</th>
+              <th>Actor</th>
+              <th>Filename</th>
+              <th>Processed</th>
+              <th>Created</th>
+              <th>Updated</th>
+              <th>Unchanged</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in holder_import_history %}
+              <tr>
+                <td>{{ row.created_at }}</td>
+                <td>{{ row.actor_username }}</td>
+                <td><code>{{ row.source_filename }}</code></td>
+                <td>{{ row.processed_count }}</td>
+                <td>{{ row.created_count }}</td>
+                <td>{{ row.updated_count }}</td>
+                <td>{{ row.unchanged_count }}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    {% else %}
+      <p class="import-help">No Holder import audit records.</p>
+    {% endif %}
+  </div>
 {% endblock %}

--- a/docs/release/user-manual.md
+++ b/docs/release/user-manual.md
@@ -340,7 +340,8 @@ Use Import Holders when you need to load holder records from an approved file.
 6. Select `Confirm and Commit Holder Import` only after the preview is correct.
 7. Review the result.
 
-Fix the file if AssetTrack reports duplicate, ambiguous, invalid, or blocked rows. Preview does not create or update Holders or Organizations. Confirmed imports currently change Holder and Organization reference data only; they do not create custody events or a separate persistent audit record. Persistent reference-data import auditing is deferred to Issue 30-27 / #1078.
+Fix the file if AssetTrack reports duplicate, ambiguous, invalid, or blocked rows. Preview does not create or update Holders or Organizations. Successful admin UI Holder imports change Holder and Organization reference data, do not create custody events, and create a persistent import audit record retained indefinitely.
+
 ## Import Assets
 
 **Admin only**

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -346,11 +346,13 @@ def test_admin_can_preview_and_confirm_holders_from_csv(client_with_temp_db) -> 
     conn = db.get_connection()
     try:
         holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        audit_count = int(conn.execute("SELECT COUNT(*) FROM holder_import_events;").fetchone()[0])
         org = conn.execute("SELECT id FROM organizations WHERE name = ?;", ("Ops Alpha",)).fetchone()
     finally:
         conn.close()
 
     assert holder_count == 0
+    assert audit_count == 0
     assert org is None
 
     commit_response = client_with_temp_db.post(
@@ -365,6 +367,9 @@ def test_admin_can_preview_and_confirm_holders_from_csv(client_with_temp_db) -> 
     assert b"Created:</strong> 1" in commit_response.data
     assert b"Updated:</strong> 0" in commit_response.data
     assert b"Errors:</strong> 0" in commit_response.data
+    assert b"Import History" in commit_response.data
+    assert b"admin-import" in commit_response.data
+    assert b"<code>holders.csv</code>" in commit_response.data
 
     conn = db.get_connection()
     try:
@@ -372,11 +377,27 @@ def test_admin_can_preview_and_confirm_holders_from_csv(client_with_temp_db) -> 
             "SELECT name, organization, email FROM holders WHERE email = ?;",
             ("jane@example.org",),
         ).fetchone()
+        audit_rows = conn.execute(
+            """
+            SELECT actor_user_id, actor_username, source_filename, processed_count, created_count, updated_count
+            FROM holder_import_events;
+            """
+        ).fetchall()
     finally:
         conn.close()
 
     assert holder is not None
     assert dict(holder) == {"name": "Jane Doe", "organization": "Ops Alpha", "email": "jane@example.org"}
+    assert [dict(row) for row in audit_rows] == [
+        {
+            "actor_user_id": admin_id,
+            "actor_username": "admin-import",
+            "source_filename": "holders.csv",
+            "processed_count": 1,
+            "created_count": 1,
+            "updated_count": 0,
+        }
+    ]
 
 def test_admin_holder_import_temp_path_ignores_uploaded_filename(client_with_temp_db, monkeypatch) -> None:
     admin_id = create_test_user(username="admin-import-hostile-name", password="admin-pass", role="admin")
@@ -425,9 +446,10 @@ def test_admin_holder_import_page_exposes_collapsible_csv_requirements(client_wi
     assert b"Preview Holders" in response.data
     assert b"CSV requirements" in response.data
     assert b"Columns and import behavior" in response.data
-    assert b"Holder imports change Holder and Organization reference data." in response.data
+    assert b"Successful admin UI Holder imports create a persistent import audit record retained indefinitely." in response.data
     assert b"Holder imports do not create asset custody events." in response.data
-    assert b"A separate persistent import audit record is not currently created." in response.data
+    assert b"Import History" in response.data
+    assert b"No Holder import audit records." in response.data
     assert b"Issue 30-27" not in response.data
     assert b'<details class="disclosure-section">' in response.data
 
@@ -458,10 +480,12 @@ def test_admin_holder_import_surfaces_existing_validation_errors(client_with_tem
     conn = db.get_connection()
     try:
         holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        audit_count = int(conn.execute("SELECT COUNT(*) FROM holder_import_events;").fetchone()[0])
     finally:
         conn.close()
 
     assert holder_count == 0
+    assert audit_count == 0
 
 
 def test_admin_holder_import_preview_shows_duplicate_and_invalid_rows(client_with_temp_db) -> None:
@@ -499,10 +523,12 @@ def test_admin_holder_import_preview_shows_duplicate_and_invalid_rows(client_wit
     conn = db.get_connection()
     try:
         holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        audit_count = int(conn.execute("SELECT COUNT(*) FROM holder_import_events;").fetchone()[0])
     finally:
         conn.close()
 
     assert holder_count == 0
+    assert audit_count == 0
 
 def test_operator_is_forbidden_for_human_readable_report(client_with_temp_db) -> None:
     operator_id = create_test_user(username="operator-report", password="op-pass", role="operator")

--- a/tests/test_holder_import.py
+++ b/tests/test_holder_import.py
@@ -67,6 +67,102 @@ class HolderImportTests(unittest.TestCase):
         finally:
             conn.close()
 
+    def _audit_context(self, *, filename: str = "holders.csv") -> holder_import.HolderImportAuditContext:
+        return holder_import.HolderImportAuditContext(
+            actor_user_id=7,
+            actor_username="admin-import",
+            source_filename=filename,
+        )
+
+    def _holder_import_events(self) -> list[dict]:
+        conn = self._connection()
+        try:
+            rows = conn.execute(
+                """
+                SELECT actor_user_id, actor_username, source_filename, processed_count, created_count, updated_count
+                FROM holder_import_events
+                ORDER BY id ASC;
+                """
+            ).fetchall()
+            return [dict(row) for row in rows]
+        finally:
+            conn.close()
+
+    def test_holder_import_audit_schema_is_idempotent_and_append_only(self) -> None:
+        bootstrap_db(self.db_path)
+        conn = self._connection()
+        try:
+            conn.execute(
+                """
+                INSERT INTO holder_import_events (
+                    created_at,
+                    actor_user_id,
+                    actor_username,
+                    source_filename,
+                    processed_count,
+                    created_count,
+                    updated_count
+                )
+                VALUES ('2026-01-01T00:00:00+00:00', 7, 'admin-import', 'holders.csv', 1, 1, 0);
+                """
+            )
+            conn.commit()
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("UPDATE holder_import_events SET source_filename = 'changed.csv' WHERE id = 1;")
+            conn.rollback()
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute("DELETE FROM holder_import_events WHERE id = 1;")
+            conn.rollback()
+
+            with self.assertRaises(sqlite3.IntegrityError):
+                conn.execute(
+                    """
+                    INSERT INTO holder_import_events (
+                        created_at,
+                        actor_user_id,
+                        actor_username,
+                        source_filename,
+                        processed_count,
+                        created_count,
+                        updated_count
+                    )
+                    VALUES ('2026-01-01T00:00:00+00:00', 7, 'admin-import', 'holders.csv', -1, 0, 0);
+                    """
+                )
+        finally:
+            conn.close()
+
+    def test_older_database_bootstrap_adds_holder_import_events_without_data_change(self) -> None:
+        conn = self._connection()
+        try:
+            conn.execute("DROP TABLE holder_import_events;")
+            conn.execute(
+                """
+                INSERT INTO holders (
+                    holder_type, name, organization, organization_id, email, identifier, contact_info, created_at, updated_at
+                )
+                VALUES ('PERSON', 'Existing Holder', 'Ad Hoc', 1, 'existing@example.org', NULL, NULL, '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00');
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        bootstrap_db(self.db_path)
+
+        conn = self._connection()
+        try:
+            audit_table = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'holder_import_events';"
+            ).fetchone()
+            holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+        finally:
+            conn.close()
+        self.assertIsNotNone(audit_table)
+        self.assertEqual(holder_count, 1)
+
     def test_preview_classifies_rows_and_performs_no_writes(self) -> None:
         original_org_id = self._insert_organization("Ops Alpha")
         self._insert_holder(
@@ -116,6 +212,7 @@ class HolderImportTests(unittest.TestCase):
             conn.close()
         self.assertEqual(holder_count, 2)
         self.assertIsNone(org)
+        self.assertEqual(self._holder_import_events(), [])
 
     def test_preview_blocks_duplicate_and_ambiguous_rows_without_writes(self) -> None:
         org_id = self._insert_organization("Ops Alpha")
@@ -145,6 +242,75 @@ class HolderImportTests(unittest.TestCase):
         finally:
             conn.close()
         self.assertEqual(holder_count, 2)
+        self.assertEqual(self._holder_import_events(), [])
+
+    def test_audited_import_creates_one_holder_import_event(self) -> None:
+        original_org_id = self._insert_organization("Ops Alpha")
+        self._insert_holder(
+            name="Existing Holder",
+            organization="Ops Alpha",
+            organization_id=original_org_id,
+            email="existing@example.org",
+        )
+        csv_path = self._write_csv(
+            "admin-upload.csv",
+            (
+                "organization,name,email\n"
+                "Ops Bravo,New Holder,new@example.org\n"
+                "Ops Alpha,Existing Holder Updated,existing@example.org\n"
+            ),
+        )
+
+        report = holder_import.import_holders_csv(
+            csv_path,
+            db_path=self.db_path,
+            audit_context=self._audit_context(filename="admin-upload.csv"),
+        )
+
+        self.assertEqual(report.summary(), {"processed": 2, "created": 1, "updated": 1, "errors": 0})
+        self.assertEqual(
+            self._holder_import_events(),
+            [
+                {
+                    "actor_user_id": 7,
+                    "actor_username": "admin-import",
+                    "source_filename": "admin-upload.csv",
+                    "processed_count": 2,
+                    "created_count": 1,
+                    "updated_count": 1,
+                }
+            ],
+        )
+
+    def test_cli_style_import_without_audit_context_creates_no_audit_event(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Alpha,Jane Doe,jane@example.org\n",
+        )
+
+        report = holder_import.import_holders_csv(csv_path, db_path=self.db_path)
+
+        self.assertEqual(report.summary(), {"processed": 1, "created": 1, "updated": 0, "errors": 0})
+        self.assertEqual(self._holder_import_events(), [])
+
+    def test_blocked_audited_import_creates_no_audit_event(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            (
+                "organization,name,email\n"
+                "Ops Alpha,Duplicate One,dup@example.org\n"
+                "Ops Alpha,Duplicate Two,dup@example.org\n"
+            ),
+        )
+
+        report = holder_import.import_holders_csv(
+            csv_path,
+            db_path=self.db_path,
+            audit_context=self._audit_context(),
+        )
+
+        self.assertEqual(report.summary(), {"processed": 2, "created": 0, "updated": 0, "errors": 2})
+        self.assertEqual(self._holder_import_events(), [])
     def test_preview_shows_duplicate_and_invalid_rows_together(self) -> None:
         csv_path = self._write_csv(
             "holders.csv",
@@ -289,6 +455,32 @@ class HolderImportTests(unittest.TestCase):
         finally:
             conn.close()
         self.assertEqual(holder_count, 0)
+
+    def test_audit_insert_failure_rolls_back_holder_and_organization_changes(self) -> None:
+        csv_path = self._write_csv(
+            "holders.csv",
+            "organization,name,email\nOps Audit,Jane Doe,jane@example.org\n",
+        )
+
+        with patch.object(holder_import, "_insert_holder_import_event", side_effect=RuntimeError("audit insert failed")):
+            with self.assertRaises(RuntimeError):
+                holder_import.import_holders_csv(
+                    csv_path,
+                    db_path=self.db_path,
+                    audit_context=self._audit_context(),
+                )
+
+        conn = self._connection()
+        try:
+            holder_count = int(conn.execute("SELECT COUNT(*) FROM holders;").fetchone()[0])
+            org = conn.execute("SELECT id FROM organizations WHERE name = 'Ops Audit';").fetchone()
+            audit_count = int(conn.execute("SELECT COUNT(*) FROM holder_import_events;").fetchone()[0])
+        finally:
+            conn.close()
+        self.assertEqual(holder_count, 0)
+        self.assertIsNone(org)
+        self.assertEqual(audit_count, 0)
+
     def test_cli_returns_summary_and_nonzero_exit_on_invalid_csv(self) -> None:
         csv_path = self._write_csv(
             "holders.csv",


### PR DESCRIPTION
# Issue 30-27: Add persistent Holder import audit records

## Summary

Adds an append-only audit record for successful administrator Holder CSV imports.

The audit record commits atomically with the Holder and Organization changes. If the audit write fails, the entire import rolls back.

## Related Issue

Closes #1078

## Changes

- Added the `holder_import_events` table.
- Added database triggers preventing audit records from being updated or deleted.
- Recorded:
  - timestamp
  - administrator identity
  - original uploaded filename
  - processed count
  - created count
  - updated count
- Added one audit record only after a successful admin UI Holder import.
- Kept preview, blocked, failed, and rolled-back imports from creating audit records.
- Left the Holder import CLI unchanged and unaudited.
- Added compact read-only Import History to the existing Holder Import page.
- Preserved Holder matching, import validation, custody events, and Restore compatibility.
- Updated the Holder import operator documentation.

## Verification

- [x] `tests/test_holder_import.py` passed: 18 tests.
- [x] `tests/test_admin_system_health.py` passed: 57 tests.
- [x] `tests/test_admin_db_restore.py` passed: 12 tests.
- [x] Python compile check passed.
- [x] `git diff --check` passed.
- [x] Docker image rebuilt successfully.
- [x] Valid Holder CSV preview and commit manually verified.
- [x] Import History fields and counts manually verified.
- [x] Blocked import created no additional history record.
- [x] Audit history survived container restart.

## Notes

Audit history applies only to successful Holder CSV imports performed through the administrator UI.

Records are retained indefinitely and remain separate from Asset custody events.