### PR TITLE
Issue 31-19: Reset session inactivity timer

### DIFF
--- a/assettrack/auth.py
+++ b/assettrack/auth.py
@@ -55,6 +55,10 @@ def _session_timing_valid() -> bool:
     return True
 
 
+def refresh_session_activity() -> None:
+    session["last_seen"] = now_seconds()
+
+
 def _prefers_json_response() -> bool:
     if request.is_json:
         return True
@@ -104,6 +108,7 @@ def require_login(view_func):
         user = current_user()
         if user is None:
             return _forbidden_response()
+        refresh_session_activity()
         return view_func(*args, **kwargs)
 
     return wrapped

--- a/tests/test_session_activity_refresh.py
+++ b/tests/test_session_activity_refresh.py
@@ -66,6 +66,42 @@ def test_authenticated_navigation_refreshes_last_seen(client_with_temp_db, monke
         assert sess["session_started_at"] == 50
 
 
+def test_protected_route_refreshes_last_seen_without_route_local_touch(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=100, session_started_at=50)
+    _set_now(monkeypatch, 200)
+
+    response = client_with_temp_db.get("/assets/search")
+
+    assert response.status_code == 200
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 200
+        assert sess["session_started_at"] == 50
+
+
+def test_authenticated_activity_keeps_session_valid_beyond_twenty_minutes_total_age(
+    client_with_temp_db, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _login(client_with_temp_db, monkeypatch, last_seen=100, session_started_at=50)
+
+    _set_now(monkeypatch, 100 + auth.SESSION_IDLE_TIMEOUT_SECONDS - 1)
+    first_response = client_with_temp_db.get("/assets/search")
+
+    assert first_response.status_code == 200
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 100 + auth.SESSION_IDLE_TIMEOUT_SECONDS - 1
+        assert sess["session_started_at"] == 50
+
+    _set_now(monkeypatch, 100 + auth.SESSION_IDLE_TIMEOUT_SECONDS + 30)
+    second_response = client_with_temp_db.get("/dashboard")
+
+    assert second_response.status_code == 200
+    with client_with_temp_db.session_transaction() as sess:
+        assert sess["last_seen"] == 100 + auth.SESSION_IDLE_TIMEOUT_SECONDS + 30
+        assert sess["session_started_at"] == 50
+
+
 def test_authenticated_pages_hide_session_status_diagnostics(
     client_with_temp_db, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
PR Title:
Issue 31-19: Reset session inactivity timer on authenticated activity

PR Description:

## Summary

Reset the existing 20-minute session timeout on valid authenticated activity so the timeout measures inactivity instead of total session age.

## Related Issue

Closes #1113

## Changes

- Refresh `last_seen` after a protected request successfully validates the authenticated user.
- Preserve the existing 20-minute inactivity limit.
- Preserve existing session-expiration behavior for expired, invalid, inactive-user, and malformed sessions.
- Add focused regression tests for protected-route activity refresh and active use beyond 20 minutes total session age.
- No JavaScript heartbeat, background keepalive, dependency, schema, persistence, role, custody, event, or workflow changes.

## Verification

- [x] Focused auth/session tests pass: 46 passed
- [x] Related role and workflow tests pass: 107 passed, 8 subtests
- [x] Full regression suite passes
- [x] compileall passes
- [x] `git diff --check` passes
- [x] Active-use timeout manual smoke test passes
- [x] Genuine 20+ minute inactivity expiration passes
- [x] Operator/admin role boundary verified
- [x] No background request is required to renew the session
- [x] Docker rebuild and application startup pass

## Notes

Manual verification confirmed that an operator remains authenticated beyond 20 minutes of total session age when making valid authenticated requests, while more than 20 minutes of genuine inactivity still requires reauthentication.

The timeout is checked before activity is refreshed, so an already-expired session cannot renew itself.

Only the following files changed:

- `assettrack/auth.py`
- `tests/test_session_activity_refresh.py`