### PR TITLE
Issue 31-35A: Allow administrators to create a new case through slot provisioning

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -8296,6 +8296,8 @@ def _validate_slot_provision_request(
     case_number: str,
     proposed_slots: list[int],
     errors: list[str],
+    *,
+    require_existing_case: bool = True,
 ) -> None:
     if not proposed_slots:
         return
@@ -8310,7 +8312,11 @@ def _validate_slot_provision_request(
         (case_number,),
     ).fetchone()
     if case_row is None:
-        errors.append("Select an existing case before provisioning empty slots.")
+        if require_existing_case:
+            errors.append("Select an existing case before provisioning empty slots.")
+        return
+    if not require_existing_case:
+        errors.append(f"Case {case_number} already exists. Select existing-case mode to add slots.")
         return
 
     placeholders = ", ".join("?" for _ in proposed_slots)
@@ -8341,7 +8347,9 @@ def admin_slot_provision():
         return guard_result
 
     case_number = ""
+    new_case_number = ""
     slot_identifiers = ""
+    provision_mode = "existing"
     proposed_slots: list[int] = []
 
     def render_slot_provision_template():
@@ -8353,14 +8361,23 @@ def admin_slot_provision():
         return render_template(
             "admin_slot_provision.html",
             case_number=case_number,
+            new_case_number=new_case_number,
             slot_identifiers=slot_identifiers,
+            provision_mode=provision_mode,
             proposed_slots=proposed_slots,
             case_options=case_options,
         )
 
     if request.method == "POST":
         action = (request.form.get("action") or "preview").strip().lower()
+        provision_mode = (request.form.get("provision_mode") or "existing").strip().lower()
+        if provision_mode not in {"existing", "new"}:
+            flash("Unsupported slot provisioning mode.", "error")
+            return render_slot_provision_template()
         case_number = (request.form.get("case_number") or "").strip().upper()
+        new_case_number = (request.form.get("new_case_number") or "").strip().upper()
+        if provision_mode == "new":
+            case_number = new_case_number
         slot_identifiers = (request.form.get("slot_identifiers") or "").strip()
 
         if not case_number:
@@ -8375,7 +8392,13 @@ def admin_slot_provision():
             errors: list[str] = []
             proposed_slots = _parse_slot_provision_identifiers(slot_identifiers, errors)
             if not errors:
-                _validate_slot_provision_request(conn, case_number, proposed_slots, errors)
+                _validate_slot_provision_request(
+                    conn,
+                    case_number,
+                    proposed_slots,
+                    errors,
+                    require_existing_case=provision_mode == "existing",
+                )
             if errors:
                 for error in errors:
                     flash(error, "error")
@@ -8391,10 +8414,15 @@ def admin_slot_provision():
 
             expected_case_number = (request.form.get("expected_case_number") or "").strip().upper()
             expected_slot_identifiers = (request.form.get("expected_slot_identifiers") or "").strip()
+            expected_provision_mode = (request.form.get("expected_provision_mode") or "existing").strip().lower()
             if request.form.get("confirm_slot_provision") != "yes":
                 flash("Please confirm you reviewed the slot provisioning preview before committing.", "error")
                 return render_slot_provision_template()
-            if expected_case_number != case_number or expected_slot_identifiers != slot_identifiers:
+            if (
+                expected_case_number != case_number
+                or expected_slot_identifiers != slot_identifiers
+                or expected_provision_mode != provision_mode
+            ):
                 flash("Preview changed. Review the slot provisioning preview again before committing.", "error")
                 proposed_slots = []
                 return render_slot_provision_template()
@@ -8402,7 +8430,13 @@ def admin_slot_provision():
             try:
                 conn.execute("BEGIN;")
                 commit_errors: list[str] = []
