### PR TITLE
Issue 31-14: Implement Asset Location Map hierarchy and labels

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -77,7 +77,7 @@ def _event_type_label(raw_event_type: object) -> str:
 
 def _building_label(value: object) -> str:
     label = str(value or "").strip()
-    return label or "Unknown Building"
+    return label or "No Building Recorded"
 
 
 def _domain_label(equipment_type: object) -> str:
@@ -120,9 +120,9 @@ def _map_holder_label(holder_name: object, holder_organization: object, current_
     return "Unassigned Holder"
 
 
-def _custody_map_thread_label(holder_organization: object) -> str:
+def _custody_map_mission_area_label(holder_organization: object) -> str:
     label = str(holder_organization or "").strip()
-    return label or "Unknown Thread"
+    return label or "No Mission Area Recorded"
 
 
 def _custody_map_holder_label(holder_name: object, current_holder_id: object) -> str:
@@ -131,7 +131,7 @@ def _custody_map_holder_label(holder_name: object, current_holder_id: object) ->
         return holder_label
     if current_holder_id is not None:
         return f"ID {current_holder_id}"
-    return "Unassigned Holder"
+    return "No Custody Holder"
 
 
 def get_recent_activity(conn: sqlite3.Connection, limit: int = 10) -> list[dict]:
@@ -539,32 +539,32 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
           ON h.id = a.current_holder_id
         WHERE COALESCE(a.location_type, '') <> 'DISPOSED'
         ORDER BY
-            COALESCE(NULLIF(TRIM(a.building), ''), 'Unknown Building') ASC,
+            COALESCE(NULLIF(TRIM(a.building), ''), 'No Building Recorded') ASC,
             a.asset_tag ASC,
             a.id ASC;
         """
     ).fetchall()
 
-    thread_nodes: dict[str, dict] = {}
+    domain_nodes: dict[str, dict] = {}
     for row in rows:
-        thread_label = _custody_map_thread_label(row["holder_organization"])
-        building_label = _building_label(row["building"])
         domain_label = _domain_label(row["equipment_type"])
+        mission_area_label = _custody_map_mission_area_label(row["holder_organization"])
+        building_label = _building_label(row["building"])
         holder_label = _custody_map_holder_label(row["holder_name"], row["current_holder_id"])
 
-        thread_node = thread_nodes.setdefault(
-            thread_label,
-            {"label": thread_label, "_buildings": {}},
-        )
-        building_node = thread_node["_buildings"].setdefault(
-            building_label,
-            {"label": building_label, "_domains": {}},
-        )
-        domain_node = building_node["_domains"].setdefault(
+        domain_node = domain_nodes.setdefault(
             domain_label,
-            {"label": domain_label, "_holders": {}},
+            {"label": domain_label, "_mission_areas": {}},
         )
-        holder_node = domain_node["_holders"].setdefault(
+        mission_area_node = domain_node["_mission_areas"].setdefault(
+            mission_area_label,
+            {"label": mission_area_label, "_buildings": {}},
+        )
+        building_node = mission_area_node["_buildings"].setdefault(
+            building_label,
+            {"label": building_label, "_holders": {}},
+        )
+        holder_node = building_node["_holders"].setdefault(
             holder_label,
             {
                 "label": holder_label,
@@ -580,20 +580,20 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
             }
         )
 
-    threads: list[dict] = []
-    for thread_label in sorted(thread_nodes):
-        thread_node = thread_nodes[thread_label]
-        buildings: list[dict] = []
-        for building_label in sorted(thread_node["_buildings"]):
-            building_node = thread_node["_buildings"][building_label]
-            domains: list[dict] = []
-            for domain_label, domain_node in sorted(
-                building_node["_domains"].items(),
-                key=lambda item: _domain_sort_key(item[0]),
-            ):
+    domains: list[dict] = []
+    for domain_label, domain_node in sorted(
+        domain_nodes.items(),
+        key=lambda item: _domain_sort_key(item[0]),
+    ):
+        mission_areas: list[dict] = []
+        for mission_area_label in sorted(domain_node["_mission_areas"]):
+            mission_area_node = domain_node["_mission_areas"][mission_area_label]
+            buildings: list[dict] = []
+            for building_label in sorted(mission_area_node["_buildings"]):
+                building_node = mission_area_node["_buildings"][building_label]
                 holders: list[dict] = []
-                for holder_label in sorted(domain_node["_holders"]):
-                    holder_node = domain_node["_holders"][holder_label]
+                for holder_label in sorted(building_node["_holders"]):
+                    holder_node = building_node["_holders"][holder_label]
                     holder_node["assets"].sort(key=lambda asset: (asset["asset_tag"], asset["equipment_type_label"]))
                     holders.append(
                         {
@@ -603,31 +603,31 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
                             "assets": holder_node["assets"],
                         }
                     )
-                domains.append(
+                buildings.append(
                     {
-                        "label": domain_label,
+                        "label": building_label,
                         "holders": holders,
                         "asset_count": sum(holder["asset_count"] for holder in holders),
                     }
                 )
-            buildings.append(
+            mission_areas.append(
                 {
-                    "label": building_label,
-                    "domains": domains,
-                    "asset_count": sum(domain["asset_count"] for domain in domains),
+                    "label": mission_area_label,
+                    "buildings": buildings,
+                    "asset_count": sum(building["asset_count"] for building in buildings),
                 }
             )
-        threads.append(
+        domains.append(
             {
-                "label": thread_label,
-                "buildings": buildings,
-                "asset_count": sum(building["asset_count"] for building in buildings),
+                "label": domain_label,
+                "mission_areas": mission_areas,
+                "asset_count": sum(mission_area["asset_count"] for mission_area in mission_areas),
             }
         )
 
     return {
-        "threads": threads,
-        "asset_count": sum(thread["asset_count"] for thread in threads),
+        "domains": domains,
+        "asset_count": sum(domain["asset_count"] for domain in domains),
     }
 
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -311,7 +311,7 @@
   {% set exception_total = overview.attention_count %}
   {% set custody_map = dashboard.snapshots.custody_map %}
   <div class="dashboard-intro">
-    <p class="dashboard-note">Custody map is read-only.</p>
+    <p class="dashboard-note">Asset location map is read-only.</p>
   </div>
 
   {% if show_first_run_guide %}
@@ -377,44 +377,44 @@
   </div>
 
   <details class="disclosure-section dashboard-map-card">
-    <summary aria-label="Custody map">
+    <summary aria-label="Asset location map">
       <span class="dashboard-map-heading">
-        <span class="disclosure-title">Custody Map</span>
+        <span class="disclosure-title">Asset Location Map</span>
         <a class="nav-link" href="{{ url_for('asset_search') }}">Asset Search</a>
       </span>
-      <span class="disclosure-hint">Thread → Building → Operational Domain → Custody Holder → Asset</span>
+      <span class="disclosure-hint">Asset Domain -> Mission Area -> Building -> Custody Holder -> Asset</span>
     </summary>
     <div class="disclosure-body">
-      {% if custody_map.threads %}
+      {% if custody_map.domains %}
         <ul class="custody-map-tree">
-          {% for thread in custody_map.threads %}
+          {% for domain in custody_map.domains %}
             <li>
               <details class="disclosure-section custody-map-node">
                 <summary>
-                  <span class="custody-map-label">Thread: {{ thread.label }}</span>
-                  <span class="custody-map-hint">{{ thread.asset_count }} asset{% if thread.asset_count != 1 %}s{% endif %}</span>
+                  <span class="custody-map-label">Asset Domain: {{ domain.label }}</span>
+                  <span class="custody-map-hint">{{ domain.asset_count }} asset{% if domain.asset_count != 1 %}s{% endif %}</span>
                 </summary>
                 <div class="disclosure-body">
                   <ul class="custody-map-children">
-                    {% for building in thread.buildings %}
+                    {% for mission_area in domain.mission_areas %}
                       <li>
                         <details class="disclosure-section custody-map-node">
                           <summary>
-                            <span class="custody-map-label">Building: {{ building.label }}</span>
-                            <span class="custody-map-hint">{{ building.asset_count }} asset{% if building.asset_count != 1 %}s{% endif %}</span>
+                            <span class="custody-map-label">Mission Area: {{ mission_area.label }}</span>
+                            <span class="custody-map-hint">{{ mission_area.asset_count }} asset{% if mission_area.asset_count != 1 %}s{% endif %}</span>
                           </summary>
                           <div class="disclosure-body">
                             <ul class="custody-map-children">
-                              {% for domain in building.domains %}
+                              {% for building in mission_area.buildings %}
                                 <li>
                                   <details class="disclosure-section custody-map-node">
                                     <summary>
-                                      <span class="custody-map-label">Operational Domain: {{ domain.label }}</span>
-                                      <span class="custody-map-hint">{{ domain.asset_count }} asset{% if domain.asset_count != 1 %}s{% endif %}</span>
+                                      <span class="custody-map-label">Building: {{ building.label }}</span>
+                                      <span class="custody-map-hint">{{ building.asset_count }} asset{% if building.asset_count != 1 %}s{% endif %}</span>
                                     </summary>
                                     <div class="disclosure-body">
                                       <ul class="custody-map-children">
-                                        {% for holder in domain.holders %}
+                                        {% for holder in building.holders %}
                                           <li>
                                             <details class="disclosure-section custody-map-node">
                                               <summary>
@@ -459,7 +459,7 @@
           {% endfor %}
         </ul>
       {% else %}
-        <p class="dashboard-note">No active assets in the custody map.</p>
+        <p class="dashboard-note">No active assets in the asset location map.</p>
       {% endif %}
     </div>
   </details>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -213,17 +213,20 @@ class DashboardTests(unittest.TestCase):
         self.assertNotIn(b"Open Return Workflow", response.data)
         self.assertNotIn(b'class="action-secondary" href="/issue">Issue Assets</a>', response.data)
         self.assertNotIn(b'class="action-secondary" href="/return">Return Assets</a>', response.data)
-        self.assertIn(b"Custody Map", response.data)
-        self.assertIn(b"Custody map is read-only.", response.data)
+        self.assertIn(b"Asset Location Map", response.data)
+        self.assertIn(b"Asset location map is read-only.", response.data)
         self.assertNotIn(b"Use this map for rough inventory orientation only.", response.data)
         self.assertNotIn(b"Field Operational Custody Map", response.data)
-        self.assertIn(b"Thread: CISR", response.data)
-        self.assertNotIn(b"Thread: <a", response.data)
-        self.assertIn(b"Operational Domain", response.data)
+        self.assertNotIn(b"Custody Map", response.data)
+        self.assertIn(b"Mission Area: CISR", response.data)
+        self.assertNotIn(b"Mission Area: <a", response.data)
+        self.assertNotIn(b"Thread:", response.data)
+        self.assertIn(b"Asset Domain", response.data)
+        self.assertNotIn(b"Operational Domain", response.data)
         self.assertIn(b"SysAdmins", response.data)
         self.assertIn(b"Alex Holder", response.data)
         self.assertIn(b"Building: HQ", response.data)
-        self.assertIn(b"Operational Domain: SysAdmins", response.data)
+        self.assertIn(b"Asset Domain: SysAdmins", response.data)
         self.assertIn(b"Custody Holder:", response.data)
         self.assertIn(b'<a class="nav-link" href="/assets/search">Asset Search</a>', response.data)
         self.assertIn(
@@ -279,7 +282,7 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b'href="#dashboard-main"', response.data)
         self.assertIn(b"Continue to Dashboard", response.data)
         self.assertIn(b"Assets Out", response.data)
-        self.assertIn(b"No active assets in the custody map.", response.data)
+        self.assertIn(b"No active assets in the asset location map.", response.data)
         for table_name in ("assets", "holders", "slots", "asset_events"):
             row_count = int(self.conn.execute(f"SELECT COUNT(*) FROM {table_name};").fetchone()[0])
             self.assertEqual(row_count, 0)
@@ -324,9 +327,9 @@ class DashboardTests(unittest.TestCase):
         self.assertIn(b'href="/return">Return</a>', response.data)
         self.assertNotIn(b"Open Issue Workflow", response.data)
         self.assertNotIn(b"Open Return Workflow", response.data)
-        self.assertIn(b"Custody Map", response.data)
-        self.assertIn(b"Custody map is read-only.", response.data)
-        self.assertIn(b"No active assets in the custody map.", response.data)
+        self.assertIn(b"Asset Location Map", response.data)
+        self.assertIn(b"Asset location map is read-only.", response.data)
+        self.assertIn(b"No active assets in the asset location map.", response.data)
         self.assertIn(b'id="problems-panel"', response.data)
         self.assertNotIn(b'id="problems-panel" open', response.data)
         self.assertIn(b"Asset Search", response.data)
@@ -638,8 +641,9 @@ class DashboardTests(unittest.TestCase):
 
         self.assertEqual(len(data["snapshots"]["recent_activity"]), MAX_DASHBOARD_RECENT_ACTIVITY)
 
-    def test_custody_map_groups_assets_by_building_domain_holder_with_fallbacks(self) -> None:
+    def test_asset_location_map_groups_non_disposed_assets_by_domain_mission_building_holder(self) -> None:
         self._insert_holder(1, "Alex Holder", organization="CISR")
+        self._insert_slot(10, "CASE-STORAGE", 1)
         self._insert_asset(
             "AT-LAPTOP",
             location_type="IN_CUSTODY",
@@ -649,15 +653,17 @@ class DashboardTests(unittest.TestCase):
             room="210",
         )
         self._insert_asset(
-            "AT-SWITCH",
+            "AT-STORED-SWITCH",
             location_type="STORAGE",
+            home_slot_id=10,
             equipment_type="switch",
             building="HQ North",
             room="Closet",
         )
         self._insert_asset(
-            "AT-ROUTER",
+            "AT-UNSLOTTED-ROUTER",
             location_type="STORAGE",
+            home_slot_id=None,
             equipment_type="router",
             building="HQ North",
             room="Closet",
@@ -669,43 +675,62 @@ class DashboardTests(unittest.TestCase):
             building="",
             room="",
         )
+        self._insert_asset(
+            "AT-DISPOSED",
+            location_type="DISPOSED",
+            current_holder_id=1,
+            equipment_type="laptop",
+            building="HQ North",
+            room="210",
+        )
         self.conn.commit()
 
         data = build_dashboard_data(self.conn, custody_days_threshold=30)
 
         custody_map = data["snapshots"]["custody_map"]
         self.assertEqual(custody_map["asset_count"], 4)
-        self.assertEqual([thread["label"] for thread in custody_map["threads"]], ["CISR", "Unknown Thread"])
+        self.assertEqual([domain["label"] for domain in custody_map["domains"]], ["SysAdmins", "Network", "Unclassified Asset"])
 
-        cisr_thread = custody_map["threads"][0]
-        self.assertEqual([building["label"] for building in cisr_thread["buildings"]], ["HQ North"])
-
-        hq_building = cisr_thread["buildings"][0]
-        self.assertEqual([domain["label"] for domain in hq_building["domains"]], ["SysAdmins"])
-        sysadmins_holder = hq_building["domains"][0]["holders"][0]
+        sysadmins_domain = custody_map["domains"][0]
+        self.assertEqual([mission_area["label"] for mission_area in sysadmins_domain["mission_areas"]], ["CISR"])
+        cisr_mission = sysadmins_domain["mission_areas"][0]
+        self.assertEqual([building["label"] for building in cisr_mission["buildings"]], ["HQ North"])
+        sysadmins_holder = cisr_mission["buildings"][0]["holders"][0]
         self.assertEqual(sysadmins_holder["label"], "Alex Holder")
         self.assertEqual(sysadmins_holder["assets"][0]["asset_tag"], "AT-LAPTOP")
         self.assertEqual(sysadmins_holder["assets"][0]["equipment_type_label"], "Laptop")
 
-        unknown_thread = custody_map["threads"][1]
-        self.assertEqual([building["label"] for building in unknown_thread["buildings"]], ["HQ North", "Unknown Building"])
-
-        hq_building = unknown_thread["buildings"][0]
-        self.assertEqual([domain["label"] for domain in hq_building["domains"]], ["Network"])
-        network_holder = hq_building["domains"][0]["holders"][0]
-        self.assertEqual(network_holder["label"], "Unassigned Holder")
+        network_domain = custody_map["domains"][1]
+        self.assertEqual([mission_area["label"] for mission_area in network_domain["mission_areas"]], ["No Mission Area Recorded"])
+        no_mission = network_domain["mission_areas"][0]
+        self.assertEqual([building["label"] for building in no_mission["buildings"]], ["HQ North"])
+        network_holder = no_mission["buildings"][0]["holders"][0]
+        self.assertEqual(network_holder["label"], "No Custody Holder")
         self.assertEqual(
             [asset["asset_tag"] for asset in network_holder["assets"]],
-            ["AT-ROUTER", "AT-SWITCH"],
+            ["AT-STORED-SWITCH", "AT-UNSLOTTED-ROUTER"],
         )
         self.assertEqual(
             [asset["equipment_type_label"] for asset in network_holder["assets"]],
-            ["Router", "Switch"],
+            ["Switch", "Router"],
         )
 
-        unknown_building = unknown_thread["buildings"][1]
-        self.assertEqual(unknown_building["domains"][0]["label"], "Unclassified Asset")
-        self.assertEqual(unknown_building["domains"][0]["holders"][0]["assets"][0]["asset_tag"], "AT-UNKNOWN")
+        unclassified_domain = custody_map["domains"][2]
+        unclassified_mission = unclassified_domain["mission_areas"][0]
+        self.assertEqual(unclassified_mission["label"], "No Mission Area Recorded")
+        self.assertEqual(unclassified_mission["buildings"][0]["label"], "No Building Recorded")
+        self.assertEqual(unclassified_mission["buildings"][0]["holders"][0]["label"], "No Custody Holder")
+        self.assertEqual(unclassified_mission["buildings"][0]["holders"][0]["assets"][0]["asset_tag"], "AT-UNKNOWN")
+
+        displayed_assets = []
+        for domain in custody_map["domains"]:
+            for mission_area in domain["mission_areas"]:
+                for building in mission_area["buildings"]:
+                    for holder in building["holders"]:
+                        displayed_assets.extend(asset["asset_tag"] for asset in holder["assets"])
+        self.assertEqual(sorted(displayed_assets), ["AT-LAPTOP", "AT-STORED-SWITCH", "AT-UNKNOWN", "AT-UNSLOTTED-ROUTER"])
+        self.assertEqual(len(displayed_assets), len(set(displayed_assets)))
+        self.assertEqual(len(displayed_assets), custody_map["asset_count"])
 
     def test_custody_map_render_is_collapsible_at_each_hierarchy_level(self) -> None:
         self._insert_holder(1, "Alex Holder", organization="CISR")
@@ -729,13 +754,14 @@ class DashboardTests(unittest.TestCase):
         response = self.client.get("/dashboard")
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'aria-label="Custody map"', response.data)
-        self.assertIn(b"Thread: CISR", response.data)
-        self.assertIn(b"Thread: Unknown Thread", response.data)
-        self.assertNotIn(b"Thread: <a", response.data)
+        self.assertIn(b'aria-label="Asset location map"', response.data)
+        self.assertIn(b"Mission Area: CISR", response.data)
+        self.assertIn(b"Mission Area: No Mission Area Recorded", response.data)
+        self.assertNotIn(b"Mission Area: <a", response.data)
+        self.assertNotIn(b"Thread:", response.data)
         self.assertIn(b"Building: HQ North", response.data)
-        self.assertIn(b"Operational Domain: SysAdmins", response.data)
-        self.assertIn(b"Operational Domain: Network", response.data)
+        self.assertIn(b"Asset Domain: SysAdmins", response.data)
+        self.assertIn(b"Asset Domain: Network", response.data)
         self.assertIn(b"Custody Holder:", response.data)
         self.assertIn(b'<a class="nav-link" href="/assets/search">Asset Search</a>', response.data)
         self.assertIn(


### PR DESCRIPTION
## Summary

Implements the Asset Location Map hierarchy, labels, data sources, and blank-value presentation approved in Issue 31-13.

## Related Issue

Closes #1108

Decision record: #1107

## Changes

- Renamed Custody Map to Asset Location Map.
- Reordered the hierarchy to:
  - Asset Domain
  - Mission Area
  - Building
  - Custody Holder
  - Asset
- Renamed Operational Domain to Asset Domain.
- Renamed Thread to Mission Area.
- Continued deriving Asset Domain from existing equipment-type logic.
- Continued using `holders.organization` for Mission Area.
- Continued using `assets.building` for Building.
- Added approved fallback labels:
  - `No Mission Area Recorded`
  - `No Building Recorded`
  - `No Custody Holder`
- Preserved deterministic ordering.
- Preserved Stored and Unslotted asset visibility.
- Continued excluding Disposed assets.
- Preserved read-only behavior and existing asset-history links.

## Verification

- [x] `pytest tests/test_dashboard.py -q` — 18 passed
- [x] `pytest tests/test_basic_auth_guard.py -q` — 36 passed
- [x] `pytest tests/test_dashboard_drilldowns.py -q` — 32 passed
- [x] Combined regression run — 86 passed
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Incognito/private browser used
- [x] Asset Location Map title verified
- [x] Approved hierarchy order verified
- [x] Stored asset visibility verified
- [x] Unslotted asset visibility verified
- [x] Disposed asset exclusion verified
- [x] Blank Mission Area label verified
- [x] Blank Building label verified
- [x] Missing Custody Holder label verified
- [x] Read-only behavior verified
- [x] Existing asset-history navigation verified
- [x] No duplicate asset display observed
- [x] Displayed total reconciled with eligible non-disposed population

## Notes

- No schema, migration, backfill, or dependency changes.
- No custody, storage, occupancy, event, audit, Issue, or Return behavior changes.
- No case, slot, or explicit Unslotted presentation changes. Those remain under Issue #1109.
- Mission Area remains derived from `holders.organization`.