### PR TITLE
Issue 31-15: Add Asset Location Map storage presentation

### DIFF
--- a/assettrack/dashboard.py
+++ b/assettrack/dashboard.py
@@ -531,12 +531,22 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
             a.building,
             a.location_type,
             a.current_holder_id,
+            s.case_name AS current_case_name,
+            s.slot_position AS current_slot_position,
             h.id AS holder_detail_id,
             h.name AS holder_name,
             h.organization AS holder_organization
         FROM assets a
         LEFT JOIN holders h
           ON h.id = a.current_holder_id
+        LEFT JOIN (
+            SELECT asset_id, MIN(slot_id) AS slot_id
+            FROM slot_occupancy
+            GROUP BY asset_id
+        ) so
+          ON so.asset_id = a.id
+        LEFT JOIN slots s
+          ON s.id = so.slot_id
         WHERE COALESCE(a.location_type, '') <> 'DISPOSED'
         ORDER BY
             COALESCE(NULLIF(TRIM(a.building), ''), 'No Building Recorded') ASC,
@@ -572,11 +582,28 @@ def _custody_map(conn: sqlite3.Connection) -> dict:
                 "assets": [],
             },
         )
+        location_type = str(row["location_type"] or "").strip()
+        current_case_name = str(row["current_case_name"] or "").strip()
+        current_slot_position = row["current_slot_position"]
+        storage_display = ""
+        storage_case_name = ""
+        storage_slot_position = None
+        if location_type == "STORAGE":
+            if current_case_name and current_slot_position is not None:
+                storage_slot_position = int(current_slot_position)
+                storage_case_name = current_case_name
+                storage_display = f"Stored in {storage_case_name}, Slot {storage_slot_position}"
+            else:
+                storage_display = "Unslotted"
+
         holder_node["assets"].append(
             {
                 "asset_tag": _asset_map_label(row["asset_tag"]),
                 "equipment_type_label": _equipment_type_label(row["equipment_type"]),
-                "location_type": str(row["location_type"] or "").strip(),
+                "location_type": location_type,
+                "storage_display": storage_display,
+                "storage_case_name": storage_case_name,
+                "storage_slot_position": storage_slot_position,
             }
         )
 

--- a/assettrack/intake/templates/dashboard.html
+++ b/assettrack/intake/templates/dashboard.html
@@ -435,6 +435,15 @@
                                                         <a class="nav-link" href="{{ url_for('asset_history', asset_tag=asset.asset_tag, return_to=url_for('dashboard')) }}"><code>{{ asset.asset_tag }}</code></a>
                                                       </span>
                                                       <span class="custody-map-asset-type">{{ asset.equipment_type_label }}</span>
+                                                      {% if asset.storage_display %}
+                                                        <span class="custody-map-asset-type">
+                                                          {% if asset.storage_case_name %}
+                                                            <a class="nav-link" href="{{ url_for('dashboard_case_detail', case_name=asset.storage_case_name, return_to=url_for('dashboard')) }}">{{ asset.storage_display }}</a>
+                                                          {% else %}
+                                                            {{ asset.storage_display }}
+                                                          {% endif %}
+                                                        </span>
+                                                      {% endif %}
                                                     </li>
                                                   {% endfor %}
                                                 </ul>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -652,13 +652,20 @@ class DashboardTests(unittest.TestCase):
             building="HQ North",
             room="210",
         )