-                _validate_slot_provision_request(conn, case_number, proposed_slots, commit_errors)
+                _validate_slot_provision_request(
+                    conn,
+                    case_number,
+                    proposed_slots,
+                    commit_errors,
+                    require_existing_case=provision_mode == "existing",
+                )
                 if commit_errors:
                     raise ValueError("; ".join(commit_errors))
                 conn.executemany(

--- a/assettrack/intake/templates/admin_case_corrections.html
+++ b/assettrack/intake/templates/admin_case_corrections.html
@@ -69,7 +69,7 @@
         <button type="submit">Preview Removal</button>
       </form>
     {% else %}
-      <p>No Cases are available to correct. <a href="{{ url_for('admin_slot_provision') }}">Admin Tools → Provision Slots</a></p>
+      <p>No Cases are available to correct. <a href="{{ url_for('admin_slot_provision') }}">Admin Tools → Provision Case / Slots</a></p>
     {% endif %}
   </div>
 

--- a/assettrack/intake/templates/admin_slot_provision.html
+++ b/assettrack/intake/templates/admin_slot_provision.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
-{% block title %}Admin Slot Capacity{% endblock %}
-{% block page_heading %}Admin: Create Empty Slots{% endblock %}
+{% block title %}Admin Case / Slot Provisioning{% endblock %}
+{% block page_heading %}Admin: Provision Case / Slots{% endblock %}
 {% block page_class %} admin-maintenance-standard-fields{% endblock %}
 
 {% block content %}
@@ -19,18 +19,33 @@
   {% endwith %}
 
   <div class="card">
-    <h2>Create empty slots</h2>
-    <p class="card-intro">Adds selected empty positions to an existing case. Existing slots are unchanged.</p>
+    <h2>Provision case / slots</h2>
+    <p class="card-intro">Adds selected empty positions to an existing case or provisions the first slots for a new case.</p>
     <form method="post" action="{{ url_for('admin_slot_provision') }}">
       <div class="admin-maintenance-grid">
         <div class="row">
-          <label for="case_number"><strong>case_number</strong> (required)</label><br />
-          <select id="case_number" name="case_number" required>
+          <strong>provision_mode</strong><br />
+          <label>
+            <input type="radio" name="provision_mode" value="existing" {% if provision_mode != 'new' %}checked{% endif %} />
+            Existing case
+          </label><br />
+          <label>
+            <input type="radio" name="provision_mode" value="new" {% if provision_mode == 'new' %}checked{% endif %} />
+            New case
+          </label>
+        </div>
+        <div class="row">
+          <label for="case_number"><strong>existing_case_number</strong></label><br />
+          <select id="case_number" name="case_number">
             <option value="" {% if not case_number %}selected{% endif %}>Select case</option>
             {% for option in case_options %}
               <option value="{{ option }}" {% if case_number == option %}selected{% endif %}>{{ option }}</option>
             {% endfor %}
           </select>
+        </div>
+        <div class="row">
+          <label for="new_case_number"><strong>new_case_number</strong></label><br />
+          <input id="new_case_number" name="new_case_number" value="{{ new_case_number or '' }}" autocomplete="off" />
         </div>
         <div class="row">
           <label for="slot_identifiers"><strong>slot_identifiers</strong> (required)</label><br />
@@ -64,8 +79,11 @@
       </table>
       <form method="post" action="{{ url_for('admin_slot_provision') }}">
         <input type="hidden" name="action" value="commit" />
+        <input type="hidden" name="provision_mode" value="{{ provision_mode }}" />
         <input type="hidden" name="case_number" value="{{ case_number }}" />
+        <input type="hidden" name="new_case_number" value="{{ new_case_number }}" />
         <input type="hidden" name="slot_identifiers" value="{{ slot_identifiers }}" />
+        <input type="hidden" name="expected_provision_mode" value="{{ provision_mode }}" />
         <input type="hidden" name="expected_case_number" value="{{ case_number }}" />
         <input type="hidden" name="expected_slot_identifiers" value="{{ slot_identifiers }}" />
         <label>

--- a/assettrack/intake/templates/admin_system.html
+++ b/assettrack/intake/templates/admin_system.html
@@ -208,7 +208,7 @@
       <h3>Storage</h3>
       <nav class="admin-tool-grid" aria-label="Storage admin tools">
         <a class="admin-tool-link" href="{{ url_for('admin_slot_provision') }}">
-          <strong>Provision Slots</strong>
+          <strong>Provision Case / Slots</strong>
         </a>
         <a class="admin-tool-link" href="{{ url_for('admin_assign_slot') }}">
           <strong>Assign Slot</strong>

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -369,6 +369,8 @@ def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_
         data={"action": "preview", "case_number": "CASE-P", "slot_identifiers": "2 3 4"},
     )
     assert preview_response.status_code == 200
+    assert b"Admin: Provision Case / Slots" in preview_response.data
+    assert b"Provision case / slots" in preview_response.data
     assert b"Slot provisioning preview ready. Review before committing." in preview_response.data
     assert b"Preview empty slots" in preview_response.data
     assert b"Empty Slot" in preview_response.data
@@ -417,6 +419,115 @@ def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_
         ("CASE-P", 3, None),
         ("CASE-P", 4, None),
     ]
