### PR TITLE
Issue 31-21: Add unused rack-position provisioning

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -8254,6 +8254,75 @@ def admin_receipt_cc_settings():
     return render_template("admin_receipt_cc.html", **_receipt_cc_settings_context())
 
 
+def _parse_slot_provision_identifiers(raw_value: str, errors: list[str]) -> list[int]:
+    tokens = [token for token in re.split(r"[\s,]+", raw_value.strip()) if token]
+    if not tokens:
+        errors.append("slot_identifiers is required.")
+        return []
+
+    parsed: list[int] = []
+    seen: set[int] = set()
+    duplicates: list[int] = []
+    for token in tokens:
+        try:
+            slot_position = int(token)
+        except ValueError:
+            errors.append("slot_identifiers must contain only integer slot positions.")
+            continue
+        if slot_position <= 0:
+            errors.append("slot_identifiers must be greater than 0.")
+            continue
+        if slot_position in seen and slot_position not in duplicates:
+            duplicates.append(slot_position)
+        seen.add(slot_position)
+        parsed.append(slot_position)
+
+    if duplicates:
+        errors.append(f"Duplicate slot identifiers in request: {', '.join(str(value) for value in duplicates)}.")
+    return parsed
+
+
+def _validate_slot_provision_request(
+    conn: sqlite3.Connection,
+    case_number: str,
+    proposed_slots: list[int],
+    errors: list[str],
+) -> None:
+    if not proposed_slots:
+        return
+
+    case_row = conn.execute(
+        """
+        SELECT 1
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+        LIMIT 1;
+        """,
+        (case_number,),
+    ).fetchone()
+    if case_row is None:
+        errors.append("Select an existing case before provisioning empty slots.")
+        return
+
+    placeholders = ", ".join("?" for _ in proposed_slots)
+    existing_rows = conn.execute(
+        f"""
+        SELECT slot_position
+        FROM slots
+        WHERE UPPER(case_name) = UPPER(?)
+          AND slot_position IN ({placeholders})
+        ORDER BY slot_position ASC;
+        """,
+        (case_number, *proposed_slots),
+    ).fetchall()
+    existing_positions = [int(row["slot_position"]) for row in existing_rows]
+    if existing_positions:
+        errors.append(
+            f"Slot identifiers already exist in case {case_number}: "
+            f"{', '.join(str(value) for value in existing_positions)}."
+        )
+
+
 @app.route("/admin/slots/provision", methods=["GET", "POST"])
 @require_login
 @require_role("admin")
@@ -8263,78 +8332,100 @@ def admin_slot_provision():
         return guard_result
 
     case_number = ""
-    slot_count = ""
-    case_size = ""
+    slot_identifiers = ""
+    proposed_slots: list[int] = []
+
+    def render_slot_provision_template():
+        conn = get_connection()
+        try:
+            case_options = _slot_case_options(_list_slot_options(conn))
+        finally:
+            conn.close()
+        return render_template(
+            "admin_slot_provision.html",
+            case_number=case_number,
+            slot_identifiers=slot_identifiers,
+            proposed_slots=proposed_slots,
+            case_options=case_options,
+        )
+
     if request.method == "POST":
+        action = (request.form.get("action") or "preview").strip().lower()
         case_number = (request.form.get("case_number") or "").strip().upper()
-        slot_count = (request.form.get("slot_count") or "").strip()
-        case_size = (request.form.get("case_size") or "").strip()
+        slot_identifiers = (request.form.get("slot_identifiers") or "").strip()
 
         if not case_number:
             flash("case_number is required.", "error")
-        if not slot_count:
-            flash("slot_count is required.", "error")
-        if not case_number or not slot_count:
-            return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count, case_size=case_size, case_size_options=CASE_SIZE_OPTIONS)
-
-        try:
-            parsed_slot_count = int(slot_count)
-        except ValueError:
-            flash("slot_count must be an integer.", "error")
-            return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count, case_size=case_size, case_size_options=CASE_SIZE_OPTIONS)
-
-        if parsed_slot_count <= 0:
-            flash("slot_count must be greater than 0.", "error")
-            return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count, case_size=case_size, case_size_options=CASE_SIZE_OPTIONS)
+        if not slot_identifiers:
+            flash("slot_identifiers is required.", "error")
+        if not case_number or not slot_identifiers:
+            return render_slot_provision_template()
 
         conn = get_connection()
         try:
