### PR TITLE
Issue 31-2: provision cases slots import

### DIFF
--- a/assettrack/import_reconciliation.py
+++ b/assettrack/import_reconciliation.py
@@ -192,7 +192,9 @@ def _slot_for_row(
         slot_position = int(row.slot_identifier)
     except ValueError:
         return None, "slot_identifier must be numeric"
-    if context is not None:`r`n        slot = context.slots_by_case_position.get((row.case_identifier.upper(), slot_position))`r`n        return slot, None
+    if context is not None:
+        slot = context.slots_by_case_position.get((row.case_identifier.upper(), slot_position))
+        return slot, None
 
     slot = conn.execute(
         """
@@ -231,7 +233,10 @@ def _same_slot(asset: sqlite3.Row | None, slot: sqlite3.Row | None) -> bool:
 def _slot_label(slot: sqlite3.Row) -> str:
     return f"{_text(slot['case_name'])} / {_text(slot['slot_position'])}"
 
-`r`ndef _row_slot_label(row: AssetImportAnalysisRow) -> str:`r`n    return f"{row.case_identifier} / {row.slot_identifier}"`r`n`r`n
+def _row_slot_label(row: AssetImportAnalysisRow) -> str:
+    return f"{row.case_identifier} / {row.slot_identifier}"
+
+
 def _asset_home_slot_label(
     conn: sqlite3.Connection,
     asset: sqlite3.Row,
@@ -320,12 +325,47 @@ def _preview_row(
                 fields=("case_identifier", "slot_identifier"),
             )
 
-        if slot is not None:`r`n            occupant = _slot_occupant(conn, int(slot["id"]), context)`r`n            legacy_current_asset_tag = _text(slot["current_asset_tag"])`r`n            occupied_by_other = occupant is not None and _text(occupant["asset_tag"]).upper() != row.asset_tag.upper()`r`n            legacy_occupied_by_other = legacy_current_asset_tag and legacy_current_asset_tag.upper() != row.asset_tag.upper()`r`n            if occupied_by_other or legacy_occupied_by_other:`r`n                occupant_tag = _text(occupant["asset_tag"]) if occupant is not None else legacy_current_asset_tag`r`n                return AssetImportPreviewRow(`r`n                    row_number=row.row_number,`r`n                    asset_tag=row.asset_tag,`r`n                    asset_identifier=row.asset_tag,`r`n                    category="slot_conflict_unslotted",`r`n                    category_label=CATEGORY_LABELS["slot_conflict_unslotted"],`r`n                    message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",`r`n                    warnings=("Existing slot occupants are never displaced.",),`r`n                    fields=("case_identifier", "slot_identifier"),`r`n                )
+        if slot is not None:
+            occupant = _slot_occupant(conn, int(slot["id"]), context)
+            legacy_current_asset_tag = _text(slot["current_asset_tag"])
+            occupied_by_other = occupant is not None and _text(occupant["asset_tag"]).upper() != row.asset_tag.upper()
+            legacy_occupied_by_other = legacy_current_asset_tag and legacy_current_asset_tag.upper() != row.asset_tag.upper()
+            if occupied_by_other or legacy_occupied_by_other:
+                occupant_tag = _text(occupant["asset_tag"]) if occupant is not None else legacy_current_asset_tag
+                return AssetImportPreviewRow(
+                    row_number=row.row_number,
+                    asset_tag=row.asset_tag,
+                    asset_identifier=row.asset_tag,
+                    category="slot_conflict_unslotted",
+                    category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
+                    message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",
+                    warnings=("Existing slot occupants are never displaced.",),
+                    fields=("case_identifier", "slot_identifier"),
+                )
 
-    if existing is None:`r`n        message = f"New {equipment_type_label(row.equipment_type)} asset with available storage."`r`n        if storage_requested and slot is None:`r`n            message = f"New {equipment_type_label(row.equipment_type)} asset with storage to create: {_row_slot_label(row)}."`r`n        return AssetImportPreviewRow(`r`n            row_number=row.row_number,`r`n            asset_tag=row.asset_tag,`r`n            asset_identifier=row.asset_tag,`r`n            category="new_asset",`r`n            category_label=CATEGORY_LABELS["new_asset"],`r`n            message=message,`r`n            warnings=("Missing storage will be created during commit.",) if storage_requested and slot is None else (),`r`n        )
+    if existing is None:
+        message = f"New {equipment_type_label(row.equipment_type)} asset with available storage."
+        if storage_requested and slot is None:
+            message = f"New {equipment_type_label(row.equipment_type)} asset with storage to create: {_row_slot_label(row)}."
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
+            category="new_asset",
+            category_label=CATEGORY_LABELS["new_asset"],
+            message=message,
+            warnings=("Missing storage will be created during commit.",) if storage_requested and slot is None else (),
+        )
 
     changes = list(_field_changes(existing, row))
-    if storage_requested and not _same_slot(existing, slot):`r`n        changes.append(`r`n            AssetImportFieldChange(`r`n                field="home_slot",`r`n                current=_asset_home_slot_label(conn, existing, context),`r`n                proposed=_slot_label(slot) if slot is not None else f"{_row_slot_label(row)} (will be created)",`r`n            )`r`n        )
+    if storage_requested and not _same_slot(existing, slot):
+        changes.append(
+            AssetImportFieldChange(
+                field="home_slot",
+                current=_asset_home_slot_label(conn, existing, context),
+                proposed=_slot_label(slot) if slot is not None else f"{_row_slot_label(row)} (will be created)",
+            )
+        )
     if changes:
         message = "Existing asset has proposed field updates."
         if len(changes) == 1 and changes[0].field == "home_slot":

--- a/assettrack/import_reconciliation.py
+++ b/assettrack/import_reconciliation.py
@@ -192,11 +192,7 @@ def _slot_for_row(
         slot_position = int(row.slot_identifier)
     except ValueError:
         return None, "slot_identifier must be numeric"
-    if context is not None:
-        slot = context.slots_by_case_position.get((row.case_identifier.upper(), slot_position))
-        if slot is None:
-            return None, "slot does not exist"
-        return slot, None
+    if context is not None:`r`n        slot = context.slots_by_case_position.get((row.case_identifier.upper(), slot_position))`r`n        return slot, None
 
     slot = conn.execute(
         """
@@ -208,8 +204,6 @@ def _slot_for_row(
         """,
         (row.case_identifier, slot_position),
     ).fetchone()
-    if slot is None:
-        return None, "slot does not exist"
     return slot, None
 
 
@@ -237,7 +231,7 @@ def _same_slot(asset: sqlite3.Row | None, slot: sqlite3.Row | None) -> bool:
 def _slot_label(slot: sqlite3.Row) -> str:
     return f"{_text(slot['case_name'])} / {_text(slot['slot_position'])}"
 
-
+`r`ndef _row_slot_label(row: AssetImportAnalysisRow) -> str:`r`n    return f"{row.case_identifier} / {row.slot_identifier}"`r`n`r`n
 def _asset_home_slot_label(
     conn: sqlite3.Connection,
     asset: sqlite3.Row,
@@ -326,44 +320,12 @@ def _preview_row(
                 fields=("case_identifier", "slot_identifier"),
             )
 
-        assert slot is not None
-        occupant = _slot_occupant(conn, int(slot["id"]), context)
-        legacy_current_asset_tag = _text(slot["current_asset_tag"])
-        occupied_by_other = occupant is not None and _text(occupant["asset_tag"]).upper() != row.asset_tag.upper()
-        legacy_occupied_by_other = legacy_current_asset_tag and legacy_current_asset_tag.upper() != row.asset_tag.upper()
-        if occupied_by_other or legacy_occupied_by_other:
-            occupant_tag = _text(occupant["asset_tag"]) if occupant is not None else legacy_current_asset_tag
-            return AssetImportPreviewRow(
-                row_number=row.row_number,
-                asset_tag=row.asset_tag,
-                asset_identifier=row.asset_tag,
-                category="slot_conflict_unslotted",
-                category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
-                message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",
-                warnings=("Existing slot occupants are never displaced.",),
-                fields=("case_identifier", "slot_identifier"),
-            )
+        if slot is not None:`r`n            occupant = _slot_occupant(conn, int(slot["id"]), context)`r`n            legacy_current_asset_tag = _text(slot["current_asset_tag"])`r`n            occupied_by_other = occupant is not None and _text(occupant["asset_tag"]).upper() != row.asset_tag.upper()`r`n            legacy_occupied_by_other = legacy_current_asset_tag and legacy_current_asset_tag.upper() != row.asset_tag.upper()`r`n            if occupied_by_other or legacy_occupied_by_other:`r`n                occupant_tag = _text(occupant["asset_tag"]) if occupant is not None else legacy_current_asset_tag`r`n                return AssetImportPreviewRow(`r`n                    row_number=row.row_number,`r`n                    asset_tag=row.asset_tag,`r`n                    asset_identifier=row.asset_tag,`r`n                    category="slot_conflict_unslotted",`r`n                    category_label=CATEGORY_LABELS["slot_conflict_unslotted"],`r`n                    message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",`r`n                    warnings=("Existing slot occupants are never displaced.",),`r`n                    fields=("case_identifier", "slot_identifier"),`r`n                )
 
-    if existing is None:
-        return AssetImportPreviewRow(
-            row_number=row.row_number,
-            asset_tag=row.asset_tag,
-            asset_identifier=row.asset_tag,
-            category="new_asset",
-            category_label=CATEGORY_LABELS["new_asset"],
-            message=f"New {equipment_type_label(row.equipment_type)} asset with available storage.",
-        )
+    if existing is None:`r`n        message = f"New {equipment_type_label(row.equipment_type)} asset with available storage."`r`n        if storage_requested and slot is None:`r`n            message = f"New {equipment_type_label(row.equipment_type)} asset with storage to create: {_row_slot_label(row)}."`r`n        return AssetImportPreviewRow(`r`n            row_number=row.row_number,`r`n            asset_tag=row.asset_tag,`r`n            asset_identifier=row.asset_tag,`r`n            category="new_asset",`r`n            category_label=CATEGORY_LABELS["new_asset"],`r`n            message=message,`r`n            warnings=("Missing storage will be created during commit.",) if storage_requested and slot is None else (),`r`n        )
 
     changes = list(_field_changes(existing, row))
-    if storage_requested and not _same_slot(existing, slot):
-        assert slot is not None
-        changes.append(
-            AssetImportFieldChange(
-                field="home_slot",
-                current=_asset_home_slot_label(conn, existing, context),
-                proposed=_slot_label(slot),
-            )
-        )
+    if storage_requested and not _same_slot(existing, slot):`r`n        changes.append(`r`n            AssetImportFieldChange(`r`n                field="home_slot",`r`n                current=_asset_home_slot_label(conn, existing, context),`r`n                proposed=_slot_label(slot) if slot is not None else f"{_row_slot_label(row)} (will be created)",`r`n            )`r`n        )
     if changes:
         message = "Existing asset has proposed field updates."
         if len(changes) == 1 and changes[0].field == "home_slot":

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -8245,7 +8245,7 @@ def _asset_import_slot_for_row(conn: sqlite3.Connection, row) -> sqlite3.Row | N
 def _asset_import_get_or_create_slot_for_row(conn: sqlite3.Connection, row) -> sqlite3.Row | None:
     if row.storage_intent != "slotted":
         return None
-    slot = _asset_import_get_or_create_slot_for_row(conn, row)
+    slot = _asset_import_slot_for_row(conn, row)
     if slot is not None:
         return slot
     try:
@@ -8259,7 +8259,7 @@ def _asset_import_get_or_create_slot_for_row(conn: sqlite3.Connection, row) -> s
         """,
         (row.case_identifier, slot_position),
     )
-    slot = _asset_import_get_or_create_slot_for_row(conn, row)
+    slot = _asset_import_slot_for_row(conn, row)
     if slot is None:
         raise ValueError(f"Row {row.row_number}: requested slot could not be created.")
     return slot

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -8242,7 +8242,30 @@ def _asset_import_slot_for_row(conn: sqlite3.Connection, row) -> sqlite3.Row | N
     ).fetchone()
 
 
+def _asset_import_get_or_create_slot_for_row(conn: sqlite3.Connection, row) -> sqlite3.Row | None:
+    if row.storage_intent != "slotted":
+        return None
+    slot = _asset_import_get_or_create_slot_for_row(conn, row)
+    if slot is not None:
+        return slot
+    try:
+        slot_position = int(row.slot_identifier)
+    except ValueError as exc:
+        raise ValueError(f"Row {row.row_number}: slot_identifier must be numeric.") from exc
+    conn.execute(
+        """
+        INSERT INTO slots (case_name, slot_position, current_asset_tag)
+        VALUES (?, ?, NULL);
+        """,
+        (row.case_identifier, slot_position),
+    )
+    slot = _asset_import_get_or_create_slot_for_row(conn, row)
+    if slot is None:
+        raise ValueError(f"Row {row.row_number}: requested slot could not be created.")
+    return slot
+
 def _asset_import_slot_is_available_for(conn: sqlite3.Connection, *, slot_id: int, asset_tag: str) -> bool:
+
     occupant = conn.execute(
         """
         SELECT a.asset_tag
@@ -8416,7 +8439,7 @@ def _asset_import_apply_existing_update(conn: sqlite3.Connection, row, preview_r
     metadata_values = _asset_import_metadata_updates(row)
     moved = False
     if movement_change:
-        slot = _asset_import_slot_for_row(conn, row)
+        slot = _asset_import_get_or_create_slot_for_row(conn, row)
         if slot is None:
             raise ValueError(f"Row {row.row_number}: destination slot is unavailable.")
         if not _asset_import_slot_is_available_for(conn, slot_id=int(slot["id"]), asset_tag=row.asset_tag):
@@ -8514,7 +8537,7 @@ def _commit_asset_import_pending(*, submitted_token: str) -> tuple[dict, dict]:
                 summary["unchanged"] += 1
                 continue
             if preview_row.category == "new_asset":
-                slot = _asset_import_slot_for_row(conn, row)
+                slot = _asset_import_get_or_create_slot_for_row(conn, row)
                 if slot is None:
                     raise ValueError(f"Row {row.row_number}: requested slot is unavailable.")
                 _asset_import_create_new_asset(conn, row, now_iso=now_iso, actor=actor, slot=slot)

--- a/docs/fixtures/imports/asset_import_template.md
+++ b/docs/fixtures/imports/asset_import_template.md
@@ -1,19 +1,24 @@
 # Canonical Asset Import CSV Template
 
-Use `asset_import_template.csv` with Admin Tools -> Import Assets for supported bulk asset imports.
+Use `asset_import_template.csv` with Admin -> Import Assets at `/admin/assets/import` for supported bulk asset imports.
+
+The older Switch/Router CSV importer is not the Issue 31-2 workflow. Do not use it to verify storage provisioning, and do not treat it as evidence that Import Assets created case/slot storage.
 
 ## Workflow
 
-1. Open Admin Tools.
-2. Open Import Assets.
+1. Open Admin.
+2. Open Import Assets at `/admin/assets/import`.
 3. Choose a CSV or XLSX file.
 4. Select Analyze Import.
 5. Review the preview.
-6. Confirm the preview.
-7. Commit the approved rows.
-8. Review the results.
+6. Open Technical Details and review row diagnostics.
+7. Confirm the preview.
+8. Commit the approved rows.
+9. Open Cases and verify the case, slot, and occupancy results.
 
-Analyze Import creates a preview only. It does not write assets, events, slots, or occupancy. Commit requires explicit confirmation. Approved safe rows commit atomically, and blocked rows do not modify state.
+Analyze Import and Preview do not modify the database. They do not create cases, slots, assets, occupancy, or events.
+
+Commit requires explicit confirmation. Approved safe rows commit atomically, and blocked rows do not modify state.
 
 ## Required Fields
 
@@ -46,7 +51,23 @@ Supported `equipment_type` values:
 
 Storage fields are optional. Leave `case_identifier` and `slot_identifier` blank when storage is unknown or unavailable.
 
-Rows with missing or unavailable storage may continue as Unslotted only when the admin acknowledges that behavior during preview.
+When both storage fields are present, the import treats them as requested home-slot storage. Preview shows whether the requested slot already exists, is occupied, or will be created.
+
+In Technical Details, Preview explicitly identifies missing case/slot storage that will be created during commit.
+
+Confirmed Commit creates missing slots, assigns the imported assets to those slots, and updates occupancy atomically. If any commit failure occurs, slots, assets, occupancy, and events from that batch roll back together.
+
+Occupied slots remain protected. Import never displaces an existing slot occupant. Rows requesting occupied or unavailable storage may continue as Unslotted only when the admin acknowledges that behavior during preview.
+
+Repeating the same unified import does not create duplicate slots or duplicate occupancy. Existing matching slots and unchanged exact-match assets are reused or left unchanged.
+
+When both `case_identifier` and `slot_identifier` are blank, the row retains the acknowledged Unslotted behavior. The asset can be created in storage with no home slot only after the admin acknowledges Unslotted import during preview.
+
+## After Commit Verification
+
+Use the Cases view as the operator verification point after commit.
+
+A successful import for rows that requested valid case and slot storage must show the new case and slot assignments in Cases. The Unslotted asset count must not increase for those rows.
 
 ## Unsupported Fields
 

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -90,6 +90,7 @@ def _table_counts() -> dict[str, int]:
         return {
             "assets": int(conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0]),
             "asset_events": int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0]),
+            "slots": int(conn.execute("SELECT COUNT(*) FROM slots;").fetchone()[0]),
             "slot_occupancy": int(conn.execute("SELECT COUNT(*) FROM slot_occupancy;").fetchone()[0]),
         }
     finally:
@@ -1366,6 +1367,24 @@ def _slot_record(slot_id: int) -> sqlite3.Row:
         conn.close()
 
 
+def _slot_records_for_case(case_name: str) -> list[sqlite3.Row]:
+    conn = db.get_connection()
+    try:
+        return list(
+            conn.execute(
+                """
+                SELECT *
+                FROM slots
+                WHERE UPPER(case_name) = UPPER(?)
+                ORDER BY slot_position;
+                """,
+                (case_name,),
+            ).fetchall()
+        )
+    finally:
+        conn.close()
+
+
 def _occupancy_asset_tags() -> dict[int, str]:
     conn = db.get_connection()
     try:
@@ -1381,6 +1400,227 @@ def _occupancy_asset_tags() -> dict[int, str]:
         }
     finally:
         conn.close()
+
+
+def test_asset_import_missing_requested_slot_previews_and_commits_created_storage(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,manufacturer,model,case_identifier,slot_identifier\n"
+        b"CREATE-SLOT-100,SER-CREATE-SLOT-100,laptop,Dell,Latitude,CASE-CREATE,12\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"Ready to commit" in response.data
+    assert b"New Asset: 1" in response.data
+    assert b"New Laptop asset with storage to create: CASE-CREATE / 12." in response.data
+    assert b"Missing storage will be created during commit." in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    assert b"Asset import committed." in commit_response.data
+    asset = _asset_record("CREATE-SLOT-100")
+    assert asset is not None
+    assert asset["case_number"] == "CASE-CREATE"
+    assert asset["slot_number"] == "12"
+    assert asset["home_slot_id"] is not None
+    created_slot = _slot_record(int(asset["home_slot_id"]))
+    assert created_slot["case_name"] == "CASE-CREATE"
+    assert int(created_slot["slot_position"]) == 12
+    assert created_slot["current_asset_tag"] == "CREATE-SLOT-100"
+    assert _occupancy_asset_tags()[int(created_slot["id"])] == "CREATE-SLOT-100"
+    assert [row["event_type"] for row in _asset_events("CREATE-SLOT-100")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+
+
+def test_asset_import_creates_multiple_missing_sequential_slots_in_one_case(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"SEQ-101,SER-SEQ-101,laptop,CASE-SEQ,1\n"
+        b"SEQ-102,SER-SEQ-102,laptop,CASE-SEQ,2\n"
+        b"SEQ-103,SER-SEQ-103,laptop,CASE-SEQ,3\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert response.data.count(b"Missing storage will be created during commit.") == 3
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    slots = _slot_records_for_case("CASE-SEQ")
+    assert [int(slot["slot_position"]) for slot in slots] == [1, 2, 3]
+    assert [slot["current_asset_tag"] for slot in slots] == ["SEQ-101", "SEQ-102", "SEQ-103"]
+    assert set(_occupancy_asset_tags().values()) == {"SEQ-101", "SEQ-102", "SEQ-103"}
+    for asset_tag in ("SEQ-101", "SEQ-102", "SEQ-103"):
+        assert [row["event_type"] for row in _asset_events(asset_tag)] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+
+
+def test_asset_import_creates_missing_slots_alongside_existing_slots(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=951, case_name="CASE-MIXED", slot_position=1)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"MIXED-EXISTING,SER-MIXED-EXISTING,laptop,CASE-MIXED,1\n"
+        b"MIXED-MISSING,SER-MIXED-MISSING,laptop,CASE-MIXED,2\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"New Laptop asset with available storage." in response.data
+    assert b"New Laptop asset with storage to create: CASE-MIXED / 2." in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    slots = _slot_records_for_case("CASE-MIXED")
+    assert [int(slot["slot_position"]) for slot in slots] == [1, 2]
+    assert slots[0]["id"] == 951
+    assert [slot["current_asset_tag"] for slot in slots] == ["MIXED-EXISTING", "MIXED-MISSING"]
+
+
+def test_asset_import_creates_missing_slots_for_multiple_new_cases(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"MULTICASE-A,SER-MULTICASE-A,laptop,CASE-MULTI-A,1\n"
+        b"MULTICASE-B,SER-MULTICASE-B,laptop,CASE-MULTI-B,1\n",
+        "assets.csv",
+    )
+
+    assert response.status_code == 200
+    assert b"CASE-MULTI-A / 1" in response.data
+    assert b"CASE-MULTI-B / 1" in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    assert _slot_records_for_case("CASE-MULTI-A")[0]["current_asset_tag"] == "MULTICASE-A"
+    assert _slot_records_for_case("CASE-MULTI-B")[0]["current_asset_tag"] == "MULTICASE-B"
+
+
+def test_asset_import_occupied_slot_remains_protected_during_commit(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=952, case_name="CASE-OCCUPIED", slot_position=1, current_asset_tag="OCCUPANT-100")
+    _insert_asset(asset_tag="OCCUPANT-100", home_slot_id=952, case_number="CASE-OCCUPIED", slot_number="1", slotted=True)
+
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"OCCUPIED-IMPORT,SER-OCCUPIED-IMPORT,laptop,CASE-OCCUPIED,1\n",
+        "assets.csv",
+        form={"acknowledge_unslotted": "1"},
+    )
+
+    assert response.status_code == 200
+    assert b"Slot Conflict Eligible For Unslotted Import: 1" in response.data
+    assert b"Existing slot occupants are never displaced." in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    imported = _asset_record("OCCUPIED-IMPORT")
+    assert imported is not None
+    assert imported["home_slot_id"] is None
+    assert _slot_record(952)["current_asset_tag"] == "OCCUPANT-100"
+    assert _occupancy_asset_tags()[952] == "OCCUPANT-100"
+    assert [row["event_type"] for row in _asset_events("OCCUPIED-IMPORT")] == ["ASSET_CREATED"]
+
+
+def test_repeated_asset_import_creates_no_duplicate_slots_or_occupancy(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    content = (
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"REPEAT-SLOT-100,SER-REPEAT-SLOT-100,laptop,CASE-REPEAT,1\n"
+    )
+    first_response = _post_file(client_with_temp_db, content, "assets.csv")
+    first_commit = _post_commit(client_with_temp_db, _preview_token(first_response))
+    assert first_commit.status_code == 200
+    after_first = _table_counts()
+
+    second_response = _post_file(client_with_temp_db, content, "assets.csv")
+    assert second_response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in second_response.data
+    second_commit = _post_commit(client_with_temp_db, _preview_token(second_response))
+
+    assert second_commit.status_code == 200
+    assert _table_counts() == after_first
+    assert len(_slot_records_for_case("CASE-REPEAT")) == 1
+    assert list(_occupancy_asset_tags().values()).count("REPEAT-SLOT-100") == 1
+    assert [row["event_type"] for row in _asset_events("REPEAT-SLOT-100")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+
+
+def test_asset_import_analyze_and_preview_do_not_create_missing_storage(
+    client_with_temp_db,
+    tmp_path: Path,
+) -> None:
+    csv_path = tmp_path / "assets.csv"
+    csv_path.write_text(
+        "asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        "PREVIEW-ONLY-100,SER-PREVIEW-ONLY-100,laptop,CASE-PREVIEW-ONLY,1\n",
+        encoding="utf-8",
+    )
+    before_analyze = _table_counts()
+    analysis = analyze_asset_import_csv(csv_path, filename="assets.csv")
+    after_analyze = _table_counts()
+
+    conn = db.get_connection()
+    try:
+        preview = build_asset_import_preview(conn, analysis)
+    finally:
+        conn.close()
+
+    assert after_analyze == before_analyze
+    assert _table_counts() == before_analyze
+    assert preview.rows[0].category == "new_asset"
+    assert preview.rows[0].message == "New Laptop asset with storage to create: CASE-PREVIEW-ONLY / 1."
+    assert _slot_records_for_case("CASE-PREVIEW-ONLY") == []
+
+
+def test_asset_import_acknowledged_blank_storage_commits_unslotted_without_slot_assignment(
+    client_with_temp_db,
+) -> None:
+    _login_admin(client_with_temp_db)
+    response = _post_file(
+        client_with_temp_db,
+        b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
+        b"BLANK-STORAGE-100,SER-BLANK-STORAGE-100,laptop,,\n",
+        "assets.csv",
+        form={"acknowledge_unslotted": "1"},
+    )
+
+    assert response.status_code == 200
+    assert b"Unslotted Import: 1" in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    asset = _asset_record("BLANK-STORAGE-100")
+    assert asset is not None
+    assert asset["home_slot_id"] is None
+    assert asset["case_number"] in (None, "")
+    assert asset["slot_number"] in (None, "")
+    assert _occupancy_asset_tags() == {}
+    assert [row["event_type"] for row in _asset_events("BLANK-STORAGE-100")] == ["ASSET_CREATED"]
 
 
 def test_asset_import_commit_writes_approved_safe_rows_atomically_and_leaves_blocked_rows(
@@ -1599,8 +1839,6 @@ def test_asset_import_commit_rolls_back_complete_batch_on_mid_batch_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _login_admin(client_with_temp_db)
-    _insert_slot(slot_id=941, case_name="CASE-ROLL", slot_position=1)
-    _insert_slot(slot_id=942, case_name="CASE-ROLL", slot_position=2)
     response = _post_file(
         client_with_temp_db,
         b"asset_tag,serial_number,equipment_type,case_identifier,slot_identifier\n"
@@ -1626,8 +1864,7 @@ def test_asset_import_commit_rolls_back_complete_batch_on_mid_batch_failure(
     assert _asset_events("ROLL-OK") == []
     assert _asset_events("ROLL-FAIL") == []
     assert _occupancy_asset_tags() == {}
-    assert _slot_record(941)["current_asset_tag"] is None
-    assert _slot_record(942)["current_asset_tag"] is None
+    assert _slot_records_for_case("CASE-ROLL") == []
 
 
 def test_asset_import_replacing_preview_removes_previous_pending_file(client_with_temp_db) -> None:


### PR DESCRIPTION
# Issue 31-2: Provision missing storage during asset import

## Summary

Asset Import now provisions missing requested storage during confirmed commit instead of importing valid slotted rows as Unslotted.

## Related Issue

Closes #1094

## Changes

- Allow Preview to identify missing case and slot storage that will be created.
- Create missing slots during confirmed Asset Import commit.
- Assign imported assets to their requested home slots.
- Create slot occupancy without displacing existing occupants.
- Keep Analyze and Preview read-only.
- Preserve acknowledged Unslotted behavior when both storage fields are blank.
- Prevent duplicate slots and occupancy on repeated imports.
- Update Asset Import operator documentation.
- Clarify that the older Switch/Router CSV importer does not provide Issue 31-2 storage provisioning.

## Verification

- [x] Python compilation passed for changed application and test files.
- [x] Asset Import test module passed: 57 tests.
- [x] `git diff --check` passed.
- [x] Manual unified Asset Import preview showed missing storage would be created.
- [x] Confirmed commit created `CASE-31-2-SMOKE` with Slots 1 and 2.
- [x] Imported assets occupied their requested slots.
- [x] Unslotted asset count did not increase for valid slotted rows.
- [ ] Docker restart persistence verification.

## Notes

No schema changes, dependency additions, new event types, or custody-history changes were introduced.