+
+
+def test_admin_slot_provision_creates_new_case_from_typed_identifier(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    preview_response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "preview",
+            "provision_mode": "new",
+            "new_case_number": "case-new-provision",
+            "slot_identifiers": "1 2 3",
+        },
+    )
+    assert preview_response.status_code == 200
+    assert b"Slot provisioning preview ready. Review before committing." in preview_response.data
+    assert b'name="provision_mode" value="new"' in preview_response.data
+    assert b"<code>CASE-NEW-PROVISION</code>" in preview_response.data
+    assert b"<code>1</code>" in preview_response.data
+    assert b"<code>2</code>" in preview_response.data
+    assert b"<code>3</code>" in preview_response.data
+
+    conn = db.get_connection()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM slots;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM assets;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM slot_occupancy;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM asset_events;").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM case_metadata;").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+    commit_response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "commit",
+            "provision_mode": "new",
+            "case_number": "CASE-NEW-PROVISION",
+            "new_case_number": "CASE-NEW-PROVISION",
+            "slot_identifiers": "1 2 3",
+            "expected_provision_mode": "new",
+            "expected_case_number": "CASE-NEW-PROVISION",
+            "expected_slot_identifiers": "1 2 3",
+            "confirm_slot_provision": "yes",
+        },
+        follow_redirects=True,
+    )
+    assert commit_response.status_code == 200
+    assert b"Created 3 empty slots for case CASE-NEW-PROVISION: 1, 2, 3." in commit_response.data
+
+    verify_conn = db.get_connection()
+    try:
+        rows = verify_conn.execute(
+            """
+            SELECT case_name, slot_position, current_asset_tag
+            FROM slots
+            WHERE case_name = 'CASE-NEW-PROVISION'
+            ORDER BY slot_position ASC;
+            """
+        ).fetchall()
+    finally:
+        verify_conn.close()
+
+    assert [(row["case_name"], row["slot_position"], row["current_asset_tag"]) for row in rows] == [
+        ("CASE-NEW-PROVISION", 1, None),
+        ("CASE-NEW-PROVISION", 2, None),
+        ("CASE-NEW-PROVISION", 3, None),
+    ]
+
+    detail_response = client_with_temp_db.get("/dashboard/cases/CASE-NEW-PROVISION")
+    assert detail_response.status_code == 200
+    assert b"CASE-NEW-PROVISION" in detail_response.data
+    assert b"Total slots:</strong> 3" in detail_response.data
+
+
+def test_admin_slot_provision_new_case_mode_rejects_existing_case(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (3911, 'CASE-EXISTS', 1, NULL);
+            """
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "preview",
+            "provision_mode": "new",
+            "new_case_number": "case-exists",
+            "slot_identifiers": "2",
+        },
+    )
+
+    assert response.status_code == 200
+    assert b"Case CASE-EXISTS already exists. Select existing-case mode to add slots." in response.data
+    verify_conn = db.get_connection()
+    try:
+        rows = verify_conn.execute(
+            "SELECT slot_position FROM slots WHERE case_name = 'CASE-EXISTS' ORDER BY slot_position ASC;"
+        ).fetchall()
+    finally:
+        verify_conn.close()
+    assert [int(row["slot_position"]) for row in rows] == [1]
 
 
 def test_existing_case_may_remain_blank_case_size(client_with_temp_db) -> None:
@@ -785,7 +896,7 @@ def test_case_correction_page_shows_empty_case_message(client_with_temp_db) -> N
 
     assert response.status_code == 200
     assert "No Cases are available to correct." in html
-    assert "Admin Tools → Provision Slots" in html
+    assert "Admin Tools → Provision Case / Slots" in html
     assert "/admin/slots/provision" in html
     assert 'name="old_case_name"' not in html
     assert 'name="new_case_name"' not in html

--- a/tests/test_admin_system_health.py
+++ b/tests/test_admin_system_health.py
@@ -140,7 +140,7 @@ def test_admin_can_view_system_health_counts(client_with_temp_db) -> None:
     assert response.data.count(b'href="/admin/assets/import"') == 1
     assert b"Import Switch/Router CSV" not in response.data
     assert b'href="/admin/network-assets/import"' not in response.data
-    assert b"Provision Slots" in response.data
+    assert b"Provision Case / Slots" in response.data
     assert b"Assign Slot" in response.data
     assert b"Move Slot" in response.data
     assert b"Receipt Search" in response.data


### PR DESCRIPTION
## Summary
Allows administrators to create a new case through the existing slot provisioning workflow.

## Related Issue
Closes #1174

## Changes
- Adds new-case mode to the existing Provision Case / Slots workflow
- Reuses existing slot parsing, preview, transaction, and persistence paths
- Preserves existing-case slot provisioning
- Updates Admin wording so the new capability is discoverable

## Verification
- [x] Focused tests: 125 passed
- [x] git diff --check
- [x] Docker rebuild
- [x] Incognito new-case preview and commit
- [x] Duplicate new-case attempt blocked
- [x] Container restart persistence verified
- [x] Existing-case provisioning regression verified

## Notes
No schema, migration, dependency, authentication, custody, or event-history changes.