### PR TITLE
Issue 31-12: natural-sort cases and slots

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from assettrack.audit import ACTIVE_EVENTS_WHERE
 from assettrack.event_types import issue_event_type_values, normalize_event_type
+from assettrack.natural_sort import natural_identifier_sort_key
 
 from datetime import datetime, timezone
-import re
 import sqlite3
 
 MAX_DASHBOARD_TOP_HOLDERS = 5
@@ -289,12 +289,6 @@ def _top_custody_holders(conn: sqlite3.Connection, limit: int) -> list[dict]:
     ]
 
 
-def _case_name_natural_sort_key(case_name: object) -> tuple[int, int, str]:
-    label = str(case_name or "").strip()
-    match = re.fullmatch(r"CASE-(\d+)", label.upper())
-    if match:
-        return (0, int(match.group(1)), label.upper())
-    return (1, 0, label.upper())
 
 
 def _case_space_status_flag(available_slots: int) -> tuple[str, str]:
@@ -337,7 +331,7 @@ def _dashboard_case_utilization(conn: sqlite3.Connection) -> list[dict]:
             }
         )
 
-    results.sort(key=lambda row: _case_name_natural_sort_key(row["case_name"]))
+    results.sort(key=lambda row: natural_identifier_sort_key(row["case_name"]))
     return results
 
 

--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -2,12 +2,12 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-import re
 import sqlite3
 
 from assettrack.assets import get_asset_table_columns
 from assettrack.audit import ACTIVE_EVENTS_WHERE
 from assettrack.event_types import issue_event_type_values
+from assettrack.natural_sort import natural_identifier_sort_key
 
 
 def _parse_utc_timestamp(value: object) -> datetime | None:
@@ -194,15 +194,7 @@ def list_case_summaries(conn: sqlite3.Connection) -> list[dict]:
             }
         )
 
