### PR TITLE
Issue 31-6A: Add atomic batch assignment for case slots

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2181,6 +2181,362 @@ def _assign_slot_building_room_label(building: object, room: object) -> str:
     return "/".join(part for part in parts if part)
 
 
+def _write_assign_slot_occupancy_in_tx(
+    conn: sqlite3.Connection,
+    *,
+    slot_id: int,
+    asset_id: int,
+    asset_tag: str,
+    assigned_at: str,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+        VALUES (?, ?, ?);
+        """,
+        (slot_id, asset_id, assigned_at),
+    )
+    conn.execute(
+        """
+        UPDATE slots
+        SET current_asset_tag = ?
+        WHERE id = ?;
+        """,
+        (asset_tag, slot_id),
+    )
+
+
+def _append_slot_assign_event_in_tx(
+    conn: sqlite3.Connection,
+    *,
+    asset_tag: str,
+    event_date: str,
+    actor: str,
+    notes: str,
+    payload: dict,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO asset_events (
+            asset_tag,
+            event_type,
+            event_date,
+            actor,
+            notes,
+            payload,
+            holder_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            asset_tag,
+            "SLOT_ASSIGN",
+            event_date,
+            actor,
+            notes or None,
+            json.dumps(payload),
+            None,
+        ),
+    )
+
+
+def _validate_assign_slot_asset_row(conn: sqlite3.Connection, asset_tag: str):
+    asset_row = _find_asset_for_scan_tag(conn, asset_tag)
+    if not asset_row:
+        raise ValueError("asset_tag not found")
+
+    location_type = _normalize_location_type(asset_row.get("location_type"))
+    if _is_terminal_location_type(location_type):
+        raise ValueError("Asset is retired/disposed and cannot be assigned to a slot.")
+    if location_type != "STORAGE":
+        raise ValueError("Asset must be location_type=STORAGE.")
+    if location_type == "IN_CUSTODY":
+        raise ValueError("Asset is IN_CUSTODY and cannot be assigned to a slot.")
+
+    occupied_by_asset = conn.execute(
+        """
+        SELECT 1
+        FROM slot_occupancy
+        WHERE asset_id = ?
+        LIMIT 1;
+        """,
+        (asset_row["id"],),
+    ).fetchone()
+    legacy_occupied_by_asset = conn.execute(
+        """
+        SELECT 1
+        FROM slots
+        WHERE UPPER(current_asset_tag) = UPPER(?)
+           OR REPLACE(REPLACE(UPPER(current_asset_tag), '-', ''), ' ', '') = UPPER(?)
+        LIMIT 1;
+        """,
+        (asset_row["asset_tag"], asset_row["asset_tag"]),
+    ).fetchone()
+    if occupied_by_asset or legacy_occupied_by_asset:
+        raise ValueError("Asset is already slotted.")
+    return asset_row
+
+
+def _validate_assign_slot_destination_row(
+    conn: sqlite3.Connection,
+    *,
+    slot_id: int,
+    case_name: str,
+):
+    slot = conn.execute(
+        """
+        SELECT id, case_name, slot_position, current_asset_tag
+        FROM slots
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (slot_id,),
+    ).fetchone()
+    if not slot:
+        raise ValueError("Selected slot does not exist.")
+    if str(slot["case_name"] or "").strip().upper() != str(case_name or "").strip().upper():
+        raise ValueError("Selected slot does not belong to selected case.")
+
+    occupied_by_slot = conn.execute(
+        """
+        SELECT 1
+        FROM slot_occupancy
+        WHERE slot_id = ?
+        LIMIT 1;
+        """,
+        (slot["id"],),
+    ).fetchone()
+    if occupied_by_slot:
+        raise ValueError("Selected slot is already occupied.")
+    legacy_slot_occupied = str(slot["current_asset_tag"] or "").strip()
+    if legacy_slot_occupied:
+        raise ValueError("Selected slot is already occupied.")
+    return slot
+
+
+def _prepare_assign_slot_batch_in_tx(
+    conn: sqlite3.Connection,
+    assignments: list[dict],
+) -> list[dict]:
+    if not assignments:
+        raise ValueError("Batch assignment requires at least one assignment.")
+
+    prepared: list[dict] = []
+    seen_asset_ids: set[int] = set()
+    seen_slot_ids: set[int] = set()
+    for assignment in assignments:
+        asset_tag = str(assignment.get("asset_tag") or "").strip()
+        case_name = str(assignment.get("case_name") or "").strip()
+        slot_id_raw = assignment.get("slot_id")
+        building = str(assignment.get("building") or "").strip()
+        room = str(assignment.get("room") or "").strip()
+
+        if not asset_tag:
+            raise ValueError("asset_tag is required.")
+        if not case_name:
+            raise ValueError("case is required.")
+        if slot_id_raw in (None, ""):
+            raise ValueError("slot is required.")
+        try:
+            slot_id = int(slot_id_raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Select a valid slot.") from exc
+
+        asset_row = _validate_assign_slot_asset_row(conn, asset_tag)
+        asset_id = int(asset_row["id"])
+        if asset_id in seen_asset_ids:
+            raise ValueError("Each asset may appear only once in a batch.")
+        seen_asset_ids.add(asset_id)
+
+        slot = _validate_assign_slot_destination_row(conn, slot_id=slot_id, case_name=case_name)
+        resolved_slot_id = int(slot["id"])
+        if resolved_slot_id in seen_slot_ids:
+            raise ValueError("Each destination slot may appear only once in a batch.")
+        seen_slot_ids.add(resolved_slot_id)
+
+        prepared.append(
+            {
+                "asset": asset_row,
+                "slot": slot,
+                "building": building,
+                "room": room,
+            }
+        )
+    return prepared
+
+
+def _commit_prepared_assign_slot_in_tx(
+    conn: sqlite3.Connection,
+    *,
+    prepared_assignment: dict,
+    actor: str,
+    notes: str,
+    event_date: str,
+) -> dict:
+    asset_row = prepared_assignment["asset"]
+    slot = prepared_assignment["slot"]
+    asset_id = int(asset_row["id"])
+    slot_id = int(slot["id"])
+    asset_tag = str(asset_row["asset_tag"])
+    building = str(prepared_assignment["building"])
+    room = str(prepared_assignment["room"])
+    building_room = _assign_slot_building_room_label(building, room)
+
+    _write_assign_slot_occupancy_in_tx(
+        conn,
+        slot_id=slot_id,
+        asset_id=asset_id,
+        asset_tag=asset_tag,
+        assigned_at=event_date,
+    )
+
+    asset_columns = get_asset_table_columns(conn)
+    update_clauses: list[str] = []
+    update_values: list[object] = []
+    if "home_slot_id" not in asset_columns:
+        raise ValueError("Assets table missing required column: home_slot_id.")
+    update_clauses.append("home_slot_id = ?")
+    update_values.append(slot_id)
+    if "building_room" in asset_columns:
+        update_clauses.append("building_room = ?")
+        update_values.append(building_room)
+    if "case_number" in asset_columns:
+        update_clauses.append("case_number = ?")
+        update_values.append(str(slot["case_name"]))
+    if "slot_number" in asset_columns:
+        update_clauses.append("slot_number = ?")
+        update_values.append(str(slot["slot_position"]))
+    if "updated_date" in asset_columns:
+        update_clauses.append("updated_date = ?")
+        update_values.append(event_date)
+    update_values.append(asset_id)
+    conn.execute(
+        f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
+        tuple(update_values),
+    )
+
+    payload = {
+        "slot_id": slot_id,
+        "building_room": building_room,
+        "case_number": str(slot["case_name"]),
+        "slot_number": int(slot["slot_position"]),
+    }
+    _append_slot_assign_event_in_tx(
+        conn,
+        asset_tag=asset_tag,
+        event_date=event_date,
+        actor=actor,
+        notes=notes,
+        payload=payload,
+    )
+
+    canonical_asset = conn.execute(
+        """
+        SELECT home_slot_id, case_number, slot_number
+        FROM assets
+        WHERE id = ?
+        LIMIT 1;
+        """,
+        (asset_id,),
+    ).fetchone()
+    if canonical_asset is None:
+        raise ValueError("Asset disappeared during assignment.")
+    if canonical_asset["home_slot_id"] is None or int(canonical_asset["home_slot_id"]) != slot_id:
+        raise ValueError("Slot assignment failed to persist home_slot_id.")
+    occupancy_link = conn.execute(
+        """
+        SELECT 1
+        FROM slot_occupancy
+        WHERE slot_id = ? AND asset_id = ?
+        LIMIT 1;
+        """,
+        (slot_id, asset_id),
+    ).fetchone()
+    if occupancy_link is None:
+        raise ValueError("Slot assignment failed to persist slot_occupancy link.")
+    event_link = conn.execute(
+        """
+        SELECT 1
+        FROM asset_events
+        WHERE asset_tag = ?
+          AND event_type = 'SLOT_ASSIGN'
+          AND event_date = ?
+        LIMIT 1;
+        """,
+        (asset_tag, event_date),
+    ).fetchone()
+    if event_link is None:
+        raise ValueError("Slot assignment failed to append SLOT_ASSIGN event.")
+    if "case_number" in asset_columns and str(canonical_asset["case_number"] or "") != str(slot["case_name"]):
+        raise ValueError("Slot assignment failed to persist canonical case_number.")
+    if "slot_number" in asset_columns and str(canonical_asset["slot_number"] or "") != str(slot["slot_position"]):
+        raise ValueError("Slot assignment failed to persist canonical slot_number.")
+
+    return {
+        "asset_tag": asset_tag,
+        "slot_id": slot_id,
+        "case_name": str(slot["case_name"]),
+        "slot_position": int(slot["slot_position"]),
+    }
+
+
+def _assign_slot_batch(
+    conn: sqlite3.Connection,
+    assignments: list[dict],
+    *,
+    actor: str = "admin",
+    notes: str = "",
+    event_date: Optional[str] = None,
+) -> list[dict]:
+    conn.execute("BEGIN;")
+    try:
+        prepared = _prepare_assign_slot_batch_in_tx(conn, assignments)
+        now_iso = event_date or datetime.now(timezone.utc).isoformat()
+        results = [
+            _commit_prepared_assign_slot_in_tx(
+                conn,
+                prepared_assignment=prepared_assignment,
+                actor=actor,
+                notes=notes,
+                event_date=now_iso,
+            )
+            for prepared_assignment in prepared
+        ]
+        conn.commit()
+        return results
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _assign_single_asset_to_slot(
+    conn: sqlite3.Connection,
+    *,
+    asset_tag: str,
+    case_name: str,
+    slot_id: int,
+    building: str,
+    room: str,
+    actor: str = "admin",
+    notes: str = "",
+) -> dict:
+    results = _assign_slot_batch(
+        conn,
+        [
+            {
+                "asset_tag": asset_tag,
+                "case_name": case_name,
+                "slot_id": slot_id,
+                "building": building,
+                "room": room,
+            }
+        ],
+        actor=actor,
+        notes=notes,
+    )
+    return results[0]
+
+
 def _build_admin_edit_asset_view(conn, scan_tag: str) -> tuple[Optional[dict], list[str]]:
     asset = _find_asset_for_scan_tag(conn, scan_tag)
     if not asset:
@@ -11005,187 +11361,16 @@ def admin_assign_slot():
                     )
 
                 try:
