### PR TITLE
Issue 31-24: Import and reconcile BQ26 inventory

### DIFF
--- a/assettrack/barcodes.py
+++ b/assettrack/barcodes.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def barcode_lookup_key(value: object) -> str:
+    text = str(value or "").strip().upper()
+    return "".join(character for character in text if character not in {" ", "-"})

--- a/assettrack/import_analysis.py
+++ b/assettrack/import_analysis.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import re
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
@@ -12,6 +13,8 @@ from assettrack.assets import (
     equipment_type_label,
     validate_new_equipment_type,
 )
+from assettrack.barcodes import barcode_lookup_key
+from assettrack.cases import normalize_case_size
 
 IDENTITY_COLUMNS = ("asset_tag", "barcode", "clean_asset_tag")
 REQUIRED_COLUMNS = {"equipment_type"}
@@ -31,6 +34,27 @@ ALLOWED_COLUMNS = {
     "case_number",
     "slot_number",
     "notes_comments",
+}
+BQ26_PLACEHOLDER_BARCODES = {"", "--"}
+BQ26_TYPE_CORRECTIONS = {
+    "swtich": "switch",
+    "cisco 4331": "router",
+    "cisco 4431": "router",
+    "dell poweredge r640": "server",
+    "3560cx_12": "switch",
+    "3560cx-12": "switch",
+    "cisco 3560cx_12": "switch",
+    "cisco 3560cx-12": "switch",
+    "server monitor kvm": "kvm",
+}
+BQ26_KNOWN_MANUFACTURERS = {
+    "apc",
+    "cisco",
+    "dell",
+    "dkx3-832",
+    "microsemi",
+    "rairtan",
+    "synology",
 }
 REJECTED_CMDB_COLUMNS = {
     "ip_address",
@@ -60,6 +84,9 @@ class AssetImportAnalysisRow:
     slot_identifier: str
     notes: str
     source_fields: frozenset[str] = frozenset()
+    barcode_key: str = ""
+    source_workbook: str = ""
+    warnings: tuple[str, ...] = ()
 
     @property
     def storage_intent(self) -> str:
@@ -85,6 +112,9 @@ class AssetImportAnalysis:
     rows: tuple[AssetImportAnalysisRow, ...]
     warnings: tuple[str, ...] = ()
     issues: tuple[AssetImportAnalysisIssue, ...] = ()
+    case_plans: tuple[dict[str, object], ...] = ()
+    ignored_rows: int = 0
+    barcode_keys: tuple[str, ...] = ()
 
     @property
     def equipment_types(self) -> list[str]:
@@ -98,6 +128,8 @@ class AssetImportAnalysis:
             "equipment_types": self.equipment_types,
             "warnings": list(self.warnings),
             "issues": [issue.__dict__ for issue in self.issues],
+            "case_plans": list(self.case_plans),
+            "ignored_rows": self.ignored_rows,
         }
 
 
@@ -139,6 +171,446 @@ def _normalize_slot_identifier(value: object) -> str:
 def _first_line(value: object) -> str:
     text = str(value or "").strip()
     return text.splitlines()[0] if text else ""
