### PR TITLE
Issue 31-5: Improve Assign Slots asset identification and list scaling

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2094,6 +2094,7 @@ def _build_admin_assign_asset_view(conn, scan_tag: str) -> tuple[Optional[dict],
         "manufacturer": str(asset.get("manufacturer") or ""),
         "model": str(asset.get("model") or ""),
         "serial": str(asset.get("serial_number") or ""),
+        "equipment_type": str(asset.get("equipment_type") or ""),
         "location_type": str(asset.get("location_type") or ""),
         "current_holder": holder_label,
         "current_slot": current_slot,
@@ -2106,6 +2107,7 @@ def _list_unslotted_storage_assets(conn: sqlite3.Connection) -> list[dict]:
     asset_columns = get_asset_table_columns(conn)
     select_fields = [
         "a.asset_tag AS asset_tag",
+        "a.serial_number AS serial_number",
         "a.equipment_type AS equipment_type",
         "a.created_date AS created_date",
     ]
@@ -2129,6 +2131,7 @@ def _list_unslotted_storage_assets(conn: sqlite3.Connection) -> list[dict]:
     return [
         {
             "asset_tag": str(row["asset_tag"] or ""),
+            "serial_number": str(row["serial_number"] or ""),
             "equipment_type": str(row["equipment_type"] or ""),
             "created_date": str(row["created_date"] or ""),
             "updated_date": str(row["updated_date"] or ""),

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -23,6 +23,15 @@
       font-size: 0.85rem;
       margin-top: 0.15rem;
     }
+    .assign-slot-list-details {
+      margin: 0;
+    }
+    .assign-slot-list-details summary {
+      cursor: pointer;
+      color: var(--color-text-muted);
+      font-weight: 600;
+      margin-bottom: 0.75rem;
+    }
     .compact-details {
       margin-top: 0.75rem;
     }
@@ -38,6 +47,49 @@
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
       gap: 0.4rem 0.9rem;
+    }
+    @media (max-width: 640px) {
+      .assign-slot-table,
+      .assign-slot-table thead,
+      .assign-slot-table tbody,
+      .assign-slot-table tr,
+      .assign-slot-table th,
+      .assign-slot-table td {
+        display: block;
+        width: 100%;
+      }
+      .assign-slot-table thead {
+        display: none;
+      }
+      .assign-slot-table tr {
+        border-top: 1px solid var(--color-border);
+        padding: 0.65rem 0;
+      }
+      .assign-slot-table tr:first-child {
+        border-top: 0;
+      }
+      .assign-slot-table td {
+        padding: 0.2rem 0;
+      }
+      .assign-slot-table td::before {
+        color: var(--color-text-muted);
+        content: attr(data-label);
+        display: block;
+        font-size: 0.78rem;
+        font-weight: 600;
+        margin-bottom: 0.1rem;
+      }
+      .assign-slot-table td:last-child,
+      .assign-slot-table th:last-child {
+        text-align: left;
+        white-space: normal;
+      }
+      .assign-slot-table td:last-child form {
+        margin-top: 0.25rem;
+      }
+      .assign-slot-table td:last-child button {
+        width: 100%;
+      }
     }
   </style>
 {% endblock %}
@@ -58,37 +110,49 @@
   <div class="card">
     <h2>Unslotted Assets</h2>
     {% if unslotted_assets %}
-      <table class="assign-slot-table">
-        <thead>
-          <tr>
-            <th>Asset tag</th>
-            <th>Equipment type</th>
-            <th>Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for row in unslotted_assets %}
+      {% set long_asset_list = unslotted_assets|length > 12 %}
+      <details class="assign-slot-list-details" {% if not long_asset_list %}open{% endif %}>
+        <summary>
+          {% if long_asset_list %}
+            Show {{ unslotted_assets|length }} unslotted assets
+          {% else %}
+            {{ unslotted_assets|length }} unslotted asset{% if unslotted_assets|length != 1 %}s{% endif %}
+          {% endif %}
+        </summary>
+        <table class="assign-slot-table">
+          <thead>
             <tr>
-              <td class="asset-tag-cell">
-                <code>{{ row.asset_tag }}</code>
-                {% if row.updated_date or row.created_date %}
-                  <div class="asset-meta">
-                    {% if row.updated_date %}Updated {{ row.updated_date }}{% elif row.created_date %}Created {{ row.created_date }}{% endif %}
-                  </div>
-                {% endif %}
-              </td>
-              <td>{{ row.equipment_type or "Unknown" }}</td>
-              <td>
-                <form method="post" action="{{ url_for('admin_assign_slot') }}">
-                  <input type="hidden" name="action" value="lookup" />
-                  <input type="hidden" name="asset_tag" value="{{ row.asset_tag }}" />
-                  <button type="submit">Assign</button>
-                </form>
-              </td>
+              <th>Asset tag</th>
+              <th>Serial number</th>
+              <th>Equipment type</th>
+              <th>Action</th>
             </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {% for row in unslotted_assets %}
+              <tr>
+                <td class="asset-tag-cell" data-label="Asset tag">
+                  <code>{{ row.asset_tag }}</code>
+                  {% if row.updated_date or row.created_date %}
+                    <div class="asset-meta">
+                      {% if row.updated_date %}Updated {{ row.updated_date }}{% elif row.created_date %}Created {{ row.created_date }}{% endif %}
+                    </div>
+                  {% endif %}
+                </td>
+                <td data-label="Serial number">{{ row.serial_number or "Not recorded" }}</td>
+                <td data-label="Equipment type">{{ row.equipment_type or "Unknown" }}</td>
+                <td data-label="Action">
+                  <form method="post" action="{{ url_for('admin_assign_slot') }}">
+                    <input type="hidden" name="action" value="lookup" />
+                    <input type="hidden" name="asset_tag" value="{{ row.asset_tag }}" />
+                    <button type="submit">Assign</button>
+                  </form>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </details>
     {% else %}
       <p class="muted">No unslotted assets found.</p>
     {% endif %}
