### PR TITLE
Issue 31-10: improve case detail asset state

### DIFF
--- a/assettrack/drilldowns.py
+++ b/assettrack/drilldowns.py
@@ -197,6 +197,18 @@ def list_case_summaries(conn: sqlite3.Connection) -> list[dict]:
     return sorted(results, key=lambda row: natural_identifier_sort_key(row["case_name"]))
 
 
+def _holder_label(name: object, organization: object, holder_id: object) -> str:
+    holder_name = str(name or "").strip()
+    holder_organization = str(organization or "").strip()
+    if holder_name and holder_organization:
+        return f"{holder_name} ({holder_organization})"
+    if holder_name:
+        return holder_name
+    if holder_id is not None:
+        return f"ID {holder_id}"
+    return ""
+
+
 def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | None:
     exists_row = conn.execute(
         """
@@ -216,7 +228,10 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
             s.id AS slot_id,
             s.slot_position,
             a.asset_tag,
-            a.location_type AS asset_location_type
+            a.location_type AS asset_location_type,
+            a.current_holder_id,
+            h.name AS holder_name,
+            h.organization AS holder_organization
         FROM slots s
         LEFT JOIN (
             SELECT so.slot_id, so.asset_id
@@ -231,6 +246,8 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
           ON chosen.slot_id = s.id
         LEFT JOIN assets a
           ON a.id = chosen.asset_id
+        LEFT JOIN holders h
+          ON h.id = a.current_holder_id
         WHERE s.case_name = ?
         ORDER BY s.slot_position ASC, s.id ASC;
         """,
@@ -242,10 +259,16 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
         SELECT
             a.asset_tag,
             a.location_type,
+            a.current_holder_id,
+            h.name AS holder_name,
+            h.organization AS holder_organization,
+            s.case_name,
             s.slot_position
         FROM assets a
         JOIN slots s
           ON s.id = a.home_slot_id
+        LEFT JOIN holders h
+          ON h.id = a.current_holder_id
         WHERE s.case_name = ?
           AND UPPER(COALESCE(a.location_type, '')) = 'IN_CUSTODY'
         ORDER BY s.slot_position ASC, UPPER(a.asset_tag) ASC, a.id ASC;
@@ -261,6 +284,7 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
                 "slot_position": int(row["slot_position"]),
                 "asset_tag": row["asset_tag"],
                 "asset_location_type": "" if row["asset_location_type"] is None else str(row["asset_location_type"]),
+                "holder_label": _holder_label(row["holder_name"], row["holder_organization"], row["current_holder_id"]),
             }
             for row in slot_rows
         ],
@@ -268,6 +292,8 @@ def get_case_slot_detail(conn: sqlite3.Connection, case_name: str) -> dict | Non
             {
                 "asset_tag": str(row["asset_tag"] or ""),
                 "location_type": str(row["location_type"] or ""),
+                "holder_label": _holder_label(row["holder_name"], row["holder_organization"], row["current_holder_id"]),
+                "case_name": str(row["case_name"] or case_name),
                 "slot_position": int(row["slot_position"]),
             }
             for row in return_candidate_rows

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -108,6 +108,7 @@
             <th class="select-cell">Issue</th>
             <th>Slot Position</th>
             <th>Asset Tag</th>
+            <th>Current Status</th>
           </tr>
         </thead>
         <tbody>
@@ -122,11 +123,27 @@
                 {% endif %}
               </td>
               <td>{{ row.slot_position }}</td>
-              <td class="mono">{{ row.asset_tag if row.asset_tag else "Empty" }}</td>
+              <td class="mono">
+                {% if row.asset_tag %}
+                  <a class="nav-link drill-link" href="{{ url_for('asset_history', asset_tag=row.asset_tag, return_to=request.full_path.rstrip('?')) }}">{{ row.asset_tag }}</a>
+                {% else %}
+                  Empty
+                {% endif %}
+              </td>
+              <td>
+                {% if row.asset_tag and row.asset_location_type|upper == "IN_CUSTODY" and row.holder_label %}
+                  Issued to {{ row.holder_label }}<br />
+                  <span class="muted">Home slot: {{ case_detail.case_name }}, Slot {{ row.slot_position }}</span>
+                {% elif row.asset_tag %}
+                  Stored in {{ case_detail.case_name }}, Slot {{ row.slot_position }}
+                {% else %}
+                  Empty Slot
+                {% endif %}
+              </td>
             </tr>
           {% else %}
             <tr>
-              <td colspan="3">None</td>
+              <td colspan="4">None</td>
             </tr>
           {% endfor %}
         </tbody>
@@ -156,6 +173,7 @@
             <th class="select-cell">Return</th>
             <th>Home Slot</th>
             <th>Asset Tag</th>
+            <th>Current Status</th>
           </tr>
         </thead>
         <tbody>
@@ -164,12 +182,13 @@
               <td class="select-cell">
                 <input type="checkbox" name="asset_tag" value="{{ row.asset_tag }}" aria-label="Select {{ row.asset_tag }} for return" data-eligible-asset="return" />
               </td>