+
+
+def _type_source_key(value: object) -> str:
+    text = _normalize_bq26_text(value).lower()
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _normalize_bq26_text(value: object) -> str:
+    if pd.isna(value):
+        return ""
+    if isinstance(value, bool):
+        return str(value).strip()
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    try:
+        numeric_value = Decimal(text)
+    except InvalidOperation:
+        return text
+    if numeric_value.is_finite() and numeric_value == numeric_value.to_integral_value():
+        return str(int(numeric_value))
+    return text
+
+
+def _normalize_bq26_type(value: object, *, make: object = "", model: object = "") -> str:
+    source_key = _type_source_key(value)
+    make_model_key = _type_source_key(f"{_normalize_bq26_text(make)} {_normalize_bq26_text(model)}")
+    if make_model_key in BQ26_TYPE_CORRECTIONS:
+        return validate_new_equipment_type(BQ26_TYPE_CORRECTIONS[make_model_key])
+    if source_key in BQ26_TYPE_CORRECTIONS:
+        return validate_new_equipment_type(BQ26_TYPE_CORRECTIONS[source_key])
+    try:
+        return validate_new_equipment_type(value)
+    except ValueError:
+        if make_model_key:
+            return validate_new_equipment_type(make_model_key)
+        raise
+
+
+def normalize_bq26_case_name(value: object) -> str:
+    text = _normalize_text(value)
+    if not text:
+        return ""
+    text = re.split(r"\s+-\s+", text, maxsplit=1)[0]
+    text = re.split(r"\s+[A-Za-z]{3,9}-\d{1,2}\b", text, maxsplit=1)[0]
+    text = re.sub(r"\s+", "", text).upper()
+    match = re.fullmatch(r"(\d+)RU-?(\d+)", text)
+    if match:
+        return f"{int(match.group(1))}RU-{int(match.group(2)):02d}"
+    return text
+
+
+def _case_size_from_source(value: object) -> str:
+    text = _normalize_text(value)
+    if not text:
+        return ""
+    lowered = re.sub(r"\s+", " ", text).strip().lower()
+    aliases = {
+        "small wheel": "Small Wheel",
+        "medium wheel": "Medium Wheel",
+        "large wheel": "Large Wheel",
+        "16ru": "16 Rack Unit Wheel",
+        "16 ru": "16 Rack Unit Wheel",
+        "16 rack unit wheel": "16 Rack Unit Wheel",
+        "4ru": "4 Rack Unit Wheel",
+        "4 ru": "4 Rack Unit Wheel",
+        "4 rack unit wheel": "4 Rack Unit Wheel",
+        "6ru": "6 Rack Unit Wheel",
+        "6 ru": "6 Rack Unit Wheel",
+        "6 rack unit wheel": "6 Rack Unit Wheel",
+        "8ru": "8 Rack Unit Wheel",
+        "8 ru": "8 Rack Unit Wheel",
+        "8 rack unit wheel": "8 Rack Unit Wheel",
+        "white case": "White Case",
+        "white cases": "White Case",
+        "sm-case": "SM-Case",
+        "sm case": "SM-Case",
+    }
+    return normalize_case_size(aliases.get(lowered, text))
+
+
+def _is_placeholder_barcode(value: object) -> bool:
+    text = _normalize_bq26_text(value).lower()
+    return text in BQ26_PLACEHOLDER_BARCODES or bool(re.fullmatch(r"-{2,}", text))
+
+
+def _normalize_bq26_header(value: object) -> str:
+    text = _normalize_bq26_text(value).lower()
+    text = text.replace("\\", " ")
+    text = re.sub(r"\([^)]*\)", "", text)
+    text = text.replace("#", "_#")
+    text = re.sub(r"[^a-z0-9#]+", "_", text)
+    text = re.sub(r"_+", "_", text).strip("_")
+    aliases = {
+        "case_#": "case_#",
+        "commnet": "commnet",
+        "make_model": "make_model",
+        "seriel": "serial",
+        "product": "equipment_type",
+    }
+    return aliases.get(text, text)
+
+
+def _bq26_raw_rows(dataframe: pd.DataFrame) -> list[list[object]]:
+    return [
+        [row[index] for index in range(len(row))]
+        for row in dataframe.itertuples(index=False, name=None)
+    ]
+
+
+def _bq26_header_map(values: list[object]) -> dict[str, int]:
+    header: dict[str, int] = {}
+    for index, value in enumerate(values):
+        key = _normalize_bq26_header(value)
+        if key:
+            header.setdefault(key, index)
+    return header
+
+
+def _bq26_cell(row: list[object], index: int | None) -> object:
+    if index is None or index >= len(row):
+        return ""
+    return row[index]
+
+
+def _split_bq26_make_model(make: object, model: object, make_model: object) -> tuple[str, str]:
+    make_text = _normalize_bq26_text(make)
+    model_text = _normalize_bq26_text(model)
+    make_model_text = _normalize_bq26_text(make_model)
+    if make_text or model_text or not make_model_text:
+        return make_text, model_text or make_model_text
+    parts = make_model_text.split(maxsplit=1)
+    if len(parts) == 2 and parts[0].lower() in BQ26_KNOWN_MANUFACTURERS:
+        return parts[0], parts[1]
+    return "", make_model_text
+
+
+def _read_bq26_case_plans(dataframe: pd.DataFrame) -> tuple[dict[str, dict[str, object]], tuple[str, ...]]:
+    raw_rows = _bq26_raw_rows(dataframe)
+    warnings: list[str] = []
+    plans: dict[str, dict[str, object]] = {}
+    for header_index, values in enumerate(raw_rows):
+        header = _bq26_header_map(values)
+        if "name_cases" in header and "quantity" in header:
+            case_column = header["name_cases"]
+            quantity_column = header["quantity"]
+            case_size_column = header.get("case_size")
+            case_number_column = header.get("case_#")
+            for row in raw_rows[header_index + 1 :]:
+                raw_case = _bq26_cell(row, case_column) or _bq26_cell(row, case_number_column)
+                case_name = normalize_bq26_case_name(raw_case)
+                if not case_name:
+                    continue
+                try:
+                    quantity = int(Decimal(_normalize_slot_identifier(_bq26_cell(row, quantity_column))))
+                except (InvalidOperation, ValueError) as exc:
+                    raise ValueError(f"Name Cases row for {case_name}: quantity must be a whole number.") from exc
+                if quantity < 0:
+                    raise ValueError(f"Name Cases row for {case_name}: quantity cannot be negative.")
+                case_size = _case_size_from_source(_bq26_cell(row, case_size_column)) if case_size_column is not None else ""
+                if case_name in plans:
+                    warnings.append(f"Duplicate Name Cases entry for {case_name}; first entry was used.")
+                    continue
+                plans[case_name] = {
+                    "case_name": case_name,
+                    "case_size": case_size,
+                    "quantity": quantity,
+                    "assigned_count": 0,
+                    "warnings": [],
+                }
+            break
+        quantity_pairs = [
+            (index, index + 1)
+            for index, value in enumerate(values[:-1])
+            if _normalize_bq26_text(value) and _normalize_bq26_header(values[index + 1]).startswith("qty")
+        ]
+        if quantity_pairs:
+            for case_column, quantity_column in quantity_pairs:
+                case_size = _case_size_from_source(values[case_column])
+                for row in raw_rows[header_index + 1 :]:
+                    case_name = normalize_bq26_case_name(_bq26_cell(row, case_column))
+                    if not case_name:
+                        continue
+                    try:
+                        quantity = int(Decimal(_normalize_slot_identifier(_bq26_cell(row, quantity_column))))
+                    except (InvalidOperation, ValueError) as exc:
+                        raise ValueError(f"Name Cases row for {case_name}: quantity must be a whole number.") from exc
+                    if quantity < 0:
+                        raise ValueError(f"Name Cases row for {case_name}: quantity cannot be negative.")
+                    if case_name in plans:
+                        warnings.append(f"Duplicate Name Cases entry for {case_name}; first entry was used.")
+                        continue
+                    plans[case_name] = {
+                        "case_name": case_name,
+                        "case_size": case_size,
+                        "quantity": quantity,
+                        "assigned_count": 0,
+                        "warnings": [],
+                    }
+            break
+    if not plans:
+        raise ValueError("Malformed BQ26 workbook. Name Cases contains no valid cases.")
+    return plans, tuple(warnings)
+
+
+def _bq26_asset_sheet_names(sheets: dict[str, pd.DataFrame]) -> tuple[str, ...]:
+    sheet_names: list[str] = []
+    for sheet_name, dataframe in sheets.items():
+        if sheet_name.strip().lower() == "name cases":
+            continue
+        for values in _bq26_raw_rows(dataframe):
+            header = _bq26_header_map(values)
+            if "barcode" in header and "case_#" in header:
+                sheet_names.append(sheet_name)
+                break
+    if not sheet_names:
+        raise ValueError("Malformed BQ26 workbook. No asset worksheet with Barcode and Case # columns was found.")
+    return tuple(sheet_names)
+
+
+def _bq26_row_value(raw_row: dict[str, object], *names: str) -> object:
+    for name in names:
+        if name in raw_row:
+            return raw_row.get(name)
+    return ""
+
+
+def _iter_bq26_asset_rows(sheets: dict[str, pd.DataFrame]):
+    logical_row_number = 1
+    for sheet_name, dataframe in sheets.items():
+        if sheet_name.strip().lower() == "name cases":
+            continue
+        header: dict[str, int] | None = None
+        for values in _bq26_raw_rows(dataframe):
+            candidate = _bq26_header_map(values)
+            if "barcode" in candidate and "case_#" in candidate:
+                header = candidate
+                continue
+            if "barcode" in candidate:
+                continue
+            if header is None:
+                continue
+            barcode = _bq26_cell(values, header.get("barcode"))
+            if not _normalize_bq26_text(barcode) and not any(_normalize_bq26_text(value) for value in values):
+                continue
+            logical_row_number += 1
+            make, model = _split_bq26_make_model(
+                _bq26_cell(values, header.get("make")),
+                _bq26_cell(values, header.get("model")),
+                _bq26_cell(values, header.get("make_model")),
+            )
+            yield (
+                logical_row_number,
+                sheet_name,
+                {
+                    "barcode": barcode,
+                    "serial": _bq26_cell(values, header.get("serial")),
+                    "equipment_type": _bq26_cell(values, header.get("equipment_type")),
+                    "make": make,
+                    "model": model,
+                    "case_#": _bq26_cell(values, header.get("case_#")),
+                    "commnet": _bq26_cell(values, header.get("commnet")),
+                },
+            )
+
+
+def _analyze_bq26_workbook(
+    sheets: dict[str, pd.DataFrame],
+    *,
+    filename: str,
+) -> AssetImportAnalysis:
+    case_sheet = next(
+        (dataframe for sheet_name, dataframe in sheets.items() if sheet_name.strip().lower() == "name cases"),
+        None,
+    )
+    if case_sheet is None:
+        raise ValueError("Malformed BQ26 workbook. Name Cases worksheet is required.")
+    case_plans, case_warnings = _read_bq26_case_plans(case_sheet)
+    asset_sheet_names = _bq26_asset_sheet_names(sheets)
+    warnings = list(case_warnings)
+    if any(sheet_name.strip().lower() not in {"network", "network inventory", "bq26 network"} for sheet_name in asset_sheet_names):
+        warnings.append("Asset worksheet names are descriptive only and were accepted.")
+
+    rows: list[AssetImportAnalysisRow] = []
+    issues: list[AssetImportAnalysisIssue] = []
+    case_asset_ordinals: dict[str, int] = {}
+    ignored_rows = 0
+    seen_barcodes: dict[str, int] = {}
+    seen_serials: dict[str, int] = {}
+
+    for offset, _sheet_name, raw in _iter_bq26_asset_rows(sheets):
+        raw_barcode = _normalize_bq26_text(_bq26_row_value(raw, "barcode"))
+        if _is_placeholder_barcode(raw_barcode):
+            ignored_rows += 1
+            continue
+        barcode_key = barcode_lookup_key(raw_barcode)
+        if not barcode_key:
+            ignored_rows += 1
+            continue
+        case_name = normalize_bq26_case_name(_bq26_row_value(raw, "case_#"))
+        if not case_name or case_name not in case_plans:
+            issues.append(
+                AssetImportAnalysisIssue(
+                    row_number=offset,
+                    category="invalid_upload_row",
+                    message=f"Case # does not match Name Cases: {_normalize_text(_bq26_row_value(raw, 'case_#')) or 'blank'}.",
+                    fields=("case_#",),
+                    asset_identifier=raw_barcode,
+                )
+            )
+            continue
+        previous_barcode_row = seen_barcodes.get(barcode_key)
+        if previous_barcode_row is not None:
+            issues.append(
+                AssetImportAnalysisIssue(
+                    row_number=offset,
+                    category="duplicate_upload_row",
+                    message=f"duplicate normalized barcode matches row {previous_barcode_row}: {raw_barcode}.",
+                    fields=("barcode",),
+                    asset_identifier=raw_barcode,
+                )
+            )
+            continue
+        seen_barcodes[barcode_key] = offset
+
+        serial = _normalize_text(_bq26_row_value(raw, "serial"))
+        normalized_serial = serial.upper()
+        if normalized_serial:
+            previous_serial_row = seen_serials.get(normalized_serial)
+            if previous_serial_row is not None:
+                issues.append(
+                    AssetImportAnalysisIssue(
+                        row_number=offset,
+                        category="duplicate_upload_row",
+                        message=f"duplicate serial matches row {previous_serial_row}: {serial}.",
+                        fields=("serial",),
+                        asset_identifier=raw_barcode,
+                    )
+                )
+                continue
+            seen_serials[normalized_serial] = offset
+
+        try:
+            equipment_type = _normalize_bq26_type(
+                _bq26_row_value(raw, "equipment_type", "type"),
+                make=_bq26_row_value(raw, "make"),
+                model=_bq26_row_value(raw, "model"),
+            )
+        except ValueError as exc:
+            message = _first_line(exc) or SUPPORTED_EQUIPMENT_TYPE_MESSAGE
+            issues.append(
+                AssetImportAnalysisIssue(
+                    row_number=offset,
+                    category="invalid_upload_row",
+                    message=message,
+                    fields=("equipment_type", "make", "model"),
+                    asset_identifier=raw_barcode,
+                )
+            )
+            continue
+
+        case_asset_ordinals[case_name] = case_asset_ordinals.get(case_name, 0) + 1
+        ordinal = case_asset_ordinals[case_name]
+        notes = _normalize_text(_bq26_row_value(raw, "commnet", "notes", "comment"))
+        row_warnings: list[str] = []
+        if not serial:
+            row_warnings.append("Missing serial number.")
+        rows.append(
+            AssetImportAnalysisRow(
+                row_number=offset,
+                asset_tag=raw_barcode,
+                serial_number=serial,
+                equipment_type=equipment_type,
+                manufacturer=_normalize_text(_bq26_row_value(raw, "make")),
+                model=_normalize_bq26_text(_bq26_row_value(raw, "model")),
+                model_code="",
+                building_room="",
+                location_building="",
+                case_identifier=case_name,
+                slot_identifier=str(ordinal),
+                notes=notes,
+                source_fields=frozenset(
+                    {
+                        "asset_tag",
+                        "barcode",
+                        "serial_number",
+                        "equipment_type",
+                        "manufacturer",
+                        "model",
+                        "notes_comments",
+                        "case_identifier",
+                        "slot_identifier",
+                    }
+                ),
+                barcode_key=barcode_key,
+                source_workbook="BQ26",
+                warnings=tuple(row_warnings),
+            )
+        )
+
+    for case_name, plan in case_plans.items():
+        assigned_count = int(case_asset_ordinals.get(case_name, 0))
+        quantity = int(plan["quantity"])
+        plan["assigned_count"] = assigned_count
+        plan_warnings = list(plan.get("warnings") or [])
+        if assigned_count < quantity:
+            plan_warnings.append(f"{case_name} has {assigned_count} barcoded assets for {quantity} provisioned slots.")
+        plan["warnings"] = plan_warnings
+        if assigned_count > quantity:
+            for row in rows:
+                if row.case_identifier == case_name:
+                    issues.append(
+                        AssetImportAnalysisIssue(
+                            row_number=row.row_number,
+                            category="case_over_capacity",
+                            message=f"{case_name} has {assigned_count} barcoded assets but Name Cases quantity is {quantity}.",
+                            fields=("case_#", "quantity"),
+                            asset_identifier=row.asset_tag,
+                        )
+                    )
+
+    over_capacity_rows = {issue.row_number for issue in issues if issue.category == "case_over_capacity"}
+    if over_capacity_rows:
+        rows = [row for row in rows if row.row_number not in over_capacity_rows]
+
+    warnings.extend(
+        warning
+        for plan in case_plans.values()
+        for warning in (plan.get("warnings") or [])
+    )
+    return AssetImportAnalysis(
+        filename=filename,
+        file_type="BQ26 XLSX",
+        rows=tuple(rows),
+        warnings=tuple(warnings),
+        issues=tuple(issues),
+        case_plans=tuple(case_plans[case_name] for case_name in sorted(case_plans)),
+        ignored_rows=ignored_rows,
+        barcode_keys=tuple(sorted(seen_barcodes)),
+    )
 
 
 def _validate_headers(headers: list[str], *, file_type: str) -> tuple[str, ...]:
