### PR TITLE
Issue 31-34: Reconcile authoritative government inventory

### DIFF
--- a/docs/release/user-manual.md
+++ b/docs/release/user-manual.md
@@ -379,6 +379,50 @@ Expected result:
 - The results show category totals and committed row counts.
 
 Legacy network CSV command-line utilities are not normal operator procedures. They are retained for internal or maintainer use only.
+## Reconcile Government Inventory
+
+**Admin or maintainer CLI only**
+
+Use government inventory reconciliation to compare an operator-supplied authoritative inventory file with the current AssetTrack database. This is a read-only report. It does not create, update, retire, delete, issue, return, assign, or move assets.
+
+Supported files:
+
+- CSV
+- XLSX
+
+The inventory filename is supplied by the operator. It is not hard-coded.
+
+Command syntax from the repository root:
+
+```text
+python scripts/reconcile_government_inventory.py <inventory.xlsx-or.csv> --db <assettrack.db>
+```
+
+Equivalent module command:
+
+```text
+python -m scripts.reconcile_government_inventory <inventory.xlsx-or.csv> --db <assettrack.db>
+```
+
+Use `--db` to choose the SQLite database to compare. For example:
+
+```text
+python scripts/reconcile_government_inventory.py "BQ26 ETP.xlsx" --db ./data/assettrack.db
+```
+
+Major result categories:
+
+- `exact_or_normalized_tag_matches`: government and AssetTrack records match by asset tag after existing barcode normalization.
+- `government_only_assets`: the government file lists an asset that AssetTrack does not list as an active or retired/disposed normalized-tag match.
+- `assettrack_only_active_assets`: AssetTrack has an active asset absent from the government file.
+- `identity_conflicts`: the normalized asset tag matches, but serial numbers differ.
+- `ambiguous_normalized_tags`: duplicate normalized asset tags exist on either side and are not silently classified.
+- `duplicate_serial_warnings` and `duplicate_mac_warnings`: duplicate serial or MAC values in the government file. These are warnings and supporting evidence only; they are not used to auto-match records.
+- `retired_disposed_assettrack_records`, `retired_disposed_tag_matches`, and `retired_disposed_assettrack_only`: retired or disposed AssetTrack records reported separately from active discrepancies.
+
+No automatic AssetTrack corrections are performed. Review the report and use approved AssetTrack workflows for any later correction work.
+
+Normal operator GUI access for this reconciliation will be implemented separately under Issue 31-34A / #1169. Do not treat this CLI as the future GUI workflow.
 
 ## Backup The Database
 