-    def _sort_key(item: tuple[int, dict]) -> tuple[int, int, int]:
-        original_index, case = item
-        case_name = str(case["case_name"] or "").strip().upper()
-        match = re.fullmatch(r"CASE-(\d+)", case_name)
-        if match:
-            return (0, int(match.group(1)), original_index)
-        return (1, original_index, 0)
-
-    return [case for _, case in sorted(enumerate(results), key=_sort_key)]
+    return sorted(results, key=lambda row: natural_identifier_sort_key(row["case_name"]))
 
 
 def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | None:

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -78,6 +78,7 @@ from assettrack.holder_import import (
 )
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.import_reconciliation import build_asset_import_preview
+from assettrack.natural_sort import natural_identifier_sort_key
 from assettrack.reference_data import (
     create_building,
     create_organization,
@@ -1294,7 +1295,7 @@ def _list_slot_options(conn) -> list[dict]:
         ORDER BY UPPER(s.case_name) ASC, s.slot_position ASC, s.id ASC;
         """
     ).fetchall()
-    return [
+    slot_options = [
         {
             "id": int(row["id"]),
             "case_name": str(row["case_name"] or ""),
@@ -1304,11 +1305,21 @@ def _list_slot_options(conn) -> list[dict]:
         }
         for row in rows
     ]
+    return sorted(
+        slot_options,
+        key=lambda row: (
+            natural_identifier_sort_key(row["case_name"]),
+            natural_identifier_sort_key(row["slot_position"]),
+            int(row["id"]),
+        ),
+    )
 
 
 def _slot_case_options(slot_options: list[dict]) -> list[str]:
-    return sorted({str(row["case_name"]) for row in slot_options if str(row["case_name"]).strip()})
-
+    return sorted(
+        {str(row["case_name"]) for row in slot_options if str(row["case_name"]).strip()},
+        key=natural_identifier_sort_key,
+    )
 
 def _resolve_slot_selection(
     conn: sqlite3.Connection,
@@ -1743,28 +1754,32 @@ def _lookup_cases_for_asset_search(conn: sqlite3.Connection, query: str) -> list
         """
         SELECT
             case_name,
-            COUNT(*) AS slot_count
-        FROM slots
-        WHERE REPLACE(UPPER(case_name), '-', '') LIKE ?
-        GROUP BY case_name
-        ORDER BY
+            COUNT(*) AS slot_count,
             CASE
                 WHEN UPPER(case_name) = UPPER(?) THEN 0
                 WHEN REPLACE(UPPER(case_name), '-', '') = ? THEN 1
                 ELSE 2
-            END,
-            UPPER(case_name) ASC;
+            END AS match_rank
+        FROM slots
+        WHERE REPLACE(UPPER(case_name), '-', '') LIKE ?
+        GROUP BY case_name
+        ORDER BY match_rank ASC, UPPER(case_name) ASC;
         """,
-        (f"{query_key}%", query_clean, query_key),
+        (query_clean, query_key, f"{query_key}%"),
     ).fetchall()
 
-    return [
+    case_matches = [
         {
             "case_name": str(row["case_name"] or ""),
             "slot_count": int(row["slot_count"] or 0),
+            "match_rank": int(row["match_rank"] or 0),
         }
         for row in rows
     ]
+    return sorted(
+        case_matches,
+        key=lambda row: (int(row["match_rank"]), natural_identifier_sort_key(row["case_name"])),
+    )
 
 
 def _asset_search_status_cue(*, location_type: str, holder_label: str, movement_proof: dict[str, object]) -> dict[str, str]:

--- a/assettrack/natural_sort.py
+++ b/assettrack/natural_sort.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import re
+
+_NATURAL_PART_RE = re.compile(r"(\d+)")
+
+
+def natural_identifier_sort_key(value: object) -> tuple:
+    label = str(value or "").strip()
+    parts: list[tuple[int, object]] = []
+    has_numeric_part = False
+    for part in _NATURAL_PART_RE.split(label):
+        if not part:
+            continue
+        if part.isdigit():
+            has_numeric_part = True
+            parts.append((0, int(part)))
+        else:
+            parts.append((1, part.upper()))
+    numeric_group = 0 if has_numeric_part else 1
+    return (numeric_group, tuple(parts), label)

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -1664,3 +1664,60 @@ def test_slot_move_commit_rejects_terminal_assets_without_partial_change(
     assert response.status_code == 200
     assert b"Asset is retired/disposed and cannot be moved." in response.data
     assert after == before
+
+def test_assign_slot_dropdowns_render_cases_and_slots_in_natural_numeric_order(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.executemany(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, NULL);
+            """,
+            [
+                (610, "CASE-10", 10),
+                (602, "CASE-2", 2),
+                (609, "CASE-9", 9),
+                (601, "CASE-1", 1),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    created = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": "AT-NATURAL-SLOT",
+            "serial_number": "SER-NATURAL-SLOT",
+            "manufacturer": "Dell",
+            "equipment_type": "laptop",
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert created.status_code == 302
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-NATURAL-SLOT"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    rendered = response.data
+    case_positions = [
+        rendered.index(b'<option value="CASE-1"'),
+        rendered.index(b'<option value="CASE-2"'),
+        rendered.index(b'<option value="CASE-9"'),
+        rendered.index(b'<option value="CASE-10"'),
+    ]
+    slot_positions = [
+        rendered.index(b"CASE-1 / Slot 1"),
+        rendered.index(b"CASE-2 / Slot 2"),
+        rendered.index(b"CASE-9 / Slot 9"),
+        rendered.index(b"CASE-10 / Slot 10"),
+    ]
+    assert case_positions == sorted(case_positions)
+    assert slot_positions == sorted(slot_positions)

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -230,6 +230,29 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"<code>CASE-13</code>", response.data)
         self.assertNotIn(b"<code>KIT-1</code>", response.data)
 
+    def test_search_case_prefix_renders_case_results_in_natural_numeric_order(self) -> None:
+        for slot_id, case_name in [
+            (120, "CASE-1"),
+            (121, "CASE-10"),
+            (122, "CASE-2"),
+            (123, "CASE-20"),
+            (124, "CASE-9"),
+        ]:
+            self._insert_slot(slot_id, case_name, 1)
+
+        response = self.client.get("/assets/search?asset_tag=CASE-")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Cases Found", response.data)
+        positions = [
+            response.data.index(b"<code>CASE-1</code>"),
+            response.data.index(b"<code>CASE-2</code>"),
+            response.data.index(b"<code>CASE-9</code>"),
+            response.data.index(b"<code>CASE-10</code>"),
+            response.data.index(b"<code>CASE-20</code>"),
+        ]
+        self.assertEqual(positions, sorted(positions))
+
     def test_search_lowercase_case_prefix_returns_matching_cases(self) -> None:
         self._insert_slot(24, "CASE-21", 1)
         self._insert_slot(25, "CASE22", 1)

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -600,7 +600,7 @@ def test_holders_and_cases_deterministic_ordering(app_client) -> None:
     assert [row["holder_name"] for row in holders] == ["Alpha", "Bravo"]
 
     cases = list_case_summaries(conn)
-    assert [row["case_name"] for row in cases] == ["CASE-B", "CASE-A"]
+    assert [row["case_name"] for row in cases] == ["CASE-A", "CASE-B"]
 
 
 def test_case_summaries_sort_case_numbers_naturally(app_client) -> None:
@@ -687,3 +687,55 @@ def test_dashboard_holder_detail_shows_organization_and_outstanding_count(app_cl
     assert b"Outstanding Assets:</strong> 2" in response.data
     assert b"AT-100" in response.data
     assert b"AT-101" in response.data
+
+def _assert_rendered_order(rendered: bytes, *needles: bytes) -> None:
+    positions = [rendered.index(needle) for needle in needles]
+    assert positions == sorted(positions)
+
+
+def test_dashboard_case_list_renders_cases_in_natural_numeric_order(app_client) -> None:
+    conn, client = app_client
+    for slot_id, case_name in enumerate(["CASE-10", "CASE-2", "CASE-9", "CASE-1"], start=1000):
+        _insert_slot(conn, slot_id, case_name, 1)
+    conn.commit()
+
+    response = client.get("/dashboard/cases")
+
+    assert response.status_code == 200
+    _assert_rendered_order(
+        response.data,
+        b'href="/dashboard/cases/CASE-1"',
+        b'href="/dashboard/cases/CASE-2"',
+        b'href="/dashboard/cases/CASE-9"',
+        b'href="/dashboard/cases/CASE-10"',
+    )
+
+
+def test_case_inventory_dropdown_renders_cases_in_natural_numeric_order(app_client) -> None:
+    conn, client = app_client
+    for slot_id, case_name in enumerate(["CASE-10", "CASE-2", "CASE-9", "CASE-1"], start=1100):
+        _insert_slot(conn, slot_id, case_name, 1)
+    conn.commit()
+
+    response = client.get("/report/case-inventory")
+
+    assert response.status_code == 200
+    _assert_rendered_order(
+        response.data,
+        b'<option value="CASE-1"',
+        b'<option value="CASE-2"',
+        b'<option value="CASE-9"',
+        b'<option value="CASE-10"',
+    )
+
+
+def test_dashboard_case_detail_renders_slots_in_numeric_order(app_client) -> None:
+    conn, client = app_client
+    for slot_id, slot_position in [(1201, 10), (1202, 2), (1203, 9), (1204, 1)]:
+        _insert_slot(conn, slot_id, "CASE-SLOTS", slot_position)
+    conn.commit()
+
+    response = client.get("/dashboard/cases/CASE-SLOTS")
+
+    assert response.status_code == 200
+    _assert_rendered_order(response.data, b">1</td>", b">2</td>", b">9</td>", b">10</td>")


### PR DESCRIPTION
# Issue 31-12: Natural-sort cases and slots

## Summary

Display case and slot identifiers in natural numeric order across existing operator interfaces.

Stored identifiers remain unchanged.

## Related Issue

Closes #1106

## Changes

- Added a shared natural identifier sort helper.
- Applied natural sorting to case summaries and case lists.
- Applied natural sorting to dashboard case utilization.
- Applied natural sorting to case and slot dropdown options.
- Applied natural sorting to Assign Slots and related operator forms.
- Applied natural sorting to Asset Search case results.
- Preserved existing Asset Search match priority.
- Added regression coverage for numeric case and slot ordering.

## Verification

- [x] Natural-sort focused tests passed.
- [x] Asset Search tests passed: 33 tests.
- [x] Dashboard tests passed: 18 tests.
- [x] Dashboard drilldown tests passed: 27 tests.
- [x] Admin slot-provision tests passed: 48 tests.
- [x] Python compilation checks passed.
- [x] `git diff --check` passed.
- [x] Manual Cases list ordering passed.
- [x] Manual Asset Search case ordering passed.
- [x] Manual CASE-20 slot ordering passed.
- [x] Full suite could not complete on Windows because `resource` is unavailable in `test_asset_import_scale_check.py`.
- [x] Windows-compatible broad run completed with unrelated environment and timing failures.

## Notes

This is presentation and comparison behavior only. No schema, migration, persistence, event, audit-history, authentication, authorization, dependency, or stored-identifier changes were made.