### PR TITLE
Issue 31-34B: Add reconciliation discrepancy disposition and closeout

### DIFF
--- a/assettrack/db.py
+++ b/assettrack/db.py
@@ -674,6 +674,50 @@ def _create_schema(conn: sqlite3.Connection):
 
     cursor.execute(
         """
+        CREATE TABLE IF NOT EXISTS inventory_reconciliation_disposition_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            created_at TEXT NOT NULL,
+            actor_user_id INTEGER NOT NULL,
+            actor_username TEXT NOT NULL CHECK(length(trim(actor_username)) > 0),
+            discrepancy_key TEXT NOT NULL CHECK(length(trim(discrepancy_key)) > 0),
+            discrepancy_category TEXT NOT NULL CHECK(length(trim(discrepancy_category)) > 0),
+            normalized_asset_key TEXT NULL,
+            discrepancy_snapshot_json TEXT NOT NULL CHECK(length(trim(discrepancy_snapshot_json)) > 0),
+            disposition_note TEXT NOT NULL CHECK(length(trim(disposition_note)) > 0),
+            is_reviewed INTEGER NOT NULL CHECK(is_reviewed IN (0, 1))
+        );
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_inventory_reconciliation_disposition_events_discrepancy_key
+            ON inventory_reconciliation_disposition_events(discrepancy_key);
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS inventory_reconciliation_disposition_events_no_update
+        BEFORE UPDATE ON inventory_reconciliation_disposition_events
+        BEGIN
+            SELECT RAISE(ABORT, 'inventory_reconciliation_disposition_events is append-only');
+        END;
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TRIGGER IF NOT EXISTS inventory_reconciliation_disposition_events_no_delete
+        BEFORE DELETE ON inventory_reconciliation_disposition_events
+        BEGIN
+            SELECT RAISE(ABORT, 'inventory_reconciliation_disposition_events is append-only');
+        END;
+        """
+    )
+
+    cursor.execute(
+        """
         CREATE TABLE IF NOT EXISTS receipt_queue (
             id INTEGER PRIMARY KEY,
             receipt_key TEXT NOT NULL UNIQUE,

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -80,7 +80,15 @@ from assettrack.holder_import import (
 )
 from assettrack.import_analysis import analyze_asset_import_csv, analyze_asset_import_xlsx
 from assettrack.import_reconciliation import build_asset_import_preview
-from scripts.reconcile_government_inventory import reconcile_inventory
+from assettrack.reconciliation_dispositions import (
+    insert_reconciliation_disposition_event,
+    latest_reconciliation_dispositions,
+)
+from scripts.reconcile_government_inventory import (
+    active_discrepancies,
+    discrepancy_key_from_snapshot,
+    reconcile_inventory,
+)
 from assettrack.natural_sort import natural_identifier_sort_key
 from assettrack.reference_data import (
     create_building,
@@ -10165,7 +10173,7 @@ def admin_db_restore():
 
 
 
-def _inventory_reconciliation_view(result) -> dict[str, object]:
+def _inventory_reconciliation_view(result, conn: sqlite3.Connection) -> dict[str, object]:
     counts = result.summary_counts()
     discrepancy_count = (
         counts["government_only_assets"]
@@ -10177,11 +10185,41 @@ def _inventory_reconciliation_view(result) -> dict[str, object]:
         + counts["retired_disposed_tag_matches"]
         + counts["retired_disposed_assettrack_only"]
     )
+    discrepancies = active_discrepancies(result)
+    latest_by_key = latest_reconciliation_dispositions(conn, tuple(item.key for item in discrepancies))
+    discrepancy_rows = []
+    reviewed_count = 0
+    for discrepancy in discrepancies:
+        latest = latest_by_key.get(discrepancy.key)
+        is_reviewed = bool(latest and latest.is_reviewed)
+        if is_reviewed:
+            reviewed_count += 1
+        discrepancy_rows.append(
+            {
+                "key": discrepancy.key,
+                "category": discrepancy.category,
+                "label": discrepancy.label,
+                "normalized_asset_key": discrepancy.normalized_asset_key,
+                "snapshot": discrepancy.snapshot,
+                "snapshot_json": discrepancy.snapshot_json,
+                "latest_disposition": latest,
+                "is_reviewed": is_reviewed,
+            }
+        )
+    if discrepancy_count == 0:
+        reconciliation_state = "CLEAN RECONCILIATION"
+    elif reviewed_count == discrepancy_count:
+        reconciliation_state = "RECONCILIATION COMPLETE"
+    else:
+        reconciliation_state = "RECONCILIATION REQUIRES ATTENTION"
     return {
         "counts": counts,
         "matched": counts["exact_or_normalized_tag_matches"],
         "discrepancies": discrepancy_count,
         "clean": discrepancy_count == 0,
+        "reconciliation_state": reconciliation_state,
+        "reviewed_discrepancies": reviewed_count,
+        "active_discrepancies": discrepancy_rows,
         "government_only": result.government_only,
         "assettrack_only_active": result.assettrack_only_active,
         "identity_conflicts": result.identity_conflicts,
@@ -10202,6 +10240,66 @@ def inventory_reconciliation():
     status_code = 200
 
     if request.method == "POST":
+        action = (request.form.get("action") or "analyze").strip().lower()
+        if action == "save_disposition":
+            note = str(request.form.get("disposition_note") or "").strip()
+            reviewed = request.form.get("is_reviewed") == "1"
+            submitted_key = str(request.form.get("discrepancy_key") or "").strip()
+            snapshot_json = str(request.form.get("discrepancy_snapshot_json") or "").strip()
+            try:
+                snapshot = json.loads(snapshot_json)
+                if not isinstance(snapshot, dict):
+                    raise ValueError("Disposition evidence is invalid.")
+                expected_key = discrepancy_key_from_snapshot(snapshot)
+                if not submitted_key or submitted_key != expected_key:
+                    raise ValueError("Disposition evidence does not match the discrepancy key.")
+                if not note:
+                    raise ValueError("Enter a disposition note before saving Reviewed / Dispositioned.")
+                user = current_user()
+                if user is None:
+                    return abort(403)
+                conn = get_connection()
+                try:
+                    conn.execute("BEGIN IMMEDIATE;")
+                    insert_reconciliation_disposition_event(
+                        conn,
+                        created_at=datetime.now(timezone.utc).isoformat(),
+                        actor_user_id=int(user["id"]),
+                        actor_username=str(user.get("username") or ""),
+                        discrepancy_key=submitted_key,
+                        discrepancy_category=str(snapshot.get("category") or ""),
+                        normalized_asset_key=str(snapshot.get("normalized_asset_key") or ""),
+                        discrepancy_snapshot_json=snapshot_json,
+                        disposition_note=note,
+                        is_reviewed=reviewed,
+                    )
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
+                finally:
+                    conn.close()
+                flash(
+                    "Disposition saved. Re-run the same inventory analysis to see the latest disposition on active discrepancies.",
+                    "success",
+                )
+                return redirect(url_for("inventory_reconciliation"))
+            except (ValueError, json.JSONDecodeError, sqlite3.Error) as exc:
+                error_message = str(exc)
+                status_code = 400
+        elif action != "analyze":
+            error_message = "Unknown inventory reconciliation action."
+            status_code = 400
+        if error_message is not None:
+            return (
+                render_template(
+                    "inventory_reconciliation.html",
+                    result=result,
+                    error_message=error_message,
+                ),
+                status_code,
+            )
+
         upload = request.files.get("inventory_file")
         filename = str((upload.filename if upload is not None else "") or "").strip()
         if upload is None or not filename:
@@ -10221,10 +10319,8 @@ def inventory_reconciliation():
                         upload.save(handle)
                         temp_path = Path(handle.name)
 
-                    resolved_db_path = _resolved_runtime_db_path()
-                    conn = sqlite3.connect(f"file:{resolved_db_path.resolve()}?mode=ro", uri=True)
-                    conn.row_factory = sqlite3.Row
-                    result = _inventory_reconciliation_view(reconcile_inventory(conn, temp_path))
+                    conn = get_connection()
+                    result = _inventory_reconciliation_view(reconcile_inventory(conn, temp_path), conn)
                     result["filename"] = filename
                 except ValueError as exc:
                     error_message = str(exc)

--- a/assettrack/intake/templates/inventory_reconciliation.html
+++ b/assettrack/intake/templates/inventory_reconciliation.html
@@ -27,6 +27,22 @@
     .recon-section summary { cursor: pointer; font-weight: 700; }
     .recon-count { color: var(--color-text-muted); font-weight: 400; margin-left: 0.5rem; }
     .recon-list { margin: 0.5rem 0 0 1.25rem; }
+    .recon-disposition {
+      border: 1px solid var(--color-surface);
+      background: var(--color-surface-bg);
+      margin: 0.75rem 0;
+      padding: 0.75rem;
+    }
+    .recon-disposition.reviewed { border-color: var(--color-success); }
+    .recon-disposition h4 { margin: 0 0 0.5rem 0; }
+    .recon-evidence {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+      gap: 0.75rem;
+      margin: 0.5rem 0;
+    }
+    .recon-evidence ul { margin: 0.25rem 0 0 1.25rem; }
+    .recon-disposition textarea { width: 100%; min-height: 5rem; }
   </style>
 {% endblock %}
 
@@ -62,10 +78,16 @@
       <h2>Reconciliation Result</h2>
       <p class="recon-help"><strong>File:</strong> {{ result.filename }}</p>
       {% if result.clean %}
-        <p class="flash success recon-status-pass">&#10003; INVENTORY RECONCILED</p>
+        <p class="flash success recon-status-pass">CLEAN RECONCILIATION</p>
       {% else %}
         <p class="flash error"><strong>Inventory discrepancies found.</strong> Review the counts and details below.</p>
       {% endif %}
+      <p class="{% if result.reconciliation_state == 'RECONCILIATION REQUIRES ATTENTION' %}flash error{% else %}flash success{% endif %}">
+        <strong>{{ result.reconciliation_state }}</strong>
+        {% if result.discrepancies > 0 %}
+          {{ result.reviewed_discrepancies }} of {{ result.discrepancies }} active discrepancies reviewed/accounted for.
+        {% endif %}
+      </p>
 
       <div class="recon-result-metrics" aria-label="Reconciliation totals">
         <div class="recon-result-metric"><strong>{{ result.counts.government_records }}</strong><span>Government assets</span></div>
@@ -85,6 +107,86 @@
         <li>Retired/disposed tag matches: {{ result.counts.retired_disposed_tag_matches }}</li>
         <li>Retired/disposed AssetTrack-only: {{ result.counts.retired_disposed_assettrack_only }}</li>
       </ul>
+
+      <details class="recon-section" {% if result.active_discrepancies %}open{% endif %}>
+        <summary>Disposition Active Discrepancies <span class="recon-count">{{ result.active_discrepancies|length }}</span></summary>
+        {% for discrepancy in result.active_discrepancies %}
+          <div class="recon-disposition{% if discrepancy.is_reviewed %} reviewed{% endif %}">
+            <h4>{{ discrepancy.label }}</h4>
+            <p class="recon-help">
+              Key: <code>{{ discrepancy.key }}</code>
+              {% if discrepancy.normalized_asset_key %} | normalized asset key: <code>{{ discrepancy.normalized_asset_key }}</code>{% endif %}
+            </p>
+            <div class="recon-evidence">
+              <div>
+                <strong>Government evidence</strong>
+                <ul>
+                  {% for row in discrepancy.snapshot.government %}
+                    <li>
+                      <code>{{ row.asset_tag }}</code>
+                      {% if row.serial_number %} serial {{ row.serial_number }}{% endif %}
+                      {% if row.mac_address %} MAC {{ row.mac_address }}{% endif %}
+                      {% if row.row_number %} row {{ row.row_number }}{% endif %}
+                    </li>
+                  {% else %}
+                    <li>None</li>
+                  {% endfor %}
+                </ul>
+              </div>
+              <div>
+                <strong>AssetTrack evidence</strong>
+                <ul>
+                  {% for row in discrepancy.snapshot.assettrack %}
+                    <li>
+                      <code>{{ row.asset_tag }}</code>
+                      {% if row.serial_number %} serial {{ row.serial_number }}{% endif %}
+                      {% if row.location_type %} ({{ row.location_type }}){% endif %}
+                    </li>
+                  {% else %}
+                    <li>None</li>
+                  {% endfor %}
+                </ul>
+              </div>
+            </div>
+            {% if discrepancy.snapshot.duplicate_value %}
+              <p class="recon-help">Duplicate value: <code>{{ discrepancy.snapshot.duplicate_value }}</code></p>
+            {% endif %}
+            {% if discrepancy.snapshot.member_tags %}
+              <p class="recon-help">Members: {% for tag in discrepancy.snapshot.member_tags %}<code>{{ tag }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</p>
+            {% endif %}
+
+            {% if discrepancy.latest_disposition %}
+              <p class="flash success">
+                Latest disposition: {% if discrepancy.latest_disposition.is_reviewed %}Reviewed / Dispositioned{% else %}Note saved{% endif %}
+                by {{ discrepancy.latest_disposition.actor_username }} at {{ discrepancy.latest_disposition.created_at }}.
+                Green means reviewed/accounted for; it does not mean government and AssetTrack values now agree.
+              </p>
+              <p>{{ discrepancy.latest_disposition.disposition_note }}</p>
+            {% else %}
+              <p class="flash error">No disposition saved for this active discrepancy.</p>
+            {% endif %}
+
+            <form method="post">
+              <input type="hidden" name="action" value="save_disposition" />
+              <input type="hidden" name="discrepancy_key" value="{{ discrepancy.key }}" />
+              <input type="hidden" name="discrepancy_snapshot_json" value="{{ discrepancy.snapshot_json }}" />
+              <div class="row">
+                <label for="disposition_note_{{ loop.index }}"><strong>Disposition note</strong></label><br />
+                <textarea id="disposition_note_{{ loop.index }}" name="disposition_note" required></textarea>
+              </div>
+              <label>
+                <input type="checkbox" name="is_reviewed" value="1" />
+                Reviewed / Dispositioned
+              </label>
+              <div class="row">
+                <button type="submit">Save Disposition</button>
+              </div>
+            </form>
+          </div>
+        {% else %}
+          <p class="recon-help">No active discrepancies.</p>
+        {% endfor %}
+      </details>
 
       {% set sections = [
         ('Government-Only Assets', result.government_only),

--- a/assettrack/reconciliation_dispositions.py
+++ b/assettrack/reconciliation_dispositions.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ReconciliationDisposition:
+    id: int
+    created_at: str
+    actor_user_id: int
+    actor_username: str
+    discrepancy_key: str
+    discrepancy_category: str
+    normalized_asset_key: str
+    discrepancy_snapshot_json: str
+    disposition_note: str
+    is_reviewed: bool
+
+
+def insert_reconciliation_disposition_event(
+    conn: sqlite3.Connection,
+    *,
+    created_at: str,
+    actor_user_id: int,
+    actor_username: str,
+    discrepancy_key: str,
+    discrepancy_category: str,
+    normalized_asset_key: str,
+    discrepancy_snapshot_json: str,
+    disposition_note: str,
+    is_reviewed: bool,
+) -> int:
+    json.loads(discrepancy_snapshot_json)
+    row = conn.execute(
+        """
+        INSERT INTO inventory_reconciliation_disposition_events (
+            created_at,
+            actor_user_id,
+            actor_username,
+            discrepancy_key,
+            discrepancy_category,
+            normalized_asset_key,
+            discrepancy_snapshot_json,
+            disposition_note,
+            is_reviewed
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+        """,
+        (
+            created_at,
+            int(actor_user_id),
+            str(actor_username or "").strip(),
+            str(discrepancy_key or "").strip(),
+            str(discrepancy_category or "").strip(),
+            str(normalized_asset_key or "").strip() or None,
+            discrepancy_snapshot_json,
+            str(disposition_note or "").strip(),
+            1 if is_reviewed else 0,
+        ),
+    )
+    return int(row.lastrowid)
+
+
+def latest_reconciliation_dispositions(
+    conn: sqlite3.Connection,
+    discrepancy_keys: list[str] | tuple[str, ...],
+) -> dict[str, ReconciliationDisposition]:
+    keys = [str(key or "").strip() for key in discrepancy_keys if str(key or "").strip()]
+    if not keys:
+        return {}
+    placeholders = ",".join("?" for _key in keys)
+    rows = conn.execute(
+        f"""
+        SELECT
+            id,
+            created_at,
+            actor_user_id,
+            actor_username,
+            discrepancy_key,
+            discrepancy_category,
+            normalized_asset_key,
+            discrepancy_snapshot_json,
+            disposition_note,
+            is_reviewed
+        FROM inventory_reconciliation_disposition_events
+        WHERE discrepancy_key IN ({placeholders})
+        ORDER BY id DESC;
+        """,
+        keys,
+    ).fetchall()
+    latest: dict[str, ReconciliationDisposition] = {}
+    for row in rows:
+        key = str(row["discrepancy_key"] or "")
+        if key in latest:
+            continue
+        latest[key] = ReconciliationDisposition(
+            id=int(row["id"]),
+            created_at=str(row["created_at"] or ""),
+            actor_user_id=int(row["actor_user_id"]),
+            actor_username=str(row["actor_username"] or ""),
+            discrepancy_key=key,
+            discrepancy_category=str(row["discrepancy_category"] or ""),
+            normalized_asset_key=str(row["normalized_asset_key"] or ""),
+            discrepancy_snapshot_json=str(row["discrepancy_snapshot_json"] or ""),
+            disposition_note=str(row["disposition_note"] or ""),
+            is_reviewed=int(row["is_reviewed"] or 0) == 1,
+        )
+    return latest

--- a/scripts/reconcile_government_inventory.py
+++ b/scripts/reconcile_government_inventory.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
+import json
 import sqlite3
 import sys
 from collections import defaultdict
@@ -81,6 +83,184 @@ class ReconciliationResult:
             "retired_disposed_tag_matches": len(self.terminal_matches),
             "retired_disposed_assettrack_only": len(self.terminal_assettrack_only),
         }
+
+
+@dataclass(frozen=True)
+class ReconciliationDiscrepancy:
+    key: str
+    category: str
+    label: str
+    normalized_asset_key: str
+    snapshot: dict[str, object]
+    snapshot_json: str
+
+
+def _canonical_json(data: dict[str, object]) -> str:
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def discrepancy_key_from_snapshot(snapshot: dict[str, object]) -> str:
+    return hashlib.sha256(_canonical_json(snapshot).encode("utf-8")).hexdigest()
+
+
+def _canonical_text(value: object) -> str:
+    return _normalize_text(value).upper()
+
+
+def _government_snapshot(record: GovernmentRecord) -> dict[str, object]:
+    return {
+        "asset_tag": _normalize_text(record.asset_tag),
+        "compare_tag": _normalize_text(record.compare_tag),
+        "normalized_asset_key": record.key,
+        "serial_number": _canonical_text(record.serial_number),
+        "mac_address": _canonical_text(record.mac_address),
+        "equipment_type": _canonical_text(record.equipment_type),
+        "row_number": int(record.row_number),
+    }
+
+
+def _assettrack_snapshot(record: AssetTrackRecord) -> dict[str, object]:
+    return {
+        "id": int(record.id),
+        "asset_tag": _normalize_text(record.asset_tag),
+        "normalized_asset_key": record.key,
+        "serial_number": _canonical_text(record.serial_number),
+        "location_type": _canonical_text(record.location_type),
+    }
+
+
+def _member_tags(records: tuple[GovernmentRecord, ...] | tuple[AssetTrackRecord, ...]) -> list[str]:
+    return sorted(_normalize_text(getattr(record, "asset_tag")) for record in records)
+
+
+def _make_discrepancy(
+    *,
+    category: str,
+    label: str,
+    normalized_asset_key: str,
+    government: list[dict[str, object]] | None = None,
+    assettrack: list[dict[str, object]] | None = None,
+    duplicate_value: str = "",
+    member_tags: list[str] | None = None,
+) -> ReconciliationDiscrepancy:
+    snapshot: dict[str, object] = {
+        "category": category,
+        "normalized_asset_key": normalized_asset_key,
+        "government": government or [],
+        "assettrack": assettrack or [],
+        "duplicate_value": duplicate_value,
+        "member_tags": sorted(member_tags or []),
+    }
+    snapshot_json = _canonical_json(snapshot)
+    return ReconciliationDiscrepancy(
+        key=discrepancy_key_from_snapshot(snapshot),
+        category=category,
+        label=label,
+        normalized_asset_key=normalized_asset_key,
+        snapshot=snapshot,
+        snapshot_json=snapshot_json,
+    )
+
+
+def active_discrepancies(result: ReconciliationResult) -> tuple[ReconciliationDiscrepancy, ...]:
+    discrepancies: list[ReconciliationDiscrepancy] = []
+
+    for record in result.government_only:
+        discrepancies.append(
+            _make_discrepancy(
+                category="government_only_asset",
+                label=f"Government-only asset {record.asset_tag}",
+                normalized_asset_key=record.key,
+                government=[_government_snapshot(record)],
+                member_tags=[record.asset_tag],
+            )
+        )
+    for record in result.assettrack_only_active:
+        discrepancies.append(
+            _make_discrepancy(
+                category="assettrack_only_active_asset",
+                label=f"AssetTrack-only active asset {record.asset_tag}",
+                normalized_asset_key=record.key,
+                assettrack=[_assettrack_snapshot(record)],
+                member_tags=[record.asset_tag],
+            )
+        )
+    for government, asset in result.identity_conflicts:
+        discrepancies.append(
+            _make_discrepancy(
+                category="identity_conflict",
+                label=f"Identity conflict {government.asset_tag}",
+                normalized_asset_key=government.key or asset.key,
+                government=[_government_snapshot(government)],
+                assettrack=[_assettrack_snapshot(asset)],
+                member_tags=[government.asset_tag, asset.asset_tag],
+            )
+        )
+    for key, records in result.ambiguous_government_tags:
+        discrepancies.append(
+            _make_discrepancy(
+                category="ambiguous_government_normalized_tag",
+                label=f"Ambiguous government normalized tag {key}",
+                normalized_asset_key=key,
+                government=[_government_snapshot(record) for record in records],
+                member_tags=_member_tags(records),
+            )
+        )
+    for key, records in result.ambiguous_assettrack_tags:
+        discrepancies.append(
+            _make_discrepancy(
+                category="ambiguous_assettrack_normalized_tag",
+                label=f"Ambiguous AssetTrack normalized tag {key}",
+                normalized_asset_key=key,
+                assettrack=[_assettrack_snapshot(record) for record in records],
+                member_tags=_member_tags(records),
+            )
+        )
+    for key, records in result.duplicate_serial_warnings:
+        discrepancies.append(
+            _make_discrepancy(
+                category="duplicate_government_serial",
+                label=f"Duplicate government serial {key}",
+                normalized_asset_key="",
+                government=[_government_snapshot(record) for record in records],
+                duplicate_value=key,
+                member_tags=_member_tags(records),
+            )
+        )
+    for key, records in result.duplicate_mac_warnings:
+        discrepancies.append(
+            _make_discrepancy(
+                category="duplicate_government_mac",
+                label=f"Duplicate government MAC {key}",
+                normalized_asset_key="",
+                government=[_government_snapshot(record) for record in records],
+                duplicate_value=key,
+                member_tags=_member_tags(records),
+            )
+        )
+    for government, asset in result.terminal_matches:
+        discrepancies.append(
+            _make_discrepancy(
+                category="retired_disposed_tag_match",
+                label=f"Retired/disposed tag match {government.asset_tag}",
+                normalized_asset_key=government.key or asset.key,
+                government=[_government_snapshot(government)],
+                assettrack=[_assettrack_snapshot(asset)],
+                member_tags=[government.asset_tag, asset.asset_tag],
+            )
+        )
+    for record in result.terminal_assettrack_only:
+        discrepancies.append(
+            _make_discrepancy(
+                category="retired_disposed_assettrack_only",
+                label=f"Retired/disposed AssetTrack-only asset {record.asset_tag}",
+                normalized_asset_key=record.key,
+                assettrack=[_assettrack_snapshot(record)],
+                member_tags=[record.asset_tag],
+            )
+        )
+
+    return tuple(sorted(discrepancies, key=lambda item: (item.category, item.label, item.key)))
 
 
 def _read_inventory_frame(path: Path) -> pd.DataFrame:

--- a/tests/test_government_inventory_reconciliation.py
+++ b/tests/test_government_inventory_reconciliation.py
@@ -14,6 +14,7 @@ from assettrack.intake import app as intake_app
 from tests.auth_test_utils import create_test_user, login_session
 
 from scripts.reconcile_government_inventory import (
+    active_discrepancies,
     _open_readonly_database,
     format_reconciliation,
     load_government_records,
@@ -272,6 +273,20 @@ def _app_counts() -> dict[str, int]:
         conn.close()
 
 
+def _disposition_rows() -> list[sqlite3.Row]:
+    conn = db.get_connection()
+    try:
+        return conn.execute(
+            """
+            SELECT *
+            FROM inventory_reconciliation_disposition_events
+            ORDER BY id ASC;
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+
 def _inventory_bytes(rows: list[list[str]], *, xlsx: bool = False) -> bytes:
     frame = pd.DataFrame(rows, columns=["equipment_type", "asset_tag", "clean_asset_tag", "serial_number", "mac_address"])
     if not xlsx:
@@ -287,6 +302,111 @@ def _post_inventory(client, content: bytes, filename: str):
         data={"inventory_file": (io.BytesIO(content), filename)},
         content_type="multipart/form-data",
     )
+
+
+def _active_app_discrepancy(rows: list[list[str]]):
+    content = _inventory_bytes(rows)
+    inventory_path = db.DB_PATH.parent / "disposition-source.csv"
+    inventory_path.write_bytes(content)
+    conn = db.get_connection()
+    try:
+        result = reconcile_inventory(conn, inventory_path)
+        discrepancies = active_discrepancies(result)
+    finally:
+        conn.close()
+        inventory_path.unlink(missing_ok=True)
+    assert discrepancies
+    return discrepancies[0], content
+
+
+def _post_disposition(client, discrepancy, *, note: str, reviewed: bool = True):
+    data = {
+        "action": "save_disposition",
+        "discrepancy_key": discrepancy.key,
+        "discrepancy_snapshot_json": discrepancy.snapshot_json,
+        "disposition_note": note,
+    }
+    if reviewed:
+        data["is_reviewed"] = "1"
+    return client.post("/report/inventory-reconciliation", data=data)
+
+
+def test_inventory_reconciliation_disposition_schema_is_idempotent_and_append_only(tmp_path: Path) -> None:
+    db_path = tmp_path / "assettrack.db"
+    db.initialize_schema(db_path)
+    db.initialize_schema(db_path)
+
+    conn = sqlite3.connect(db_path)
+    try:
+        table = conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'table'
+              AND name = 'inventory_reconciliation_disposition_events';
+            """
+        ).fetchone()
+        index = conn.execute(
+            """
+            SELECT name
+            FROM sqlite_master
+            WHERE type = 'index'
+              AND name = 'idx_inventory_reconciliation_disposition_events_discrepancy_key';
+            """
+        ).fetchone()
+        triggers = {
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT name
+                FROM sqlite_master
+                WHERE type = 'trigger'
+                  AND tbl_name = 'inventory_reconciliation_disposition_events';
+                """
+            ).fetchall()
+        }
+        assert table is not None
+        assert index is not None
+        assert triggers == {
+            "inventory_reconciliation_disposition_events_no_update",
+            "inventory_reconciliation_disposition_events_no_delete",
+        }
+
+        conn.execute(
+            """
+            INSERT INTO inventory_reconciliation_disposition_events (
+                created_at,
+                actor_user_id,
+                actor_username,
+                discrepancy_key,
+                discrepancy_category,
+                normalized_asset_key,
+                discrepancy_snapshot_json,
+                disposition_note,
+                is_reviewed
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
+            """,
+            (
+                "2026-08-13T00:00:00+00:00",
+                1,
+                "schema-tester",
+                "key-1",
+                "government_only_asset",
+                "GOV1",
+                '{"category":"government_only_asset"}',
+                "Reviewed against source document.",
+                1,
+            ),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute(
+                "UPDATE inventory_reconciliation_disposition_events SET disposition_note = 'changed' WHERE id = 1;"
+            )
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute("DELETE FROM inventory_reconciliation_disposition_events WHERE id = 1;")
+    finally:
+        conn.close()
 
 
 def test_inventory_reconciliation_page_access_and_role_boundary(client_with_temp_app_db) -> None:
@@ -320,7 +440,7 @@ def test_inventory_reconciliation_gui_clean_csv_uses_arbitrary_filename_and_no_m
     assert response.status_code == 200
     assert _app_counts() == before
     assert b"operator selected clean source.csv" in response.data
-    assert b"INVENTORY RECONCILED" in response.data
+    assert b"CLEAN RECONCILIATION" in response.data
     assert b"<strong>1</strong><span>Government assets" in response.data
     assert b"<strong>1</strong><span>AssetTrack active assets" in response.data
     assert b"<strong>1</strong><span>Matched" in response.data
@@ -339,7 +459,7 @@ def test_inventory_reconciliation_gui_supports_arbitrary_xlsx_filename(client_wi
 
     assert response.status_code == 200
     assert b"field inventory arbitrary name.xlsx" in response.data
-    assert b"INVENTORY RECONCILED" in response.data
+    assert b"CLEAN RECONCILIATION" in response.data
 
 
 def test_inventory_reconciliation_gui_rejects_unsupported_file(client_with_temp_app_db) -> None:
@@ -399,3 +519,115 @@ def test_inventory_reconciliation_gui_discrepancy_counts_match_engine_and_no_mut
     assert b"GOV-ONLY-GUI" in response.data
     assert b"ONLY-ACTIVE-GUI" in response.data
     assert b"CONFLICT-GUI" in response.data
+    assert b"RECONCILIATION REQUIRES ATTENTION" in response.data
+
+
+def test_inventory_reconciliation_disposition_requires_note(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-note-required", role="operator")
+    _insert_app_asset("MATCH-NOTE", "SER-MATCH")
+    discrepancy, _content = _active_app_discrepancy(
+        [
+            ["Laptop", "MATCH-NOTE", "", "SER-MATCH", "MAC-MATCH"],
+            ["Laptop", "GOV-NOTE-ONLY", "", "SER-GOV", "MAC-GOV"],
+        ]
+    )
+    before = _app_counts()
+
+    response = _post_disposition(client_with_temp_app_db, discrepancy, note="", reviewed=True)
+
+    assert response.status_code == 400
+    assert b"Enter a disposition note before saving Reviewed / Dispositioned." in response.data
+    assert _disposition_rows() == []
+    assert _app_counts() == before
+
+
+def test_inventory_reconciliation_disposition_appends_user_and_reviewed_state(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-disposition", role="operator")
+    _insert_app_asset("MATCH-DISP", "SER-MATCH")
+    discrepancy, _content = _active_app_discrepancy(
+        [
+            ["Laptop", "MATCH-DISP", "", "SER-MATCH", "MAC-MATCH"],
+            ["Laptop", "GOV-DISP-ONLY", "", "SER-GOV", "MAC-GOV"],
+        ]
+    )
+    before = _app_counts()
+
+    first = _post_disposition(client_with_temp_app_db, discrepancy, note="Verified as accounted for.", reviewed=True)
+    second = _post_disposition(client_with_temp_app_db, discrepancy, note="Supervisor confirmed.", reviewed=True)
+
+    assert first.status_code == 302
+    assert second.status_code == 302
+    assert _app_counts() == before
+    rows = _disposition_rows()
+    assert len(rows) == 2
+    assert rows[0]["discrepancy_key"] == discrepancy.key
+    assert rows[0]["discrepancy_category"] == discrepancy.category
+    assert rows[0]["normalized_asset_key"] == discrepancy.normalized_asset_key
+    assert rows[0]["disposition_note"] == "Verified as accounted for."
+    assert int(rows[0]["is_reviewed"]) == 1
+    assert int(rows[0]["actor_user_id"]) > 0
+    assert rows[0]["actor_username"] == "operator-recon-disposition"
+    assert rows[1]["disposition_note"] == "Supervisor confirmed."
+    assert int(rows[1]["id"]) > int(rows[0]["id"])
+
+
+def test_inventory_reconciliation_disposition_persists_explicit_unreviewed_state(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-unreviewed", role="operator")
+    _insert_app_asset("MATCH-UNREVIEWED", "SER-MATCH")
+    discrepancy, _content = _active_app_discrepancy(
+        [
+            ["Laptop", "MATCH-UNREVIEWED", "", "SER-MATCH", "MAC-MATCH"],
+            ["Laptop", "GOV-UNREVIEWED-ONLY", "", "SER-GOV", "MAC-GOV"],
+        ]
+    )
+
+    response = _post_disposition(client_with_temp_app_db, discrepancy, note="Research note only.", reviewed=False)
+
+    assert response.status_code == 302
+    rows = _disposition_rows()
+    assert len(rows) == 1
+    assert rows[0]["disposition_note"] == "Research note only."
+    assert int(rows[0]["is_reviewed"]) == 0
+
+
+def test_inventory_reconciliation_unchanged_discrepancy_reassociates_and_complete_state(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-complete", role="operator")
+    _insert_app_asset("MATCH-COMPLETE", "SER-MATCH")
+    rows = [
+        ["Laptop", "MATCH-COMPLETE", "", "SER-MATCH", "MAC-MATCH"],
+        ["Laptop", "GOV-COMPLETE-ONLY", "", "SER-GOV", "MAC-GOV"],
+    ]
+    discrepancy, content = _active_app_discrepancy(rows)
+    _post_disposition(client_with_temp_app_db, discrepancy, note="Documented as expected.", reviewed=True)
+
+    response = _post_inventory(client_with_temp_app_db, content, "same discrepancy.csv")
+
+    assert response.status_code == 200
+    assert b"RECONCILIATION COMPLETE" in response.data
+    assert b"Documented as expected." in response.data
+    assert b"operator-recon-complete" in response.data
+
+
+def test_inventory_reconciliation_changed_or_new_discrepancy_does_not_inherit_disposition(client_with_temp_app_db) -> None:
+    _login_role(client_with_temp_app_db, username="operator-recon-new-key", role="operator")
+    _insert_app_asset("MATCH-NEWKEY", "SER-MATCH")
+    original_rows = [
+        ["Laptop", "MATCH-NEWKEY", "", "SER-MATCH", "MAC-MATCH"],
+        ["Laptop", "GOV-NEWKEY-ONLY", "", "SER-GOV-1", "MAC-GOV-1"],
+    ]
+    changed_rows = [
+        ["Laptop", "MATCH-NEWKEY", "", "SER-MATCH", "MAC-MATCH"],
+        ["Laptop", "GOV-NEWKEY-ONLY", "", "SER-GOV-2", "MAC-GOV-1"],
+        ["Laptop", "GOV-NEWKEY-ADDED", "", "SER-GOV-ADDED", "MAC-GOV-ADDED"],
+    ]
+    original_discrepancy, _content = _active_app_discrepancy(original_rows)
+    changed_discrepancy, changed_content = _active_app_discrepancy(changed_rows)
+    _post_disposition(client_with_temp_app_db, original_discrepancy, note="Old evidence reviewed.", reviewed=True)
+
+    response = _post_inventory(client_with_temp_app_db, changed_content, "changed discrepancy.csv")
+
+    assert changed_discrepancy.key != original_discrepancy.key
+    assert response.status_code == 200
+    assert b"RECONCILIATION REQUIRES ATTENTION" in response.data
+    assert b"Old evidence reviewed." not in response.data
+    assert b"No disposition saved for this active discrepancy." in response.data


### PR DESCRIPTION
## Summary

Adds persistent, append-only disposition history for government inventory reconciliation discrepancies.

## Related Issue

Closes #1170

## Changes

- Adds append-only `inventory_reconciliation_disposition_events`.
- Adds no-update and no-delete database triggers.
- Adds deterministic discrepancy identities using canonical snapshots and SHA-256.
- Records disposition note, explicit reviewed state, reviewer, and timestamp.
- Reassociates unchanged discrepancies with prior disposition history.
- Prevents changed or unrelated discrepancies from inheriting prior dispositions.
- Adds Reviewed / Dispositioned workflow to Inventory Reconciliation.
- Preserves the underlying discrepancy evidence after disposition.
- Adds three reconciliation states:
  - CLEAN RECONCILIATION
  - RECONCILIATION COMPLETE
  - RECONCILIATION REQUIRES ATTENTION

## Verification

- [x] Focused reconciliation and DB tests pass: 36 passed
- [x] Schema initialization is idempotent
- [x] UPDATE blocked
- [x] DELETE blocked
- [x] Note-only disposition remains unresolved
- [x] Explicit Reviewed / Dispositioned state verified
- [x] Original discrepancy remains visible
- [x] Reviewer and timestamp persist
- [x] Reconciliation COMPLETE state manually verified
- [x] Docker rebuilt before operator verification
- [x] Incognito operator workflow verified
- [x] Disposition survives normal Docker restart
- [x] No asset/event/custody/slot mutation
- [x] No new dependencies

## Notes

A reviewed discrepancy means it has been accounted for. It does not mean the government and AssetTrack source values now agree.

Final authoritative reconciliation against the standalone machine's complete operational database remains a deployment verification item.