### PR TITLE
Issue 31-6B: Add multi-asset Assign Slots workflow

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -2181,6 +2181,94 @@ def _assign_slot_building_room_label(building: object, room: object) -> str:
     return "/".join(part for part in parts if part)
 
 
+
+ASSIGN_SLOT_BATCH_SESSION_KEY = "assign_slot_batch"
+ASSIGN_SLOT_PENDING_SESSION_KEY = "assign_slot_pending_preview"
+
+
+def _assign_slot_batch_tags() -> list[str]:
+    raw_tags = session.get(ASSIGN_SLOT_BATCH_SESSION_KEY, [])
+    if not isinstance(raw_tags, list):
+        return []
+
+    tags: list[str] = []
+    seen: set[str] = set()
+    for raw_tag in raw_tags:
+        tag = str(raw_tag or "").strip().upper()
+        if tag and tag not in seen:
+            tags.append(tag)
+            seen.add(tag)
+    return tags
+
+
+def _save_assign_slot_batch_tags(tags: list[str]) -> None:
+    session[ASSIGN_SLOT_BATCH_SESSION_KEY] = tags
+    session.pop(ASSIGN_SLOT_PENDING_SESSION_KEY, None)
+
+
+def _clear_assign_slot_workflow_state() -> None:
+    session.pop(ASSIGN_SLOT_BATCH_SESSION_KEY, None)
+    session.pop(ASSIGN_SLOT_PENDING_SESSION_KEY, None)
+
+
+def _build_assign_slot_batch_assets(conn: sqlite3.Connection, tags: list[str]) -> tuple[list[dict], list[str]]:
+    assets: list[dict] = []
+    errors: list[str] = []
+    for tag in tags:
+        asset_view, asset_errors = _build_admin_assign_asset_view(conn, tag)
+        if asset_errors:
+            errors.extend(f"{tag}: {error}" for error in asset_errors)
+            continue
+        if asset_view is None:
+            errors.append(f"{tag}: asset_tag not found")
+            continue
+        assets.append(asset_view)
+    return assets, errors
+
+
+def _assign_slot_empty_slot_count(slot_options: list[dict], case_name: str) -> int:
+    selected_case = str(case_name or "").strip().upper()
+    return sum(
+        1
+        for slot in slot_options
+        if str(slot.get("case_name") or "").strip().upper() == selected_case
+        and not str(slot.get("occupied_asset_tag") or "").strip()
+        and slot.get("occupied_asset_id") is None
+    )
+
+
+def _assign_slot_form_assignments(tags: list[str], case_name: str, slot_ids: list[str], building: str, room: str) -> list[dict]:
+    assignments: list[dict] = []
+    for index, tag in enumerate(tags):
+        assignments.append(
+            {
+                "asset_tag": tag,
+                "case_name": case_name,
+                "slot_id": slot_ids[index] if index < len(slot_ids) else "",
+                "building": building,
+                "room": room,
+            }
+        )
+    return assignments
+
+
+def _assign_slot_preview_rows(prepared_assignments: list[dict]) -> list[dict]:
+    rows: list[dict] = []
+    for prepared in prepared_assignments:
+        asset = prepared["asset"]
+        slot = prepared["slot"]
+        rows.append(
+            {
+                "asset_tag": str(asset["asset_tag"]),
+                "serial": str(asset.get("serial_number") or ""),
+                "equipment_type": str(asset.get("equipment_type") or ""),
+                "case_name": str(slot["case_name"]),
+                "slot_id": int(slot["id"]),
+                "slot_position": int(slot["slot_position"]),
+            }
+        )
+    return rows
+
 def _write_assign_slot_occupancy_in_tx(
     conn: sqlite3.Connection,
     *,
@@ -11228,6 +11316,7 @@ def admin_assign_slot():
     if guard_result:
         return guard_result
 
+    action = ""
     asset_tag = ""
     building = ""
     room = ""
@@ -11235,6 +11324,8 @@ def admin_assign_slot():
     slot_id = ""
     notes = ""
     asset_view: Optional[dict] = None
+    preview_rows: list[dict] = []
+    selected_slot_ids: list[str] = []
     unslotted_assets: list[dict] = []
     slot_options: list[dict] = []
     case_options: list[str] = []
@@ -11247,26 +11338,170 @@ def admin_assign_slot():
         case_options = _slot_case_options(slot_options)
         location_context = _assign_slot_location_context()
         building_options = list(location_context["building_options"])
+
+        def render_assign_slot_template():
+            batch_tags = _assign_slot_batch_tags()
+            batch_assets, batch_errors = _build_assign_slot_batch_assets(conn, batch_tags)
+            if not batch_assets and asset_view is not None and action == "assign":
+                batch_assets = [asset_view]
+            return render_template(
+                "admin_assign_slot.html",
+                asset_tag=asset_tag,
+                building=building,
+                room=room,
+                case_name=case_name,
+                slot_id=slot_id,
+                notes=notes,
+                asset=asset_view,
+                batch_assets=batch_assets,
+                batch_errors=batch_errors,
+                preview_rows=preview_rows,
+                selected_slot_ids=selected_slot_ids,
+                unslotted_assets=unslotted_assets,
+                slot_options=slot_options,
+                case_options=case_options,
+                building_options=building_options,
+            )
+
         if request.method == "POST":
             action = (request.form.get("action") or "lookup").strip().lower()
             asset_tag = (request.form.get("asset_tag") or "").strip()
+            remove_asset_tag = (request.form.get("remove_asset_tag") or "").strip().upper()
             building = (request.form.get("building") or "").strip()
             room = (request.form.get("room") or "").strip()
             case_name = (request.form.get("case_name") or "").strip().upper()
             slot_id = (request.form.get("slot_id") or "").strip()
+            selected_slot_ids = [str(value or "").strip() for value in request.form.getlist("slot_id")]
             notes = (request.form.get("notes") or "").strip()
 
-            asset_view, blocking_errors = _build_admin_assign_asset_view(conn, asset_tag)
-
             if action == "lookup":
+                asset_view, blocking_errors = _build_admin_assign_asset_view(conn, asset_tag)
                 if not asset_tag:
                     flash("asset_tag is required.", "error")
                 elif blocking_errors:
                     for msg in blocking_errors:
                         flash(msg, "error")
                 else:
-                    flash(f"Asset {asset_view['asset_tag']} is eligible for slot assignment.", "success")
+                    canonical_tag = str(asset_view["asset_tag"]).strip().upper()
+                    batch_tags = _assign_slot_batch_tags()
+                    if canonical_tag in batch_tags:
+                        flash(f"Asset {canonical_tag} is already in this assignment batch.", "error")
+                    else:
+                        batch_tags.append(canonical_tag)
+                        _save_assign_slot_batch_tags(batch_tags)
+                        flash(f"Asset {canonical_tag} is eligible for slot assignment.", "success")
+                        flash(f"Added asset {canonical_tag} to the assignment batch.", "success")
+            elif action == "remove":
+                batch_tags = _assign_slot_batch_tags()
+                if remove_asset_tag and remove_asset_tag in batch_tags:
+                    batch_tags = [tag for tag in batch_tags if tag != remove_asset_tag]
+                    _save_assign_slot_batch_tags(batch_tags)
+                    flash(f"Removed asset {remove_asset_tag} from the assignment batch.", "success")
+                else:
+                    flash("Asset was not in the assignment batch.", "error")
+            elif action == "clear":
+                _clear_assign_slot_workflow_state()
+                flash("Cleared the assignment batch.", "success")
+                return redirect(url_for("admin_assign_slot"))
+            elif action == "preview":
+                session.pop(ASSIGN_SLOT_PENDING_SESSION_KEY, None)
+                batch_tags = _assign_slot_batch_tags()
+                batch_assets, batch_errors = _build_assign_slot_batch_assets(conn, batch_tags)
+                errors: list[str] = list(batch_errors)
+                structurally_complete = True
+                if not batch_tags:
+                    errors.append("Add at least one eligible asset before previewing the assignment batch.")
+                    structurally_complete = False
+                if not case_name:
+                    errors.append("case is required.")
+                    structurally_complete = False
+                if len(selected_slot_ids) < len(batch_tags) or any(not value for value in selected_slot_ids[: len(batch_tags)]):
+                    errors.append("Select one empty destination slot for each asset.")
+                    structurally_complete = False
+
+                normalized_location, location_errors, _ = _validate_assign_slot_location_form(
+                    {"building": building, "room": room}
+                )
+                building = normalized_location["building"]
+                room = normalized_location["room"]
+                errors.extend(location_errors)
+                if batch_errors or location_errors:
+                    structurally_complete = False
+
+                if case_name and batch_tags and _assign_slot_empty_slot_count(slot_options, case_name) < len(batch_tags):
+                    errors.append("Selected case does not have enough empty slots for this assignment batch.")
+
+                assignments = _assign_slot_form_assignments(batch_tags, case_name, selected_slot_ids, building, room)
+                if structurally_complete:
+                    try:
+                        prepared = _prepare_assign_slot_batch_in_tx(conn, assignments)
+                        if not errors:
+                            preview_rows = _assign_slot_preview_rows(prepared)
+                            session[ASSIGN_SLOT_PENDING_SESSION_KEY] = {
+                                "assignments": assignments,
+                                "building": building,
+                                "room": room,
+                                "case_name": case_name,
+                                "notes": notes,
+                                "rows": preview_rows,
+                            }
+                    except ValueError as e:
+                        errors.append(str(e))
+                for error in errors:
+                    flash(error, "error")
+                if not errors:
+                    flash("Assignment batch preview ready. Review and confirm one batch to commit.", "success")
+            elif action == "commit":
+                if request.form.get("confirm_assignment") != "yes":
+                    flash("Please confirm you reviewed the assignment batch before committing.", "error")
+                    pending_preview = session.get(ASSIGN_SLOT_PENDING_SESSION_KEY)
+                    if isinstance(pending_preview, dict):
+                        preview_rows = list(pending_preview.get("rows") or [])
+                        building = str(pending_preview.get("building") or "")
+                        room = str(pending_preview.get("room") or "")
+                        case_name = str(pending_preview.get("case_name") or "")
+                        notes = str(pending_preview.get("notes") or "")
+                    return render_assign_slot_template()
+
+                pending_preview = session.get(ASSIGN_SLOT_PENDING_SESSION_KEY)
+                if not isinstance(pending_preview, dict) or not pending_preview.get("assignments"):
+                    flash("Preview the complete mapping before committing.", "error")
+                    return render_assign_slot_template()
+
+                assignments = list(pending_preview.get("assignments") or [])
+                building = str(pending_preview.get("building") or "")
+                room = str(pending_preview.get("room") or "")
+                case_name = str(pending_preview.get("case_name") or "")
+                notes = str(pending_preview.get("notes") or "")
+                preview_rows = list(pending_preview.get("rows") or [])
+                try:
+                    assignment_results = _assign_slot_batch(
+                        conn,
+                        assignments,
+                        actor="admin",
+                        notes=notes,
+                    )
+                except ValueError as e:
+                    conn.rollback()
+                    flash(str(e), "error")
+                    return render_assign_slot_template()
+                except Exception:
+                    conn.rollback()
+                    raise
+
+                _clear_assign_slot_workflow_state()
+                unslotted_assets = _list_unslotted_storage_assets(conn)
+                if len(assignment_results) == 1:
+                    result = assignment_results[0]
+                    flash(
+                        f"Assigned asset {result['asset_tag']} to {result['case_name']} slot {result['slot_position']}.",
+                        "success",
+                    )
+                else:
+                    flash(f"Assigned {len(assignment_results)} assets to slots in {case_name}.", "success")
+                return redirect(url_for("admin_assign_slot"))
             elif action == "assign":
+                asset_view, blocking_errors = _build_admin_assign_asset_view(conn, asset_tag)
                 if not asset_tag:
                     flash("asset_tag is required.", "error")
                 if not case_name:
@@ -11275,38 +11510,12 @@ def admin_assign_slot():
                     flash("slot is required.", "error")
 
                 if not asset_tag or not case_name or not slot_id:
-                    return render_template(
-                        "admin_assign_slot.html",
-                        asset_tag=asset_tag,
-                        building=building,
-                        room=room,
-                        case_name=case_name,
-                        slot_id=slot_id,
-                        notes=notes,
-                        asset=asset_view,
-                        unslotted_assets=unslotted_assets,
-                        slot_options=slot_options,
-                        case_options=case_options,
-                        building_options=building_options,
-                    )
+                    return render_assign_slot_template()
 
                 if blocking_errors:
                     for msg in blocking_errors:
                         flash(msg, "error")
-                    return render_template(
-                        "admin_assign_slot.html",
-                        asset_tag=asset_tag,
-                        building=building,
-                        room=room,
-                        case_name=case_name,
-                        slot_id=slot_id,
-                        notes=notes,
-                        asset=asset_view,
-                        unslotted_assets=unslotted_assets,
-                        slot_options=slot_options,
-                        case_options=case_options,
-                        building_options=building_options,
-                    )
+                    return render_assign_slot_template()
 
                 normalized_location, location_errors, _ = _validate_assign_slot_location_form(
                     {"building": building, "room": room}
@@ -11316,20 +11525,7 @@ def admin_assign_slot():
                 if location_errors:
                     for error in location_errors:
                         flash(error, "error")
-                    return render_template(
-                        "admin_assign_slot.html",
-                        asset_tag=asset_tag,
-                        building=building,
-                        room=room,
-                        case_name=case_name,
-                        slot_id=slot_id,
-                        notes=notes,
-                        asset=asset_view,
-                        unslotted_assets=unslotted_assets,
-                        slot_options=slot_options,
-                        case_options=case_options,
-                        building_options=building_options,
-                    )
+                    return render_assign_slot_template()
 
                 selected_slot, slot_errors = _resolve_slot_selection(
                     conn,
@@ -11345,20 +11541,7 @@ def admin_assign_slot():
                 if slot_errors:
                     for error in slot_errors:
                         flash(slot_error_map.get(error, error), "error")
-                    return render_template(
-                        "admin_assign_slot.html",
-                        asset_tag=asset_tag,
-                        building=building,
-                        room=room,
-                        case_name=case_name,
-                        slot_id=slot_id,
-                        notes=notes,
-                        asset=asset_view,
-                        unslotted_assets=unslotted_assets,
-                        slot_options=slot_options,
-                        case_options=case_options,
-                        building_options=building_options,
-                    )
+                    return render_assign_slot_template()
 
                 try:
                     assignment_result = _assign_single_asset_to_slot(
@@ -11376,24 +11559,12 @@ def admin_assign_slot():
                     flash(str(e), "error")
                     asset_view, _ = _build_admin_assign_asset_view(conn, asset_tag)
                     unslotted_assets = _list_unslotted_storage_assets(conn)
-                    return render_template(
-                        "admin_assign_slot.html",
-                        asset_tag=asset_tag,
-                        building=building,
-                        room=room,
-                        case_name=case_name,
-                        slot_id=slot_id,
-                        notes=notes,
-                        asset=asset_view,
-                        unslotted_assets=unslotted_assets,
-                        slot_options=slot_options,
-                        case_options=case_options,
-                        building_options=building_options,
-                    )
+                    return render_assign_slot_template()
                 except Exception:
                     conn.rollback()
                     raise
 
+                _clear_assign_slot_workflow_state()
                 flash(
                     f"Assigned asset {assignment_result['asset_tag']} to {assignment_result['case_name']} slot {assignment_result['slot_position']}.",
                     "success",
@@ -11401,24 +11572,10 @@ def admin_assign_slot():
                 return redirect(url_for("admin_assign_slot"))
             else:
                 flash("Unknown action.", "error")
+
+        return render_assign_slot_template()
     finally:
         conn.close()
-
-    return render_template(
-        "admin_assign_slot.html",
-        asset_tag=asset_tag,
-        building=building,
-        room=room,
-        case_name=case_name,
-        slot_id=slot_id,
-        notes=notes,
-        asset=asset_view,
-        unslotted_assets=unslotted_assets,
-        slot_options=slot_options,
-        case_options=case_options,
-        building_options=building_options,
-    )
-
 
 @app.route("/admin/slot-move", methods=["GET", "POST"])
 @require_login

--- a/assettrack/intake/templates/admin_assign_slot.html
+++ b/assettrack/intake/templates/admin_assign_slot.html
@@ -181,6 +181,7 @@
   {% if asset %}
     <div class="card">
       <h2>Selected Asset</h2>
+      <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
       <div class="asset-summary-row">
         <div><strong>asset_tag:</strong> <code>{{ asset.asset_tag }}</code></div>
         <div><strong>serial_number:</strong> {{ asset.serial or "Not recorded" }}</div>
@@ -188,12 +189,48 @@
         <div><strong>location_type:</strong> <code>{{ asset.location_type or "" }}</code></div>
       </div>
     </div>
+  {% endif %}
 
-    <div class="card">
-      <h2>Assign Slot</h2>
+  <div class="card">
+    <h2>Assignment Batch</h2>
+    {% if batch_errors %}
+      <div class="flash error">
+        {% for error in batch_errors %}
+          <div>{{ error }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    {% if batch_assets %}
+      <table class="assign-slot-table">
+        <thead>
+          <tr>
+            <th>Asset tag</th>
+            <th>Serial number</th>
+            <th>Equipment type</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in batch_assets %}
+            <tr>
+              <td class="asset-tag-cell" data-label="Asset tag"><code>{{ row.asset_tag }}</code></td>
+              <td data-label="Serial number">{{ row.serial or "Not recorded" }}</td>
+              <td data-label="Equipment type">{{ row.equipment_type or "Unknown" }}</td>
+              <td data-label="Action">
+                <form method="post" action="{{ url_for('admin_assign_slot') }}">
+                  <input type="hidden" name="action" value="remove" />
+                  <input type="hidden" name="remove_asset_tag" value="{{ row.asset_tag }}" />
+                  <button type="submit">Remove</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+
       <form method="post" action="{{ url_for('admin_assign_slot') }}">
-        <input type="hidden" name="action" value="assign" />
-        <input type="hidden" name="asset_tag" value="{{ asset.asset_tag }}" />
+        <input type="hidden" name="action" value="preview" />
 
         <div class="row">
           <label for="building"><strong>building</strong> (optional)</label><br />
@@ -230,23 +267,39 @@
           </select>
         </div>
 
-        <div class="row">
-          <label for="slot_id"><strong>slot</strong> (required)</label><br />
-          <select id="slot_id" name="slot_id" required>
-            <option value="">Select slot</option>
-            {% for slot in slot_options %}
-              {% set occupied = slot.occupied_asset_tag %}
-              <option
-                value="{{ slot.id }}"
-                data-case="{{ slot.case_name }}"
-                {% if slot_id == (slot.id|string) %}selected{% endif %}
-                {% if occupied %}disabled{% endif %}
-              >
-                {{ slot.case_name }} / Slot {{ slot.slot_position }}{% if occupied %} - occupied{% endif %}
-              </option>
+        <table class="assign-slot-table">
+          <thead>
+            <tr>
+              <th>Asset tag</th>
+              <th>Slot</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in batch_assets %}
+              {% set selected_slot_id = selected_slot_ids[loop.index0] if selected_slot_ids|length > loop.index0 else '' %}
+              <tr>
+                <td class="asset-tag-cell" data-label="Asset tag"><code>{{ row.asset_tag }}</code></td>
+                <td data-label="Slot">
+                  <label class="sr-only" for="slot_id_{{ loop.index0 }}">slot for {{ row.asset_tag }}</label>
+                  <select id="slot_id_{{ loop.index0 }}" class="assign-slot-row-slot" name="slot_id" required>
+                    <option value="">Select slot</option>
+                    {% for slot in slot_options %}
+                      {% set occupied = slot.occupied_asset_tag %}
+                      <option
+                        value="{{ slot.id }}"
+                        data-case="{{ slot.case_name }}"
+                        {% if selected_slot_id == (slot.id|string) %}selected{% endif %}
+                        {% if occupied %}disabled{% endif %}
+                      >
+                        {{ slot.case_name }} / Slot {{ slot.slot_position }}{% if occupied %} - occupied{% endif %}
+                      </option>
+                    {% endfor %}
+                  </select>
+                </td>
+              </tr>
             {% endfor %}
-          </select>
-        </div>
+          </tbody>
+        </table>
 
         <div class="row">
           <label for="notes"><strong>notes</strong> (optional)</label><br />
@@ -260,9 +313,50 @@
           />
         </div>
 
-        <button type="submit">Assign Slot</button>
+        <button type="submit">Preview Assignment Batch</button>
+      </form>
+
+      <form method="post" action="{{ url_for('admin_assign_slot') }}" style="margin-top: 0.65rem;">
+        <input type="hidden" name="action" value="clear" />
+        <button type="submit">Clear Batch</button>
       </form>
       <p class="muted" style="margin-top: 0.65rem;"><a href="{{ url_for('admin_slot_provision') }}">Create empty slots</a></p>
+    {% else %}
+      <p class="muted">No assets in the assignment batch.</p>
+    {% endif %}
+  </div>
+
+  {% if preview_rows %}
+    <div class="card">
+      <h2>Preview Assignment</h2>
+      <table class="assign-slot-table">
+        <thead>
+          <tr>
+            <th>Asset tag</th>
+            <th>Equipment type</th>
+            <th>Destination</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in preview_rows %}
+            <tr>
+              <td class="asset-tag-cell" data-label="Asset tag"><code>{{ row.asset_tag }}</code></td>
+              <td data-label="Equipment type">{{ row.equipment_type or "Unknown" }}</td>
+              <td data-label="Destination">{{ row.case_name }} / Slot {{ row.slot_position }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <form method="post" action="{{ url_for('admin_assign_slot') }}">
+        <input type="hidden" name="action" value="commit" />
+        <div class="row">
+          <label>
+            <input type="checkbox" name="confirm_assignment" value="yes" required />
+            I reviewed this assignment batch and want to assign these assets to the mapped slots.
+          </label>
+        </div>
+        <button type="submit">Commit Assignment Batch</button>
+      </form>
     </div>
   {% endif %}
 {% endblock %}
@@ -270,29 +364,31 @@
 {% block extra_scripts %}
   <script>
     const assignCaseSelect = document.getElementById("case_name");
-    const assignSlotSelect = document.getElementById("slot_id");
+    const assignSlotSelects = Array.from(document.querySelectorAll(".assign-slot-row-slot"));
 
-    if (assignCaseSelect && assignSlotSelect) {
-      const assignSlotOptions = Array.from(assignSlotSelect.options);
+    if (assignCaseSelect && assignSlotSelects.length) {
+      const slotOptionGroups = assignSlotSelects.map((select) => Array.from(select.options));
 
       function syncAssignSlotOptions() {
         const selectedCase = assignCaseSelect.value;
-        const selectedSlot = assignSlotSelect.value;
 
-        assignSlotOptions.forEach((option) => {
-          if (!option.value) {
-            option.hidden = false;
-            return;
+        assignSlotSelects.forEach((select, index) => {
+          const selectedSlot = select.value;
+          slotOptionGroups[index].forEach((option) => {
+            if (!option.value) {
+              option.hidden = false;
+              return;
+            }
+            const matchesCase = !selectedCase || option.dataset.case === selectedCase;
+            const isSelected = option.value === selectedSlot;
+            option.hidden = !matchesCase && !isSelected;
+          });
+
+          const selectedOption = select.selectedOptions[0];
+          if (selectedOption && selectedOption.value && selectedOption.dataset.case !== selectedCase) {
+            select.value = "";
           }
-          const matchesCase = !selectedCase || option.dataset.case === selectedCase;
-          const isSelected = option.value === selectedSlot;
-          option.hidden = !matchesCase && !isSelected;
         });
-
-        const selectedOption = assignSlotSelect.selectedOptions[0];
-        if (selectedOption && selectedOption.value && selectedOption.dataset.case !== selectedCase) {
-          assignSlotSelect.value = "";
-        }
       }
 
       assignCaseSelect.addEventListener("change", syncAssignSlotOptions);

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -1066,6 +1066,264 @@ def test_assign_slot_manual_lookup_still_works(client_with_temp_db) -> None:
     assert b"Asset AT-MANUAL-1 is eligible for slot assignment." in response.data
 
 
+def _insert_assign_slot_slots(rows: list[tuple[int, str, int, str | None]]) -> None:
+    conn = db.get_connection()
+    try:
+        conn.executemany(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, ?);
+            """,
+            rows,
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _assign_slot_route_state() -> dict[str, object]:
+    conn = db.get_connection()
+    try:
+        return {
+            "assets": [
+                dict(row)
+                for row in conn.execute(
+                    "SELECT asset_tag, home_slot_id, case_number, slot_number FROM assets ORDER BY asset_tag;"
+                ).fetchall()
+            ],
+            "slots": [
+                dict(row)
+                for row in conn.execute("SELECT id, current_asset_tag FROM slots ORDER BY id;").fetchall()
+            ],
+            "occupancy": [
+                dict(row)
+                for row in conn.execute("SELECT slot_id, asset_id FROM slot_occupancy ORDER BY slot_id;").fetchall()
+            ],
+            "slot_assign_events": [
+                dict(row)
+                for row in conn.execute(
+                    "SELECT asset_tag, event_type FROM asset_events WHERE event_type = 'SLOT_ASSIGN' ORDER BY id;"
+                ).fetchall()
+            ],
+        }
+    finally:
+        conn.close()
+
+
+def test_assign_slot_workflow_accumulates_previews_confirms_and_commits_mixed_batch(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    _create_unslotted_asset(client_with_temp_db, asset_tag="AT-BATCH-LAPTOP", serial_number="SER-BATCH-LAPTOP")
+    _create_unslotted_asset(
+        client_with_temp_db,
+        asset_tag="AT-BATCH-ROUTER",
+        serial_number="SER-BATCH-ROUTER",
+        equipment_type="router",
+    )
+    _insert_assign_slot_slots([(9001, "CASE-BATCH-UI", 1, None), (9002, "CASE-BATCH-UI", 2, None)])
+
+    first = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-BATCH-LAPTOP"},
+        follow_redirects=True,
+    )
+    assert first.status_code == 200
+    assert b"Asset AT-BATCH-LAPTOP is eligible for slot assignment." in first.data
+    assert b"AT-BATCH-LAPTOP" in first.data
+
+    duplicate = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "lookup", "asset_tag": "AT-BATCH-LAPTOP"},
+        follow_redirects=True,
+    )
+    assert b"Asset AT-BATCH-LAPTOP is already in this assignment batch." in duplicate.data
+
+    removed = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "remove", "remove_asset_tag": "AT-BATCH-LAPTOP"},
+        follow_redirects=True,
+    )
+    assert b"Removed asset AT-BATCH-LAPTOP from the assignment batch." in removed.data
+    assert b"No assets in the assignment batch." in removed.data
+
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-BATCH-LAPTOP"})
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-BATCH-ROUTER"})
+
+    preview = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={
+            "action": "preview",
+            "building": "HQ",
+            "room": "105",
+            "case_name": "CASE-BATCH-UI",
+            "slot_id": ["9001", "9002"],
+            "notes": "operator batch",
+        },
+        follow_redirects=True,
+    )
+    assert preview.status_code == 200
+    assert b"Assignment batch preview ready. Review and confirm one batch to commit." in preview.data
+    assert b"Preview Assignment" in preview.data
+    assert b"AT-BATCH-LAPTOP" in preview.data
+    assert b"AT-BATCH-ROUTER" in preview.data
+    assert b"CASE-BATCH-UI / Slot 1" in preview.data
+    assert b"CASE-BATCH-UI / Slot 2" in preview.data
+    assert b"I reviewed this assignment batch" in preview.data
+
+    commit = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "commit", "confirm_assignment": "yes"},
+        follow_redirects=True,
+    )
+    assert commit.status_code == 200
+    assert b"Assigned 2 assets to slots in CASE-BATCH-UI." in commit.data
+    assert b"No assets in the assignment batch." in commit.data
+
+    state = _assign_slot_route_state()
+    assert state["slots"] == [
+        {"id": 9001, "current_asset_tag": "AT-BATCH-LAPTOP"},
+        {"id": 9002, "current_asset_tag": "AT-BATCH-ROUTER"},
+    ]
+    assert state["slot_assign_events"] == [
+        {"asset_tag": "AT-BATCH-LAPTOP", "event_type": "SLOT_ASSIGN"},
+        {"asset_tag": "AT-BATCH-ROUTER", "event_type": "SLOT_ASSIGN"},
+    ]
+
+
+def test_assign_slot_workflow_requires_confirmation_and_is_repeat_submission_safe(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    _create_unslotted_asset(client_with_temp_db, asset_tag="AT-CONFIRM-1", serial_number="SER-CONFIRM-1")
+    _insert_assign_slot_slots([(9011, "CASE-CONFIRM", 1, None)])
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-CONFIRM-1"})
+    client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-CONFIRM", "slot_id": ["9011"]},
+    )
+
+    missing_confirmation = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "commit"},
+        follow_redirects=True,
+    )
+    assert b"Please confirm you reviewed the assignment batch before committing." in missing_confirmation.data
+    assert _assign_slot_route_state()["slot_assign_events"] == []
+
+    committed = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "commit", "confirm_assignment": "yes"},
+        follow_redirects=True,
+    )
+    assert b"Assigned asset AT-CONFIRM-1 to CASE-CONFIRM slot 1." in committed.data
+
+    repeated = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "commit", "confirm_assignment": "yes"},
+        follow_redirects=True,
+    )
+    assert b"Preview the complete mapping before committing." in repeated.data
+    assert _assign_slot_route_state()["slot_assign_events"] == [
+        {"asset_tag": "AT-CONFIRM-1", "event_type": "SLOT_ASSIGN"}
+    ]
+
+
+def test_assign_slot_failed_preview_clears_prior_pending_mapping(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    _create_unslotted_asset(client_with_temp_db, asset_tag="AT-PENDING-1", serial_number="SER-PENDING-1")
+    _insert_assign_slot_slots([(9015, "CASE-PENDING", 1, None)])
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-PENDING-1"})
+    ready = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-PENDING", "slot_id": ["9015"]},
+        follow_redirects=True,
+    )
+    assert b"Assignment batch preview ready." in ready.data
+
+    failed_preview = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-PENDING", "slot_id": [""]},
+        follow_redirects=True,
+    )
+    assert b"Select one empty destination slot for each asset." in failed_preview.data
+
+    commit = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "commit", "confirm_assignment": "yes"},
+        follow_redirects=True,
+    )
+    assert b"Preview the complete mapping before committing." in commit.data
+    assert _assign_slot_route_state()["slot_assign_events"] == []
+
+def test_assign_slot_workflow_blocks_insufficient_occupied_and_duplicate_slots(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    _create_unslotted_asset(client_with_temp_db, asset_tag="AT-BLOCK-1", serial_number="SER-BLOCK-1")
+    _create_unslotted_asset(client_with_temp_db, asset_tag="AT-BLOCK-2", serial_number="SER-BLOCK-2", equipment_type="switch")
+    _insert_assign_slot_slots([
+        (9021, "CASE-BLOCK", 1, None),
+        (9022, "CASE-BLOCK", 2, "AT-OCCUPANT"),
+        (9023, "CASE-ROOM", 1, None),
+        (9024, "CASE-ROOM", 2, None),
+    ])
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-BLOCK-1"})
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-BLOCK-2"})
+    before = _assign_slot_route_state()
+
+    insufficient = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-BLOCK", "slot_id": ["9021", "9022"]},
+        follow_redirects=True,
+    )
+    assert b"Selected case does not have enough empty slots for this assignment batch." in insufficient.data
+    assert _assign_slot_route_state() == before
+
+    duplicate_slot = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-ROOM", "slot_id": ["9023", "9023"]},
+        follow_redirects=True,
+    )
+    assert b"Each destination slot may appear only once in a batch." in duplicate_slot.data
+    assert _assign_slot_route_state() == before
+
+    occupied_slot = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-BLOCK", "slot_id": ["9022", "9021"]},
+        follow_redirects=True,
+    )
+    assert b"Selected slot is already occupied." in occupied_slot.data
+    assert _assign_slot_route_state() == before
+
+
+def test_assign_slot_commit_failure_does_not_show_success_or_clear_batch(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    _create_building("HQ")
+    _create_unslotted_asset(client_with_temp_db, asset_tag="AT-STALE-1", serial_number="SER-STALE-1")
+    _insert_assign_slot_slots([(9031, "CASE-STALE", 1, None)])
+    client_with_temp_db.post("/admin/assign-slot", data={"action": "lookup", "asset_tag": "AT-STALE-1"})
+    preview = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "preview", "case_name": "CASE-STALE", "slot_id": ["9031"]},
+        follow_redirects=True,
+    )
+    assert b"Preview Assignment" in preview.data
+
+    conn = db.get_connection()
+    try:
+        conn.execute("UPDATE slots SET current_asset_tag = 'EXISTING-OCCUPANT' WHERE id = 9031;")
+        conn.commit()
+    finally:
+        conn.close()
+
+    failed_commit = client_with_temp_db.post(
+        "/admin/assign-slot",
+        data={"action": "commit", "confirm_assignment": "yes"},
+        follow_redirects=True,
+    )
+    assert b"Selected slot is already occupied." in failed_commit.data
+    assert b"Assigned asset AT-STALE-1" not in failed_commit.data
+    assert b"AT-STALE-1" in failed_commit.data
+    assert _assign_slot_route_state()["slot_assign_events"] == []
 def test_assign_slot_selectors_hide_occupied_slot_options(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
     _create_building("HQ")


### PR DESCRIPTION
## Summary

Adds an operator-facing multi-asset Assign Slots workflow.

Administrators can accumulate multiple eligible assets, select one destination case, map each asset to a distinct empty slot, preview the complete mapping, explicitly confirm it, and commit the batch atomically.

## Related Issue

Closes #1132

Parent issue: #1100  
Atomic batch foundation: #1131

## Changes

- Extended the existing Assign Slots asset-entry methods to accumulate multiple eligible assets.
- Added duplicate-asset prevention and remove/clear controls.
- Added one-case batch selection and per-asset slot mapping.
- Added complete batch Preview and explicit confirmation.
- Commit uses the atomic batch operation added by Issue 31-6A.
- Preserved the existing single-asset assignment path.
- Preserved Laptop and eligible network-equipment support through the same eligibility and workflow path.
- Kept failed Preview or Commit attempts from showing success or incorrectly clearing the batch.
- Cleared workflow state after successful Commit.

## Verification

- [x] `pytest tests\test_admin_slot_provision.py -q` — 61 passed
- [x] `pytest tests\test_assign_slot_batch.py -q` — 20 passed
- [x] `pytest tests\test_basic_auth_guard.py -q` — 36 passed
- [x] `pytest tests\test_issue_slot_occupancy_consistency.py -q` — 2 passed
- [x] `pytest tests\test_dashboard_drilldowns.py -q` — 32 passed
- [x] `pytest tests\test_admin_system_health.py -q` — 57 passed
- [x] Combined regression suite — 208 passed
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Incognito/private browser used
- [x] Laptop and Router accumulated into one batch
- [x] Remove and re-add behavior verified
- [x] Duplicate asset prevention verified
- [x] Distinct empty-slot mapping verified
- [x] Complete Preview verified before Commit
- [x] Explicit confirmation verified
- [x] Atomic batch Commit succeeded
- [x] Exactly one `SLOT_ASSIGN` event created per asset
- [x] Workflow state cleared after success
- [x] Repeat submission created no duplicate occupancy or events
- [x] Insufficient-capacity blocking verified
- [x] Duplicate or invalid slot mapping blocked
- [x] Existing occupants remained unchanged
- [x] Existing single-asset workflow passed
- [x] Docker restart completed without deleting the volume
- [x] Batch and single-asset occupancy persisted
- [x] Append-only event history persisted

## Notes

- No schema or dependency changes.
- No authentication or role-boundary changes.
- No SQLite persistence changes.
- No Issue or Return behavior changes.
- No case-capacity or slot-provisioning changes.
- No asset-type eligibility changes.
- Broader case and slot selector improvements remain under Issue #1102.