### PR TITLE
Issue 31-20: normalize case and asset lookups

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -364,6 +364,27 @@ def sanitize_scan(raw: str) -> str:
     return "".join(ch for ch in raw if ch.isalnum()).upper()
 
 
+def _identifier_lookup_key(value: object) -> str:
+    return str(value or "").strip().upper().replace("-", "")
+
+
+def _single_identifier_match(
+    rows: list[sqlite3.Row],
+    *,
+    label: str,
+    input_value: str,
+    row_key: str,
+) -> Optional[sqlite3.Row]:
+    if not rows:
+        return None
+
+    distinct_values = {str(row[row_key] or "") for row in rows}
+    if len(distinct_values) > 1:
+        raise ValueError(f"Ambiguous {label} match for scan '{input_value}'")
+
+    return rows[0]
+
+
 def _demo_page_context() -> dict[str, object]:
     demo_token = str(request.args.get("token") or "").strip()
     demo_send_enabled = _demo_token_is_valid(demo_token)
@@ -852,19 +873,27 @@ def _find_asset_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
         SELECT *
         FROM assets
         WHERE UPPER(asset_tag) = UPPER(?)
-           OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
         LIMIT 2;
         """,
-        (t, t),
+        (t,),
     ).fetchall()
 
-    if not rows:
-        return None
+    row = _single_identifier_match(rows, label="asset_tag", input_value=t, row_key="asset_tag")
+    if row is not None:
+        return dict(row)
 
-    if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
-        raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM assets
+        WHERE REPLACE(UPPER(asset_tag), '-', '') = ?
+        LIMIT 2;
+        """,
+        (_identifier_lookup_key(t),),
+    ).fetchall()
 
-    return dict(rows[0])
+    row = _single_identifier_match(rows, label="asset_tag", input_value=t, row_key="asset_tag")
+    return None if row is None else dict(row)
 
 
 def _find_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
@@ -877,11 +906,20 @@ def _find_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
         SELECT id, case_name, slot_position, current_asset_tag
         FROM slots
         WHERE UPPER(case_name) = UPPER(?)
-           OR REPLACE(UPPER(case_name), '-', '') = UPPER(?)
         ORDER BY slot_position ASC, id ASC;
         """,
-        (t, t),
+        (t,),
     ).fetchall()
+    if not slot_rows:
+        slot_rows = conn.execute(
+            """
+            SELECT id, case_name, slot_position, current_asset_tag
+            FROM slots
+            WHERE REPLACE(UPPER(case_name), '-', '') = ?
+            ORDER BY slot_position ASC, id ASC;
+            """,
+            (_identifier_lookup_key(t),),
+        ).fetchall()
     if not slot_rows:
         return None
 
@@ -947,11 +985,20 @@ def _find_return_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]
         SELECT id, case_name, slot_position
         FROM slots
         WHERE UPPER(case_name) = UPPER(?)
-           OR REPLACE(UPPER(case_name), '-', '') = UPPER(?)
         ORDER BY slot_position ASC, id ASC;
         """,
-        (t, t),
+        (t,),
     ).fetchall()
+    if not slot_rows:
+        slot_rows = conn.execute(
+            """
+            SELECT id, case_name, slot_position
+            FROM slots
+            WHERE REPLACE(UPPER(case_name), '-', '') = ?
+            ORDER BY slot_position ASC, id ASC;
+            """,
+            (_identifier_lookup_key(t),),
+        ).fetchall()
     if not slot_rows:
         return None
 
@@ -1521,6 +1568,7 @@ def _lookup_asset_for_verification(
     serial_number: str,
 ) -> tuple[list[dict], Optional[str], str]:
     asset_tag_clean = str(asset_tag or "").strip().upper()
+    asset_tag_key = _identifier_lookup_key(asset_tag_clean)
     serial_clean = str(serial_number or "").strip()
     has_asset_tag = bool(asset_tag_clean)
     has_serial_number = bool(serial_clean)
