### PR TITLE
Issue 31-34A: Add in-app government inventory reconciliation workflow

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -80,6 +80,7 @@ from assettrack.holder_import import (
 )
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.import_reconciliation import build_asset_import_preview
+from scripts.reconcile_government_inventory import reconcile_inventory
 from assettrack.natural_sort import natural_identifier_sort_key
 from assettrack.reference_data import (
     create_building,
@@ -10162,6 +10163,89 @@ def admin_db_restore():
         status_code,
     )
 
+
+
+def _inventory_reconciliation_view(result) -> dict[str, object]:
+    counts = result.summary_counts()
+    discrepancy_count = (
+        counts["government_only_assets"]
+        + counts["assettrack_only_active_assets"]
+        + counts["identity_conflicts"]
+        + counts["ambiguous_normalized_tags"]
+        + counts["duplicate_serial_warnings"]
+        + counts["duplicate_mac_warnings"]
+        + counts["retired_disposed_tag_matches"]
+        + counts["retired_disposed_assettrack_only"]
+    )
+    return {
+        "counts": counts,
+        "matched": counts["exact_or_normalized_tag_matches"],
+        "discrepancies": discrepancy_count,
+        "clean": discrepancy_count == 0,
+        "government_only": result.government_only,
+        "assettrack_only_active": result.assettrack_only_active,
+        "identity_conflicts": result.identity_conflicts,
+        "ambiguous_government_tags": result.ambiguous_government_tags,
+        "ambiguous_assettrack_tags": result.ambiguous_assettrack_tags,
+        "duplicate_serial_warnings": result.duplicate_serial_warnings,
+        "duplicate_mac_warnings": result.duplicate_mac_warnings,
+        "terminal_matches": result.terminal_matches,
+        "terminal_assettrack_only": result.terminal_assettrack_only,
+    }
+
+
+@app.route("/report/inventory-reconciliation", methods=["GET", "POST"])
+@require_login
+def inventory_reconciliation():
+    result: dict[str, object] | None = None
+    error_message: str | None = None
+    status_code = 200
+
+    if request.method == "POST":
+        upload = request.files.get("inventory_file")
+        filename = str((upload.filename if upload is not None else "") or "").strip()
+        if upload is None or not filename:
+            error_message = "Choose a .csv or .xlsx inventory file to analyze."
+            status_code = 400
+        else:
+            suffix = Path(filename).suffix.lower()
+            tempfile_suffix = ASSET_IMPORT_TEMPFILE_SUFFIXES.get(suffix)
+            if tempfile_suffix is None:
+                error_message = "Unsupported file type. Upload a .csv or .xlsx file."
+                status_code = 400
+            else:
+                temp_path: Path | None = None
+                conn: sqlite3.Connection | None = None
+                try:
+                    with tempfile.NamedTemporaryFile(delete=False, suffix=tempfile_suffix) as handle:
+                        upload.save(handle)
+                        temp_path = Path(handle.name)
+
+                    resolved_db_path = _resolved_runtime_db_path()
+                    conn = sqlite3.connect(f"file:{resolved_db_path.resolve()}?mode=ro", uri=True)
+                    conn.row_factory = sqlite3.Row
+                    result = _inventory_reconciliation_view(reconcile_inventory(conn, temp_path))
+                    result["filename"] = filename
+                except ValueError as exc:
+                    error_message = str(exc)
+                    status_code = 400
+                except sqlite3.Error as exc:
+                    error_message = f"Could not read AssetTrack database: {exc}"
+                    status_code = 500
+                finally:
+                    if conn is not None:
+                        conn.close()
+                    if temp_path is not None:
+                        temp_path.unlink(missing_ok=True)
+
+    return (
+        render_template(
+            "inventory_reconciliation.html",
+            result=result,
+            error_message=error_message,
+        ),
+        status_code,
+    )
 
 @app.get("/report")
 @require_login