--- a/scripts/reconcile_government_inventory.py
+++ b/scripts/reconcile_government_inventory.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assettrack.barcodes import barcode_lookup_key
+from assettrack.db import DB_PATH
+from assettrack.import_analysis import _normalize_header, _normalize_text
+
+
+TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
+
+
+@dataclass(frozen=True)
+class GovernmentRecord:
+    row_number: int
+    asset_tag: str
+    compare_tag: str
+    serial_number: str
+    mac_address: str
+    equipment_type: str
+
+    @property
+    def key(self) -> str:
+        return barcode_lookup_key(self.compare_tag)
+
+
+@dataclass(frozen=True)
+class AssetTrackRecord:
+    id: int
+    asset_tag: str
+    serial_number: str
+    location_type: str
+
+    @property
+    def key(self) -> str:
+        return barcode_lookup_key(self.asset_tag)
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.location_type.upper() in TERMINAL_LOCATION_TYPES
+
+
+@dataclass(frozen=True)
+class ReconciliationResult:
+    government_records: tuple[GovernmentRecord, ...]
+    assettrack_active_records: tuple[AssetTrackRecord, ...]
+    assettrack_terminal_records: tuple[AssetTrackRecord, ...]
+    tag_matches: tuple[tuple[GovernmentRecord, AssetTrackRecord], ...]
+    government_only: tuple[GovernmentRecord, ...]
+    assettrack_only_active: tuple[AssetTrackRecord, ...]
+    identity_conflicts: tuple[tuple[GovernmentRecord, AssetTrackRecord], ...]
+    ambiguous_government_tags: tuple[tuple[str, tuple[GovernmentRecord, ...]], ...]
+    ambiguous_assettrack_tags: tuple[tuple[str, tuple[AssetTrackRecord, ...]], ...]
+    duplicate_serial_warnings: tuple[tuple[str, tuple[GovernmentRecord, ...]], ...]
+    duplicate_mac_warnings: tuple[tuple[str, tuple[GovernmentRecord, ...]], ...]
+    terminal_matches: tuple[tuple[GovernmentRecord, AssetTrackRecord], ...]
+    terminal_assettrack_only: tuple[AssetTrackRecord, ...]
+
+    def summary_counts(self) -> dict[str, int]:
+        return {
+            "government_records": len(self.government_records),
+            "assettrack_active_records_considered": len(self.assettrack_active_records),
+            "exact_or_normalized_tag_matches": len(self.tag_matches),
+            "government_only_assets": len(self.government_only),
+            "assettrack_only_active_assets": len(self.assettrack_only_active),
+            "identity_conflicts": len(self.identity_conflicts),
+            "ambiguous_normalized_tags": len(self.ambiguous_government_tags) + len(self.ambiguous_assettrack_tags),
+            "duplicate_serial_warnings": len(self.duplicate_serial_warnings),
+            "duplicate_mac_warnings": len(self.duplicate_mac_warnings),
+            "retired_disposed_assettrack_records": len(self.assettrack_terminal_records),
+            "retired_disposed_tag_matches": len(self.terminal_matches),
+            "retired_disposed_assettrack_only": len(self.terminal_assettrack_only),
+        }
+
+
+def _read_inventory_frame(path: Path) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pd.read_csv(path, dtype=object, keep_default_na=False)
+    if suffix == ".xlsx":
+        sheets = pd.read_excel(path, engine="openpyxl", sheet_name=None, dtype=object)
+        if len(sheets) != 1:
+            names = ", ".join(sorted(sheets))
+            raise ValueError(f"Expected one government inventory sheet; found: {names}")
+        return next(iter(sheets.values()))
+    raise ValueError("Unsupported inventory file type. Use .csv or .xlsx.")
+
+
+def load_government_records(path: str | Path) -> tuple[GovernmentRecord, ...]:
+    inventory_path = Path(path)
+    if not inventory_path.exists():
+        raise ValueError(f"Government inventory file not found: {inventory_path}")
+
+    frame = _read_inventory_frame(inventory_path)
+    column_map: dict[str, object] = {}
+    for column in frame.columns:
+        normalized = _normalize_header(column)
+        if normalized and not normalized.startswith("unnamed"):
+            column_map.setdefault(normalized, column)
+
+    tag_column = column_map.get("asset_tag") or column_map.get("barcode")
+    compare_column = column_map.get("clean_asset_tag") or tag_column
+    serial_column = column_map.get("serial_number")
+    mac_column = column_map.get("mac_address")
+    type_column = column_map.get("equipment_type")
+    if tag_column is None and compare_column is None:
+        raise ValueError("Government inventory must include asset_tag, clean_asset_tag, or barcode.")
+
+    records: list[GovernmentRecord] = []
+    for index, row in frame.iterrows():
+        asset_tag = _normalize_text(row.get(tag_column, "")) if tag_column is not None else ""
+        compare_tag = _normalize_text(row.get(compare_column, "")) if compare_column is not None else asset_tag
+        serial_number = _normalize_text(row.get(serial_column, "")) if serial_column is not None else ""
+        mac_address = _normalize_text(row.get(mac_column, "")) if mac_column is not None else ""
+        equipment_type = _normalize_text(row.get(type_column, "")) if type_column is not None else ""
+        if not any((asset_tag, compare_tag, serial_number, mac_address, equipment_type)):
+            continue
+        records.append(
+            GovernmentRecord(
+                row_number=int(index) + 2,
+                asset_tag=asset_tag or compare_tag,
+                compare_tag=compare_tag or asset_tag,
+                serial_number=serial_number,
+                mac_address=mac_address,
+                equipment_type=equipment_type,
+            )
+        )
+    return tuple(records)
+
+
+def load_assettrack_records(conn: sqlite3.Connection) -> tuple[AssetTrackRecord, ...]:
+    rows = conn.execute(
+        """
+        SELECT id, asset_tag, serial_number, location_type
+        FROM assets
+        ORDER BY UPPER(asset_tag) ASC, id ASC;
+        """
+    ).fetchall()
+    return tuple(
+        AssetTrackRecord(
+            id=int(row["id"]),
+            asset_tag=_normalize_text(row["asset_tag"]),
+            serial_number=_normalize_text(row["serial_number"]),
+            location_type=_normalize_text(row["location_type"]),
+        )
+        for row in rows
+    )
+
+
+def _group_government_by_key(records: tuple[GovernmentRecord, ...]) -> dict[str, list[GovernmentRecord]]:
+    groups: dict[str, list[GovernmentRecord]] = defaultdict(list)
+    for record in records:
+        if record.key:
+            groups[record.key].append(record)
+    return groups
+
+
+def _group_assettrack_by_key(records: tuple[AssetTrackRecord, ...]) -> dict[str, list[AssetTrackRecord]]:
+    groups: dict[str, list[AssetTrackRecord]] = defaultdict(list)
+    for record in records:
+        if record.key:
+            groups[record.key].append(record)
+    return groups
+
+
+def _duplicate_government_field(
+    records: tuple[GovernmentRecord, ...],
+    field_name: str,
+) -> tuple[tuple[str, tuple[GovernmentRecord, ...]], ...]:
+    groups: dict[str, list[GovernmentRecord]] = defaultdict(list)
+    for record in records:
+        value = _normalize_text(getattr(record, field_name)).upper()
+        if value:
+            groups[value].append(record)
+    return tuple((key, tuple(value)) for key, value in sorted(groups.items()) if len(value) > 1)
+
+
+def reconcile_inventory(conn: sqlite3.Connection, inventory_path: str | Path) -> ReconciliationResult:
+    government_records = load_government_records(inventory_path)
+    assettrack_records = load_assettrack_records(conn)
+    active_records = tuple(record for record in assettrack_records if not record.is_terminal)
+    terminal_records = tuple(record for record in assettrack_records if record.is_terminal)
+
+    government_by_key = _group_government_by_key(government_records)
+    assettrack_active_by_key = _group_assettrack_by_key(active_records)
+    assettrack_terminal_by_key = _group_assettrack_by_key(terminal_records)
+
+    ambiguous_government_tags = tuple(
+        (key, tuple(records))
+        for key, records in sorted(government_by_key.items())
+        if len(records) > 1
+    )
+    ambiguous_assettrack_tags = tuple(
+        (key, tuple(records))
+        for key, records in sorted(assettrack_active_by_key.items())
+        if len(records) > 1
+    )
+    ambiguous_government_keys = {key for key, _records in ambiguous_government_tags}
+    ambiguous_assettrack_keys = {key for key, _records in ambiguous_assettrack_tags}
+
+    tag_matches: list[tuple[GovernmentRecord, AssetTrackRecord]] = []
+    identity_conflicts: list[tuple[GovernmentRecord, AssetTrackRecord]] = []
+    government_only: list[GovernmentRecord] = []
+    terminal_matches: list[tuple[GovernmentRecord, AssetTrackRecord]] = []
+    matched_active_keys: set[str] = set()
+    matched_terminal_keys: set[str] = set()
+
+    for government in sorted(government_records, key=lambda record: (record.key, record.row_number)):
+        key = government.key
+        if not key or key in ambiguous_government_keys or key in ambiguous_assettrack_keys:
+            continue
+        active_match = assettrack_active_by_key.get(key, [])
+        if len(active_match) == 1:
+            asset = active_match[0]
+            matched_active_keys.add(key)
+            if (
+                government.serial_number
+                and asset.serial_number
+                and government.serial_number.upper() != asset.serial_number.upper()
+            ):
+                identity_conflicts.append((government, asset))
+            else:
+                tag_matches.append((government, asset))
+            continue
+        terminal_match = assettrack_terminal_by_key.get(key, [])
+        if len(terminal_match) == 1:
+            matched_terminal_keys.add(key)
+            terminal_matches.append((government, terminal_match[0]))
+            continue
+        government_only.append(government)
+
+    assettrack_only_active = tuple(
+        record
+        for record in active_records
+        if record.key and record.key not in matched_active_keys and record.key not in ambiguous_assettrack_keys
+    )
+    terminal_assettrack_only = tuple(
+        record
+        for record in terminal_records
+        if record.key and record.key not in matched_terminal_keys
+    )
+
+    return ReconciliationResult(
+        government_records=government_records,
+        assettrack_active_records=active_records,
+        assettrack_terminal_records=terminal_records,
+        tag_matches=tuple(sorted(tag_matches, key=lambda item: item[0].asset_tag)),
+        government_only=tuple(sorted(government_only, key=lambda record: record.asset_tag)),
+        assettrack_only_active=tuple(sorted(assettrack_only_active, key=lambda record: record.asset_tag)),
+        identity_conflicts=tuple(sorted(identity_conflicts, key=lambda item: item[0].asset_tag)),
+        ambiguous_government_tags=ambiguous_government_tags,
+        ambiguous_assettrack_tags=ambiguous_assettrack_tags,
+        duplicate_serial_warnings=_duplicate_government_field(government_records, "serial_number"),
+        duplicate_mac_warnings=_duplicate_government_field(government_records, "mac_address"),
+        terminal_matches=tuple(sorted(terminal_matches, key=lambda item: item[0].asset_tag)),
+        terminal_assettrack_only=tuple(sorted(terminal_assettrack_only, key=lambda record: record.asset_tag)),
+    )
+
+
+def _record_tags(records) -> str:
+    values = [getattr(record, "asset_tag") for record in records]
+    return ", ".join(values) if values else "None"
+
+
+def format_reconciliation(result: ReconciliationResult) -> str:
+    lines = ["Government Inventory Reconciliation", "", "Summary"]
+    for key, value in result.summary_counts().items():
+        lines.append(f"  {key}: {value}")
+
+    sections = [
+        ("Exact / Normalized Tag Matches", [f"{gov.asset_tag} -> {asset.asset_tag}" for gov, asset in result.tag_matches]),
+        ("Government-Only Assets", [record.asset_tag for record in result.government_only]),
+        ("AssetTrack-Only Active Assets", [record.asset_tag for record in result.assettrack_only_active]),
+        (
+            "Identity Conflicts",
+            [
+                f"{gov.asset_tag} -> {asset.asset_tag}; serial {gov.serial_number or 'blank'} != {asset.serial_number or 'blank'}"
+                for gov, asset in result.identity_conflicts
+            ],
+        ),
+        (
+            "Ambiguous Government Normalized Tags",
+            [f"{key}: {_record_tags(records)}" for key, records in result.ambiguous_government_tags],
+        ),
+        (
+            "Ambiguous AssetTrack Normalized Tags",
+            [f"{key}: {_record_tags(records)}" for key, records in result.ambiguous_assettrack_tags],
+        ),
+        (
+            "Duplicate Government Serial Warnings",
+            [f"{key}: {_record_tags(records)}" for key, records in result.duplicate_serial_warnings],
+        ),
+        (
+            "Duplicate Government MAC Warnings",
+            [f"{key}: {_record_tags(records)}" for key, records in result.duplicate_mac_warnings],
+        ),
+        (
+            "Retired / Disposed AssetTrack Tag Matches",
+            [f"{gov.asset_tag} -> {asset.asset_tag} ({asset.location_type})" for gov, asset in result.terminal_matches],
+        ),
+        (
+            "Retired / Disposed AssetTrack-Only Assets",
+            [f"{record.asset_tag} ({record.location_type})" for record in result.terminal_assettrack_only],
+        ),
+    ]
+    for title, rows in sections:
+        lines.extend(["", title])
+        if rows:
+            lines.extend(f"  - {row}" for row in rows)
+        else:
+            lines.append("  None")
+    return "\n".join(lines)
+
+
+def _open_readonly_database(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Read-only reconciliation of government inventory against AssetTrack.")
+    parser.add_argument("inventory_path", help="Path to the government inventory .xlsx or .csv file.")
+    parser.add_argument("--db", default=str(DB_PATH), help="Path to the AssetTrack SQLite database.")
+    args = parser.parse_args(argv)
+
+    try:
+        conn = _open_readonly_database(Path(args.db))
+    except sqlite3.Error as exc:
+        print(f"Could not open database read-only: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = reconcile_inventory(conn, args.inventory_path)
+    except (OSError, ValueError, sqlite3.Error) as exc:
+        print(f"Reconciliation failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    print(format_reconciliation(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_government_inventory_reconciliation.py
+++ b/tests/test_government_inventory_reconciliation.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+from scripts.reconcile_government_inventory import (
+    _open_readonly_database,
+    format_reconciliation,
+    load_government_records,
+    reconcile_inventory,
+)
+
+
+HEADERS = [
+    "building_room",
+    "case_number",
+    "slot_number",
+    "equipment_type",
+    "asset_tag",
+    "clean_asset_tag",
+    "serial_number",
+    "mac_address",
+    "manufacturer",
+    "model",
+    "model_code",
+]
+
+
+def _create_asset_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE assets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                serial_number TEXT NULL,
+                location_type TEXT NULL
+            );
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE asset_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                asset_tag TEXT NOT NULL,
+                event_type TEXT NOT NULL
+            );
+            """
+        )
+        for asset_tag, serial_number, location_type in [
+            ("DDC4CY0001", "SER-HYPHEN", "STORAGE"),
+            ("EXACT-100", "SER-EXACT", "STORAGE"),
+            ("ONLY-ACTIVE", "SER-ONLY", "IN_CUSTODY"),
+            ("CONFLICT-100", "SER-DB", "STORAGE"),
+            ("DUPSER-1", "SER-DUP", "STORAGE"),
+            ("DUPSER-2", "SER-DUP", "STORAGE"),
+            ("DUPMAC-1", "SER-MAC-1", "STORAGE"),
+            ("DUPMAC-2", "SER-MAC-2", "STORAGE"),
+            ("DUPTAG-1", "SER-DUPTAG-A", "STORAGE"),
+            ("DUPTAG1", "SER-DUPTAG-B", "STORAGE"),
+            ("TERM-RET", "SER-RET", "RETIRED"),
+            ("TERM-DISP", "SER-DISP", "DISPOSED"),
+        ]:
+            conn.execute(
+                "INSERT INTO assets (asset_tag, serial_number, location_type) VALUES (?, ?, ?);",
+                (asset_tag, serial_number, location_type),
+            )
+        conn.execute(
+            "INSERT INTO asset_events (asset_tag, event_type) VALUES (?, ?);",
+            ("ONLY-ACTIVE", "created"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _write_inventory(path: Path) -> None:
+    rows = [
+        ["283", "1", "1-1", "Laptop", "DDC4CY-0001", "DDC4CY0001", "SER-HYPHEN", "MAC-HYPHEN", "Dell", "Precision", ""],
+        ["283", "1", "1-2", "Laptop", "EXACT-100", "", "SER-EXACT", "MAC-EXACT", "Dell", "Precision", ""],
+        ["283", "1", "1-3", "Laptop", "GOV-ONLY", "", "SER-GOV-ONLY", "MAC-GOV-ONLY", "Dell", "Precision", ""],
+        ["283", "1", "1-4", "Laptop", "CONFLICT-100", "", "SER-GOV", "MAC-CONFLICT", "Dell", "Precision", ""],
+        ["283", "1", "1-5", "Laptop", "DUPSER-1", "", "SER-DUP", "MAC-SER-1", "Dell", "Precision", ""],
+        ["283", "1", "1-6", "Laptop", "DUPSER-2", "", "SER-DUP", "MAC-SER-2", "Dell", "Precision", ""],
+        ["283", "1", "1-7", "Laptop", "DUPMAC-1", "", "SER-MAC-1", "MAC-DUP", "Dell", "Precision", ""],
+        ["283", "1", "1-8", "Laptop", "DUPMAC-2", "", "SER-MAC-2", "mac-dup", "Dell", "Precision", ""],
+        ["283", "1", "1-9", "Laptop", "DUPTAG-1", "", "SER-DUPTAG-GOV", "MAC-DUPTAG", "Dell", "Precision", ""],
+        ["283", "1", "1-10", "Laptop", "GOV-DUP", "", "SER-GOV-DUP-1", "MAC-GOV-DUP-1", "Dell", "Precision", ""],
+        ["283", "1", "1-11", "Laptop", "GOVDUP", "", "SER-GOV-DUP-2", "MAC-GOV-DUP-2", "Dell", "Precision", ""],
+        ["283", "1", "1-12", "Laptop", "TERM-RET", "", "SER-RET", "MAC-RET", "Dell", "Precision", ""],
+    ]
+    pd.DataFrame(rows, columns=HEADERS).to_csv(path, index=False)
+
+
+def _counts(db_path: Path) -> dict[str, int]:
+    conn = sqlite3.connect(db_path)
+    try:
+        return {
+            "assets": int(conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0]),
+            "asset_events": int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0]),
+        }
+    finally:
+        conn.close()
+
+
+def test_government_inventory_reconciliation_is_readonly_and_deterministic(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    inventory_path = tmp_path / "government.csv"
+    _create_asset_db(db_path)
+    _write_inventory(inventory_path)
+    before_counts = _counts(db_path)
+
+    conn = _open_readonly_database(db_path)
+    try:
+        result = reconcile_inventory(conn, inventory_path)
+    finally:
+        conn.close()
+
+    assert _counts(db_path) == before_counts
+    assert result.summary_counts() == {
+        "government_records": 12,
+        "assettrack_active_records_considered": 10,
+        "exact_or_normalized_tag_matches": 6,
+        "government_only_assets": 1,
+        "assettrack_only_active_assets": 1,
+        "identity_conflicts": 1,
+        "ambiguous_normalized_tags": 2,
+        "duplicate_serial_warnings": 1,
+        "duplicate_mac_warnings": 1,
+        "retired_disposed_assettrack_records": 2,
+        "retired_disposed_tag_matches": 1,
+        "retired_disposed_assettrack_only": 1,
+    }
+
+    assert [(gov.asset_tag, asset.asset_tag) for gov, asset in result.tag_matches] == [
+        ("DDC4CY-0001", "DDC4CY0001"),
+        ("DUPMAC-1", "DUPMAC-1"),
+        ("DUPMAC-2", "DUPMAC-2"),
+        ("DUPSER-1", "DUPSER-1"),
+        ("DUPSER-2", "DUPSER-2"),
+        ("EXACT-100", "EXACT-100"),
+    ]
+    assert [record.asset_tag for record in result.government_only] == ["GOV-ONLY"]
+    assert [record.asset_tag for record in result.assettrack_only_active] == ["ONLY-ACTIVE"]
+    assert [(gov.asset_tag, asset.asset_tag) for gov, asset in result.identity_conflicts] == [("CONFLICT-100", "CONFLICT-100")]
+    assert [(key, [record.asset_tag for record in records]) for key, records in result.ambiguous_government_tags] == [
+        ("GOVDUP", ["GOV-DUP", "GOVDUP"])
+    ]
+    assert [(key, [record.asset_tag for record in records]) for key, records in result.ambiguous_assettrack_tags] == [
+        ("DUPTAG1", ["DUPTAG-1", "DUPTAG1"])
+    ]
+    assert [(key, [record.asset_tag for record in records]) for key, records in result.duplicate_serial_warnings] == [
+        ("SER-DUP", ["DUPSER-1", "DUPSER-2"])
+    ]
+    assert [(key, [record.asset_tag for record in records]) for key, records in result.duplicate_mac_warnings] == [
+        ("MAC-DUP", ["DUPMAC-1", "DUPMAC-2"])
+    ]
+    assert [(gov.asset_tag, asset.asset_tag, asset.location_type) for gov, asset in result.terminal_matches] == [
+        ("TERM-RET", "TERM-RET", "RETIRED")
+    ]
+    assert [(record.asset_tag, record.location_type) for record in result.terminal_assettrack_only] == [
+        ("TERM-DISP", "DISPOSED")
+    ]
+
+    rendered = format_reconciliation(result)
+    assert rendered == format_reconciliation(result)
+    assert "government_records: 12" in rendered
+    assert "DDC4CY-0001 -> DDC4CY0001" in rendered
+    assert "CONFLICT-100 -> CONFLICT-100; serial SER-GOV != SER-DB" in rendered
+
+
+def test_government_inventory_loader_supports_xlsx(tmp_path: Path) -> None:
+    xlsx_path = tmp_path / "government.xlsx"
+    pd.DataFrame(
+        [["Laptop", "XLSX-100", "XLSX100", "SER-XLSX-100", "MAC-XLSX-100"]],
+        columns=["equipment_type", "asset_tag", "clean_asset_tag", "serial_number", "mac_address"],
+    ).to_excel(xlsx_path, index=False)
+
+    records = load_government_records(xlsx_path)
+
+    assert len(records) == 1
+    assert records[0].asset_tag == "XLSX-100"
+    assert records[0].compare_tag == "XLSX100"
+    assert records[0].key == "XLSX100"
+
+def test_reconciliation_cli_supports_direct_and_module_execution(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    inventory_path = tmp_path / "government.csv"
+    _create_asset_db(db_path)
+    _write_inventory(inventory_path)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    direct = subprocess.run(
+        [
+            sys.executable,
+            "scripts/reconcile_government_inventory.py",
+            str(inventory_path),
+            "--db",
+            str(db_path),
+        ],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    module = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "scripts.reconcile_government_inventory",
+            str(inventory_path),
+            "--db",
+            str(db_path),
+        ],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert direct.returncode == 0, direct.stderr
+    assert module.returncode == 0, module.stderr
+    assert "government_records: 12" in direct.stdout
+    assert direct.stdout == module.stdout


### PR DESCRIPTION
## Summary

Adds a read-only reconciliation tool that compares an operator-supplied government inventory file against AssetTrack.

## Related Issue

Closes #1163

## Changes

- Adds offline government inventory reconciliation for `.xlsx` and `.csv`.
- Uses existing AssetTrack asset-tag normalization.
- Uses normalized asset tag as the primary match key.
- Reports government-only and AssetTrack-only active assets.
- Reports identity conflicts and ambiguous normalized tags.
- Reports duplicate serial and MAC warnings without using them for automatic matching.
- Separates retired/disposed AssetTrack records.
- Supports arbitrary operator-supplied inventory filenames.
- Supports direct script and module execution.
- Opens the AssetTrack database read-only.
- Adds focused regression tests.
- Adds operator documentation.

## Verification

- [x] Focused tests pass: 3 passed
- [x] Direct CLI execution verified
- [x] Module execution verified
- [x] Arbitrary inventory filename verified
- [x] Read-only database behavior verified
- [x] No schema changes
- [x] No new dependencies
- [x] No event/database mutation path added
- [x] Operator documentation updated
- [ ] Final reconciliation against the full operational database on the standalone machine

## Notes

The work machine contains only the 15-asset development database. Final authoritative inventory reconciliation against the complete operational database is intentionally deferred to the standalone deployment machine.

GUI-based inventory selection and reconciliation is scoped separately under Issue 31-34A / #1169.