### PR TITLE
Issue 31-11: add case capacity summary

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1478,6 +1478,7 @@ def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[st
     total = int(total_slots or 0)
     occupied = int(occupied_slots or 0)
     available = max(0, total - occupied)
+    utilization_percent = int((occupied * 100.0 / total) + 0.5) if total > 0 else 0
 
     if available == 0:
         return {
@@ -1485,6 +1486,7 @@ def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[st
             "text": "FULL - No space",
             "class_name": "full",
             "available_slots": available,
+            "utilization_percent": utilization_percent,
         }
     if available <= 3:
         return {
@@ -1492,12 +1494,14 @@ def _case_status_summary(total_slots: object, occupied_slots: object) -> dict[st
             "text": "LOW - Getting tight",
             "class_name": "low",
             "available_slots": available,
+            "utilization_percent": utilization_percent,
         }
     return {
         "label": "OPEN",
         "text": "OPEN - Use now",
         "class_name": "open",
         "available_slots": available,
+        "utilization_percent": utilization_percent,
     }
 
 

--- a/assettrack/intake/templates/dashboard_case_detail.html
+++ b/assettrack/intake/templates/dashboard_case_detail.html
@@ -21,6 +21,28 @@
       flex-wrap: wrap;
     }
     .status-card { margin-bottom: 1rem; }
+    .case-status-summary {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1rem 1.5rem;
+      flex-wrap: wrap;
+    }
+    .case-status-main,
+    .case-capacity-summary {
+      min-width: 14rem;
+    }
+    .case-status-main {
+      flex: 1 1 18rem;
+    }
+    .case-capacity-summary {
+      flex: 0 1 18rem;
+      line-height: 1.55;
+    }
+    .case-capacity-summary p,
+    .case-status-main p {
+      margin: 0;
+    }
     .status-dot.full { background: #12b76a; }
     .status-dot.low { background: #f79009; }
     .status-dot.open { background: #b42318; }
@@ -56,7 +78,7 @@
 {% block content %}
   {% set occupied_slots = case_detail.slots | selectattr("asset_tag") | list | length %}
   {% set total_slots = case_detail.slots | length %}
-  {% set empty_slots = total_slots - occupied_slots %}
+  {% set available_slots = total_slots - occupied_slots %}
   {% set status = case_status_summary(total_slots, occupied_slots) %}
   <div class="page-header-bar">
     <nav class="page-header-nav" aria-label="Contextual navigation">
@@ -77,33 +99,42 @@
   {% endwith %}
 
   <section class="card status-card">
-    <h2>Case Status</h2>
-    <p>
-      <span class="status-badge">
-        <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>
-        <span>{{ status.text }}</span>
-      </span>
-      <br />
-      <strong>Total slots:</strong> {{ total_slots }}<br />
-      <strong>Occupied slots:</strong> {{ occupied_slots }}<br />
-      <strong>Empty slots:</strong> {{ empty_slots }}<br />
-      <strong>Case Size:</strong> {{ case_detail.case_size or "Not recorded" }}
-    </p>
-    {% if authenticated_role == 'admin' %}
-      <form method="post" action="{{ url_for('admin_case_size_update', case_name=case_detail.case_name) }}" class="case-action-row">
-        {% if return_to %}
-          <input type="hidden" name="return_to" value="{{ return_to }}" />
+    <div class="case-status-summary">
+      <div class="case-status-main">
+        <h2>Case Status</h2>
+        <p>
+          <span class="status-badge">
+            <span class="status-dot {{ status.class_name }}" aria-hidden="true"></span>
+            <span>{{ status.text }}</span>
+          </span>
+          <br />
+          <strong>Case Size:</strong> {{ case_detail.case_size or "Not recorded" }}
+        </p>
+        {% if authenticated_role == 'admin' %}
+          <form method="post" action="{{ url_for('admin_case_size_update', case_name=case_detail.case_name) }}" class="case-action-row">
+            {% if return_to %}
+              <input type="hidden" name="return_to" value="{{ return_to }}" />
+            {% endif %}
+            <label for="case_size"><strong>Case Size</strong></label>
+            <select id="case_size" name="case_size">
+              <option value="" {% if not case_detail.case_size %}selected{% endif %}>Not recorded</option>
+              {% for option in case_size_options %}
+                <option value="{{ option }}" {% if case_detail.case_size == option %}selected{% endif %}>{{ option }}</option>
+              {% endfor %}
+            </select>
+            <button type="submit">Save Case Size</button>
+          </form>
         {% endif %}
-        <label for="case_size"><strong>Case Size</strong></label>
-        <select id="case_size" name="case_size">
-          <option value="" {% if not case_detail.case_size %}selected{% endif %}>Not recorded</option>
-          {% for option in case_size_options %}
-            <option value="{{ option }}" {% if case_detail.case_size == option %}selected{% endif %}>{{ option }}</option>
-          {% endfor %}
-        </select>
-        <button type="submit">Save Case Size</button>
-      </form>
-    {% endif %}
+      </div>
+      <div class="case-capacity-summary" aria-label="Slot capacity summary">
+        <p>
+          <strong>Total slots:</strong> {{ total_slots }}<br />
+          <strong>Occupied slots:</strong> {{ occupied_slots }}<br />
+          <strong>Available slots:</strong> {{ available_slots }}<br />
+          <strong>Utilization:</strong> {{ status.utilization_percent }}%
+        </p>
+      </div>
+    </div>
   </section>
 
   <section class="card">

--- a/tests/test_dashboard_drilldowns.py
+++ b/tests/test_dashboard_drilldowns.py
@@ -246,7 +246,8 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
     assert b"status-dot low" in response.data
     assert b"Total slots:</strong> 3" in response.data
     assert b"Occupied slots:</strong> 1" in response.data
-    assert b"Empty slots:</strong> 2" in response.data
+    assert b"Available slots:</strong> 2" in response.data
+    assert b"Utilization:</strong> 33%" in response.data
     assert b"Check boxes to select assets." in response.data
     assert b"Select all" in response.data
     assert b"Select all eligible assets" not in response.data
@@ -264,6 +265,12 @@ def test_dashboard_case_detail_200_includes_expected_slot_positions(app_client) 
     assert b"AT-OUT" in response.data
     assert b"Empty" in response.data
 
+
+def test_dashboard_case_detail_capacity_summary_handles_zero_slots() -> None:
+    summary = intake_app._case_status_summary(0, 0)
+
+    assert summary["available_slots"] == 0
+    assert summary["utilization_percent"] == 0
 
 def test_dashboard_case_detail_asset_tags_link_to_asset_history(app_client) -> None:
     conn, client = app_client


### PR DESCRIPTION
## Summary

Add a compact capacity and availability summary to Case Detail using existing provisioned-slot and occupancy data.

## Related Issue

Closes #1105

## Changes

- Added total provisioned slot count.
- Added occupied slot count.
- Added available slot count.
- Added zero-safe utilization percentage.
- Kept Case Status and Case Size on the left side of the summary card.
- Added the slot availability summary on the right side.
- Added responsive wrapping for narrow screens.
- Omitted an issued-from-case count because the existing data does not safely prove that relationship.

## Verification

- [x] Focused Case Detail tests - 2 passed
- [x] `pytest -q tests/test_dashboard_drilldowns.py` - 33 passed
- [x] `python -m py_compile assettrack/intake/app.py`
- [x] `git diff --check`
- [x] `docker compose up -d --build`
- [x] Desktop Case Detail summary verified
- [x] Total, occupied, available, and utilization values verified
- [x] Occupied + available = total
- [x] Responsive narrow-width layout verified
- [x] No horizontal overflow
- [x] Existing Case Size control remains usable

## Notes

Capacity and utilization are derived from actual provisioned slots. No summary values are persisted.

An issued-from-case count was intentionally omitted because the current data model does not establish that relationship without inference.