### PR TITLE
Issue 31-33: Validate ReportLab 5 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pandas==3.0.5
 pillow==12.3.0
 pypdf==6.15.0
 python-dateutil==2.9.0.post0
-reportlab==4.4.9
+reportlab==5.0.0
 six==1.17.0
 Flask==3.1.3
 bcrypt==5.0.0


### PR DESCRIPTION
## Summary
Validate and adopt ReportLab 5.0.0 with no PDF/report behavior changes.

Closes #1159

## Changes
- Updated ReportLab from 4.4.9 to 5.0.0.
- No application compatibility changes required.

## Verification
- [x] 15 focused report/PDF tests passed
- [x] Full suite: 758 passed, 8 subtests passed
- [x] `git diff --check` passed
- [x] Docker rebuilt successfully with ReportLab 5.0.0
- [x] Admin report PDF passed
- [x] Case inventory PDF passed
- [x] Receipt PDF passed
- [x] Retired asset report state passed
- [x] Multi-page case PDF passed
- [x] PDF filenames verified

## Notes
No schema, auth, persistence, event, custody, workflow, or PDF design changes.