-                    conn.execute("BEGIN;")
-
-                    asset_row = _find_asset_for_scan_tag(conn, asset_tag)
-                    if not asset_row:
-                        raise ValueError("asset_tag not found")
-
-                    location_type = _normalize_location_type(asset_row.get("location_type"))
-                    if _is_terminal_location_type(location_type):
-                        raise ValueError("Asset is retired/disposed and cannot be assigned to a slot.")
-                    if location_type != "STORAGE":
-                        raise ValueError("Asset must be location_type=STORAGE.")
-                    if location_type == "IN_CUSTODY":
-                        raise ValueError("Asset is IN_CUSTODY and cannot be assigned to a slot.")
-
-                    occupied_by_asset = conn.execute(
-                        """
-                        SELECT 1
-                        FROM slot_occupancy
-                        WHERE asset_id = ?
-                        LIMIT 1;
-                        """,
-                        (asset_row["id"],),
-                    ).fetchone()
-                    legacy_occupied_by_asset = conn.execute(
-                        """
-                        SELECT 1
-                        FROM slots
-                        WHERE UPPER(current_asset_tag) = UPPER(?)
-                           OR REPLACE(REPLACE(UPPER(current_asset_tag), '-', ''), ' ', '') = UPPER(?)
-                        LIMIT 1;
-                        """,
-                        (asset_row["asset_tag"], asset_row["asset_tag"]),
-                    ).fetchone()
-                    if occupied_by_asset or legacy_occupied_by_asset:
-                        raise ValueError("Asset is already slotted.")
-
-                    slot = conn.execute(
-                        """
-                        SELECT id, case_name, slot_position, current_asset_tag
-                        FROM slots
-                        WHERE id = ?
-                        LIMIT 1;
-                        """,
-                        (int(selected_slot["id"]),),
-                    ).fetchone()
-                    if not slot:
-                        raise ValueError("Selected slot does not exist.")
-
-                    occupied_by_slot = conn.execute(
-                        """
-                        SELECT 1
-                        FROM slot_occupancy
-                        WHERE slot_id = ?
-                        LIMIT 1;
-                        """,
-                        (slot["id"],),
-                    ).fetchone()
-                    if occupied_by_slot:
-                        raise ValueError("Selected slot is already occupied.")
-                    legacy_slot_occupied = str(slot["current_asset_tag"] or "").strip()
-                    if legacy_slot_occupied:
-                        raise ValueError("Selected slot is already occupied.")
-
-                    now_iso = datetime.now(timezone.utc).isoformat()
-
-                    conn.execute(
-                        """
-                        INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
-                        VALUES (?, ?, ?);
-                        """,
-                        (slot["id"], asset_row["id"], now_iso),
+                    assignment_result = _assign_single_asset_to_slot(
+                        conn,
+                        asset_tag=asset_tag,
+                        case_name=case_name,
+                        slot_id=int(selected_slot["id"]),
+                        building=building,
+                        room=room,
+                        actor="admin",
+                        notes=notes,
                     )
-
-                    conn.execute(
-                        """
-                        UPDATE slots
-                        SET current_asset_tag = ?
-                        WHERE id = ?;
-                        """,
-                        (asset_row["asset_tag"], slot["id"]),
-                    )
-
-                    asset_columns = get_asset_table_columns(conn)
-                    update_clauses: list[str] = []
-                    update_values: list[object] = []
-                    if "home_slot_id" not in asset_columns:
-                        raise ValueError("Assets table missing required column: home_slot_id.")
-                    update_clauses.append("home_slot_id = ?")
-                    update_values.append(slot["id"])
-                    if "building_room" in asset_columns:
-                        update_clauses.append("building_room = ?")
-                        update_values.append(_assign_slot_building_room_label(building, room))
-                    if "case_number" in asset_columns:
-                        update_clauses.append("case_number = ?")
-                        update_values.append(str(slot["case_name"]))
-                    if "slot_number" in asset_columns:
-                        update_clauses.append("slot_number = ?")
-                        update_values.append(str(slot["slot_position"]))
-                    if "updated_date" in asset_columns:
-                        update_clauses.append("updated_date = ?")
-                        update_values.append(now_iso)
-                    if update_clauses:
-                        update_values.append(asset_row["id"])
-                        conn.execute(
-                            f"UPDATE assets SET {', '.join(update_clauses)} WHERE id = ?;",
-                            tuple(update_values),
-                        )
-
-                    payload = {
-                        "slot_id": int(slot["id"]),
-                        "building_room": _assign_slot_building_room_label(building, room),
-                        "case_number": str(slot["case_name"]),
-                        "slot_number": int(slot["slot_position"]),
-                    }
-                    conn.execute(
-                        """
-                        INSERT INTO asset_events (
-                            asset_tag,
-                            event_type,
-                            event_date,
-                            actor,
-                            notes,
-                            payload,
-                            holder_id
-                        )
-                        VALUES (?, ?, ?, ?, ?, ?, ?);
-                        """,
-                        (
-                            str(asset_row["asset_tag"]),
-                            "SLOT_ASSIGN",
-                            now_iso,
-                            "admin",
-                            notes or None,
-                            json.dumps(payload),
-                            None,
-                        ),
-                    )
-
-                    canonical_asset = conn.execute(
-                        """
-                        SELECT home_slot_id, case_number, slot_number
-                        FROM assets
-                        WHERE id = ?
-                        LIMIT 1;
-                        """,
-                        (asset_row["id"],),
-                    ).fetchone()
-                    if canonical_asset is None:
-                        raise ValueError("Asset disappeared during assignment.")
-                    if canonical_asset["home_slot_id"] is None or int(canonical_asset["home_slot_id"]) != int(slot["id"]):
-                        raise ValueError("Slot assignment failed to persist home_slot_id.")
-                    occupancy_link = conn.execute(
-                        """
-                        SELECT 1
-                        FROM slot_occupancy
-                        WHERE slot_id = ? AND asset_id = ?
-                        LIMIT 1;
-                        """,
-                        (slot["id"], asset_row["id"]),
-                    ).fetchone()
-                    if occupancy_link is None:
-                        raise ValueError("Slot assignment failed to persist slot_occupancy link.")
-                    event_link = conn.execute(
-                        """
-                        SELECT 1
-                        FROM asset_events
-                        WHERE asset_tag = ?
-                          AND event_type = 'SLOT_ASSIGN'
-                          AND event_date = ?
-                        LIMIT 1;
-                        """,
-                        (str(asset_row["asset_tag"]), now_iso),
-                    ).fetchone()
-                    if event_link is None:
-                        raise ValueError("Slot assignment failed to append SLOT_ASSIGN event.")
-                    if "case_number" in asset_columns and str(canonical_asset["case_number"] or "") != str(slot["case_name"]):
-                        raise ValueError("Slot assignment failed to persist canonical case_number.")
-                    if "slot_number" in asset_columns and str(canonical_asset["slot_number"] or "") != str(slot["slot_position"]):
-                        raise ValueError("Slot assignment failed to persist canonical slot_number.")
-
-                    conn.commit()
                 except ValueError as e:
                     conn.rollback()
                     flash(str(e), "error")
@@ -11210,7 +11395,7 @@ def admin_assign_slot():
                     raise
 
                 flash(
-                    f"Assigned asset {asset_row['asset_tag']} to {slot['case_name']} slot {slot['slot_position']}.",
+                    f"Assigned asset {assignment_result['asset_tag']} to {assignment_result['case_name']} slot {assignment_result['slot_position']}.",
                     "success",
                 )
                 return redirect(url_for("admin_assign_slot"))

--- a/tests/test_assign_slot_batch.py
+++ b/tests/test_assign_slot_batch.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _insert_slot(slot_id: int, case_name: str, position: int, current_asset_tag: str | None = None) -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            (slot_id, case_name, position, current_asset_tag),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _insert_asset(asset_tag: str, *, equipment_type: str = "laptop", location_type: str = "STORAGE") -> int:
+    conn = db.get_connection()
+    try:
+        cursor = conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag, serial_number, equipment_type, manufacturer, building, room,
+                building_room, custody_state, accountability_status, condition,
+                created_date, updated_date, location_type, current_holder_id, home_slot_id
+            )
+            VALUES (?, ?, ?, 'Dell', 'HQ', '100', 'HQ/100', 'in_stock', 'accountable',
+                    'serviceable', '2026-01-01', '2026-01-01T00:00:00Z', ?, NULL, NULL);
+            """,
+            (asset_tag, f"SER-{asset_tag}", equipment_type, location_type),
+        )
+        conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES (?, 'ASSET_CREATED', '2026-01-01T00:00:00Z', 'admin', NULL, NULL, NULL);
+            """,
+            (asset_tag,),
+        )
+        conn.commit()
+        return int(cursor.lastrowid)
+    finally:
+        conn.close()
+
+
+def _batch(assignments: list[dict]) -> list[dict]:
+    conn = db.get_connection()
+    try:
+        return intake_app._assign_slot_batch(
+            conn,
+            assignments,
+            actor="admin",
+            notes="batch assign",
+            event_date="2026-02-01T00:00:00+00:00",
+        )
+    finally:
+        conn.close()
+
+
+def _state() -> dict[str, object]:
+    conn = db.get_connection()
+    try:
+        return {
+            "assets": [dict(row) for row in conn.execute("SELECT asset_tag, home_slot_id, case_number, slot_number FROM assets ORDER BY asset_tag;").fetchall()],
+            "slots": [dict(row) for row in conn.execute("SELECT id, current_asset_tag FROM slots ORDER BY id;").fetchall()],
+            "occupancy": [dict(row) for row in conn.execute("SELECT slot_id, asset_id FROM slot_occupancy ORDER BY slot_id;").fetchall()],
+            "events": [dict(row) for row in conn.execute("SELECT asset_tag, event_type, event_date, payload FROM asset_events ORDER BY id;").fetchall()],
+        }
+    finally:
+        conn.close()
+
+
+def _slot_assign_events(asset_tag: str) -> list[dict]:
+    conn = db.get_connection()
+    try:
+        return [
+            dict(row)
+            for row in conn.execute(
+                """
+                SELECT event_type, event_date, payload
+                FROM asset_events
+                WHERE asset_tag = ? AND event_type = 'SLOT_ASSIGN'
+                ORDER BY id;
+                """,
+                (asset_tag,),
+            ).fetchall()
+        ]
+    finally:
+        conn.close()
+
+
+def test_batch_assigns_laptop_and_network_asset_to_distinct_empty_slots(client_with_temp_db) -> None:
+    _insert_slot(101, "CASE-BATCH", 1)
+    _insert_slot(102, "CASE-BATCH", 2)
+    laptop_id = _insert_asset("BATCH-LAPTOP", equipment_type="laptop")
+    router_id = _insert_asset("BATCH-ROUTER", equipment_type="router")
+
+    result = _batch(
+        [
+            {"asset_tag": "BATCH-LAPTOP", "case_name": "CASE-BATCH", "slot_id": 101, "building": "HQ", "room": "100"},
+            {"asset_tag": "BATCH-ROUTER", "case_name": "CASE-BATCH", "slot_id": 102, "building": "HQ", "room": "101"},
+        ]
+    )
+
+    assert [(row["asset_tag"], row["slot_id"]) for row in result] == [("BATCH-LAPTOP", 101), ("BATCH-ROUTER", 102)]
+    state = _state()
+    assert state["occupancy"] == [{"slot_id": 101, "asset_id": laptop_id}, {"slot_id": 102, "asset_id": router_id}]
+    assert state["slots"] == [{"id": 101, "current_asset_tag": "BATCH-LAPTOP"}, {"id": 102, "current_asset_tag": "BATCH-ROUTER"}]
+    assert [row["event_type"] for row in _slot_assign_events("BATCH-LAPTOP")] == ["SLOT_ASSIGN"]
+    router_event = _slot_assign_events("BATCH-ROUTER")[0]
+    assert json.loads(router_event["payload"])["slot_id"] == 102
+
+
+@pytest.mark.parametrize("equipment_type", ["switch", "router", "server", "firewall", "ntp", "kvm", "storage"])
+def test_batch_assignment_reuses_storage_eligibility_for_network_equipment(client_with_temp_db, equipment_type: str) -> None:
+    _insert_slot(200, f"CASE-{equipment_type.upper()}", 1)
+    _insert_asset(f"ASSET-{equipment_type.upper()}", equipment_type=equipment_type)
+
+    _batch([{"asset_tag": f"ASSET-{equipment_type.upper()}", "case_name": f"CASE-{equipment_type.upper()}", "slot_id": 200}])
+
+    state = _state()
+    assert state["slots"] == [{"id": 200, "current_asset_tag": f"ASSET-{equipment_type.upper()}"}]
+    assert [row["event_type"] for row in _slot_assign_events(f"ASSET-{equipment_type.upper()}")] == ["SLOT_ASSIGN"]
+
+
+@pytest.mark.parametrize(
+    ("assignments", "expected"),
+    [
+        ([], "Batch assignment requires at least one assignment."),
+        ([{"asset_tag": "MISSING", "case_name": "CASE-V", "slot_id": 301}], "asset_tag not found"),
+        ([{"asset_tag": "VALID-1", "case_name": "CASE-V", "slot_id": 999}], "Selected slot does not exist."),
+        ([{"asset_tag": "VALID-1", "case_name": "CASE-OTHER", "slot_id": 301}], "Selected slot does not belong to selected case."),
+        ([{"asset_tag": "VALID-1", "case_name": "CASE-V", "slot_id": 301}, {"asset_tag": "VALID-1", "case_name": "CASE-V", "slot_id": 302}], "Each asset may appear only once in a batch."),
+        ([{"asset_tag": "VALID-1", "case_name": "CASE-V", "slot_id": 301}, {"asset_tag": "VALID-2", "case_name": "CASE-V", "slot_id": 301}], "Each destination slot may appear only once in a batch."),
+    ],
+)
+def test_batch_validation_rejects_complete_batch_without_writes(client_with_temp_db, assignments: list[dict], expected: str) -> None:
+    _insert_slot(301, "CASE-V", 1)
+    _insert_slot(302, "CASE-V", 2)
+    _insert_asset("VALID-1")
+    _insert_asset("VALID-2")
+    before = _state()
+
+    with pytest.raises(ValueError, match=expected):
+        _batch(assignments)
+
+    assert _state() == before
+
+
+def test_batch_rejects_ineligible_asset_without_writes(client_with_temp_db) -> None:
+    _insert_slot(401, "CASE-INELIGIBLE", 1)
+    _insert_asset("IN-CUSTODY-1", location_type="IN_CUSTODY")
+    before = _state()
+
+    with pytest.raises(ValueError, match="Asset must be location_type=STORAGE"):
+        _batch([{"asset_tag": "IN-CUSTODY-1", "case_name": "CASE-INELIGIBLE", "slot_id": 401}])
+
+    assert _state() == before
+
+
+def test_batch_rejects_occupied_slot_and_preserves_existing_occupant(client_with_temp_db) -> None:
+    _insert_slot(501, "CASE-OCC", 1, current_asset_tag="OCCUPANT")
+    occupant_id = _insert_asset("OCCUPANT")
+    _insert_asset("NEW-ASSET")
+    assert occupant_id is not None
+    before = _state()
+
+    with pytest.raises(ValueError, match="Selected slot is already occupied"):
+        _batch([{"asset_tag": "NEW-ASSET", "case_name": "CASE-OCC", "slot_id": 501}])
+
+    assert _state() == before
+
+
+def test_batch_rolls_back_occupancy_and_events_after_occupancy_write_failure(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_slot(601, "CASE-FAIL-OCC", 1)
+    _insert_slot(602, "CASE-FAIL-OCC", 2)
+    _insert_asset("FAIL-OCC-1")
+    _insert_asset("FAIL-OCC-2")
+    original = intake_app._write_assign_slot_occupancy_in_tx
+    calls = {"count": 0}
+
+    def fail_second(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise RuntimeError("forced occupancy failure")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(intake_app, "_write_assign_slot_occupancy_in_tx", fail_second)
+
+    with pytest.raises(RuntimeError, match="forced occupancy failure"):
+        _batch([
+            {"asset_tag": "FAIL-OCC-1", "case_name": "CASE-FAIL-OCC", "slot_id": 601},
+            {"asset_tag": "FAIL-OCC-2", "case_name": "CASE-FAIL-OCC", "slot_id": 602},
+        ])
+
+    state = _state()
+    assert state["occupancy"] == []
+    assert [row for row in state["events"] if row["event_type"] == "SLOT_ASSIGN"] == []
+    assert all(row["current_asset_tag"] is None for row in state["slots"])
+
+
+def test_batch_rolls_back_occupancy_and_events_after_event_write_failure(client_with_temp_db, monkeypatch: pytest.MonkeyPatch) -> None:
+    _insert_slot(701, "CASE-FAIL-EVENT", 1)
+    _insert_slot(702, "CASE-FAIL-EVENT", 2)
+    _insert_asset("FAIL-EVENT-1")
+    _insert_asset("FAIL-EVENT-2")
+    original = intake_app._append_slot_assign_event_in_tx
+    calls = {"count": 0}
+
+    def fail_second(*args, **kwargs):
+        calls["count"] += 1
+        if calls["count"] == 2:
+            raise RuntimeError("forced event failure")
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(intake_app, "_append_slot_assign_event_in_tx", fail_second)
+
+    with pytest.raises(RuntimeError, match="forced event failure"):
+        _batch([
+            {"asset_tag": "FAIL-EVENT-1", "case_name": "CASE-FAIL-EVENT", "slot_id": 701},
+            {"asset_tag": "FAIL-EVENT-2", "case_name": "CASE-FAIL-EVENT", "slot_id": 702},
+        ])
+
+    state = _state()
+    assert state["occupancy"] == []
+    assert [row for row in state["events"] if row["event_type"] == "SLOT_ASSIGN"] == []
+    assert all(row["current_asset_tag"] is None for row in state["slots"])
+
+
+def test_repeated_batch_submission_does_not_duplicate_effects_or_events(client_with_temp_db) -> None:
+    _insert_slot(801, "CASE-REPEAT", 1)
+    _insert_slot(802, "CASE-REPEAT", 2)
+    _insert_asset("REPEAT-1")
+    _insert_asset("REPEAT-2")
+    assignments = [
+        {"asset_tag": "REPEAT-1", "case_name": "CASE-REPEAT", "slot_id": 801},
+        {"asset_tag": "REPEAT-2", "case_name": "CASE-REPEAT", "slot_id": 802},
+    ]
+
+    _batch(assignments)
+    after_first = _state()
+    with pytest.raises(ValueError, match="Asset is already slotted"):
+        _batch(assignments)
+
+    assert _state() == after_first
+    assert len(_slot_assign_events("REPEAT-1")) == 1
+    assert len(_slot_assign_events("REPEAT-2")) == 1
+
+
+def test_existing_assign_slot_route_authorization_and_single_assignment_still_work(client_with_temp_db) -> None:
+    operator_id = create_test_user(username="operator-assign-slot-boundary", password="op-pass", role="operator")
+    login_session(client_with_temp_db, operator_id)
+    assert client_with_temp_db.get("/admin/assign-slot").status_code == 403
+
+    admin_id = create_test_user(username="admin-assign-slot-boundary", password="admin-pass", role="admin")
+    login_session(client_with_temp_db, admin_id)
+    _insert_slot(901, "CASE-ROUTE", 1)
+    _insert_asset("ROUTE-LAPTOP", equipment_type="laptop")
+
+    response = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "assign", "asset_tag": "ROUTE-LAPTOP", "case_name": "CASE-ROUTE", "slot_id": "901"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b"Assigned asset ROUTE-LAPTOP to CASE-ROUTE slot 1." in response.data
+    assert len(_slot_assign_events("ROUTE-LAPTOP")) == 1


### PR DESCRIPTION
## Summary

Adds an internal atomic batch operation for assigning multiple eligible assets to distinct case slots.

The existing single-asset Assign Slots workflow now uses the shared assignment path, but no new multi-asset operator interface is exposed by this issue.

## Related Issue

Closes #1131

Parent issue: #1100  
Follow-on operator workflow: #1132

## Changes

- Added a private batch-assignment operation for complete asset-to-slot assignment collections.
- Reused existing Assign Slots eligibility and occupancy rules.
- Validated assets, destination cases, slots, duplicate assets, duplicate slots, and occupied destinations before retaining writes.
- Kept occupancy changes, slot markers, asset storage fields, and `SLOT_ASSIGN` events in one SQLite transaction.
- Rolled back the complete batch when an occupancy or event write fails.
- Preserved state-based repeat-submission protection.
- Updated the existing single-asset commit path to use the shared assignment operation.
- Added focused batch-assignment tests.
- Kept the operation asset-type agnostic for Laptop and currently eligible network equipment.

## Verification

- [x] `pytest tests\test_assign_slot_batch.py` — 20 passed
- [x] `pytest tests\test_admin_slot_provision.py -k "assign_slot or operator_denied_slot_move"` — 15 passed
- [x] `pytest tests\test_admin_slot_provision.py tests\test_admin_system_health.py tests\test_issue_slot_occupancy_consistency.py` — 115 passed
- [x] `pytest tests\test_admin_asset_import.py -k "SLOT_ASSIGN or slot or bq26 or repeat"` — 26 passed
- [x] `pytest tests\test_return_batch.py -k "slot or occupancy"` — 7 passed
- [x] Combined regression slice — 106 passed
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Manual incognito Laptop assignment
- [x] Manual incognito Router assignment
- [x] One append-only `SLOT_ASSIGN` event verified for each test asset
- [x] Existing Laptop assignment remained unchanged after Router assignment
- [x] Docker restart completed without deleting the volume
- [x] Laptop occupancy and event history persisted
- [x] Router occupancy and event history persisted
- [x] Exactly one `SLOT_ASSIGN` event remained for each asset after restart

## Notes

- No schema or dependency changes.
- No authentication or role-boundary changes.
- No SQLite persistence changes.
- No visible multi-asset workflow was added.
- No Issue or Return behavior changed.
- No case-capacity, slot-provisioning, or asset-eligibility behavior changed.
- Issue #1132 will add the operator-facing multi-asset workflow after this foundation is merged.