+            errors: list[str] = []
+            proposed_slots = _parse_slot_provision_identifiers(slot_identifiers, errors)
+            if not errors:
+                _validate_slot_provision_request(conn, case_number, proposed_slots, errors)
+            if errors:
+                for error in errors:
+                    flash(error, "error")
+                return render_slot_provision_template()
+
+            if action == "preview":
+                flash("Slot provisioning preview ready. Review before committing.", "success")
+                return render_slot_provision_template()
+
+            if action != "commit":
+                flash("Unsupported slot provisioning action.", "error")
+                return render_slot_provision_template()
+
+            expected_case_number = (request.form.get("expected_case_number") or "").strip().upper()
+            expected_slot_identifiers = (request.form.get("expected_slot_identifiers") or "").strip()
+            if request.form.get("confirm_slot_provision") != "yes":
+                flash("Please confirm you reviewed the slot provisioning preview before committing.", "error")
+                return render_slot_provision_template()
+            if expected_case_number != case_number or expected_slot_identifiers != slot_identifiers:
+                flash("Preview changed. Review the slot provisioning preview again before committing.", "error")
+                proposed_slots = []
+                return render_slot_provision_template()
+
             try:
                 conn.execute("BEGIN;")
-                current_max = conn.execute(
-                    """
-                    SELECT MAX(slot_position) AS max_slot_position
-                    FROM slots
-                    WHERE UPPER(case_name) = UPPER(?);
-                    """,
-                    (case_number,),
-                ).fetchone()
-                start_position = int(current_max["max_slot_position"] or 0) + 1
-                rows = [
-                    (case_number, slot_position, None)
-                    for slot_position in range(start_position, start_position + parsed_slot_count)
-                ]
+                commit_errors: list[str] = []
+                _validate_slot_provision_request(conn, case_number, proposed_slots, commit_errors)
+                if commit_errors:
+                    raise ValueError("; ".join(commit_errors))
                 conn.executemany(
                     """
                     INSERT INTO slots (case_name, slot_position, current_asset_tag)
                     VALUES (?, ?, ?);
                     """,
-                    rows,
+                    [(case_number, slot_position, None) for slot_position in proposed_slots],
                 )
-                save_case_size(conn, case_number, case_size)
                 conn.commit()
             except ValueError as e:
                 conn.rollback()
                 flash(str(e), "error")
-                return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count, case_size=case_size, case_size_options=CASE_SIZE_OPTIONS)
+                return render_slot_provision_template()
             except sqlite3.IntegrityError as e:
                 conn.rollback()
                 flash(f"Could not create empty slots: {e}", "error")
-                return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count, case_size=case_size, case_size_options=CASE_SIZE_OPTIONS)
+                return render_slot_provision_template()
             except Exception:
                 conn.rollback()
                 raise
         finally:
             conn.close()
 
-        end_position = start_position + parsed_slot_count - 1
         flash(
-            f"Created {parsed_slot_count} empty slots for case {case_number} (slots {start_position}-{end_position}).",
+            f"Created {len(proposed_slots)} empty slots for case {case_number}: "
+            f"{', '.join(str(slot) for slot in proposed_slots)}.",
             "success",
         )
         return redirect(url_for("admin_slot_provision"))
 
-    return render_template("admin_slot_provision.html", case_number=case_number, slot_count=slot_count, case_size=case_size, case_size_options=CASE_SIZE_OPTIONS)
+    return render_slot_provision_template()
 
 
 @app.route("/admin/case-corrections", methods=["GET", "POST"])

--- a/assettrack/intake/templates/admin_slot_provision.html
+++ b/assettrack/intake/templates/admin_slot_provision.html
@@ -20,28 +20,60 @@
 
   <div class="card">
     <h2>Create empty slots</h2>
-    <p class="card-intro">Adds new empty capacity for a case by appending slot numbers. Existing slots are unchanged.</p>
+    <p class="card-intro">Adds selected empty positions to an existing case. Existing slots are unchanged.</p>
     <form method="post" action="{{ url_for('admin_slot_provision') }}">
       <div class="admin-maintenance-grid">
         <div class="row">
           <label for="case_number"><strong>case_number</strong> (required)</label><br />