@@ -1541,15 +1589,20 @@ def _lookup_asset_for_verification(
             FROM assets a
             LEFT JOIN holders h
               ON h.id = a.current_holder_id
-            WHERE UPPER(a.asset_tag) LIKE UPPER(?)
+            WHERE (
+                UPPER(a.asset_tag) LIKE UPPER(?)
+                OR REPLACE(UPPER(a.asset_tag), '-', '') = ?
+            )
               AND TRIM(COALESCE(a.serial_number, '')) <> ''
               AND UPPER(a.serial_number) LIKE UPPER(?)
             ORDER BY
                 CASE
                     WHEN UPPER(a.asset_tag) = UPPER(?) AND UPPER(a.serial_number) = UPPER(?) THEN 0
-                    WHEN UPPER(a.asset_tag) = UPPER(?) THEN 1
-                    WHEN UPPER(a.serial_number) = UPPER(?) THEN 2
-                    ELSE 3
+                    WHEN REPLACE(UPPER(a.asset_tag), '-', '') = ? AND UPPER(a.serial_number) = UPPER(?) THEN 1
+                    WHEN UPPER(a.asset_tag) = UPPER(?) THEN 2
+                    WHEN REPLACE(UPPER(a.asset_tag), '-', '') = ? THEN 3
+                    WHEN UPPER(a.serial_number) = UPPER(?) THEN 4
+                    ELSE 5
                 END,
                 UPPER(a.asset_tag) ASC,
                 UPPER(a.serial_number) ASC,
@@ -1558,10 +1611,14 @@ def _lookup_asset_for_verification(
             """,
             (
                 f"%{asset_tag_clean}%",
+                asset_tag_key,
                 f"%{serial_clean}%",
                 asset_tag_clean,
                 serial_clean,
+                asset_tag_key,
+                serial_clean,
                 asset_tag_clean,
+                asset_tag_key,
                 serial_clean,
             ),
         ).fetchall()
@@ -1582,13 +1639,18 @@ def _lookup_asset_for_verification(
             LEFT JOIN holders h
               ON h.id = a.current_holder_id
             WHERE UPPER(a.asset_tag) LIKE UPPER(?)
+               OR REPLACE(UPPER(a.asset_tag), '-', '') = ?
             ORDER BY
-                CASE WHEN UPPER(a.asset_tag) = UPPER(?) THEN 0 ELSE 1 END,
+                CASE
+                    WHEN UPPER(a.asset_tag) = UPPER(?) THEN 0
+                    WHEN REPLACE(UPPER(a.asset_tag), '-', '') = ? THEN 1
+                    ELSE 2
+                END,
                 UPPER(a.asset_tag) ASC,
                 a.id ASC
             LIMIT 25;
             """,
-            (like_pattern, asset_tag_clean),
+            (like_pattern, asset_tag_key, asset_tag_clean, asset_tag_key),
         ).fetchall()
         if not rows:
             return [], "Asset not found.", lookup_mode
@@ -1669,6 +1731,40 @@ def _lookup_asset_for_verification(
         )
 
     return (results, None, lookup_mode)
+
+
+def _lookup_cases_for_asset_search(conn: sqlite3.Connection, query: str) -> list[dict[str, object]]:
+    query_clean = str(query or "").strip()
+    query_key = _identifier_lookup_key(query_clean)
+    if not query_key:
+        return []
+
+    rows = conn.execute(
+        """
+        SELECT
+            case_name,
+            COUNT(*) AS slot_count
+        FROM slots
+        WHERE REPLACE(UPPER(case_name), '-', '') LIKE ?
+        GROUP BY case_name
+        ORDER BY
+            CASE
+                WHEN UPPER(case_name) = UPPER(?) THEN 0
+                WHEN REPLACE(UPPER(case_name), '-', '') = ? THEN 1
+                ELSE 2
+            END,
+            UPPER(case_name) ASC;
+        """,
+        (f"{query_key}%", query_clean, query_key),
+    ).fetchall()
+
+    return [
+        {
+            "case_name": str(row["case_name"] or ""),
+            "slot_count": int(row["slot_count"] or 0),
+        }
+        for row in rows
+    ]
 
 
 def _asset_search_status_cue(*, location_type: str, holder_label: str, movement_proof: dict[str, object]) -> dict[str, str]:
@@ -3819,28 +3915,7 @@ def _build_issue_preview_state(asset_tags: list[str], selected_holder: Optional[
         blocking_issues.append(error)
 
     def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
-        t = (scan_tag or "").strip()
-        if not t:
-            return None
-
-        rows = conn.execute(
-            """
-            SELECT id, asset_tag, location_type, current_holder_id, building_room, home_slot_id
-            FROM assets
-            WHERE UPPER(asset_tag) = UPPER(?)
-               OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
-            LIMIT 2;
-            """,
-            (t, t),
-        ).fetchall()
-
-        if not rows:
-            return None
-
-        if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
-            raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
-
-        return dict(rows[0])
+        return _find_asset_for_scan_tag(conn, scan_tag)
 
     conn = get_connection()
     try:
@@ -3958,28 +4033,7 @@ def _build_return_preview_state(asset_tags: list[str]) -> dict:
         return {"assets": assets, "ready_count": 0, "blocking_issues": blocking_issues}
 
     def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
-        t = (scan_tag or "").strip()
-        if not t:
-            return None
-
-        rows = conn.execute(
-            """
-            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id
-            FROM assets
-            WHERE UPPER(asset_tag) = UPPER(?)
-               OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
-            LIMIT 2;
-            """,
-            (t, t),
-        ).fetchall()
-
-        if not rows:
-            return None
-
-        if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
-            raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
-
-        return dict(rows[0])
+        return _find_asset_for_scan_tag(conn, scan_tag)
 
     conn = get_connection()
     try:
@@ -4507,36 +4561,7 @@ def _issue_batch(
         raise ValueError("No assets in the queue to issue.")
 
     def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
-        """
-        Accept either:
-          - exact tag match
-          - match where dashes are removed from DB value (common label format)
-        Returns the canonical DB row (including canonical asset_tag).
-        Hard-stops if multiple distinct matches.
-        """
-        t = (scan_tag or "").strip()
-        if not t:
-            return None
-
-        rows = conn.execute(
-            """
-            SELECT id, asset_tag, location_type, building_room, home_slot_id
-            FROM assets
-            WHERE UPPER(asset_tag) = UPPER(?)
-               OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
-            LIMIT 2;
-            """,
-            (t, t),
-        ).fetchall()
-
-        if not rows:
-            return None
-
-        # If we got 2 rows and the canonical tags differ, that's ambiguous.
-        if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
-            raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
-
-        return dict(rows[0])
+        return _find_asset_for_scan_tag(conn, scan_tag)
 
     conn = get_connection()
     try:
@@ -4715,28 +4740,7 @@ def _return_batch(
         raise ValueError("No assets in the queue to return")
 
     def _canon_asset_row_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
-        t = (scan_tag or "").strip()
-        if not t:
-            return None
-
-        rows = conn.execute(
-            """
-            SELECT id, asset_tag, location_type, current_holder_id, home_slot_id
-            FROM assets
-            WHERE UPPER(asset_tag) = UPPER(?)
-               OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
-            LIMIT 2;
-            """,
-            (t, t),
-        ).fetchall()
-
-        if not rows:
-            return None
-
-        if len(rows) > 1 and str(rows[0]["asset_tag"]) != str(rows[1]["asset_tag"]):
-            raise ValueError(f"Ambiguous asset_tag match for scan '{t}'")
-
-        return dict(rows[0])
+        return _find_asset_for_scan_tag(conn, scan_tag)
 
     conn = get_connection()
     try:
@@ -5470,6 +5474,7 @@ def asset_search():
         "serial_number": (request.args.get("serial_number") or "").strip(),
     }
     assets: list[dict] = []
+    case_matches: list[dict[str, object]] = []
     error_message: Optional[str] = None
     lookup_mode = "none"
 
@@ -5481,6 +5486,10 @@ def asset_search():
                 asset_tag=form_state["asset_tag"],
                 serial_number=form_state["serial_number"],
             )
+            if form_state["asset_tag"] and not form_state["serial_number"]:
+                case_matches = _lookup_cases_for_asset_search(conn, form_state["asset_tag"])
+                if case_matches:
+                    error_message = None
         finally:
             conn.close()
 
@@ -5497,6 +5506,7 @@ def asset_search():
         "asset_search.html",
         form=form_state,
         assets=assets,
+        case_matches=case_matches,
         error_message=error_message,
         lookup_mode=lookup_mode,
         return_to=return_to,

--- a/assettrack/intake/templates/asset_search.html
+++ b/assettrack/intake/templates/asset_search.html
@@ -267,17 +267,46 @@
         </tbody>
       </table>
     </div>
-  {% elif form.asset_tag or form.serial_number %}
-    <div class="card asset-search-no-results">
-      <h2>No asset found</h2>
-      <p class="muted">Check the asset tag or serial number and search again.</p>
-    </div>
-  {% else %}
+  {% endif %}
+
+  {% if case_matches %}
     <div class="card">
-      <h2>Ready to search</h2>
-      <p class="asset-search-empty">
-        Enter an asset tag or serial number to see custody status, holder, assigned location, and existing movement proof.
+      <h2>{% if case_matches|length == 1 %}Case Found{% else %}Cases Found{% endif %}</h2>
+      <p class="asset-results-count">
+        {% if case_matches|length == 1 %}1 case match shown.{% else %}{{ case_matches|length }} case matches shown.{% endif %}
       </p>
+      <table class="results-table">
+        <thead>
+          <tr>
+            <th>Case</th>
+            <th>Slots</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for case_match in case_matches %}
+            <tr>
+              <td><code>{{ case_match.case_name }}</code></td>
+              <td>{{ case_match.slot_count }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
     </div>
+  {% endif %}
+
+  {% if not assets and not case_matches %}
+    {% if form.asset_tag or form.serial_number %}
+      <div class="card asset-search-no-results">
+        <h2>No asset found</h2>
+        <p class="muted">Check the asset tag or serial number and search again.</p>
+      </div>
+    {% else %}
+      <div class="card">
+        <h2>Ready to search</h2>
+        <p class="asset-search-empty">
+          Enter an asset tag or serial number to see custody status, holder, assigned location, and existing movement proof.
+        </p>
+      </div>
+    {% endif %}
   {% endif %}
 {% endblock %}

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -181,6 +181,89 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b'href="/assets/history?asset_tag=AT-100', response.data)
         self.assertNotIn(b'href="/admin/assets/edit?asset_tag=AT-100"', response.data)
 
+    def test_search_finds_hyphenated_asset_when_query_omits_hyphen(self) -> None:
+        self._insert_asset("ABC-123", serial_number="SER-HYPHEN", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=ABC123")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset Found", response.data)
+        self.assertIn(b"ABC-123", response.data)
+        self.assertIn(b"SER-HYPHEN", response.data)
+
+    def test_search_finds_unhyphenated_asset_when_query_includes_hyphen_without_rewriting_tag(self) -> None:
+        self._insert_asset("ABC123", serial_number="SER-NOHYPHEN", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=ABC-123")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset Found", response.data)
+        self.assertIn(b"ABC123", response.data)
+        self.assertIn(b"SER-NOHYPHEN", response.data)
+        row = self.conn.execute(
+            "SELECT asset_tag FROM assets WHERE serial_number = 'SER-NOHYPHEN';"
+        ).fetchone()
+        self.assertEqual(row["asset_tag"], "ABC123")
+
+    def test_search_finds_case_when_query_format_differs(self) -> None:
+        self._insert_slot(20, "CASE-12", 1)
+
+        response = self.client.get("/assets/search?asset_tag=case12")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Case Found", response.data)
+        self.assertIn(b"1 case match shown.", response.data)
+        self.assertIn(b"<code>CASE-12</code>", response.data)
+        self.assertNotIn(b"No asset found", response.data)
+
+    def test_search_case_prefix_returns_matching_cases(self) -> None:
+        self._insert_slot(21, "CASE-12", 1)
+        self._insert_slot(22, "CASE-13", 1)
+        self._insert_slot(23, "KIT-1", 1)
+
+        response = self.client.get("/assets/search?asset_tag=CASE-")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Cases Found", response.data)
+        self.assertIn(b"2 case matches shown.", response.data)
+        self.assertIn(b"<code>CASE-12</code>", response.data)
+        self.assertIn(b"<code>CASE-13</code>", response.data)
+        self.assertNotIn(b"<code>KIT-1</code>", response.data)
+
+    def test_search_lowercase_case_prefix_returns_matching_cases(self) -> None:
+        self._insert_slot(24, "CASE-21", 1)
+        self._insert_slot(25, "CASE22", 1)
+
+        response = self.client.get("/assets/search?asset_tag=case")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Cases Found", response.data)
+        self.assertIn(b"<code>CASE-21</code>", response.data)
+        self.assertIn(b"<code>CASE22</code>", response.data)
+
+    def test_search_case_results_keep_stored_case_formatting(self) -> None:
+        self._insert_slot(26, "Case-Mixed-12", 1)
+
+        response = self.client.get("/assets/search?asset_tag=case-mixed-12")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"<code>Case-Mixed-12</code>", response.data)
+        self.assertNotIn(b"<code>CASE-MIXED-12</code>", response.data)
+        row = self.conn.execute("SELECT case_name FROM slots WHERE id = 26;").fetchone()
+        self.assertEqual(row["case_name"], "Case-Mixed-12")
+
+    def test_search_exact_case_match_is_listed_before_prefix_matches(self) -> None:
+        self._insert_slot(27, "CASE-12", 1)
+        self._insert_slot(28, "CASE-123", 1)
+
+        response = self.client.get("/assets/search?asset_tag=CASE12")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertLess(
+            response.data.index(b"<code>CASE-12</code>"),
+            response.data.index(b"<code>CASE-123</code>"),
+        )
+
     def test_admin_search_links_asset_tag_to_admin_edit_asset(self) -> None:
         admin_user_id = create_test_user(username="admin-search", password="admin-pass", role="admin")
         login_session(self.client, admin_user_id)

--- a/tests/test_issue_case_scan.py
+++ b/tests/test_issue_case_scan.py
@@ -270,6 +270,46 @@ def test_issue_case_scan_without_dash_also_expands_matching_case(client_with_tem
     assert b"Case CASE-2 added 2 assets to queue." in response.data
 
 
+def test_issue_case_scan_with_dash_matches_case_stored_without_dash(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-case-stored-no-dash")
+
+    conn = db.get_connection()
+    _insert_slot(conn, 52, "CASE12", 1)
+    _insert_asset(conn, 502, "CI-502", home_slot_id=52)
+    _occupy_slot(conn, 52, 502)
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "case-12", "return_to": "/issue#queue-section"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["CI502"]
+    assert b"Case CASE12 added 1 asset to queue." in response.data
+
+
+def test_issue_asset_scan_accepts_hyphen_variant_without_rewriting_stored_tag(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db, "operator-asset-tag-variant")
+
+    conn = db.get_connection()
+    _insert_asset(conn, 503, "ABC123")
+    conn.commit()
+    conn.close()
+
+    response = client_with_temp_db.post(
+        "/",
+        data={"scan_text": "ABC-123", "return_to": "/issue#queue-section"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert [scan.asset_tag for scan in intake_app.SCAN_QUEUE] == ["ABC123"]
+    assert b"ABC123" in response.data
+
+
 def test_invalid_case_scan_does_not_enqueue_pseudo_asset(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db, "operator-invalid-case")
 

--- a/tests/test_return_batch.py
+++ b/tests/test_return_batch.py
@@ -720,6 +720,20 @@ class ReturnBatchTests(unittest.TestCase):
         self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT200", "RT201"])
         self.assertIn(b"Case CASE-20 added 1 asset to queue. Skipped 1 already queued.", response.data)
 
+    def test_return_case_scan_with_dash_matches_case_stored_without_dash(self) -> None:
+        self._insert_slot(82, "CASE12", 1, None)
+        self._insert_asset("RT-202", location_type="IN_CUSTODY", holder_id=5, home_slot_id=82)
+
+        response = self.client.post(
+            "/",
+            data={"scan_text": "case-12", "return_to": "/return"},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([scan.asset_tag for scan in intake_app.SCAN_QUEUE], ["RT202"])
+        self.assertIn(b"Case CASE12 added 1 asset to queue.", response.data)
+
     def test_return_case_scan_allows_selective_removal_before_preview(self) -> None:
         self._insert_slot(90, "CASE-30", 1, None)
         self._insert_slot(91, "CASE-30", 2, None)


### PR DESCRIPTION
# Issue 31-20: Normalize case and asset-tag lookups across Issue, Return, and Search

## Summary

Normalize case and asset-tag comparisons so operators can find identifiers despite differences in capitalization or hyphen formatting.

Stored identifiers and audit history remain unchanged.

## Related Issue

Closes #1114

## Changes

* Added comparison-only normalization for case and asset-tag lookups.
* Kept exact matches ahead of normalized matches.
* Applied shared asset lookup behavior across Issue and Return preview and commit paths.
* Added normalized asset-tag matching to Asset Search.
* Added case results to Asset Search.
* Added normalized exact and prefix case searching.
* Preserved original stored case and asset-tag formatting in displayed results.
* Preserved existing ambiguity handling when multiple identifiers share the same normalized comparison value.
* Added regression coverage for Issue, Return, asset search, and case search behavior.

## Verification

* [x] Focused regression tests passed.
* [x] Asset Search module passed: 32 tests and 2 subtests.
* [x] Affected Issue, Return, and Search modules passed: 65 tests and 2 subtests.
* [x] Full suite passed: 685 tests and 2 subtests.
* [x] `git diff --check` passed.
* [x] Manual exact case search passed.
* [x] Manual lowercase and hyphenless case search passed.
* [x] Manual `CASE-`, `case-`, `CASE`, and `case` prefix searches passed.
* [x] Stored case formatting remained unchanged.
* [ ] One additional planned manual scenario could not be exercised with the available test state.

## Notes

Normalization is used for comparison only. No schema, persistence, event, audit-history, authentication, authorization, or dependency changes were made.
