### PR TITLE
Issue 31-31: Disable Flask debug mode

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -12183,4 +12183,4 @@ def admin_force_vacate():
 
 if __name__ == "__main__":
     # Local dev run (and container run).
-    app.run(host="0.0.0.0", port=8000, debug=True)
+    app.run(host="0.0.0.0", port=8000, debug=False)

--- a/tests/test_runtime_entrypoint.py
+++ b/tests/test_runtime_entrypoint.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+from flask import Flask
+
+import assettrack.db as db
+
+
+def test_runtime_entrypoint_does_not_enable_flask_debug(
+    tmp_path: Path, monkeypatch
+) -> None:
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+
+    def fake_run(self: Flask, *args: object, **kwargs: object) -> None:
+        calls.append({"args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr(Flask, "run", fake_run)
+
+    runpy.run_module("assettrack.intake.app", run_name="__main__")
+
+    assert calls == [
+        {
+            "args": (),
+            "kwargs": {"host": "0.0.0.0", "port": 8000, "debug": False},
+        }
+    ]


### PR DESCRIPTION
## Summary
Disable Flask debug mode in the AssetTrack runtime.

Closes #1156

## Changes
- Set the Flask runtime entrypoint to `debug=False`.
- Added a regression test for the runtime configuration.

## Verification
- [x] Focused pytest passed
- [x] `git diff --check` passed
- [x] Docker rebuilt successfully
- [x] Container healthy
- [x] Debug mode confirmed off
- [x] Admin login passed
- [x] `/admin/assets/import` rendered successfully

## Notes
No auth, schema, persistence, event, custody, or workflow behavior changed.