@@ -119,7 +183,8 @@
       <h2>Selected Asset</h2>
       <div class="asset-summary-row">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
-        <div><strong>equipment type:</strong> {{ asset.model or asset.manufacturer or "Unknown" }}</div>
+        <div><strong>serial_number:</strong> {{ asset.serial or "Not recorded" }}</div>
+        <div><strong>equipment type:</strong> {{ asset.equipment_type or "Unknown" }}</div>
         <div><strong>location_type:</strong> <code>{{ asset.location_type or "" }}</code></div>
       </div>
     </div>

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -40,6 +40,27 @@ def _create_building(name: str) -> None:
         conn.close()
 
 
+def _create_unslotted_asset(
+    client_with_temp_db,
+    *,
+    asset_tag: str,
+    serial_number: str,
+    equipment_type: str = "laptop",
+) -> None:
+    response = client_with_temp_db.post(
+        "/admin/assets/new",
+        data={
+            "asset_tag": asset_tag,
+            "serial_number": serial_number,
+            "manufacturer": "Dell",
+            "equipment_type": equipment_type,
+            "building": "HQ",
+            "room": "100",
+        },
+    )
+    assert response.status_code == 302
+
+
 def _insert_slot_move_fixture(
     *,
     asset_tag: str = "MOVE-100",
@@ -814,8 +835,47 @@ def test_assign_slot_page_lists_unslotted_storage_assets(client_with_temp_db) ->
     assert response.status_code == 200
     assert b"Unslotted Assets" in response.data
     assert b"AT-LIST-1" in response.data
+    assert b"SER-LIST-1" in response.data
+    assert b"laptop" in response.data
+    assert b'data-label="Asset tag"' in response.data
+    assert b'data-label="Serial number"' in response.data
+    assert b'data-label="Equipment type"' in response.data
+    assert b'data-label="Action"' in response.data
+    assert b"@media (max-width: 640px)" in response.data
+    assert b"width: 100%" in response.data
     assert b"Assign" in response.data
 
+
+def test_assign_slot_long_asset_list_collapses_and_keeps_selected_asset_visible(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    for index in range(13):
+        _create_unslotted_asset(
+            client_with_temp_db,
+            asset_tag=f"AT-LONG-{index:03d}",
+            serial_number=f"SER-LONG-{index:03d}",
+            equipment_type="router" if index == 5 else "laptop",
+        )
+
+    list_response = client_with_temp_db.get("/admin/assign-slot")
+    assert list_response.status_code == 200
+    assert b'class="assign-slot-list-details"' in list_response.data
+    assert b"Show 13 unslotted assets" in list_response.data
+    assert b"SER-LONG-005" in list_response.data
+    assert b"router" in list_response.data
+
+    selected_response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-LONG-005"},
+        follow_redirects=True,
+    )
+    assert selected_response.status_code == 200
+    assert b"Selected Asset" in selected_response.data
+    assert b"AT-LONG-005" in selected_response.data
+    assert b"SER-LONG-005" in selected_response.data
+    assert b"router" in selected_response.data
+    assert b'input type="hidden" name="asset_tag" value="AT-LONG-005"' in selected_response.data
+    assert b"Show 13 unslotted assets" in selected_response.data
 
 def test_assign_slot_page_hides_slotted_assets_from_unslotted_list(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
@@ -874,6 +934,8 @@ def test_assign_slot_page_can_select_unslotted_asset_from_list(client_with_temp_
     assert response.status_code == 200
     assert b"Asset AT-SELECT-1 is eligible for slot assignment." in response.data
     assert b'input type="hidden" name="asset_tag" value="AT-SELECT-1"' in response.data
+    assert b"SER-SELECT-1" in response.data
+    assert b"laptop" in response.data
     assert b'name="case_name"' in response.data
     assert b'name="slot_id"' in response.data
 


### PR DESCRIPTION
## Summary

Improve asset identification and list usability in the Assign Slots workflow.

Closes #1099

## Changes

- Display the asset tag, serial number, and equipment type for each unslotted asset.
- Collapse asset lists longer than 12 items using the existing page layout.
- Keep selected asset details visible during assignment.
- Preserve selection state when the asset list is collapsed.
- Stack asset details vertically at narrow browser widths.
- Make the Assign button full-width and usable on narrow screens.
- Add focused regression coverage for the updated presentation.

## Verification

- [x] Focused Assign Slots tests passed: 5 passed
- [x] Full `tests/test_admin_slot_provision.py` passed: 49 passed
- [x] Related admin asset UI tests passed: 52 passed
- [x] `git diff --check` passed
- [x] Docker image rebuilt successfully
- [x] Application container verified running
- [x] Incognito desktop operator check completed
- [x] Asset tag, serial number, and equipment type verified
- [x] Selected asset details verified
- [x] Narrow-width operator check completed
- [x] Assign buttons verified fully visible and usable
- [x] No assignment, storage, event, audit, schema, authentication, or persistence behavior changed

## Notes

The broad Windows test run remains limited by existing Unix-only test dependencies, direct shell-script execution, and temporary XLSX permission failures. These were not introduced by this issue.