### PR TITLE
Issue 31-7: Simplify location handling in Assign Slots

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2158,25 +2158,25 @@ def _validate_assign_slot_location_form(form: dict[str, str]) -> tuple[dict[str,
     errors: list[str] = []
 
     building = normalized_form["building"]
-    room = normalized_form["room"]
     building_options = list(context["building_options"])
     building_name_map = {name.upper(): name for name in building_options}
 
-    if not building:
-        errors.append("Choose a building.")
-    elif building_name_map:
-        matched_name = building_name_map.get(building.upper())
-        if matched_name is None:
-            errors.append("Choose a valid building.")
+    if building:
+        if building_name_map:
+            matched_name = building_name_map.get(building.upper())
+            if matched_name is None:
+                errors.append("Choose a valid building.")
+            else:
+                normalized_form["building"] = matched_name
         else:
-            normalized_form["building"] = matched_name
-    else:
-        errors.append("No buildings are configured. Add a building in Admin Reference Data first.")
-
-    if not room:
-        errors.append("Enter room or area.")
+            errors.append("No buildings are configured. Add a building in Admin Reference Data first.")
 
     return normalized_form, errors, context
+
+
+def _assign_slot_building_room_label(building: object, room: object) -> str:
+    parts = [str(value or "").strip() for value in (building, room)]
+    return "/".join(part for part in parts if part)
 
 
 def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
@@ -10686,16 +10686,12 @@ def admin_assign_slot():
             elif action == "assign":
                 if not asset_tag:
                     flash("asset_tag is required.", "error")
-                if not building:
-                    flash("building is required.", "error")
-                if not room:
-                    flash("room/area is required.", "error")
                 if not case_name:
                     flash("case is required.", "error")
                 if not slot_id:
                     flash("slot is required.", "error")
 
-                if not asset_tag or not building or not room or not case_name or not slot_id:
+                if not asset_tag or not case_name or not slot_id:
                     return render_template(
                         "admin_assign_slot.html",
                         asset_tag=asset_tag,
@@ -10873,7 +10869,7 @@ def admin_assign_slot():
                     update_values.append(slot["id"])
                     if "building_room" in asset_columns:
                         update_clauses.append("building_room = ?")
-                        update_values.append(f"{building}/{room}")
+                        update_values.append(_assign_slot_building_room_label(building, room))
                     if "case_number" in asset_columns:
                         update_clauses.append("case_number = ?")
                         update_values.append(str(slot["case_name"]))
@@ -10892,7 +10888,7 @@ def admin_assign_slot():
 
                     payload = {
                         "slot_id": int(slot["id"]),
-                        "building_room": f"{building}/{room}",
+                        "building_room": _assign_slot_building_room_label(building, room),
                         "case_number": str(slot["case_name"]),
                         "slot_number": int(slot["slot_position"]),
                     }

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -196,9 +196,12 @@
         <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
 
         <div class="row">
-          <label for="building"><strong>building</strong> (required)</label><br />
-          <select id="building" name="building" required>
-            <option value="">Select building</option>
+          <label for="building"><strong>building</strong> (optional)</label><br />
+          <select id="building" name="building">
+            <option value="">No building entered</option>
+            {% if building and building not in building_options %}
+              <option value="{{ building }}" selected>{{ building }}</option>
+            {% endif %}
             {% for option in building_options %}
               <option value="{{ option }}" {% if building == option %}selected{% endif %}>{{ option }}</option>
             {% endfor %}
@@ -206,15 +209,14 @@
         </div>
 
         <div class="row">
-          <label for="room"><strong>room/area</strong> (required)</label><br />
+          <label for="room"><strong>room/area</strong> (optional)</label><br />
           <input
             type="text"
             id="room"
             name="room"
             value="{{ room or '' }}"
-            placeholder="e.g. 101"
+            placeholder="Optional room or area"
             autocomplete="off"
-            required
           />
         </div>
 

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -1004,6 +1004,159 @@ def test_assign_slot_selectors_hide_occupied_slot_options(client_with_temp_db) -
     assert b"disabled" in lookup.data
 
 
+def test_assign_slot_allows_blank_building_and_room_without_default_location(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (720, 'CASE-BLANK-LOC', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _create_unslotted_asset(
+        client_with_temp_db,
+        asset_tag="AT-BLANK-LOC",
+        serial_number="SER-BLANK-LOC",
+    )
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "assign",
+            "asset_tag": "AT-BLANK-LOC",
+            "building": "",
+            "room": "",
+            "case_name": "CASE-BLANK-LOC",
+            "slot_id": "720",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Assigned asset AT-BLANK-LOC to CASE-BLANK-LOC slot 1." in response.data
+    assert b"building is required." not in response.data
+    assert b"room/area is required." not in response.data
+    assert b"Suffolk" not in response.data
+    assert b"Base" not in response.data
+    assert b"Unknown" not in response.data
+
+    verify_conn = db.get_connection()
+    try:
+        asset_row = verify_conn.execute(
+            "SELECT building_room, home_slot_id FROM assets WHERE asset_tag = 'AT-BLANK-LOC' LIMIT 1;"
+        ).fetchone()
+        event_row = verify_conn.execute(
+            "SELECT payload FROM asset_events WHERE asset_tag = 'AT-BLANK-LOC' AND event_type = 'SLOT_ASSIGN' LIMIT 1;"
+        ).fetchone()
+    finally:
+        verify_conn.close()
+
+    assert asset_row is not None
+    assert str(asset_row["building_room"] or "") == ""
+    assert int(asset_row["home_slot_id"]) == 720
+    assert event_row is not None
+    assert json.loads(str(event_row["payload"]))["building_room"] == ""
+
+
+def test_assign_slot_stores_explicit_building_and_room(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (721, 'CASE-EXPLICIT-LOC', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _create_unslotted_asset(
+        client_with_temp_db,
+        asset_tag="AT-EXPLICIT-LOC",
+        serial_number="SER-EXPLICIT-LOC",
+    )
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "assign",
+            "asset_tag": "AT-EXPLICIT-LOC",
+            "building": "HQ",
+            "room": "105",
+            "case_name": "CASE-EXPLICIT-LOC",
+            "slot_id": "721",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Assigned asset AT-EXPLICIT-LOC to CASE-EXPLICIT-LOC slot 1." in response.data
+
+    verify_conn = db.get_connection()
+    try:
+        asset_row = verify_conn.execute(
+            "SELECT building_room FROM assets WHERE asset_tag = 'AT-EXPLICIT-LOC' LIMIT 1;"
+        ).fetchone()
+        event_row = verify_conn.execute(
+            "SELECT payload FROM asset_events WHERE asset_tag = 'AT-EXPLICIT-LOC' AND event_type = 'SLOT_ASSIGN' LIMIT 1;"
+        ).fetchone()
+    finally:
+        verify_conn.close()
+
+    assert asset_row is not None
+    assert str(asset_row["building_room"] or "") == "HQ/105"
+    assert event_row is not None
+    assert json.loads(str(event_row["payload"]))["building_room"] == "HQ/105"
+
+
+def test_assign_slot_validation_error_preserves_submitted_location_values(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (722, 'CASE-RETAIN-LOC', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _create_unslotted_asset(
+        client_with_temp_db,
+        asset_tag="AT-RETAIN-LOC",
+        serial_number="SER-RETAIN-LOC",
+    )
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "assign",
+            "asset_tag": "AT-RETAIN-LOC",
+            "building": "Closed HQ",
+            "room": "105A",
+            "case_name": "CASE-RETAIN-LOC",
+            "slot_id": "722",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Choose a valid building." in response.data
+    assert b'<option value="Closed HQ" selected>Closed HQ</option>' in response.data
+    assert b'value="105A"' in response.data
+    assert b'value="CASE-RETAIN-LOC" selected' in response.data
+    assert b'value="722"' in response.data
+
+
 def test_assign_slot_page_shows_known_buildings_as_choices(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
     _create_building("HQ North")

--- a/tests/test_issue_location_wiring.py
+++ b/tests/test_issue_location_wiring.py
@@ -320,6 +320,20 @@ def test_issue_does_not_reuse_last_current_location_when_building_becomes_inacti
         assert sess["last_issue_room"] == "210"
 
 
+def test_issue_location_post_still_requires_building_and_room(client_with_temp_db) -> None:
+    _login_issue_operator(client_with_temp_db)
+
+    response = client_with_temp_db.post(
+        "/issue/location",
+        data={"building": "", "room": ""},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Choose the current building." in response.data
+    assert b"Enter the current room or area." in response.data
+
+
 def test_issue_location_post_rejects_inactive_building(client_with_temp_db) -> None:
     _login_issue_operator(client_with_temp_db)
     conn = db.get_connection()


### PR DESCRIPTION
Title: Issue 31-7: Simplify location handling in Assign Slots

## Summary

Allow Assign Slots to operate without requiring or silently defaulting Building and Room.

Closes #1101

## Changes

- Make Building optional in Assign Slots.
- Make Room optional in Assign Slots.
- Remove automatic location defaults.
- Store only location values explicitly entered by the operator.
- Leave the stored location blank when neither field is entered.
- Preserve submitted Building and Room values after validation errors.
- Continue validating explicitly selected Building values.
- Keep Issue workflow location requirements unchanged.
- Add focused regression coverage for Assign Slots and Issue workflow separation.

## Verification

- [x] Focused blank and explicit Assign Slots location tests passed: 5 passed
- [x] Focused Issue workflow location tests passed: 3 passed
- [x] Combined affected test files passed: 66 passed
- [x] `git diff --check` passed
- [x] Docker image rebuilt successfully
- [x] Application container verified running
- [x] Incognito administrator smoke test completed
- [x] Building and Room verified optional and blank by default
- [x] Case and slot assignment succeeded with both location fields blank
- [x] Assigned asset showed the correct case and slot
- [x] No Suffolk, Base, Unknown, slash, or other placeholder location was recorded
- [x] Storage assignment event appeared normally
- [x] Issue workflow location requirements remained covered by regression tests

## Notes

This change is limited to Assign Slots location validation and presentation. It does not change schemas, existing location data, custody behavior, event history, authentication, routes, or persistence semantics.