-        self._insert_asset(
+        stored_switch_id = self._insert_asset(
             "AT-STORED-SWITCH",
             location_type="STORAGE",
             home_slot_id=10,
             equipment_type="switch",
             building="HQ North",
             room="Closet",
+        )
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (10, ?, '2026-01-01T00:00:00Z');
+            """,
+            (stored_switch_id,),
         )
         self._insert_asset(
             "AT-UNSLOTTED-ROUTER",
@@ -699,6 +706,7 @@ class DashboardTests(unittest.TestCase):
         self.assertEqual(sysadmins_holder["label"], "Alex Holder")
         self.assertEqual(sysadmins_holder["assets"][0]["asset_tag"], "AT-LAPTOP")
         self.assertEqual(sysadmins_holder["assets"][0]["equipment_type_label"], "Laptop")
+        self.assertEqual(sysadmins_holder["assets"][0]["storage_display"], "")
 
         network_domain = custody_map["domains"][1]
         self.assertEqual([mission_area["label"] for mission_area in network_domain["mission_areas"]], ["No Mission Area Recorded"])
@@ -714,6 +722,14 @@ class DashboardTests(unittest.TestCase):
             [asset["equipment_type_label"] for asset in network_holder["assets"]],
             ["Switch", "Router"],
         )
+        self.assertEqual(
+            [asset["storage_display"] for asset in network_holder["assets"]],
+            ["Stored in CASE-STORAGE, Slot 1", "Unslotted"],
+        )
+        self.assertEqual(network_holder["assets"][0]["storage_case_name"], "CASE-STORAGE")
+        self.assertEqual(network_holder["assets"][0]["storage_slot_position"], 1)
+        self.assertEqual(network_holder["assets"][1]["storage_case_name"], "")
+        self.assertIsNone(network_holder["assets"][1]["storage_slot_position"])
 
         unclassified_domain = custody_map["domains"][2]
         unclassified_mission = unclassified_domain["mission_areas"][0]
@@ -734,6 +750,7 @@ class DashboardTests(unittest.TestCase):
 
     def test_custody_map_render_is_collapsible_at_each_hierarchy_level(self) -> None:
         self._insert_holder(1, "Alex Holder", organization="CISR")
+        self._insert_slot(20, "CASE-MAP", 7)
         self._insert_asset(
             "AT-LAPTOP",
             location_type="IN_CUSTODY",
@@ -742,10 +759,25 @@ class DashboardTests(unittest.TestCase):
             building="HQ North",
             room="210",
         )
-        self._insert_asset(
+        stored_switch_id = self._insert_asset(
             "AT-SWITCH",
             location_type="STORAGE",
+            home_slot_id=20,
             equipment_type="switch",
+            building="HQ North",
+            room="Closet",
+        )
+        self.conn.execute(
+            """
+            INSERT INTO slot_occupancy (slot_id, asset_id, assigned_at)
+            VALUES (20, ?, '2026-01-01T00:00:00Z');
+            """,
+            (stored_switch_id,),
+        )
+        self._insert_asset(
+            "AT-UNSLOTTED",
+            location_type="STORAGE",
+            equipment_type="router",
             building="HQ North",
             room="Closet",
         )
@@ -772,5 +804,10 @@ class DashboardTests(unittest.TestCase):
             b'<a class="nav-link" href="/assets/history?asset_tag=AT-SWITCH&amp;return_to=/dashboard"><code>AT-SWITCH</code></a>',
             response.data,
         )
+        self.assertIn(
+            b'<a class="nav-link" href="/dashboard/cases/CASE-MAP?return_to=/dashboard">Stored in CASE-MAP, Slot 7</a>',
+            response.data,
+        )
+        self.assertIn(b"Unslotted", response.data)
         self.assertGreaterEqual(response.data.count(b'class="disclosure-section custody-map-node"'), 4)
         self.assertIn(b'class="custody-map-asset"', response.data)


### PR DESCRIPTION
## Summary

Adds asset-level storage presentation to the Asset Location Map so Stored assets show either their current case and slot or an explicit Unslotted label.

## Related Issue

Closes #1109

## Changes

- Uses existing occupancy and slot data in the Asset Location Map.
- Shows Stored assets with current occupancy as `Stored in <case>, Slot <slot>`.
- Links case metadata through the existing case-detail route.
- Shows Stored assets without current occupancy as `Unslotted`.
- Preserves the approved Asset Domain → Mission Area → Building → Custody Holder → Asset hierarchy.
- Preserves one appearance per eligible asset and total reconciliation.

## Verification

- [x] 18 focused tests passed
- [x] 282 relevant regression tests passed
- [x] `git diff --check` passed
- [x] Docker image rebuilt
- [x] Incognito operator verification passed
- [x] Stored, Unslotted, Issued, fallback, and Disposed behavior verified
- [x] Asset totals reconcile
- [x] Container restart persistence verified
- [x] Event and audit integrity confirmed
- [x] Authentication and role behavior unchanged

## Notes

No schema, dependency, custody, occupancy, event, audit, authentication, persistence, Issue, Return, Assign Slots, case-capacity, or slot-provisioning behavior changed.

GitHub Actions is currently blocking required checks. This PR is eligible for the documented outage exception because local automated testing and manual operator verification passed.