-              <td>{{ row.slot_position }}</td>
-              <td class="mono">{{ row.asset_tag }}</td>
+              <td>Home slot: {{ row.case_name }}, Slot {{ row.slot_position }}</td>
+              <td class="mono"><a class="nav-link drill-link" href="{{ url_for('asset_history', asset_tag=row.asset_tag, return_to=request.full_path.rstrip('?')) }}">{{ row.asset_tag }}</a></td>
+              <td>Issued to {{ row.holder_label }}</td>
             </tr>
           {% else %}
             <tr>
-              <td colspan="3">No assets currently out from this case.</td>
+              <td colspan="4">No assets currently out from this case.</td>
             </tr>
           {% endfor %}
         </tbody>

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -265,6 +265,62 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
     assert b"Empty" in response.data
 
 
+def test_dashboard_case_detail_asset_tags_link_to_asset_history(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 20, "CASE-LINK", 1)
+    asset_id = _insert_asset(conn, "AT-LINK-1", location_type="STORAGE")
+    _occupy_slot(conn, 20, asset_id)
+    conn.commit()
+
+    response = client.get("/dashboard/cases/CASE-LINK")
+
+    assert response.status_code == 200
+    assert b'href="/assets/history?asset_tag=AT-LINK-1' in response.data
+    assert b">AT-LINK-1</a>" in response.data
+
+
+def test_dashboard_case_detail_shows_stored_asset_wording(app_client) -> None:
+    conn, client = app_client
+    _insert_slot(conn, 21, "CASE-12", 4)
+    asset_id = _insert_asset(conn, "AT-STORED-1", location_type="STORAGE")
+    _occupy_slot(conn, 21, asset_id)
+    conn.commit()
+
+    response = client.get("/dashboard/cases/CASE-12")
+
+    assert response.status_code == 200
+    assert b"Stored in CASE-12, Slot 4" in response.data
+
+
+def test_dashboard_case_detail_shows_issued_asset_holder(app_client) -> None:
+    conn, client = app_client
+    _insert_holder(conn, 22, "Jamie Holder", organization="Field Ops")
+    _insert_slot(conn, 22, "CASE-ISSUED", 4)
+    _insert_asset(conn, "AT-ISSUED-1", location_type="IN_CUSTODY", holder_id=22, home_slot_id=22)
+    conn.commit()
+
+    response = client.get("/dashboard/cases/CASE-ISSUED")
+
+    assert response.status_code == 200
+    assert b"Issued to Jamie Holder (Field Ops)" in response.data
+
+
+def test_dashboard_case_detail_issued_asset_with_home_slot_is_not_stored(app_client) -> None:
+    conn, client = app_client
+    _insert_holder(conn, 23, "Case Holder", organization="Ops")
+    _insert_slot(conn, 23, "CASE-12", 4)
+    _insert_asset(conn, "AT-OUT-HOME", location_type="IN_CUSTODY", holder_id=23, home_slot_id=23)
+    conn.commit()
+
+    response = client.get("/dashboard/cases/CASE-12")
+
+    assert response.status_code == 200
+    assert b"AT-OUT-HOME" in response.data
+    assert b"Issued to Case Holder (Ops)" in response.data
+    assert b"Home slot: CASE-12, Slot 4" in response.data
+    assert b"Stored in CASE-12, Slot 4" not in response.data
+
+
 def test_case_inventory_preview_supports_mixed_case_and_is_read_only(app_client) -> None:
     conn, client = app_client
     _insert_slot(conn, 101, "CASE-PRINT", 1)


### PR DESCRIPTION
# Issue 31-10: Improve Case Detail asset navigation and state display

## Summary

Make Case Detail asset rows directly navigable and clearly distinguish current custody from home storage.

## Related Issue

Closes #1104

## Changes

- Linked asset tags to the existing protected Asset History route.
- Displayed stored assets as `Stored in CASE-X, Slot N`.
- Displayed issued assets as `Issued to <holder>`.
- Labeled an issued asset’s assigned storage as its home slot.
- Added holder-label data to the existing read-only Case Detail query.
- Added rendered-route regression tests for asset links and state wording.

## Verification

- [x] Focused Case Detail tests passed: 4 tests.
- [x] Dashboard drilldown tests passed: 31 tests.
- [x] Admin slot-provision and dashboard tests passed: 66 tests.
- [x] `git diff --check` passed.
- [x] Manual stored-asset display and link verification passed.
- [x] Manual issued-asset display and home-slot wording verification passed.
- [ ] Full suite could not complete normally on Windows because the Unix-only `resource` module is unavailable.
- [ ] Windows-compatible broad run completed with unrelated shell-script and temporary XLSX permission failures.

## Notes

This change uses existing protected routes and read-only drilldown data. No schema, migration, custody, occupancy, event, persistence, authentication, authorization, dependency, or workflow behavior changed.