--- a/assettrack/intake/templates/inventory_reconciliation.html
+++ b/assettrack/intake/templates/inventory_reconciliation.html
@@ -1,0 +1,160 @@
+{% extends "base.html" %}
+
+{% block title %}Inventory Reconciliation{% endblock %}
+{% block page_heading %}Inventory Reconciliation{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .recon-help { margin: 0 0 1rem 0; color: var(--color-text-muted); }
+    .recon-result-metrics {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+    }
+    .recon-result-metric {
+      border: 1px solid var(--color-surface);
+      padding: 0.75rem;
+      background: var(--color-surface-bg);
+    }
+    .recon-result-metric strong {
+      display: block;
+      font-size: 1.75rem;
+      line-height: 1;
+    }
+    .recon-status-pass { font-size: 1.3rem; font-weight: 800; }
+    .recon-section { margin-top: 1rem; border-top: 1px solid var(--color-surface); padding-top: 0.75rem; }
+    .recon-section summary { cursor: pointer; font-weight: 700; }
+    .recon-count { color: var(--color-text-muted); font-weight: 400; margin-left: 0.5rem; }
+    .recon-list { margin: 0.5rem 0 0 1.25rem; }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <div class="report-actions report-utility-links" aria-label="Report navigation">
+    <a class="nav-link" href="{{ url_for('human_report') }}">Back to Reports</a>
+  </div>
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <div class="card">
+    <h2>Analyze Government Inventory</h2>
+    <p class="recon-help">Upload a government inventory CSV or XLSX file. Analyze Inventory reads the current AssetTrack database and does not change assets, events, custody, or slots.</p>
+    <form method="post" enctype="multipart/form-data">
+      <div class="row">
+        <label for="inventory_file"><strong>Inventory file</strong></label><br />
+        <input
+          id="inventory_file"
+          type="file"
+          name="inventory_file"
+          accept=".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          required
+        />
+      </div>
+      <button type="submit" name="action" value="analyze">Analyze Inventory</button>
+    </form>
+  </div>
+
+  {% if result is not none %}
+    <div class="card">
+      <h2>Reconciliation Result</h2>
+      <p class="recon-help"><strong>File:</strong> {{ result.filename }}</p>
+      {% if result.clean %}
+        <p class="flash success recon-status-pass">&#10003; INVENTORY RECONCILED</p>
+      {% else %}
+        <p class="flash error"><strong>Inventory discrepancies found.</strong> Review the counts and details below.</p>
+      {% endif %}
+
+      <div class="recon-result-metrics" aria-label="Reconciliation totals">
+        <div class="recon-result-metric"><strong>{{ result.counts.government_records }}</strong><span>Government assets</span></div>
+        <div class="recon-result-metric"><strong>{{ result.counts.assettrack_active_records_considered }}</strong><span>AssetTrack active assets</span></div>
+        <div class="recon-result-metric"><strong>{{ result.matched }}</strong><span>Matched</span></div>
+        <div class="recon-result-metric"><strong>{{ result.discrepancies }}</strong><span>Discrepancies</span></div>
+      </div>
+
+      <h3>Discrepancy Counts</h3>
+      <ul class="recon-list">
+        <li>Government-only: {{ result.counts.government_only_assets }}</li>
+        <li>AssetTrack-only active: {{ result.counts.assettrack_only_active_assets }}</li>
+        <li>Identity conflicts: {{ result.counts.identity_conflicts }}</li>
+        <li>Ambiguous normalized tags: {{ result.counts.ambiguous_normalized_tags }}</li>
+        <li>Duplicate serial warnings: {{ result.counts.duplicate_serial_warnings }}</li>
+        <li>Duplicate MAC warnings: {{ result.counts.duplicate_mac_warnings }}</li>
+        <li>Retired/disposed tag matches: {{ result.counts.retired_disposed_tag_matches }}</li>
+        <li>Retired/disposed AssetTrack-only: {{ result.counts.retired_disposed_assettrack_only }}</li>
+      </ul>
+
+      {% set sections = [
+        ('Government-Only Assets', result.government_only),
+        ('AssetTrack-Only Active Assets', result.assettrack_only_active),
+        ('Retired / Disposed AssetTrack-Only Assets', result.terminal_assettrack_only)
+      ] %}
+      {% for title, rows in sections %}
+        <details class="recon-section" {% if rows %}open{% endif %}>
+          <summary>{{ title }} <span class="recon-count">{{ rows|length }}</span></summary>
+          <ul class="recon-list">
+            {% for row in rows %}
+              <li><code>{{ row.asset_tag }}</code>{% if row.serial_number %} serial {{ row.serial_number }}{% endif %}{% if row.location_type %} ({{ row.location_type }}){% endif %}</li>
+            {% else %}
+              <li>None</li>
+            {% endfor %}
+          </ul>
+        </details>
+      {% endfor %}
+
+      <details class="recon-section" {% if result.identity_conflicts %}open{% endif %}>
+        <summary>Identity Conflicts <span class="recon-count">{{ result.identity_conflicts|length }}</span></summary>
+        <ul class="recon-list">
+          {% for government, asset in result.identity_conflicts %}
+            <li><code>{{ government.asset_tag }}</code> matched <code>{{ asset.asset_tag }}</code>; government serial {{ government.serial_number or "blank" }}, AssetTrack serial {{ asset.serial_number or "blank" }}</li>
+          {% else %}
+            <li>None</li>
+          {% endfor %}
+        </ul>
+      </details>
+
+      <details class="recon-section" {% if result.ambiguous_government_tags or result.ambiguous_assettrack_tags %}open{% endif %}>
+        <summary>Ambiguous Normalized Tags <span class="recon-count">{{ result.counts.ambiguous_normalized_tags }}</span></summary>
+        <ul class="recon-list">
+          {% for key, rows in result.ambiguous_government_tags %}
+            <li>Government <code>{{ key }}</code>: {% for row in rows %}<code>{{ row.asset_tag }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</li>
+          {% endfor %}
+          {% for key, rows in result.ambiguous_assettrack_tags %}
+            <li>AssetTrack <code>{{ key }}</code>: {% for row in rows %}<code>{{ row.asset_tag }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</li>
+          {% endfor %}
+          {% if not result.ambiguous_government_tags and not result.ambiguous_assettrack_tags %}
+            <li>None</li>
+          {% endif %}
+        </ul>
+      </details>
+
+      <details class="recon-section" {% if result.duplicate_serial_warnings or result.duplicate_mac_warnings %}open{% endif %}>
+        <summary>Duplicate Serial / MAC Warnings <span class="recon-count">{{ result.counts.duplicate_serial_warnings + result.counts.duplicate_mac_warnings }}</span></summary>
+        <ul class="recon-list">
+          {% for key, rows in result.duplicate_serial_warnings %}
+            <li>Serial <code>{{ key }}</code>: {% for row in rows %}<code>{{ row.asset_tag }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</li>
+          {% endfor %}
+          {% for key, rows in result.duplicate_mac_warnings %}
+            <li>MAC <code>{{ key }}</code>: {% for row in rows %}<code>{{ row.asset_tag }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</li>
+          {% endfor %}
+          {% if not result.duplicate_serial_warnings and not result.duplicate_mac_warnings %}
+            <li>None</li>
+          {% endif %}
+        </ul>
+      </details>
+
+      <details class="recon-section" {% if result.terminal_matches %}open{% endif %}>
+        <summary>Retired / Disposed Tag Matches <span class="recon-count">{{ result.terminal_matches|length }}</span></summary>
+        <ul class="recon-list">
+          {% for government, asset in result.terminal_matches %}
+            <li><code>{{ government.asset_tag }}</code> matched retired/disposed AssetTrack record <code>{{ asset.asset_tag }}</code> ({{ asset.location_type }})</li>
+          {% else %}
+            <li>None</li>
+          {% endfor %}
+        </ul>
+      </details>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -65,6 +65,7 @@
       <span class="report-utility-label">Report utilities</span>
       <a class="nav-link" href="{{ url_for('case_inventory') }}">Case inventory</a>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Search receipts</a>
+      <a class="nav-link" href="{{ url_for('inventory_reconciliation') }}">Inventory Reconciliation</a>
       {% if include_retired_assets %}
         <a class="nav-link" href="{{ url_for('human_report') }}">View active inventory only</a>
       {% else %}

--- a/tests/test_government_inventory_reconciliation.py
+++ b/tests/test_government_inventory_reconciliation.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import io
 import sqlite3
 import subprocess
 import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
 
 from scripts.reconcile_government_inventory import (
     _open_readonly_database,
@@ -227,3 +233,169 @@ def test_reconciliation_cli_supports_direct_and_module_execution(tmp_path: Path)
     assert module.returncode == 0, module.stderr
     assert "government_records: 12" in direct.stdout
     assert direct.stdout == module.stdout
+
+@pytest.fixture
+def client_with_temp_app_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_role(client, *, username: str, role: str) -> None:
+    user_id = create_test_user(username=username, password="test-pass", role=role)
+    login_session(client, user_id)
+
+
+def _insert_app_asset(asset_tag: str, serial_number: str, location_type: str = "STORAGE") -> None:
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            "INSERT INTO assets (asset_tag, serial_number, location_type) VALUES (?, ?, ?);",
+            (asset_tag, serial_number, location_type),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _app_counts() -> dict[str, int]:
+    conn = db.get_connection()
+    try:
+        return {
+            "assets": int(conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0]),
+            "asset_events": int(conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0]),
+            "slots": int(conn.execute("SELECT COUNT(*) FROM slots;").fetchone()[0]),
+        }
+    finally:
+        conn.close()
+
+
+def _inventory_bytes(rows: list[list[str]], *, xlsx: bool = False) -> bytes:
+    frame = pd.DataFrame(rows, columns=["equipment_type", "asset_tag", "clean_asset_tag", "serial_number", "mac_address"])
+    if not xlsx:
+        return frame.to_csv(index=False).encode("utf-8")
+    output = io.BytesIO()
+    frame.to_excel(output, index=False)
+    return output.getvalue()
+
+
+def _post_inventory(client, content: bytes, filename: str):
+    return client.post(
+        "/report/inventory-reconciliation",
+        data={"inventory_file": (io.BytesIO(content), filename)},
+        content_type="multipart/form-data",
+    )
+
+
+def test_inventory_reconciliation_page_access_and_role_boundary(client_with_temp_app_db) -> None:
+    anonymous = client_with_temp_app_db.get("/report/inventory-reconciliation")
+    assert anonymous.status_code == 403
+
+    _login_role(client_with_temp_app_db, username="operator-recon-page", role="operator")
+    operator_response = client_with_temp_app_db.get("/report/inventory-reconciliation")
+    assert operator_response.status_code == 200
+    assert b"Analyze Government Inventory" in operator_response.data
+
+    report_response = client_with_temp_app_db.get("/report")
+    assert b'href="/report/inventory-reconciliation"' in report_response.data
+
+    _login_role(client_with_temp_app_db, username="admin-recon-page", role="admin")
+    admin_response = client_with_temp_app_db.get("/report/inventory-reconciliation")
+    assert admin_response.status_code == 200
+
+
+def test_inventory_reconciliation_gui_clean_csv_uses_arbitrary_filename_and_no_mutation(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-clean", role="operator")
+    _insert_app_asset("CLEAN100", "SER-CLEAN")
+    before = _app_counts()
+
+    response = _post_inventory(
+        client_with_temp_app_db,
+        _inventory_bytes([["Laptop", "CLEAN-100", "CLEAN100", "SER-CLEAN", "MAC-CLEAN"]]),
+        "operator selected clean source.csv",
+    )
+
+    assert response.status_code == 200
+    assert _app_counts() == before
+    assert b"operator selected clean source.csv" in response.data
+    assert b"INVENTORY RECONCILED" in response.data
+    assert b"<strong>1</strong><span>Government assets" in response.data
+    assert b"<strong>1</strong><span>AssetTrack active assets" in response.data
+    assert b"<strong>1</strong><span>Matched" in response.data
+    assert b"<strong>0</strong><span>Discrepancies" in response.data
+
+
+def test_inventory_reconciliation_gui_supports_arbitrary_xlsx_filename(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-xlsx", role="operator")
+    _insert_app_asset("XLSX100", "SER-XLSX")
+
+    response = _post_inventory(
+        client_with_temp_app_db,
+        _inventory_bytes([["Laptop", "XLSX-100", "XLSX100", "SER-XLSX", "MAC-XLSX"]], xlsx=True),
+        "field inventory arbitrary name.xlsx",
+    )
+
+    assert response.status_code == 200
+    assert b"field inventory arbitrary name.xlsx" in response.data
+    assert b"INVENTORY RECONCILED" in response.data
+
+
+def test_inventory_reconciliation_gui_rejects_unsupported_file(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-reject", role="operator")
+
+    response = _post_inventory(client_with_temp_app_db, b"not an inventory", "inventory.txt")
+
+    assert response.status_code == 400
+    assert b"Unsupported file type. Upload a .csv or .xlsx file." in response.data
+
+
+def test_inventory_reconciliation_gui_discrepancy_counts_match_engine_and_no_mutation(client_with_temp_app_db, tmp_path: Path) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-discrepancy", role="operator")
+    _insert_app_asset("MATCH100", "SER-MATCH")
+    _insert_app_asset("ONLY-ACTIVE-GUI", "SER-ONLY")
+    _insert_app_asset("CONFLICT-GUI", "SER-DB")
+    _insert_app_asset("DUPTAG-GUI", "SER-DUPTAG-A")
+    _insert_app_asset("DUPTAGGUI", "SER-DUPTAG-B")
+    _insert_app_asset("TERM-GUI", "SER-TERM", "RETIRED")
+    before = _app_counts()
+    rows = [
+        ["Laptop", "MATCH-100", "MATCH100", "SER-MATCH", "MAC-MATCH"],
+        ["Laptop", "GOV-ONLY-GUI", "", "SER-GOV", "MAC-GOV"],
+        ["Laptop", "CONFLICT-GUI", "", "SER-GOV-CONFLICT", "MAC-CONFLICT"],
+        ["Laptop", "DUPTAG-GUI", "", "SER-DUPTAG-GOV", "MAC-DUPTAG"],
+        ["Laptop", "DUPSER-GUI-1", "", "SER-DUP-GUI", "MAC-SER-1"],
+        ["Laptop", "DUPSER-GUI-2", "", "SER-DUP-GUI", "MAC-SER-2"],
+        ["Laptop", "DUPMAC-GUI-1", "", "SER-MAC-1", "MAC-DUP-GUI"],
+        ["Laptop", "DUPMAC-GUI-2", "", "SER-MAC-2", "mac-dup-gui"],
+        ["Laptop", "GOV-DUP-GUI", "", "SER-GOV-DUP-1", "MAC-GOV-DUP-1"],
+        ["Laptop", "GOVDUPGUI", "", "SER-GOV-DUP-2", "MAC-GOV-DUP-2"],
+        ["Laptop", "TERM-GUI", "", "SER-TERM", "MAC-TERM"],
+    ]
+    content = _inventory_bytes(rows)
+    inventory_path = tmp_path / "same-engine-source.csv"
+    inventory_path.write_bytes(content)
+
+    conn = sqlite3.connect(f"file:{db.DB_PATH.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    try:
+        engine_counts = reconcile_inventory(conn, inventory_path).summary_counts()
+    finally:
+        conn.close()
+
+    response = _post_inventory(client_with_temp_app_db, content, "operator discrepancy source.csv")
+
+    assert response.status_code == 200
+    assert _app_counts() == before
+    assert b"Inventory discrepancies found." in response.data
+    assert f"Government-only: {engine_counts['government_only_assets']}".encode() in response.data
+    assert f"AssetTrack-only active: {engine_counts['assettrack_only_active_assets']}".encode() in response.data
+    assert f"Identity conflicts: {engine_counts['identity_conflicts']}".encode() in response.data
+    assert f"Ambiguous normalized tags: {engine_counts['ambiguous_normalized_tags']}".encode() in response.data
+    assert f"Duplicate serial warnings: {engine_counts['duplicate_serial_warnings']}".encode() in response.data
+    assert f"Duplicate MAC warnings: {engine_counts['duplicate_mac_warnings']}".encode() in response.data
+    assert f"Retired/disposed tag matches: {engine_counts['retired_disposed_tag_matches']}".encode() in response.data
+    assert b"GOV-ONLY-GUI" in response.data
+    assert b"ONLY-ACTIVE-GUI" in response.data
+    assert b"CONFLICT-GUI" in response.data


### PR DESCRIPTION
## Summary

Adds an in-app workflow for running government inventory reconciliation from AssetTrack without requiring CLI access.

## Related Issue

Closes #1169

## Changes

- Adds `/report/inventory-reconciliation`.
- Adds Inventory Reconciliation to Reports.
- Supports operator-selected `.xlsx` and `.csv` files.
- Supports arbitrary filenames.
- Reuses the Issue 31-34 reconciliation engine.
- Opens the AssetTrack database read-only.
- Uses temporary uploaded files and removes them after analysis.
- Shows a clear INVENTORY RECONCILED success state.
- Shows reconciliation counts and individual discrepancy sections when review is required.
- Adds focused workflow and regression tests.

## Verification

- [x] Focused tests pass: 8 passed
- [x] Python compile check passes
- [x] Docker rebuilt before manual verification
- [x] Incognito operator smoke test passes
- [x] File upload works
- [x] Analyze workflow works
- [x] Discrepancy results render correctly
- [x] No asset/event/custody/slot mutation
- [x] No schema changes
- [x] No new dependencies
- [x] No Issue 31-34B work included

## Notes

Final reconciliation against the complete operational database remains a standalone-machine verification.

Issue 31-34B / #1170 separately covers persistent discrepancy disposition and closeout.