### PR TITLE
Issue 31-16: classify Router as Network

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -82,7 +82,7 @@ def _building_label(value: object) -> str:
 
 def _domain_label(equipment_type: object) -> str:
     normalized = str(equipment_type or "").strip().lower()
-    if normalized in {"switch", "other network equipment", "voip"}:
+    if normalized in {"router", "switch", "other network equipment", "voip"}:
         return DOMAIN_NETWORK
     if normalized in {"laptop", "monitor", "peripheral"}:
         return DOMAIN_SYSADMINS

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -651,6 +651,13 @@ class DashboardTests(unittest.TestCase):
             room="Closet",
         )
         self._insert_asset(
+            "AT-ROUTER",
+            location_type="STORAGE",
+            equipment_type="router",
+            building="HQ North",
+            room="Closet",
+        )
+        self._insert_asset(
             "AT-UNKNOWN",
             location_type="STORAGE",
             equipment_type="other",
@@ -662,7 +669,7 @@ class DashboardTests(unittest.TestCase):
         data = build_dashboard_data(self.conn, custody_days_threshold=30)
 
         custody_map = data["snapshots"]["custody_map"]
-        self.assertEqual(custody_map["asset_count"], 3)
+        self.assertEqual(custody_map["asset_count"], 4)
         self.assertEqual([thread["label"] for thread in custody_map["threads"]], ["CISR", "Unknown Thread"])
 
         cisr_thread = custody_map["threads"][0]
@@ -682,7 +689,14 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual([domain["label"] for domain in hq_building["domains"]], ["Network"])
         network_holder = hq_building["domains"][0]["holders"][0]
         self.assertEqual(network_holder["label"], "Unassigned Holder")
-        self.assertEqual(network_holder["assets"][0]["asset_tag"], "AT-SWITCH")
+        self.assertEqual(
+            [asset["asset_tag"] for asset in network_holder["assets"]],
+            ["AT-ROUTER", "AT-SWITCH"],
+        )
+        self.assertEqual(
+            [asset["equipment_type_label"] for asset in network_holder["assets"]],
+            ["Router", "Switch"],
+        )
 
         unknown_building = unknown_thread["buildings"][1]
         self.assertEqual(unknown_building["domains"][0]["label"], "Unclassified Asset")


### PR DESCRIPTION
Issue 31-16: Classify Router as Network in the Custody Map

# PR Description

## Summary

Classifies Router assets under the existing Network grouping in the Custody Map.

## Related Issue

Closes #1110

## Changes

- Added `router` to the existing Network equipment-type classification.
- Preserved the existing Switch, Laptop, and unknown-equipment classifications.
- Extended focused Custody Map coverage for Router, Switch, Laptop, and unknown equipment types.

## Verification

- [x] `git diff --check`
- [x] Focused Custody Map tests: 2 passed, 16 deselected
- [x] Full `tests/test_dashboard.py` test file passed
- [x] Full test suite: 675 passed
- [x] Rebuilt with `docker compose up -d --build`
- [x] Manually verified Router and Switch appear under Network
- [x] Manually verified Laptop remains under SysAdmins
- [x] Automated test verifies unknown equipment remains under Unclassified Asset

## Notes

- No asset records, events, imports, schema, persistence behavior, or Custody Map hierarchy were changed.