### PR TITLE
Issue 31-26: update pypdf security version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy==2.4.1
 openpyxl==3.1.5
 pandas==3.0.0
 pillow==12.3.0
-pypdf==6.14.2
+pypdf==6.15.0
 python-dateutil==2.9.0.post0
 reportlab==4.4.9
 six==1.17.0


### PR DESCRIPTION
## Summary

Update pypdf to the minimum fixed version required to clear the current Trivy Security Baseline findings.

## Related Issue

Closes #1140

## Changes

- Updated `pypdf` from `6.14.2` to `6.15.0`.
- No application code, scanner configuration, Docker configuration, or unrelated dependencies changed.

## Verification

- [x] `pypdf 6.15.0` confirmed locally
- [x] Focused PDF/receipt tests - 120 passed
- [x] `python -m compileall assettrack tests`
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Running container reports `pypdf 6.15.0`
- [x] Receipt PDF manual smoke test
- [x] Case inventory PDF manual smoke test
- [ ] GitHub filesystem Trivy scan
- [ ] GitHub container-image Trivy scan

## Notes

The two Medium pypdf findings were pre-existing on `main` and surfaced during Security Baseline verification of PR #1139.

Findings addressed:

- CVE-2026-71852
- CVE-2026-71870

Both list `pypdf 6.15.0` as the fixed version.

No Security Baseline threshold, exclusion, or scanner configuration was changed.