-          <input type="text" id="case_number" name="case_number" value="{{ case_number or '' }}" autocomplete="off" required />
-        </div>
-        <div class="row">
-          <label for="slot_count"><strong>slot_count</strong> (required)</label><br />
-          <input type="text" id="slot_count" name="slot_count" value="{{ slot_count or '' }}" autocomplete="off" required />
-        </div>
-        <div class="row">
-          <label for="case_size"><strong>Case Size</strong></label><br />
-          <select id="case_size" name="case_size">
-            <option value="" {% if not case_size %}selected{% endif %}>Not recorded</option>
-            {% for option in case_size_options %}
-              <option value="{{ option }}" {% if case_size == option %}selected{% endif %}>{{ option }}</option>
+          <select id="case_number" name="case_number" required>
+            <option value="" {% if not case_number %}selected{% endif %}>Select case</option>
+            {% for option in case_options %}
+              <option value="{{ option }}" {% if case_number == option %}selected{% endif %}>{{ option }}</option>
             {% endfor %}
           </select>
         </div>
+        <div class="row">
+          <label for="slot_identifiers"><strong>slot_identifiers</strong> (required)</label><br />
+          <textarea id="slot_identifiers" name="slot_identifiers" rows="4" required>{{ slot_identifiers or '' }}</textarea>
+        </div>
       </div>
-      <button type="submit">Create empty slots</button>
+      <button type="submit" name="action" value="preview">Preview empty slots</button>
     </form>
   </div>
+
+  {% if proposed_slots %}
+    <div class="card">
+      <h2>Preview empty slots</h2>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">case_number</th>
+            <th scope="col">slot_position</th>
+            <th scope="col">Occupancy</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for slot_position in proposed_slots %}
+            <tr>
+              <td><code>{{ case_number }}</code></td>
+              <td><code>{{ slot_position }}</code></td>
+              <td>Empty Slot</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <form method="post" action="{{ url_for('admin_slot_provision') }}">
+        <input type="hidden" name="action" value="commit" />
+        <input type="hidden" name="case_number" value="{{ case_number }}" />
+        <input type="hidden" name="slot_identifiers" value="{{ slot_identifiers }}" />
+        <input type="hidden" name="expected_case_number" value="{{ case_number }}" />
+        <input type="hidden" name="expected_slot_identifiers" value="{{ slot_identifiers }}" />
+        <label>
+          <input type="checkbox" name="confirm_slot_provision" value="yes" />
+          I reviewed this slot provisioning preview.
+        </label>
+        <button type="submit">Commit empty slots</button>
+      </form>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -352,18 +352,55 @@ def _case_correction_state() -> dict[str, object]:
 
 def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (3901, 'CASE-P', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
 
-    response = client_with_temp_db.post(
+    preview_response = client_with_temp_db.post(
         "/admin/slots/provision",
-        data={"case_number": "CASE-P", "slot_count": "3"},
-        follow_redirects=True,
+        data={"action": "preview", "case_number": "CASE-P", "slot_identifiers": "2 3 4"},
     )
-    assert response.status_code == 200
-    assert b"Created 3 empty slots for case CASE-P (slots 1-3)." in response.data
+    assert preview_response.status_code == 200
+    assert b"Slot provisioning preview ready. Review before committing." in preview_response.data
+    assert b"Preview empty slots" in preview_response.data
+    assert b"Empty Slot" in preview_response.data
 
     conn = db.get_connection()
     try:
-        rows = conn.execute(
+        assert conn.execute("SELECT COUNT(*) FROM slots WHERE case_name = 'CASE-P';").fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM slot_occupancy;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM case_metadata;").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+    commit_response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "commit",
+            "case_number": "CASE-P",
+            "slot_identifiers": "2 3 4",
+            "expected_case_number": "CASE-P",
+            "expected_slot_identifiers": "2 3 4",
+            "confirm_slot_provision": "yes",
+        },
+        follow_redirects=True,
+    )
+    assert commit_response.status_code == 200
+    assert b"Created 3 empty slots for case CASE-P: 2, 3, 4." in commit_response.data
+
+    verify_conn = db.get_connection()
+    try:
+        rows = verify_conn.execute(
             """
             SELECT case_name, slot_position, current_asset_tag
             FROM slots
@@ -372,34 +409,14 @@ def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_
             """
         ).fetchall()
     finally:
-        conn.close()
+        verify_conn.close()
 
     assert [(row["case_name"], row["slot_position"], row["current_asset_tag"]) for row in rows] == [
         ("CASE-P", 1, None),
         ("CASE-P", 2, None),
         ("CASE-P", 3, None),
+        ("CASE-P", 4, None),
     ]
-
-
-def test_admin_slot_provision_stores_case_size_without_changing_slot_count(client_with_temp_db) -> None:
-    _login_admin(client_with_temp_db)
-
-    response = client_with_temp_db.post(
-        "/admin/slots/provision",
-        data={"case_number": "CASE-SIZE", "slot_count": "2", "case_size": "16 Rack Unit Wheel"},
-        follow_redirects=True,
-    )
-    assert response.status_code == 200
-
-    conn = db.get_connection()
-    try:
-        slot_count = conn.execute("SELECT COUNT(*) FROM slots WHERE case_name = 'CASE-SIZE';").fetchone()[0]
-        metadata = conn.execute("SELECT case_size FROM case_metadata WHERE case_name = 'CASE-SIZE';").fetchone()
-    finally:
-        conn.close()
-
-    assert slot_count == 2
-    assert metadata["case_size"] == "16 Rack Unit Wheel"
 
 
 def test_existing_case_may_remain_blank_case_size(client_with_temp_db) -> None:
@@ -555,13 +572,27 @@ def test_admin_slot_provision_appends_slots_for_existing_case(client_with_temp_d
     conn.commit()
     conn.close()
 
+    preview_response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"action": "preview", "case_number": "CASE-P", "slot_identifiers": "3, 4"},
+    )
+    assert preview_response.status_code == 200
+    assert b"Slot provisioning preview ready. Review before committing." in preview_response.data
+
     response = client_with_temp_db.post(
         "/admin/slots/provision",
-        data={"case_number": "CASE-P", "slot_count": "2"},
+        data={
+            "action": "commit",
+            "case_number": "CASE-P",
+            "slot_identifiers": "3, 4",
+            "expected_case_number": "CASE-P",
+            "expected_slot_identifiers": "3, 4",
+            "confirm_slot_provision": "yes",
+        },
         follow_redirects=True,
     )
     assert response.status_code == 200