@@ -374,12 +846,18 @@ def analyze_asset_import_xlsx(
         with path.open("rb") as handle:
             if handle.read(2) != b"PK":
                 raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.")
-        dataframe = pd.read_excel(path, engine="openpyxl")
+        sheets = pd.read_excel(path, engine="openpyxl", sheet_name=None)
     except ValueError:
         raise
     except Exception as exc:
         raise ValueError("Malformed XLSX file. Upload a valid .xlsx workbook.") from exc
 
+    normalized_sheet_names = {sheet_name.strip().lower() for sheet_name in sheets}
+    if "name cases" in normalized_sheet_names:
+        raw_sheets = pd.read_excel(path, engine="openpyxl", sheet_name=None, header=None)
+        return _analyze_bq26_workbook(raw_sheets, filename=filename)
+
+    dataframe = next(iter(sheets.values()))
     headers = [_normalize_header(header) for header in dataframe.columns]
     raw_rows = [
         {str(column): row[column] for column in dataframe.columns}

--- a/assettrack/import_reconciliation.py
+++ b/assettrack/import_reconciliation.py
@@ -4,6 +4,7 @@ import sqlite3
 from dataclasses import dataclass
 
 from assettrack.assets import equipment_type_label
+from assettrack.barcodes import barcode_lookup_key
 from assettrack.import_analysis import AssetImportAnalysis, AssetImportAnalysisRow
 
 DEFAULTS_BEFORE_COMMIT = (
@@ -32,15 +33,19 @@ CATEGORY_LABELS = {
     "proposed_update": "Proposed Update",
     "unslotted_import": "Unslotted Import",
     "slot_conflict_unslotted": "Slot Conflict Eligible For Unslotted Import",
+    "blocked_conflict": "Blocked Conflict",
     "identity_conflict": "Identity Conflict",
     "invalid_duplicate_upload_row": "Invalid Or Duplicate Upload Row",
+    "case_over_capacity": "Case Over Capacity",
 }
 CATEGORY_ORDER = tuple(CATEGORY_LABELS)
 ATTENTION_CATEGORIES = (
     "proposed_update",
     "slot_conflict_unslotted",
+    "blocked_conflict",
     "identity_conflict",
     "invalid_duplicate_upload_row",
+    "case_over_capacity",
 )
 
 
@@ -67,6 +72,7 @@ class AssetImportPreviewRow:
 @dataclass(frozen=True)
 class AssetImportPreviewContext:
     assets_by_tag: dict[str, sqlite3.Row]
+    assets_by_barcode_key: dict[str, sqlite3.Row]
     assets_by_serial: dict[str, sqlite3.Row]
     slots_by_case_position: dict[tuple[str, int], sqlite3.Row]
     occupants_by_slot_id: dict[int, sqlite3.Row]
@@ -81,6 +87,9 @@ class AssetImportPreview:
     warnings: tuple[str, ...]
     defaults: tuple[tuple[str, str], ...]
     unslotted_acknowledged: bool
+    case_plans: tuple[dict[str, object], ...] = ()
+    obsolete_assets: tuple[dict[str, str], ...] = ()
+    ignored_rows: int = 0
 
     @property
     def totals(self) -> dict[str, int]:
@@ -138,6 +147,9 @@ class AssetImportPreview:
             "unslotted_acknowledged": self.unslotted_acknowledged,
             "requires_unslotted_acknowledgment": self.requires_unslotted_acknowledgment,
             "blocks_without_unslotted_acknowledgment": self.blocks_without_unslotted_acknowledgment,
+            "case_plans": list(self.case_plans),
+            "obsolete_assets": list(self.obsolete_assets),
+            "ignored_rows": self.ignored_rows,
         }
 
 
@@ -152,7 +164,10 @@ def _chunked(values: list[str], size: int = 900):
 
 def _asset_by_tag(conn: sqlite3.Connection, asset_tag: str, context: AssetImportPreviewContext | None = None) -> sqlite3.Row | None:
     if context is not None:
-        return context.assets_by_tag.get(asset_tag.upper())
+        exact = context.assets_by_tag.get(asset_tag.upper())
+        if exact is not None:
+            return exact
+        return context.assets_by_barcode_key.get(barcode_lookup_key(asset_tag))
     return conn.execute(
         """
         SELECT *
@@ -287,7 +302,19 @@ def _preview_row(
 ) -> AssetImportPreviewRow:
     existing = _asset_by_tag(conn, row.asset_tag, context)
     serial_match = _asset_by_serial(conn, row.serial_number, context)
-    if serial_match is not None and _text(serial_match["asset_tag"]).upper() != row.asset_tag.upper():
+    row_warnings = tuple(getattr(row, "warnings", ()) or ())
+    if existing is not None and row.serial_number and _text(existing["serial_number"]) and _text(existing["serial_number"]).upper() != row.serial_number.upper():
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
+            category="identity_conflict",
+            category_label=CATEGORY_LABELS["identity_conflict"],
+            message=f"normalized barcode matches existing asset {existing['asset_tag']} but serial differs: {_text(existing['serial_number'])} -> {row.serial_number}",
+            warnings=row_warnings,
+            fields=("barcode", "serial_number"),
+        )
+    if serial_match is not None and barcode_lookup_key(serial_match["asset_tag"]) != barcode_lookup_key(row.asset_tag):
         return AssetImportPreviewRow(
             row_number=row.row_number,
             asset_tag=row.asset_tag,
@@ -295,6 +322,7 @@ def _preview_row(
             category="identity_conflict",
             category_label=CATEGORY_LABELS["identity_conflict"],
             message=f"serial_number matches existing asset {serial_match['asset_tag']}",
+            warnings=row_warnings,
             fields=("serial_number",),
         )
 
@@ -307,7 +335,7 @@ def _preview_row(
             category="unslotted_import",
             category_label=CATEGORY_LABELS["unslotted_import"],
             message="No storage case and slot supplied; row can continue as Unslotted after acknowledgment.",
-            warnings=("Storage will remain Unslotted.",),
+            warnings=row_warnings + ("Storage will remain Unslotted.",),
         )
 
     slot = None
@@ -321,17 +349,28 @@ def _preview_row(
                 category="slot_conflict_unslotted",
                 category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
                 message=f"{slot_error}; row can continue as Unslotted after acknowledgment.",
-                warnings=("Requested storage is unavailable.",),
+                warnings=row_warnings + ("Requested storage is unavailable.",),
                 fields=("case_identifier", "slot_identifier"),
             )
 
         if slot is not None:
             occupant = _slot_occupant(conn, int(slot["id"]), context)
             legacy_current_asset_tag = _text(slot["current_asset_tag"])
-            occupied_by_other = occupant is not None and _text(occupant["asset_tag"]).upper() != row.asset_tag.upper()
-            legacy_occupied_by_other = legacy_current_asset_tag and legacy_current_asset_tag.upper() != row.asset_tag.upper()
+            occupied_by_other = occupant is not None and barcode_lookup_key(occupant["asset_tag"]) != barcode_lookup_key(row.asset_tag)
+            legacy_occupied_by_other = legacy_current_asset_tag and barcode_lookup_key(legacy_current_asset_tag) != barcode_lookup_key(row.asset_tag)
             if occupied_by_other or legacy_occupied_by_other:
                 occupant_tag = _text(occupant["asset_tag"]) if occupant is not None else legacy_current_asset_tag
+                if row.source_workbook == "BQ26":
+                    return AssetImportPreviewRow(
+                        row_number=row.row_number,
+                        asset_tag=row.asset_tag,
+                        asset_identifier=row.asset_tag,
+                        category="blocked_conflict",
+                        category_label=CATEGORY_LABELS["blocked_conflict"],
+                        message=f"Destination slot {_slot_label(slot)} is occupied by {occupant_tag}.",
+                        warnings=row_warnings + ("Existing slot occupants are never displaced.",),
+                        fields=("case_identifier", "slot_identifier"),
+                    )
                 return AssetImportPreviewRow(
                     row_number=row.row_number,
                     asset_tag=row.asset_tag,
@@ -339,7 +378,7 @@ def _preview_row(
                     category="slot_conflict_unslotted",
                     category_label=CATEGORY_LABELS["slot_conflict_unslotted"],
                     message=f"Requested slot is occupied by {occupant_tag}; row can continue as Unslotted after acknowledgment.",
-                    warnings=("Existing slot occupants are never displaced.",),
+                    warnings=row_warnings + ("Existing slot occupants are never displaced.",),
                     fields=("case_identifier", "slot_identifier"),
                 )
 
@@ -354,10 +393,21 @@ def _preview_row(
             category="new_asset",
             category_label=CATEGORY_LABELS["new_asset"],
             message=message,
-            warnings=("Missing storage will be created during commit.",) if storage_requested and slot is None else (),
+            warnings=row_warnings + (("Missing storage will be created during commit.",) if storage_requested and slot is None else ()),
         )
 
     changes = list(_field_changes(existing, row))
+    if row.source_workbook == "BQ26" and _text(existing["location_type"]).upper() == "IN_CUSTODY":
+        return AssetImportPreviewRow(
+            row_number=row.row_number,
+            asset_tag=row.asset_tag,
+            asset_identifier=row.asset_tag,
+            category="blocked_conflict",
+            category_label=CATEGORY_LABELS["blocked_conflict"],
+            message="Workbook assigns this asset to storage, but AssetTrack shows it issued.",
+            warnings=row_warnings + ("Issued assets are never silently returned by import.",),
+            fields=("location_type",),
+        )
     if storage_requested and not _same_slot(existing, slot):
         changes.append(
             AssetImportFieldChange(
@@ -378,6 +428,7 @@ def _preview_row(
             category_label=CATEGORY_LABELS["proposed_update"],
             message=message,
             changed_fields=tuple(changes),
+            warnings=row_warnings,
         )
 
     return AssetImportPreviewRow(
@@ -387,12 +438,15 @@ def _preview_row(
         category="unchanged_exact_match",
         category_label=CATEGORY_LABELS["unchanged_exact_match"],
         message="Upload row matches current asset data exactly.",
+        warnings=row_warnings,
     )
 
 def _build_preview_context(conn: sqlite3.Connection, rows: tuple[AssetImportAnalysisRow, ...]) -> AssetImportPreviewContext:
     asset_tags = {row.asset_tag.upper() for row in rows if row.asset_tag}
+    barcode_keys = {barcode_lookup_key(row.asset_tag) for row in rows if row.asset_tag}
     serial_numbers = {row.serial_number.upper() for row in rows if row.serial_number}
     assets_by_tag: dict[str, sqlite3.Row] = {}
+    assets_by_barcode_key: dict[str, sqlite3.Row] = {}
     assets_by_serial: dict[str, sqlite3.Row] = {}
     home_slot_ids: set[int] = set()
 
@@ -408,6 +462,9 @@ def _build_preview_context(conn: sqlite3.Connection, rows: tuple[AssetImportAnal
         ).fetchall():
             normalized_tag = _text(asset["asset_tag"]).upper()
             assets_by_tag.setdefault(normalized_tag, asset)
+            key = barcode_lookup_key(asset["asset_tag"])
+            if key:
+                assets_by_barcode_key.setdefault(key, asset)
             if asset["home_slot_id"] is not None:
                 home_slot_ids.add(int(asset["home_slot_id"]))
 
@@ -415,12 +472,15 @@ def _build_preview_context(conn: sqlite3.Connection, rows: tuple[AssetImportAnal
     if unmatched_asset_tags or serial_numbers:
         for asset in conn.execute("SELECT * FROM assets;").fetchall():
             normalized_tag = _text(asset["asset_tag"]).upper()
+            key = barcode_lookup_key(asset["asset_tag"])
             normalized_serial = _text(asset["serial_number"]).upper()
-            if normalized_tag in unmatched_asset_tags:
+            if normalized_tag in unmatched_asset_tags or key in barcode_keys:
                 assets_by_tag.setdefault(normalized_tag, asset)
+                if key:
+                    assets_by_barcode_key.setdefault(key, asset)
             if normalized_serial and normalized_serial in serial_numbers:
                 assets_by_serial.setdefault(normalized_serial, asset)
-            if (normalized_tag in unmatched_asset_tags or normalized_serial in serial_numbers) and asset["home_slot_id"] is not None:
+            if (normalized_tag in unmatched_asset_tags or key in barcode_keys or normalized_serial in serial_numbers) and asset["home_slot_id"] is not None:
                 home_slot_ids.add(int(asset["home_slot_id"]))
 
     requested_cases: set[str] = set()
@@ -483,6 +543,7 @@ def _build_preview_context(conn: sqlite3.Connection, rows: tuple[AssetImportAnal
 
     return AssetImportPreviewContext(
         assets_by_tag=assets_by_tag,
+        assets_by_barcode_key=assets_by_barcode_key,
         assets_by_serial=assets_by_serial,
         slots_by_case_position=slots_by_case_position,
         occupants_by_slot_id=occupants_by_slot_id,
@@ -497,13 +558,16 @@ def build_asset_import_preview(
     unslotted_acknowledged: bool = False,
 ) -> AssetImportPreview:
     context = _build_preview_context(conn, analysis.rows)
+    def _issue_preview_category(category: str) -> str:
+        return category if category in CATEGORY_LABELS else "invalid_duplicate_upload_row"
+
     rows: list[AssetImportPreviewRow] = [
         AssetImportPreviewRow(
             row_number=issue.row_number,
             asset_tag="",
             asset_identifier=issue.asset_identifier,
-            category="invalid_duplicate_upload_row",
-            category_label=CATEGORY_LABELS["invalid_duplicate_upload_row"],
+            category=_issue_preview_category(issue.category),
+            category_label=CATEGORY_LABELS[_issue_preview_category(issue.category)],
             message=issue.message,
             fields=issue.fields,
         )
@@ -518,4 +582,38 @@ def build_asset_import_preview(
         warnings=analysis.warnings,
         defaults=DEFAULTS_BEFORE_COMMIT,
         unslotted_acknowledged=unslotted_acknowledged,
+        case_plans=analysis.case_plans,
+        obsolete_assets=_obsolete_network_assets(conn, analysis),
+        ignored_rows=analysis.ignored_rows,
     )
+
+
+def _obsolete_network_assets(conn: sqlite3.Connection, analysis: AssetImportAnalysis) -> tuple[dict[str, str], ...]:
+    if not analysis.barcode_keys:
+        return ()
+    network_types = {"laptop", "switch", "router", "server", "storage", "firewall", "ntp", "kvm"}
+    workbook_keys = set(analysis.barcode_keys)
+    rows = conn.execute(
+        """
+        SELECT asset_tag, serial_number, equipment_type, location_type
+        FROM assets
+        WHERE COALESCE(location_type, '') NOT IN ('DISPOSED', 'RETIRED')
+        ORDER BY UPPER(asset_tag) ASC, id ASC;
+        """
+    ).fetchall()
+    obsolete: list[dict[str, str]] = []
+    for row in rows:
+        equipment_type = _text(row["equipment_type"]).lower()
+        if equipment_type not in network_types:
+            continue
+        if barcode_lookup_key(row["asset_tag"]) in workbook_keys:
+            continue
+        obsolete.append(
+            {
+                "asset_tag": _text(row["asset_tag"]),
+                "serial_number": _text(row["serial_number"]),
+                "equipment_type": equipment_type,
+                "location_type": _text(row["location_type"]),
+            }
+        )
+    return tuple(obsolete)

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -46,6 +46,7 @@ from assettrack.assets import (
     normalize_equipment_type,
     validate_new_equipment_type,
 )
+from assettrack.barcodes import barcode_lookup_key
 from assettrack.cases import CASE_SIZE_OPTIONS, save_case_size
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import bootstrap_db, get_connection
@@ -367,7 +368,7 @@ def sanitize_scan(raw: str) -> str:
 
 
 def _identifier_lookup_key(value: object) -> str:
-    return str(value or "").strip().upper().replace("-", "")
+    return barcode_lookup_key(value)
 
 
 def _single_identifier_match(
@@ -888,7 +889,7 @@ def _find_asset_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
         """
         SELECT *
         FROM assets
-        WHERE REPLACE(UPPER(asset_tag), '-', '') = ?
+        WHERE REPLACE(REPLACE(UPPER(asset_tag), '-', ''), ' ', '') = ?
         LIMIT 2;
         """,
         (_identifier_lookup_key(t),),
@@ -917,7 +918,7 @@ def _find_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]:
             """
             SELECT id, case_name, slot_position, current_asset_tag
             FROM slots
-            WHERE REPLACE(UPPER(case_name), '-', '') = ?
+            WHERE REPLACE(REPLACE(UPPER(case_name), '-', ''), ' ', '') = ?
             ORDER BY slot_position ASC, id ASC;
             """,
             (_identifier_lookup_key(t),),
@@ -996,7 +997,7 @@ def _find_return_case_assets_for_scan_tag(conn, scan_tag: str) -> Optional[dict]
             """
             SELECT id, case_name, slot_position
             FROM slots
-            WHERE REPLACE(UPPER(case_name), '-', '') = ?
+            WHERE REPLACE(REPLACE(UPPER(case_name), '-', ''), ' ', '') = ?
             ORDER BY slot_position ASC, id ASC;
             """,
             (_identifier_lookup_key(t),),
@@ -1096,7 +1097,7 @@ def _queue_case_detail_issue_selection(conn: sqlite3.Connection, case_name: str,
             WHERE s.case_name = ?
               AND (
                 UPPER(a.asset_tag) = UPPER(?)
-                OR REPLACE(UPPER(a.asset_tag), '-', '') = UPPER(?)
+                OR REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = UPPER(?)
               )
             LIMIT 1;
             """,
@@ -1160,7 +1161,7 @@ def _queue_case_detail_return_selection(conn: sqlite3.Connection, case_name: str
             WHERE s.case_name = ?
               AND (
                 UPPER(a.asset_tag) = UPPER(?)
-                OR REPLACE(UPPER(a.asset_tag), '-', '') = UPPER(?)
+                OR REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = UPPER(?)
               )
             LIMIT 1;
             """,
@@ -1219,7 +1220,7 @@ def _asset_current_slot(conn, asset_id: int, asset_tag: str) -> Optional[dict]:
         SELECT id AS slot_id, case_name, slot_position
         FROM slots
         WHERE UPPER(current_asset_tag) = UPPER(?)
-           OR REPLACE(UPPER(current_asset_tag), '-', '') = UPPER(?)
+           OR REPLACE(REPLACE(UPPER(current_asset_tag), '-', ''), ' ', '') = UPPER(?)
         LIMIT 1;
         """,
         (asset_tag, asset_tag),
@@ -1603,16 +1604,16 @@ def _lookup_asset_for_verification(
               ON h.id = a.current_holder_id
             WHERE (
                 UPPER(a.asset_tag) LIKE UPPER(?)
-                OR REPLACE(UPPER(a.asset_tag), '-', '') = ?
+                OR REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = ?
             )
               AND TRIM(COALESCE(a.serial_number, '')) <> ''
               AND UPPER(a.serial_number) LIKE UPPER(?)
             ORDER BY
                 CASE
                     WHEN UPPER(a.asset_tag) = UPPER(?) AND UPPER(a.serial_number) = UPPER(?) THEN 0
-                    WHEN REPLACE(UPPER(a.asset_tag), '-', '') = ? AND UPPER(a.serial_number) = UPPER(?) THEN 1
+                    WHEN REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = ? AND UPPER(a.serial_number) = UPPER(?) THEN 1
                     WHEN UPPER(a.asset_tag) = UPPER(?) THEN 2
-                    WHEN REPLACE(UPPER(a.asset_tag), '-', '') = ? THEN 3
+                    WHEN REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = ? THEN 3
                     WHEN UPPER(a.serial_number) = UPPER(?) THEN 4
                     ELSE 5
                 END,
@@ -1651,11 +1652,11 @@ def _lookup_asset_for_verification(
             LEFT JOIN holders h
               ON h.id = a.current_holder_id
             WHERE UPPER(a.asset_tag) LIKE UPPER(?)
-               OR REPLACE(UPPER(a.asset_tag), '-', '') = ?
+               OR REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = ?
             ORDER BY
                 CASE
                     WHEN UPPER(a.asset_tag) = UPPER(?) THEN 0
-                    WHEN REPLACE(UPPER(a.asset_tag), '-', '') = ? THEN 1
+                    WHEN REPLACE(REPLACE(UPPER(a.asset_tag), '-', ''), ' ', '') = ? THEN 1
                     ELSE 2
                 END,
                 UPPER(a.asset_tag) ASC,
@@ -1758,11 +1759,11 @@ def _lookup_cases_for_asset_search(conn: sqlite3.Connection, query: str) -> list
             COUNT(*) AS slot_count,
             CASE
                 WHEN UPPER(case_name) = UPPER(?) THEN 0
-                WHEN REPLACE(UPPER(case_name), '-', '') = ? THEN 1
+                WHEN REPLACE(REPLACE(UPPER(case_name), '-', ''), ' ', '') = ? THEN 1
                 ELSE 2
             END AS match_rank
         FROM slots
-        WHERE REPLACE(UPPER(case_name), '-', '') LIKE ?
+        WHERE REPLACE(REPLACE(UPPER(case_name), '-', ''), ' ', '') LIKE ?
         GROUP BY case_name
         ORDER BY match_rank ASC, UPPER(case_name) ASC;
         """,
@@ -3683,7 +3684,7 @@ def _retire_admin_asset_in_tx(
         UPDATE slots
         SET current_asset_tag = NULL
         WHERE UPPER(current_asset_tag) = UPPER(?)
-           OR REPLACE(UPPER(current_asset_tag), '-', '') = UPPER(?);
+           OR REPLACE(REPLACE(UPPER(current_asset_tag), '-', ''), ' ', '') = UPPER(?);
         """,
         (asset_tag, asset_tag),
     )
@@ -4350,7 +4351,7 @@ def _receipt_asset_row_snapshot(conn, asset_tag: str) -> Optional[sqlite3.Row]:
         SELECT id, asset_tag, serial_number, equipment_type, manufacturer, model, model_code, notes, building_room
         FROM assets
         WHERE UPPER(asset_tag) = UPPER(?)
-           OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?)
+           OR REPLACE(REPLACE(UPPER(asset_tag), '-', ''), ' ', '') = UPPER(?)
         LIMIT 1;
         """,
         (asset_tag, asset_tag),
@@ -4684,7 +4685,7 @@ def _issue_batch(
                     UPDATE assets
                     SET {', '.join(update_clauses)}
                     WHERE UPPER(asset_tag) = UPPER(?)
-                       OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?);
+                       OR REPLACE(REPLACE(UPPER(asset_tag), '-', ''), ' ', '') = UPPER(?);
                     """,
                     tuple(update_values),
                 )
@@ -4856,7 +4857,7 @@ def _return_batch(
                     UPDATE assets
                     SET location_type = ?, current_holder_id = NULL
                     WHERE UPPER(asset_tag) = UPPER(?)
-                       OR REPLACE(UPPER(asset_tag), '-', '') = UPPER(?);
+                       OR REPLACE(REPLACE(UPPER(asset_tag), '-', ''), ' ', '') = UPPER(?);
                     """,
                     ("STORAGE", canon_tag, canon_tag),
                 )
@@ -8296,7 +8297,7 @@ def _asset_import_existing_asset(conn: sqlite3.Connection, asset_tag: str) -> sq
     ).fetchone()
     if exact is not None:
         return exact
-    return conn.execute(
+    case_match = conn.execute(
         """
         SELECT *
         FROM assets
@@ -8305,6 +8306,15 @@ def _asset_import_existing_asset(conn: sqlite3.Connection, asset_tag: str) -> sq
         """,
         (asset_tag,),
     ).fetchone()
+    if case_match is not None:
+        return case_match
+    lookup_key = barcode_lookup_key(asset_tag)
+    if not lookup_key:
+        return None
+    for row in conn.execute("SELECT * FROM assets;").fetchall():
+        if barcode_lookup_key(row["asset_tag"]) == lookup_key:
+            return row
+    return None
 
 
 def _asset_import_slot_for_row(conn: sqlite3.Connection, row) -> sqlite3.Row | None:
@@ -8357,6 +8367,27 @@ def _asset_import_get_or_create_slot_for_row(conn: sqlite3.Connection, row) -> s
         raise ValueError(f"Row {row.row_number}: requested slot could not be created.")
     return slot
 
+
+def _asset_import_provision_case_plans(conn: sqlite3.Connection, case_plans: tuple[dict[str, object], ...]) -> None:
+    for plan in case_plans:
+        case_name = str(plan.get("case_name") or "").strip().upper()
+        if not case_name:
+            continue
+        quantity = int(plan.get("quantity") or 0)
+        assigned_count = int(plan.get("assigned_count") or 0)
+        if assigned_count > quantity:
+            continue
+        save_case_size(conn, case_name, plan.get("case_size") or "")
+        for slot_position in range(1, quantity + 1):
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO slots (case_name, slot_position, current_asset_tag)
+                VALUES (?, ?, NULL);
+                """,
+                (case_name, slot_position),
+            )
+
+
 def _asset_import_slot_is_available_for(conn: sqlite3.Connection, *, slot_id: int, asset_tag: str) -> bool:
 
     occupant = conn.execute(
@@ -8369,11 +8400,11 @@ def _asset_import_slot_is_available_for(conn: sqlite3.Connection, *, slot_id: in
         """,
         (slot_id,),
     ).fetchone()
-    if occupant is not None and str(occupant["asset_tag"] or "").strip().upper() != asset_tag.upper():
+    if occupant is not None and barcode_lookup_key(occupant["asset_tag"]) != barcode_lookup_key(asset_tag):
         return False
     slot = conn.execute("SELECT current_asset_tag FROM slots WHERE id = ? LIMIT 1;", (slot_id,)).fetchone()
     current_tag = str(slot["current_asset_tag"] or "").strip() if slot else ""
-    return not current_tag or current_tag.upper() == asset_tag.upper()
+    return not current_tag or barcode_lookup_key(current_tag) == barcode_lookup_key(asset_tag)
 
 
 def _asset_import_new_asset_values(conn: sqlite3.Connection, row, *, now_iso: str, slot: sqlite3.Row | None) -> dict[str, object]:
@@ -8524,6 +8555,83 @@ def _asset_import_apply_metadata_update(
     return True
 
 
+def _asset_import_move_existing_asset_to_slot(
+    conn: sqlite3.Connection,
+    *,
+    asset: sqlite3.Row,
+    source_slot_id: int,
+    destination_slot: sqlite3.Row,
+    row,
+    now_iso: str,
+    actor: str,
+) -> None:
+    destination_slot_id = int(destination_slot["id"])
+    source_slot = conn.execute(
+        """
+        SELECT id, case_name, slot_position
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (source_slot_id,),
+    ).fetchone()
+    if source_slot is None:
+        raise ValueError(f"Row {row.row_number}: source slot is missing.")
+    delete_source = conn.execute(
+        """
+        DELETE FROM slot_occupancy
+        WHERE slot_id = ? AND asset_id = ?;
+        """,
+        (source_slot_id, int(asset["id"])),
+    )
+    if delete_source.rowcount != 1:
+        raise ValueError(f"Row {row.row_number}: source slot is missing or empty.")
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (?, ?, ?);
+        """,
+        (destination_slot_id, int(asset["id"]), now_iso),
+    )
+    conn.execute("UPDATE slots SET current_asset_tag = NULL WHERE id = ?;", (source_slot_id,))
+    conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", (str(asset["asset_tag"]), destination_slot_id))
+    update_values: dict[str, object] = {
+        "home_slot_id": destination_slot_id,
+        "case_number": str(destination_slot["case_name"]),
+        "slot_number": str(destination_slot["slot_position"]),
+        "location_type": "STORAGE",
+        "updated_date": now_iso,
+    }
+    asset_columns = get_asset_table_columns(conn)
+    filtered = {field: value for field, value in update_values.items() if field in asset_columns}
+    if filtered:
+        conn.execute(
+            f"UPDATE assets SET {', '.join(f'{field} = ?' for field in filtered)} WHERE id = ?;",
+            [filtered[field] for field in filtered] + [int(asset["id"])],
+        )
+    _asset_import_append_event(
+        conn,
+        asset_tag=str(asset["asset_tag"]),
+        event_type="SLOT_MOVE",
+        event_date=now_iso,
+        actor=actor,
+        notes="Asset import slot move",
+        payload={
+            "from_slot": {
+                "slot_id": source_slot_id,
+                "case_number": str(source_slot["case_name"]),
+                "slot_number": int(source_slot["slot_position"]),
+            },
+            "to_slot": {
+                "slot_id": destination_slot_id,
+                "case_number": str(destination_slot["case_name"]),
+                "slot_number": int(destination_slot["slot_position"]),
+            },
+            "row_number": row.row_number,
+        },
+    )
+
+
 def _asset_import_apply_existing_update(conn: sqlite3.Connection, row, preview_row, *, now_iso: str, actor: str) -> tuple[bool, bool]:
     asset = _asset_import_existing_asset(conn, row.asset_tag)
     if asset is None:
@@ -8539,16 +8647,52 @@ def _asset_import_apply_existing_update(conn: sqlite3.Connection, row, preview_r
             raise ValueError(f"Row {row.row_number}: requested slot is no longer available.")
         source_slot_id = asset["home_slot_id"]
         if source_slot_id is None:
-            raise ValueError(f"Row {row.row_number}: asset is not currently slotted.")
-        building_room = row.building_room or str(asset["building_room"] or "")
-        move_preview = _build_admin_slot_move_preview(
-            conn,
-            source_slot_id=int(source_slot_id),
-            building_room=building_room,
-            case_number=str(slot["case_name"]),
-            slot_number=str(slot["slot_position"]),
-        )
-        move_asset_between_slots_in_tx(conn, move_preview=move_preview, notes="Asset import slot move", actor=actor, event_date=now_iso)
+            conn.execute(
+                """
+                INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+                VALUES (?, ?, ?);
+                """,
+                (int(slot["id"]), int(asset["id"]), now_iso),
+            )
+            conn.execute("UPDATE slots SET current_asset_tag = ? WHERE id = ?;", (row.asset_tag, int(slot["id"])))
+            update_values: dict[str, object] = {
+                "home_slot_id": int(slot["id"]),
+                "case_number": str(slot["case_name"]),
+                "slot_number": str(slot["slot_position"]),
+                "location_type": "STORAGE",
+                "updated_date": now_iso,
+            }
+            asset_columns = get_asset_table_columns(conn)
+            filtered = {field: value for field, value in update_values.items() if field in asset_columns}
+            conn.execute(
+                f"UPDATE assets SET {', '.join(f'{field} = ?' for field in filtered)} WHERE id = ?;",
+                [filtered[field] for field in filtered] + [int(asset["id"])],
+            )
+            _asset_import_append_event(
+                conn,
+                asset_tag=str(asset["asset_tag"]),
+                event_type="SLOT_ASSIGN",
+                event_date=now_iso,
+                actor=actor,
+                payload={
+                    "slot": {
+                        "slot_id": int(slot["id"]),
+                        "case_number": str(slot["case_name"]),
+                        "slot_number": int(slot["slot_position"]),
+                    },
+                    "row_number": row.row_number,
+                },
+            )
+        else:
+            _asset_import_move_existing_asset_to_slot(
+                conn,
+                asset=asset,
+                source_slot_id=int(source_slot_id),
+                destination_slot=slot,
+                row=row,
+                now_iso=now_iso,
+                actor=actor,
+            )
         moved = True
         asset = _asset_import_existing_asset(conn, row.asset_tag)
         if asset is None:
@@ -8620,6 +8764,7 @@ def _commit_asset_import_pending(*, submitted_token: str) -> tuple[dict, dict]:
             "blocked": 0,
             "committed_rows": 0,
         }
+        _asset_import_provision_case_plans(conn, analysis.case_plans)
         safe_unslotted_categories = {"unslotted_import", "slot_conflict_unslotted"}
         for preview_row in preview.rows:
             row = rows_by_number.get(int(preview_row.row_number))
@@ -8702,6 +8847,19 @@ def _asset_import_reconciliation_csv_response() -> object:
                 "; ".join(row.warnings),
             ]
         )
+    if preview.obsolete_assets:
+        writer.writerow([])
+        writer.writerow(["active_network_assets_absent_from_workbook"])
+        writer.writerow(["asset_tag", "serial_number", "equipment_type", "location_type"])
+        for asset in preview.obsolete_assets:
+            writer.writerow(
+                [
+                    asset["asset_tag"],
+                    asset["serial_number"],
+                    asset["equipment_type"],
+                    asset["location_type"],
+                ]
+            )
     wrapper.flush()
     response = make_response(output.getvalue())
     response.headers["Content-Type"] = "text/csv; charset=utf-8"
@@ -10875,7 +11033,7 @@ def admin_assign_slot():
                         SELECT 1
                         FROM slots
                         WHERE UPPER(current_asset_tag) = UPPER(?)
-                           OR REPLACE(UPPER(current_asset_tag), '-', '') = UPPER(?)
+                           OR REPLACE(REPLACE(UPPER(current_asset_tag), '-', ''), ' ', '') = UPPER(?)
                         LIMIT 1;
                         """,
                         (asset_row["asset_tag"], asset_row["asset_tag"]),

--- a/assettrack/intake/templates/admin_asset_import.html
+++ b/assettrack/intake/templates/admin_asset_import.html
@@ -85,7 +85,7 @@
   </details>
 
   {% if result is not none %}
-    {% set blocked_rows = result.rows_by_category["identity_conflict"] + result.rows_by_category["invalid_duplicate_upload_row"] %}
+    {% set blocked_rows = result.rows_by_category["blocked_conflict"] + result.rows_by_category["identity_conflict"] + result.rows_by_category["invalid_duplicate_upload_row"] + result.rows_by_category["case_over_capacity"] %}
     <div class="card">
       <h2>Analysis Result</h2>
       <p class="import-summary">
@@ -94,6 +94,9 @@
         <strong>Type:</strong> {{ result.file_type }}
       </p>
       <p class="import-help">Preview generated successfully. No database changes were made.</p>
+      {% if result.ignored_rows %}
+        <p class="import-help">{{ result.ignored_rows }} blank or placeholder barcode row{% if result.ignored_rows != 1 %}s{% endif %} ignored.</p>
+      {% endif %}
       {% if result.warnings %}
         <p class="import-help"><strong>Warnings:</strong></p>
         <ul class="compact-list">
@@ -145,6 +148,10 @@
                   <td>
                     {% if row.category == "identity_conflict" %}
                       Use a unique asset tag and serial number, or update the existing asset outside this import.
+                    {% elif row.category == "blocked_conflict" %}
+                      Resolve the custody or storage conflict, then analyze the file again.
+                    {% elif row.category == "case_over_capacity" %}
+                      Reconcile the Name Cases quantity or workbook case rows, then analyze the file again.
                     {% else %}
                       Correct the upload row, then analyze the file again.
                     {% endif %}
@@ -199,6 +206,58 @@
               <li><code>{{ default.field }}</code>: {{ default.value }}</li>
             {% endfor %}
           </ul>
+          {% if result.case_plans %}
+            <h3>Case Plans</h3>
+            <div class="import-row-table-wrap" tabindex="0" aria-label="BQ26 case plans">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Case</th>
+                    <th>Case Size</th>
+                    <th>Quantity</th>
+                    <th>Barcoded Assets</th>
+                    <th>Warnings</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for plan in result.case_plans %}
+                    <tr>
+                      <td><code>{{ plan.case_name }}</code></td>
+                      <td>{{ plan.case_size or "Not recorded" }}</td>
+                      <td>{{ plan.quantity }}</td>
+                      <td>{{ plan.assigned_count }}</td>
+                      <td>{{ plan.warnings|join("; ") }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
+          {% if result.obsolete_assets %}
+            <h3>Active Network Assets Absent From Workbook</h3>
+            <div class="import-row-table-wrap" tabindex="0" aria-label="Obsolete network reconciliation">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Asset</th>
+                    <th>Serial</th>
+                    <th>Type</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for asset in result.obsolete_assets %}
+                    <tr>
+                      <td><code>{{ asset.asset_tag }}</code></td>
+                      <td>{{ asset.serial_number or "" }}</td>
+                      <td>{{ equipment_type_label(asset.equipment_type) }}</td>
+                      <td>{{ asset.location_type or "" }}</td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          {% endif %}
           <h3>Rows</h3>
           {% for category in result.category_order %}
             {% set category_rows = result.rows_by_category[category] %}

--- a/tests/test_admin_asset_import.py
+++ b/tests/test_admin_asset_import.py
@@ -284,6 +284,61 @@ def _xlsx_bytes(rows: list[dict[str, object]] | None = None) -> bytes:
     return buffer.getvalue()
 
 
+def _bq26_xlsx_bytes(
+    *,
+    asset_rows: list[dict[str, object]],
+    case_rows: list[dict[str, object]],
+    asset_sheet_name: str = "Network",
+) -> bytes:
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        pd.DataFrame(asset_rows).to_excel(writer, index=False, sheet_name=asset_sheet_name)
+        pd.DataFrame(case_rows).to_excel(writer, index=False, sheet_name="Name Cases")
+    return buffer.getvalue()
+
+
+def _bq26_real_shape_xlsx_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with pd.ExcelWriter(buffer, engine="openpyxl") as writer:
+        pd.DataFrame(
+            [
+                ["Large Wheel", "qty", "16 Rack Unit wheel", "qty 2", "White Cases", "qty 6"],
+                ["LG-WHE-01", 1, "16RU-01", 2, "AAA-16", 1],
+                ["", "", "16RU-02", 1, "AAA-30", 1],
+            ]
+        ).to_excel(writer, index=False, header=False, sheet_name="Name Cases")
+        pd.DataFrame(
+            [
+                ["", "2026-08-05", "", "", "", "", "", ""],
+                ["", "Product", "Make\\Model", "Barcode", "Serial", "Case #", "Quantity", "Commnet"],
+                ["", "Switch", "Cisco 9300", "BQ26-SAFE-1", "SER-BQ26-SAFE-1", "16RU-1", 1, "Front"],
+                ["", "Router", "Cisco 4331", "BQ26-SAFE-2", "SER-BQ26-SAFE-2", "16RU-1", 1, "Router correction"],
+                ["", "PDU", "Rairtan", "----", "SER-IGNORED", "16RU-1", 1, "placeholder"],
+            ]
+        ).to_excel(writer, index=False, header=False, sheet_name="Network Box (16RU-1)-BQMN")
+        pd.DataFrame(
+            [
+                ["", "Product", "Make", "Model", "Barcode", "Seriel", "Case #", "Quantity", "Commnet (F/B)"],
+                ["", "Switch", "Cisco", "3560CX-12", "BQ26-SAFE-3", "SER-BQ26-SAFE-3", "AAA-16", 1, "typo serial"],
+                ["", "", "", "3560CX-12", "BQ26-SAFE-4", "SER-BQ26-SAFE-4", "AAA-30", 1, "model-only type correction"],
+                ["", "Product", "Make", "Model", "Barcode", "Serial", "Quantity", "Quantity", "Commnet"],
+                ["", "Cable", "---", "---", "----", "---", "LG-WHE-01", "---", "---"],
+            ]
+        ).to_excel(writer, index=False, header=False, sheet_name="White-Cases")
+    return buffer.getvalue()
+
+
+def _case_metadata(case_name: str) -> sqlite3.Row | None:
+    conn = db.get_connection()
+    try:
+        return conn.execute(
+            "SELECT case_name, case_size FROM case_metadata WHERE case_name = ?;",
+            (case_name,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+
 def test_csv_and_xlsx_use_equivalent_canonical_analysis_rows(tmp_path: Path) -> None:
     csv_path = tmp_path / "assets.csv"
     csv_path.write_text(
@@ -435,6 +490,295 @@ def test_xlsx_numeric_slot_identifier_reaches_available_slot_classification(
     assert analysis.rows[0].case_identifier == "CASE-2912-SMOKE"
     assert analysis.rows[0].slot_identifier == "4"
     assert preview.rows[0].category == "new_asset"
+
+
+def test_bq26_xlsx_normalizes_barcodes_cases_types_and_warnings(tmp_path: Path) -> None:
+    xlsx_path = tmp_path / "BQ26_network_mod (1).xlsx"
+    xlsx_path.write_bytes(
+        _bq26_xlsx_bytes(
+            asset_rows=[
+                {"Barcode": " sw-1 ", "Serial": "", "Commnet": "needs serial", "Make": "", "Model": "", "Equipment Type": "Swtich", "Case #": "6Ru-1"},
+                {"Barcode": "--", "Serial": "IGNORED-1", "Equipment Type": "Switch", "Case #": "6Ru-1"},
+                {"Barcode": "", "Serial": "IGNORED-2", "Equipment Type": "Router", "Case #": "6Ru-1"},
+                {"Barcode": "RTR-1", "Serial": "SER-RTR-1", "Commnet": "router note", "Make": "Cisco", "Model": "4331", "Equipment Type": "", "Case #": "4RU-5 Aug-12"},
+                {"Barcode": "SRV-1", "Serial": "SER-SRV-1", "Make": "Dell", "Model": "PowerEdge R640", "Equipment Type": "", "Case #": "8RU-2"},
+            ],
+            case_rows=[
+                {"Name Cases": "6Ru-1", "Case Size": "6RU", "Quantity": 2},
+                {"Name Cases": "4RU-05 - need Shipped", "Case Size": "4 Rack Unit Wheel", "Quantity": 1},
+                {"Name Cases": "8RU-2", "Case Size": "8RU", "Quantity": 1},
+            ],
+            asset_sheet_name="Network workbook",
+        )
+    )
+
+    analysis = analyze_asset_import_xlsx(xlsx_path, filename="BQ26_network_mod (1).xlsx", collect_row_errors=True)
+
+    assert analysis.file_type == "BQ26 XLSX"
+    assert analysis.ignored_rows == 2
+    assert [row.asset_tag for row in analysis.rows] == ["sw-1", "RTR-1", "SRV-1"]
+    assert [row.barcode_key for row in analysis.rows] == ["SW1", "RTR1", "SRV1"]
+    assert [row.equipment_type for row in analysis.rows] == ["switch", "router", "server"]
+    assert [row.case_identifier for row in analysis.rows] == ["6RU-01", "4RU-05", "8RU-02"]
+    assert [row.slot_identifier for row in analysis.rows] == ["1", "1", "1"]
+    assert analysis.rows[0].warnings == ("Missing serial number.",)
+    assert "6RU-01 has 1 barcoded assets for 2 provisioned slots." in analysis.warnings
+    assert any("descriptive only" in warning for warning in analysis.warnings)
+
+
+def test_bq26_xlsx_recognizes_real_workbook_shape_without_deployment_data(tmp_path: Path) -> None:
+    xlsx_path = tmp_path / "BQ26_network_mod.xlsx"
+    xlsx_path.write_bytes(_bq26_real_shape_xlsx_bytes())
+
+    analysis = analyze_asset_import_xlsx(xlsx_path, filename="BQ26_network_mod.xlsx", collect_row_errors=True)
+
+    assert analysis.file_type == "BQ26 XLSX"
+    assert len(analysis.case_plans) == 5
+    assert [(plan["case_name"], plan["case_size"], plan["quantity"], plan["assigned_count"]) for plan in analysis.case_plans] == [
+        ("16RU-01", "16 Rack Unit Wheel", 2, 2),
+        ("16RU-02", "16 Rack Unit Wheel", 1, 0),
+        ("AAA-16", "White Case", 1, 1),
+        ("AAA-30", "White Case", 1, 1),
+        ("LG-WHE-01", "Large Wheel", 1, 0),
+    ]
+    assert analysis.ignored_rows == 2
+    assert analysis.issues == ()
+    assert [row.asset_tag for row in analysis.rows] == ["BQ26-SAFE-1", "BQ26-SAFE-2", "BQ26-SAFE-3", "BQ26-SAFE-4"]
+    assert [row.equipment_type for row in analysis.rows] == ["switch", "router", "switch", "switch"]
+    assert [row.case_identifier for row in analysis.rows] == ["16RU-01", "16RU-01", "AAA-16", "AAA-30"]
+    assert [row.slot_identifier for row in analysis.rows] == ["1", "2", "1", "1"]
+    assert "16RU-02 has 0 barcoded assets for 1 provisioned slots." in analysis.warnings
+    assert "LG-WHE-01 has 0 barcoded assets for 1 provisioned slots." in analysis.warnings
+
+
+def test_bq26_preview_and_commit_provisions_quantity_slots_and_ordinal_assignments(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    workbook = _bq26_xlsx_bytes(
+        asset_rows=[
+            {"Barcode": "BQ-1", "Serial": "SER-BQ-1", "Commnet": "first", "Make": "Cisco", "Model": "3560CX-12", "Equipment Type": "", "Case #": "16RU-1"},
+            {"Barcode": "BQ-2", "Serial": "SER-BQ-2", "Commnet": "second", "Make": "", "Model": "", "Equipment Type": "Server Monitor KVM", "Case #": "16RU-1"},
+        ],
+        case_rows=[
+            {"Name Cases": "16RU-1", "Case Size": "16RU", "Quantity": 3},
+            {"Name Cases": "WHITE-1", "Case Size": "White Case", "Quantity": 0},
+        ],
+    )
+
+    response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+
+    assert response.status_code == 200
+    assert b"BQ26 XLSX" in response.data
+    assert b"16RU-01 has 2 barcoded assets for 3 provisioned slots." in response.data
+    assert b"Case Plans" in response.data
+    assert b"16RU-01" in response.data
+    assert b"16 Rack Unit Wheel" in response.data
+    assert b"WHITE-1" in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    assert b"Asset import committed." in commit_response.data
+    slots = _slot_records_for_case("16RU-01")
+    assert [int(slot["slot_position"]) for slot in slots] == [1, 2, 3]
+    assert [slot["current_asset_tag"] for slot in slots] == ["BQ-1", "BQ-2", None]
+    assert _slot_records_for_case("WHITE-1") == []
+    assert _case_metadata("16RU-01")["case_size"] == "16 Rack Unit Wheel"
+    assert _case_metadata("WHITE-1")["case_size"] == "White Case"
+    assert _asset_record("BQ-1")["equipment_type"] == "switch"
+    assert _asset_record("BQ-2")["equipment_type"] == "kvm"
+    assert [row["event_type"] for row in _asset_events("BQ-1")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+    assert [row["event_type"] for row in _asset_events("BQ-2")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+
+
+def test_bq26_over_capacity_case_blocks_affected_rows_without_writes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    workbook = _bq26_xlsx_bytes(
+        asset_rows=[
+            {"Barcode": "OVER-1", "Serial": "SER-OVER-1", "Equipment Type": "Switch", "Case #": "8RU-2"},
+            {"Barcode": "OVER-2", "Serial": "SER-OVER-2", "Equipment Type": "Router", "Case #": "8RU-2"},
+        ],
+        case_rows=[{"Name Cases": "8RU-2", "Case Size": "8RU", "Quantity": 1}],
+    )
+
+    response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+
+    assert response.status_code == 200
+    assert b"Case Over Capacity: 2" in response.data
+    assert b"8RU-02 has 2 barcoded assets but Name Cases quantity is 1." in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    assert _asset_record("OVER-1") is None
+    assert _asset_record("OVER-2") is None
+    assert _slot_records_for_case("8RU-02") == []
+    assert _case_metadata("8RU-02") is None
+
+
+def test_bq26_reuses_normalized_barcode_match_and_moves_existing_asset(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=551, case_name="OLD-BQ26", slot_position=1, current_asset_tag="BQ 26-1")
+    _insert_asset(
+        asset_tag="BQ 26-1",
+        serial_number="SER-BQ26-1",
+        equipment_type="switch",
+        manufacturer="Old Maker",
+        model="Old Model",
+        case_number="OLD-BQ26",
+        slot_number="1",
+        home_slot_id=551,
+        slotted=True,
+    )
+    workbook = _bq26_xlsx_bytes(
+        asset_rows=[
+            {"Barcode": "bq-26 1", "Serial": "SER-BQ26-1", "Make": "Cisco", "Model": "3560CX-12", "Equipment Type": "", "Case #": "16RU-1"},
+        ],
+        case_rows=[{"Name Cases": "16RU-1", "Case Size": "16RU", "Quantity": 1}],
+    )
+
+    response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+
+    assert response.status_code == 200
+    assert b"Proposed Update: 1" in response.data
+    assert b"home_slot</code>: OLD-BQ26 / 1 -> 16RU-01 / 1" in response.data
+    assert b"New Asset: 0" in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    assert _asset_record("bq-26 1") is None
+    asset = _asset_record("BQ 26-1")
+    assert asset is not None
+    assert asset["case_number"] == "16RU-01"
+    assert asset["slot_number"] == "1"
+    assert asset["manufacturer"] == "Cisco"
+    assert asset["model"] == "3560CX-12"
+    assert _slot_records_for_case("OLD-BQ26")[0]["current_asset_tag"] is None
+    assert _slot_records_for_case("16RU-01")[0]["current_asset_tag"] == "BQ 26-1"
+    assert [row["event_type"] for row in _asset_events("BQ 26-1")] == ["SLOT_MOVE", "ASSET_UPDATED"]
+
+
+def test_bq26_blocks_conflicts_but_commits_unrelated_safe_rows(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_slot(slot_id=552, case_name="6RU-01", slot_position=1, current_asset_tag="BQ26-OCCUPANT")
+    _insert_asset(asset_tag="BQ26-OCCUPANT", equipment_type="router", home_slot_id=552, case_number="6RU-01", slot_number="1", slotted=True)
+    _insert_asset(asset_tag="ISSUED-1", serial_number="SER-ISSUED-1", equipment_type="switch")
+    _insert_asset(asset_tag="SERIAL-OWNER-BQ26", serial_number="SER-BQ26-CONFLICT", equipment_type="server")
+    _insert_asset(asset_tag="BAR CODE-1", serial_number="SER-OLD-BARCODE", equipment_type="firewall")
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE assets SET location_type = 'IN_CUSTODY' WHERE asset_tag = 'ISSUED-1';")
+        conn.commit()
+    finally:
+        conn.close()
+    workbook = _bq26_xlsx_bytes(
+        asset_rows=[
+            {"Barcode": "ISSUED-1", "Serial": "SER-ISSUED-1", "Equipment Type": "Switch", "Case #": "16RU-1"},
+            {"Barcode": "OCCUPIED-1", "Serial": "SER-OCCUPIED-1", "Equipment Type": "Router", "Case #": "6Ru-1"},
+            {"Barcode": "NEW-CONFLICT", "Serial": "SER-BQ26-CONFLICT", "Equipment Type": "Server", "Case #": "8RU-2"},
+            {"Barcode": "barcode1", "Serial": "SER-NEW-BARCODE", "Equipment Type": "Firewall", "Case #": "4RU-5 Aug-12"},
+            {"Barcode": "SAFE-BQ26", "Serial": "SER-SAFE-BQ26", "Equipment Type": "NTP", "Case #": "SAFE-1"},
+        ],
+        case_rows=[
+            {"Name Cases": "16RU-1", "Case Size": "16RU", "Quantity": 1},
+            {"Name Cases": "6Ru-1", "Case Size": "6RU", "Quantity": 1},
+            {"Name Cases": "8RU-2", "Case Size": "8RU", "Quantity": 1},
+            {"Name Cases": "4RU-05 - need Shipped", "Case Size": "4 Rack Unit Wheel", "Quantity": 1},
+            {"Name Cases": "SAFE-1", "Case Size": "Small Wheel", "Quantity": 1},
+        ],
+    )
+
+    response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+
+    assert response.status_code == 200
+    assert b"Blocked Conflict: 2" in response.data
+    assert b"Identity Conflict: 2" in response.data
+    assert b"New Asset: 1" in response.data
+    assert b"AssetTrack shows it issued" in response.data
+    assert b"Destination slot 6RU-01 / 1 is occupied by BQ26-OCCUPANT" in response.data
+    assert b"serial_number matches existing asset SERIAL-OWNER-BQ26" in response.data
+    assert b"normalized barcode matches existing asset BAR CODE-1" in response.data
+
+    commit_response = _post_commit(client_with_temp_db, _preview_token(response))
+
+    assert commit_response.status_code == 200
+    assert b"1 row committed. 4 blocked rows left unchanged." in commit_response.data
+    assert _asset_record("SAFE-BQ26") is not None
+    assert _asset_record("OCCUPIED-1") is None
+    assert _asset_record("NEW-CONFLICT") is None
+    assert _asset_record("barcode1") is None
+    assert _asset_record("ISSUED-1")["location_type"] == "IN_CUSTODY"
+    assert _slot_records_for_case("6RU-01")[0]["current_asset_tag"] == "BQ26-OCCUPANT"
+    assert [row["event_type"] for row in _asset_events("SAFE-BQ26")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+
+
+def test_bq26_commit_rolls_back_case_metadata_slots_assets_and_events_on_failure(
+    client_with_temp_db,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _login_admin(client_with_temp_db)
+    workbook = _bq26_xlsx_bytes(
+        asset_rows=[
+            {"Barcode": "ROLL-BQ26-1", "Serial": "SER-ROLL-BQ26-1", "Equipment Type": "Switch", "Case #": "16RU-1"},
+            {"Barcode": "ROLL-BQ26-2", "Serial": "SER-ROLL-BQ26-2", "Equipment Type": "Router", "Case #": "16RU-1"},
+        ],
+        case_rows=[{"Name Cases": "16RU-1", "Case Size": "16RU", "Quantity": 2}],
+    )
+    response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+    token = _preview_token(response)
+    original_append_event = intake_app._asset_import_append_event
+
+    def fail_second_created(*args, **kwargs):
+        if kwargs.get("asset_tag") == "ROLL-BQ26-2" and kwargs.get("event_type") == "ASSET_CREATED":
+            raise RuntimeError("forced bq26 import failure")
+        return original_append_event(*args, **kwargs)
+
+    monkeypatch.setattr(intake_app, "_asset_import_append_event", fail_second_created)
+
+    with pytest.raises(RuntimeError, match="forced bq26 import failure"):
+        _post_commit(client_with_temp_db, token)
+
+    assert _asset_record("ROLL-BQ26-1") is None
+    assert _asset_record("ROLL-BQ26-2") is None
+    assert _asset_events("ROLL-BQ26-1") == []
+    assert _asset_events("ROLL-BQ26-2") == []
+    assert _slot_records_for_case("16RU-01") == []
+    assert _case_metadata("16RU-01") is None
+
+
+def test_bq26_repeat_import_is_safe_and_reports_absent_active_inventory(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _insert_asset(asset_tag="ABSENT-BQ26", serial_number="SER-ABSENT-BQ26", equipment_type="laptop")
+    workbook = _bq26_xlsx_bytes(
+        asset_rows=[
+            {"Barcode": "REPEAT-BQ26", "Serial": "SER-REPEAT-BQ26", "Equipment Type": "Storage", "Case #": "16RU-1"},
+        ],
+        case_rows=[{"Name Cases": "16RU-1", "Case Size": "16RU", "Quantity": 1}],
+    )
+
+    first_response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+    assert first_response.status_code == 200
+    assert b"Active Network Assets Absent From Workbook" in first_response.data
+    assert b"ABSENT-BQ26" in first_response.data
+    csv_response = client_with_temp_db.get("/admin/assets/import/reconciliation.csv")
+    assert csv_response.status_code == 200
+    assert b"active_network_assets_absent_from_workbook" in csv_response.data
+    assert b"ABSENT-BQ26" in csv_response.data
+    first_commit = _post_commit(client_with_temp_db, _preview_token(first_response))
+    assert first_commit.status_code == 200
+    assert _asset_record("ABSENT-BQ26")["location_type"] == "STORAGE"
+    after_first = _table_counts()
+
+    second_response = _post_file(client_with_temp_db, workbook, "BQ26_network_mod (1).xlsx")
+    assert second_response.status_code == 200
+    assert b"Unchanged Exact Match: 1" in second_response.data
+    second_commit = _post_commit(client_with_temp_db, _preview_token(second_response))
+
+    assert second_commit.status_code == 200
+    assert _table_counts() == after_first
+    assert len(_slot_records_for_case("16RU-01")) == 1
+    assert [row["event_type"] for row in _asset_events("REPEAT-BQ26")] == ["ASSET_CREATED", "SLOT_ASSIGN"]
+    assert _asset_events("ABSENT-BQ26") == []
 
 
 def test_admin_can_open_asset_import_upload_page(client_with_temp_db) -> None:

--- a/tests/test_asset_search_ui.py
+++ b/tests/test_asset_search_ui.py
@@ -188,6 +188,16 @@ class AssetSearchUiTests(unittest.TestCase):
         self.assertIn(b"ABC-123", response.data)
         self.assertIn(b"SER-HYPHEN", response.data)
 
+    def test_search_finds_spaced_hyphenated_asset_when_query_omits_spacing(self) -> None:
+        self._insert_asset("BQ 26-1", serial_number="SER-BQ26-SEARCH", location_type="STORAGE", home_slot_id=None)
+
+        response = self.client.get("/assets/search?asset_tag=bq261")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Asset Found", response.data)
+        self.assertIn(b"BQ 26-1", response.data)
+        self.assertIn(b"SER-BQ26-SEARCH", response.data)
+
     def test_search_finds_unhyphenated_asset_when_query_includes_hyphen_without_rewriting_tag(self) -> None:
         self._insert_asset("ABC123", serial_number="SER-NOHYPHEN", location_type="STORAGE", home_slot_id=None)
 

--- a/tools/asset_import_scale_check.py
+++ b/tools/asset_import_scale_check.py
@@ -74,8 +74,10 @@ class ScalePlan:
             "proposed_update": self.update_rows,
             "unslotted_import": 0,
             "slot_conflict_unslotted": self.slot_conflict_rows,
+            "blocked_conflict": 0,
             "identity_conflict": self.identity_conflict_rows,
             "invalid_duplicate_upload_row": self.duplicate_pairs + self.invalid_rows,
+            "case_over_capacity": 0,
         }
 
 
@@ -435,9 +437,18 @@ def run_scale_check(plan: ScalePlan, *, db_path: Path, progress: Callable[[str],
     progress = progress or (lambda _message: None)
     _validate_plan(plan)
     db.DB_PATH = db_path
+    previous_testing = intake_app.app.config.get("TESTING")
+    previous_propagate_exceptions = intake_app.app.config.get("PROPAGATE_EXCEPTIONS")
     intake_app.app.config["TESTING"] = True
     intake_app.app.config["PROPAGATE_EXCEPTIONS"] = False
+    try:
+        return _run_scale_check(plan, db_path=db_path, progress=progress)
+    finally:
+        intake_app.app.config["TESTING"] = previous_testing
+        intake_app.app.config["PROPAGATE_EXCEPTIONS"] = previous_propagate_exceptions
 
+
+def _run_scale_check(plan: ScalePlan, *, db_path: Path, progress: Callable[[str], None]) -> dict[str, object]:
     progress(f"initializing database at {db_path}")
     conn = db.get_connection()
     try:


### PR DESCRIPTION
## Summary

Adds support for importing and reconciling the BQ26 network inventory through the existing unified Asset Import workflow.

The real deployment workbook was verified with 161 eligible barcoded assets and 23 authoritative cases.

## Related Issue

Closes #1129

## Changes

- Added BQ26 workbook detection through the `Name Cases` worksheet.
- Parsed the workbook’s wide case-size and quantity layout.
- Supported repeated asset header blocks across the network worksheets.
- Imported only rows with valid barcodes.
- Ignored blank and placeholder barcodes.
- Normalized barcode comparison across case, spacing, and hyphen differences while preserving source formatting.
- Added approved equipment-type corrections.
- Normalized case names and Case Size values.
- Provisioned slots from authoritative workbook quantities.
- Assigned assets ordinally by workbook row order.
- Reused matching existing assets, cases, and slots.
- Added preview blocking for identity conflicts, issued assets, occupied destinations, unknown cases, and over-capacity cases.
- Added read-only obsolete-inventory reconciliation without retirement or deletion.
- Updated Search to use the same normalized barcode comparison.
- Preserved the existing Analyze, Preview, Confirm, Commit, and Results workflow.

## Verification

- [x] Real workbook analysis: 161 eligible assets
- [x] Real workbook analysis: 23 authoritative cases
- [x] Real workbook analysis: 32 blank or placeholder rows ignored
- [x] Real workbook analysis: 0 analysis issues
- [x] First commit: 161 committed, 0 blocked
- [x] Repeat import: 0 new, 161 unchanged exact matches
- [x] Reconciliation CSV downloaded successfully
- [x] Search and History manually verified
- [x] Issue workflow manually verified
- [x] Return workflow manually verified
- [x] Docker rebuild completed
- [x] SQLite persistence verified after container restart
- [x] Admin import route protections preserved
- [x] `tests/test_admin_asset_import.py`: 66 passed
- [x] Import regression suite: 85 passed
- [x] `tests/test_asset_search_ui.py`: 39 passed, 8 subtests passed
- [x] `git diff --check` passed

## Notes

The deployment workbook was used read-only from `.local-untracked` and was not committed.

Obsolete inventory is identified for operator reconciliation only. No assets, custody records, or event history are automatically retired or deleted.