### PR TITLE
Issue 31-18: reorder Operator Report sections

### DIFF
--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -97,6 +97,90 @@
 
   <details class="report-section">
     <summary>
+      <span class="report-section-title">Current Custody</span>
+      <span class="report-section-hint">{{ current_custody|length }} assets out</span>
+    </summary>
+    <div class="report-section-body">
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Holder</th>
+            <th>Organization</th>
+            <th>Asset Tag</th>
+            <th>Type</th>
+            <th>Current Location</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in current_custody %}
+            <tr>
+              <td>
+                {% if row.holder_detail_id %}
+                  <a class="nav-link report-drill-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
+                {% else %}
+                  {{ row.holder_name }}
+                {% endif %}
+              </td>
+              <td>{{ row.organization }}</td>
+              <td><a class="nav-link report-drill-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
+              <td>{{ row.equipment_type }}</td>
+              <td>{{ row.current_location }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5">No assets are currently in custody.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    </div>
+  </details>
+
+  <details class="report-section">
+    <summary>
+      <span class="report-section-title">Last 10 Events</span>
+    </summary>
+    <div class="report-section-body">
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>When</th>
+            <th>Asset Tag</th>
+            <th>Event Type</th>
+            <th>Holder</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in recent_active_events %}
+            <tr>
+              <td><code>{{ row.id }}</code></td>
+              <td>{{ row.event_date_display }}</td>
+              <td><a class="nav-link report-drill-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
+              <td>{{ row.event_type }}</td>
+              <td>
+                {% if row.holder_name %}
+                  {% if row.holder_detail_id %}
+                    <a class="nav-link report-drill-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
+                  {% else %}
+                    {{ row.holder_name }}
+                  {% endif %}
+                  {% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
+                {% endif %}
+              </td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5">No active events found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    </div>
+  </details>
+
+  <details class="report-section">
+    <summary>
       <span class="report-section-title">Assets</span>
       <span class="report-section-hint">
         {% if include_retired_assets %}
@@ -234,90 +318,6 @@
             </tr>
           {% else %}
             <tr><td colspan="2">No organization-to-building mappings found.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    </div>
-  </details>
-
-  <details class="report-section">
-    <summary>
-      <span class="report-section-title">Current Custody</span>
-      <span class="report-section-hint">{{ current_custody|length }} assets out</span>
-    </summary>
-    <div class="report-section-body">
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>Holder</th>
-            <th>Organization</th>
-            <th>Asset Tag</th>
-            <th>Type</th>
-            <th>Current Location</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in current_custody %}
-            <tr>
-              <td>
-                {% if row.holder_detail_id %}
-                  <a class="nav-link report-drill-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
-                {% else %}
-                  {{ row.holder_name }}
-                {% endif %}
-              </td>
-              <td>{{ row.organization }}</td>
-              <td><a class="nav-link report-drill-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
-              <td>{{ row.equipment_type }}</td>
-              <td>{{ row.current_location }}</td>
-            </tr>
-          {% else %}
-            <tr><td colspan="5">No assets are currently in custody.</td></tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    </div>
-  </details>
-
-  <details class="report-section">
-    <summary>
-      <span class="report-section-title">Last 10 Events</span>
-    </summary>
-    <div class="report-section-body">
-    <div class="table-wrap">
-      <table>
-        <thead>
-          <tr>
-            <th>ID</th>
-            <th>When</th>
-            <th>Asset Tag</th>
-            <th>Event Type</th>
-            <th>Holder</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in recent_active_events %}
-            <tr>
-              <td><code>{{ row.id }}</code></td>
-              <td>{{ row.event_date_display }}</td>
-              <td><a class="nav-link report-drill-link" href="{{ url_for('asset_search', asset_tag=row.asset_tag, return_to=report_return_to) }}"><code>{{ row.asset_tag }}</code></a></td>
-              <td>{{ row.event_type }}</td>
-              <td>
-                {% if row.holder_name %}
-                  {% if row.holder_detail_id %}
-                    <a class="nav-link report-drill-link" href="{{ url_for('holder_detail', holder_id=row.holder_detail_id, return_to=report_return_to) }}">{{ row.holder_name }}</a>
-                  {% else %}
-                    {{ row.holder_name }}
-                  {% endif %}
-                  {% if row.holder_organization and row.holder_organization != row.holder_name %} ({{ row.holder_organization }}){% endif %}
-                {% endif %}
-              </td>
-            </tr>
-          {% else %}
-            <tr><td colspan="5">No active events found.</td></tr>
           {% endfor %}
         </tbody>
       </table>

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -918,6 +918,18 @@ def test_operator_report_is_actionable_with_safe_drill_in_links(client_with_temp
     assert b"Search receipts" in response.data
     assert b"Include retired assets" in response.data
     assert response.data.count(b"<details class=\"report-section\"") >= 5
+    assert response.data.count(b"Current Custody") == 1
+    assert response.data.count(b"Last 10 Events") == 1
+    section_order = [
+        b'<span class="report-section-title">Current Custody</span>',
+        b'<span class="report-section-title">Last 10 Events</span>',
+        b'<span class="report-section-title">Assets</span>',
+        b'<span class="report-section-title">Holders</span>',
+        b'<span class="report-section-title">Organizations and Building Access</span>',
+        b'<span class="report-section-title">Location and Case Data</span>',
+    ]
+    section_positions = [response.data.index(section_title) for section_title in section_order]
+    assert section_positions == sorted(section_positions)
     assert b'href="/assets/search?return_to=/report"' not in response.data
     assert b'href="/dashboard/cases?return_to=/report"' not in response.data
     assert b'href="/dashboard/holders?return_to=/report"' not in response.data


### PR DESCRIPTION
Issue 31-18: Reorder the Operator Report for current operations

## Summary

Reorders the existing `/report` sections so current operational information appears first.

## Related Issue

Closes #1112

## Changes

- Moved Current Custody to the top of `/report`.
- Moved Last 10 Events immediately after Current Custody.
- Preserved the existing order and layout of all remaining report sections.
- Added focused coverage for the report section order.
- Left `/dashboard` unchanged.

## Verification

- [x] Focused report tests: 2 passed
- [x] Full `tests/test_admin_system_health.py`: 57 passed
- [x] `git diff --check`
- [x] Rebuilt with `docker compose up -d --build`
- [x] Verified Current Custody appears first
- [x] Verified Last 10 Events appears second
- [x] Verified remaining report sections retain their prior order
- [x] Verified report links, counts, and layout
- [x] Verified `/dashboard` remains unchanged

## Notes

- No report queries, event ordering, custody behavior, routes, authentication, schema, persistence, or dependencies were changed.
- The full repository test suite is left to CI because this is a focused Class 1 presentation change.