-    assert b"Created 2 empty slots for case CASE-P (slots 3-4)." in response.data
+    assert b"Created 2 empty slots for case CASE-P: 3, 4." in response.data
 
     verify_conn = db.get_connection()
     try:
@@ -571,6 +602,116 @@ def test_admin_slot_provision_appends_slots_for_existing_case(client_with_temp_d
     finally:
         verify_conn.close()
     assert [int(row["slot_position"]) for row in rows] == [1, 2, 3, 4]
+
+
+def test_admin_slot_provision_blocks_duplicate_identifiers_in_request(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute("INSERT INTO slots (case_name, slot_position, current_asset_tag) VALUES ('CASE-DUP', 1, NULL);")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"action": "preview", "case_number": "CASE-DUP", "slot_identifiers": "2 2"},
+    )
+
+    assert response.status_code == 200
+    assert b"Duplicate slot identifiers in request: 2." in response.data
+    verify_conn = db.get_connection()
+    try:
+        assert verify_conn.execute("SELECT COUNT(*) FROM slots WHERE case_name = 'CASE-DUP';").fetchone()[0] == 1
+    finally:
+        verify_conn.close()
+
+
+def test_admin_slot_provision_blocks_existing_slots_and_repeat_submission(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute("INSERT INTO slots (case_name, slot_position, current_asset_tag) VALUES ('CASE-REPEAT', 1, NULL);")
+        conn.commit()
+    finally:
+        conn.close()
+
+    data = {
+        "action": "commit",
+        "case_number": "CASE-REPEAT",
+        "slot_identifiers": "2 3",
+        "expected_case_number": "CASE-REPEAT",
+        "expected_slot_identifiers": "2 3",
+        "confirm_slot_provision": "yes",
+    }
+    first_response = client_with_temp_db.post("/admin/slots/provision", data=data, follow_redirects=True)
+    second_response = client_with_temp_db.post("/admin/slots/provision", data=data)
+
+    assert first_response.status_code == 200
+    assert b"Created 2 empty slots for case CASE-REPEAT: 2, 3." in first_response.data
+    assert second_response.status_code == 200
+    assert b"Slot identifiers already exist in case CASE-REPEAT: 2, 3." in second_response.data
+    verify_conn = db.get_connection()
+    try:
+        rows = verify_conn.execute(
+            "SELECT slot_position, current_asset_tag FROM slots WHERE case_name = 'CASE-REPEAT' ORDER BY slot_position;"
+        ).fetchall()
+        assert verify_conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0] == 0
+        assert verify_conn.execute("SELECT COUNT(*) FROM slot_occupancy;").fetchone()[0] == 0
+        assert verify_conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0] == 0
+        assert verify_conn.execute("SELECT COUNT(*) FROM case_metadata;").fetchone()[0] == 0
+    finally:
+        verify_conn.close()
+
+    assert [(int(row["slot_position"]), row["current_asset_tag"]) for row in rows] == [(1, None), (2, None), (3, None)]
+
+
+def test_admin_slot_provision_requires_existing_case(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"action": "preview", "case_number": "CASE-MISSING", "slot_identifiers": "1"},
+    )
+
+    assert response.status_code == 200
+    assert b"Select an existing case before provisioning empty slots." in response.data
+    conn = db.get_connection()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM slots;").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_admin_slot_provision_blocks_commit_when_preview_values_change(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute("INSERT INTO slots (case_name, slot_position, current_asset_tag) VALUES ('CASE-PREVIEW', 1, NULL);")
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "commit",
+            "case_number": "CASE-PREVIEW",
+            "slot_identifiers": "2 3",
+            "expected_case_number": "CASE-PREVIEW",
+            "expected_slot_identifiers": "2",
+            "confirm_slot_provision": "yes",
+        },
+    )
+
+    assert response.status_code == 200
+    assert b"Preview changed. Review the slot provisioning preview again before committing." in response.data
+    verify_conn = db.get_connection()
+    try:
+        rows = verify_conn.execute("SELECT slot_position FROM slots WHERE case_name = 'CASE-PREVIEW';").fetchall()
+    finally:
+        verify_conn.close()
+    assert [int(row["slot_position"]) for row in rows] == [1]
 
 
 def test_case_correction_schema_is_append_only(client_with_temp_db) -> None:
