### PR TITLE
Issue 31-17: add Custody Map navigation links

### DIFF
--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -148,6 +148,22 @@
     .dashboard-map-card {
       margin-bottom: 1rem;
     }
+    .dashboard-map-card > summary {
+      flex-wrap: wrap;
+      align-items: baseline;
+    }
+    .dashboard-map-heading {
+      display: inline-flex;
+      flex: 1 1 auto;
+      flex-wrap: wrap;
+      align-items: baseline;
+      gap: 0.45rem 0.65rem;
+      min-width: 14rem;
+      text-align: left;
+    }
+    .dashboard-map-heading .disclosure-title {
+      flex: 0 0 auto;
+    }
     .dashboard-map-intro {
       margin: 0 0 0.9rem 0;
       color: var(--color-text-muted);
@@ -362,7 +378,10 @@
 
   <details class="disclosure-section dashboard-map-card">
     <summary aria-label="Custody map">
-      <span class="disclosure-title">Custody Map</span>
+      <span class="dashboard-map-heading">
+        <span class="disclosure-title">Custody Map</span>
+        <a class="nav-link" href="{{ url_for('asset_search') }}">Asset Search</a>
+      </span>
       <span class="disclosure-hint">Thread → Building → Operational Domain → Custody Holder → Asset</span>
     </summary>
     <div class="disclosure-body">
@@ -412,7 +431,9 @@
                                                 <ul class="custody-map-assets">
                                                   {% for asset in holder.assets %}
                                                     <li class="custody-map-asset">
-                                                      <span class="custody-map-label">Asset: <code>{{ asset.asset_tag }}</code></span>
+                                                      <span class="custody-map-label">Asset:
+                                                        <a class="nav-link" href="{{ url_for('asset_history', asset_tag=asset.asset_tag, return_to=url_for('dashboard')) }}"><code>{{ asset.asset_tag }}</code></a>
+                                                      </span>
                                                       <span class="custody-map-asset-type">{{ asset.equipment_type_label }}</span>
                                                     </li>
                                                   {% endfor %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -225,7 +225,12 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Building: HQ", response.data)
         self.assertIn(b"Operational Domain: SysAdmins", response.data)
         self.assertIn(b"Custody Holder:", response.data)
-        self.assertIn(b"Asset: <code>AT-CUST</code>", response.data)
+        self.assertIn(b'<a class="nav-link" href="/assets/search">Asset Search</a>', response.data)
+        self.assertIn(
+            b'<a class="nav-link" href="/assets/history?asset_tag=AT-CUST&amp;return_to=/dashboard"><code>AT-CUST</code></a>',
+            response.data,
+        )
+        self.assertNotIn(b"Asset: <code>AT-CUST</code>", response.data)
         self.assertGreaterEqual(response.data.count(b'class="disclosure-section custody-map-node"'), 4)
         self.assertIn(b'id="problems-panel"', response.data)
         self.assertIn(b'id="problems-panel" open', response.data)
@@ -732,7 +737,14 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b"Operational Domain: SysAdmins", response.data)
         self.assertIn(b"Operational Domain: Network", response.data)
         self.assertIn(b"Custody Holder:", response.data)
-        self.assertIn(b"Asset: <code>AT-LAPTOP</code>", response.data)
-        self.assertIn(b"Asset: <code>AT-SWITCH</code>", response.data)
+        self.assertIn(b'<a class="nav-link" href="/assets/search">Asset Search</a>', response.data)
+        self.assertIn(
+            b'<a class="nav-link" href="/assets/history?asset_tag=AT-LAPTOP&amp;return_to=/dashboard"><code>AT-LAPTOP</code></a>',
+            response.data,
+        )
+        self.assertIn(
+            b'<a class="nav-link" href="/assets/history?asset_tag=AT-SWITCH&amp;return_to=/dashboard"><code>AT-SWITCH</code></a>',
+            response.data,
+        )
         self.assertGreaterEqual(response.data.count(b'class="disclosure-section custody-map-node"'), 4)
         self.assertIn(b'class="custody-map-asset"', response.data)


### PR DESCRIPTION
Issue 31-17: Add Custody Map navigation links

## Summary

Adds direct navigation from the Custody Map to Asset Search and individual asset records.

## Related Issue

Closes #1111

## Changes

- Added an Asset Search link beside the Custody Map heading.
- Linked each displayed asset tag to its existing asset history page.
- Kept the hierarchy guide separately aligned on the right.
- Preserved responsive wrapping on narrow screens.
- Added focused assertions for the new navigation links.

## Verification

- [x] Focused Custody Map test: 1 passed
- [x] Dashboard route and Custody Map tests: 2 passed
- [x] Full `tests/test_dashboard.py`: 18 passed
- [x] Asset-history authentication and equipment-type tests passed
- [x] `git diff --check`
- [x] Rebuilt with `docker compose up -d --build`
- [x] Verified Asset Search navigation
- [x] Verified asset-history links
- [x] Verified expand and collapse behavior
- [x] Verified grouping and asset counts remained unchanged
- [x] Verified holder links remained functional
- [x] Verified corrected heading placement

## Notes

- No routes, authorization rules, custody behavior, storage behavior, schema, persistence, or event history were changed.
- The full repository test suite was left to CI because this was a focused Class 1 presentation change.