@@ -912,10 +1053,29 @@ def test_case_remove_blocks_event_history_reference(client_with_temp_db) -> None
 def test_unslotted_storage_asset_can_be_assigned_after_slot_provision(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
     _create_building("HQ")
+    conn = db.get_connection()
+    try:
+        conn.execute("INSERT INTO slots (case_name, slot_position, current_asset_tag) VALUES ('CASE-Q', 2, NULL);")
+        conn.commit()
+    finally:
+        conn.close()
+
+    previewed = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={"action": "preview", "case_number": "CASE-Q", "slot_identifiers": "1"},
+    )
+    assert previewed.status_code == 200
 
     provisioned = client_with_temp_db.post(
         "/admin/slots/provision",
-        data={"case_number": "CASE-Q", "slot_count": "1"},
+        data={
+            "action": "commit",
+            "case_number": "CASE-Q",
+            "slot_identifiers": "1",
+            "expected_case_number": "CASE-Q",
+            "expected_slot_identifiers": "1",
+            "confirm_slot_provision": "yes",
+        },
         follow_redirects=True,
     )
     assert provisioned.status_code == 200


### PR DESCRIPTION
## Summary

Add an admin-only preview and commit workflow for provisioning selected empty slot positions in an existing case without creating assets, occupancy, events, or metadata.

## Related Issue

Closes #1115

## Changes

- Require selection of an existing case.
- Accept explicit slot identifiers.
- Preview proposed empty slots before commit.
- Keep Preview read-only.
- Commit only slot records.
- Revalidate requested positions inside the commit transaction.
- Reject duplicate requested or existing slot identifiers.
- Prevent repeat submission from creating duplicate slots.
- Preserve existing admin-only role enforcement.
- Do not create placeholder assets, occupancy, events, or case metadata.

## Verification

- [x] Focused provisioning tests: 66 passed
- [x] Affected Case Detail / Assign Slots / dashboard tests: 71 passed
- [x] Auth and admin-route tests: 37 passed
- [x] Full regression suite passes
- [x] compileall passes
- [x] `git diff --check` passes
- [x] Docker rebuild and application startup pass
- [x] Preview verified read-only
- [x] Empty-slot commit verified
- [x] New positions display as Empty Slots
- [x] Existing slots remain unchanged
- [x] No placeholder asset created
- [x] No occupancy created
- [x] Duplicate existing position blocked
- [x] Repeat submission blocked
- [x] Operator remains denied access to the admin provisioning route

## Notes

Existing slot provisioning was already admin-only. This change preserves that authorization boundary.

No schema, persistence semantics, dependencies, authentication, custody, event, import, or occupancy behavior changed.