### PR TITLE
Issue 31-35B: Generate initial slots from case capacity

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -8291,6 +8291,22 @@ def _parse_slot_provision_identifiers(raw_value: str, errors: list[str]) -> list
     return parsed
 
 
+def _parse_slot_provision_count(raw_value: str, errors: list[str]) -> list[int]:
+    value = str(raw_value or "").strip()
+    if not value:
+        errors.append("slot_count is required.")
+        return []
+    try:
+        slot_count = int(value)
+    except ValueError:
+        errors.append("slot_count must be an integer.")
+        return []
+    if slot_count <= 0:
+        errors.append("slot_count must be greater than 0.")
+        return []
+    return list(range(1, slot_count + 1))
+
+
 def _validate_slot_provision_request(
     conn: sqlite3.Connection,
     case_number: str,
@@ -8349,6 +8365,7 @@ def admin_slot_provision():
     case_number = ""
     new_case_number = ""
     slot_identifiers = ""
+    slot_count = ""
     provision_mode = "existing"
     proposed_slots: list[int] = []
 
@@ -8363,6 +8380,7 @@ def admin_slot_provision():
             case_number=case_number,
             new_case_number=new_case_number,
             slot_identifiers=slot_identifiers,
+            slot_count=slot_count,
             provision_mode=provision_mode,
             proposed_slots=proposed_slots,
             case_options=case_options,
@@ -8379,18 +8397,26 @@ def admin_slot_provision():
         if provision_mode == "new":
             case_number = new_case_number
         slot_identifiers = (request.form.get("slot_identifiers") or "").strip()
+        slot_count = (request.form.get("slot_count") or "").strip()
 
         if not case_number:
             flash("case_number is required.", "error")
-        if not slot_identifiers:
+        if provision_mode == "existing" and not slot_identifiers:
             flash("slot_identifiers is required.", "error")
-        if not case_number or not slot_identifiers:
+        if provision_mode == "new" and not slot_count:
+            flash("slot_count is required.", "error")
+        missing_existing_slots = provision_mode == "existing" and not slot_identifiers
+        missing_new_count = provision_mode == "new" and not slot_count
+        if not case_number or missing_existing_slots or missing_new_count:
             return render_slot_provision_template()
 
         conn = get_connection()
         try:
             errors: list[str] = []
-            proposed_slots = _parse_slot_provision_identifiers(slot_identifiers, errors)
+            if provision_mode == "new":
+                proposed_slots = _parse_slot_provision_count(slot_count, errors)
+            else:
+                proposed_slots = _parse_slot_provision_identifiers(slot_identifiers, errors)
             if not errors:
                 _validate_slot_provision_request(
                     conn,
@@ -8414,13 +8440,15 @@ def admin_slot_provision():
 
             expected_case_number = (request.form.get("expected_case_number") or "").strip().upper()
             expected_slot_identifiers = (request.form.get("expected_slot_identifiers") or "").strip()
+            expected_slot_count = (request.form.get("expected_slot_count") or "").strip()
             expected_provision_mode = (request.form.get("expected_provision_mode") or "existing").strip().lower()
             if request.form.get("confirm_slot_provision") != "yes":
                 flash("Please confirm you reviewed the slot provisioning preview before committing.", "error")
                 return render_slot_provision_template()
             if (
                 expected_case_number != case_number
-                or expected_slot_identifiers != slot_identifiers
+                or (provision_mode == "existing" and expected_slot_identifiers != slot_identifiers)
+                or (provision_mode == "new" and expected_slot_count != slot_count)
                 or expected_provision_mode != provision_mode
             ):
                 flash("Preview changed. Review the slot provisioning preview again before committing.", "error")

--- a/assettrack/intake/templates/admin_slot_provision.html
+++ b/assettrack/intake/templates/admin_slot_provision.html
@@ -48,8 +48,12 @@
           <input id="new_case_number" name="new_case_number" value="{{ new_case_number or '' }}" autocomplete="off" />
         </div>
         <div class="row">
-          <label for="slot_identifiers"><strong>slot_identifiers</strong> (required)</label><br />
-          <textarea id="slot_identifiers" name="slot_identifiers" rows="4" required>{{ slot_identifiers or '' }}</textarea>
+          <label for="slot_identifiers"><strong>slot_identifiers</strong> (existing case)</label><br />
+          <textarea id="slot_identifiers" name="slot_identifiers" rows="4">{{ slot_identifiers or '' }}</textarea>
+        </div>
+        <div class="row">
+          <label for="slot_count"><strong>slot_count</strong> (new case)</label><br />
+          <input id="slot_count" name="slot_count" value="{{ slot_count or '' }}" inputmode="numeric" autocomplete="off" />
         </div>
       </div>
       <button type="submit" name="action" value="preview">Preview empty slots</button>
@@ -83,9 +87,11 @@
         <input type="hidden" name="case_number" value="{{ case_number }}" />
         <input type="hidden" name="new_case_number" value="{{ new_case_number }}" />
         <input type="hidden" name="slot_identifiers" value="{{ slot_identifiers }}" />
+        <input type="hidden" name="slot_count" value="{{ slot_count }}" />
         <input type="hidden" name="expected_provision_mode" value="{{ provision_mode }}" />
         <input type="hidden" name="expected_case_number" value="{{ case_number }}" />
         <input type="hidden" name="expected_slot_identifiers" value="{{ slot_identifiers }}" />
+        <input type="hidden" name="expected_slot_count" value="{{ slot_count }}" />
         <label>
           <input type="checkbox" name="confirm_slot_provision" value="yes" />
           I reviewed this slot provisioning preview.

--- a/tests/test_admin_slot_provision.py
+++ b/tests/test_admin_slot_provision.py
@@ -421,7 +421,7 @@ def test_admin_slot_provision_creates_new_empty_slots_for_case(client_with_temp_
     ]
 
 
-def test_admin_slot_provision_creates_new_case_from_typed_identifier(client_with_temp_db) -> None:
+def test_admin_slot_provision_creates_new_case_slots_from_slot_count(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
 
     preview_response = client_with_temp_db.post(
@@ -430,16 +430,19 @@ def test_admin_slot_provision_creates_new_case_from_typed_identifier(client_with
             "action": "preview",
             "provision_mode": "new",
             "new_case_number": "case-new-provision",
-            "slot_identifiers": "1 2 3",
+            "slot_count": "3",
         },
     )
     assert preview_response.status_code == 200
     assert b"Slot provisioning preview ready. Review before committing." in preview_response.data
     assert b'name="provision_mode" value="new"' in preview_response.data
+    assert b'name="slot_count" value="3"' in preview_response.data
+    assert b'name="expected_slot_count" value="3"' in preview_response.data
     assert b"<code>CASE-NEW-PROVISION</code>" in preview_response.data
     assert b"<code>1</code>" in preview_response.data
     assert b"<code>2</code>" in preview_response.data
     assert b"<code>3</code>" in preview_response.data
+    assert preview_response.data.count(b"Empty Slot") == 3
 
     conn = db.get_connection()
     try:
@@ -458,10 +461,10 @@ def test_admin_slot_provision_creates_new_case_from_typed_identifier(client_with
             "provision_mode": "new",
             "case_number": "CASE-NEW-PROVISION",
             "new_case_number": "CASE-NEW-PROVISION",
-            "slot_identifiers": "1 2 3",
+            "slot_count": "3",
             "expected_provision_mode": "new",
             "expected_case_number": "CASE-NEW-PROVISION",
-            "expected_slot_identifiers": "1 2 3",
+            "expected_slot_count": "3",
             "confirm_slot_provision": "yes",
         },
         follow_redirects=True,
@@ -494,6 +497,68 @@ def test_admin_slot_provision_creates_new_case_from_typed_identifier(client_with
     assert b"Total slots:</strong> 3" in detail_response.data
 
 
+@pytest.mark.parametrize(
+    ("slot_count", "message"),
+    [
+        ("", "slot_count is required."),
+        ("0", "slot_count must be greater than 0."),
+        ("-1", "slot_count must be greater than 0."),
+        ("abc", "slot_count must be an integer."),
+    ],
+)
+def test_admin_slot_provision_new_case_rejects_invalid_slot_count(
+    client_with_temp_db,
+    slot_count: str,
+    message: str,
+) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "preview",
+            "provision_mode": "new",
+            "new_case_number": "case-bad-count",
+            "slot_count": slot_count,
+        },
+    )
+
+    assert response.status_code == 200
+    assert message.encode() in response.data
+    conn = db.get_connection()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM slots;").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_admin_slot_provision_new_case_blocks_commit_when_slot_count_changes(client_with_temp_db) -> None:
+    _login_admin(client_with_temp_db)
+
+    response = client_with_temp_db.post(
+        "/admin/slots/provision",
+        data={
+            "action": "commit",
+            "provision_mode": "new",
+            "case_number": "CASE-COUNT-TAMPER",
+            "new_case_number": "CASE-COUNT-TAMPER",
+            "slot_count": "4",
+            "expected_provision_mode": "new",
+            "expected_case_number": "CASE-COUNT-TAMPER",
+            "expected_slot_count": "3",
+            "confirm_slot_provision": "yes",
+        },
+    )
+
+    assert response.status_code == 200
+    assert b"Preview changed. Review the slot provisioning preview again before committing." in response.data
+    conn = db.get_connection()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM slots WHERE case_name = 'CASE-COUNT-TAMPER';").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_admin_slot_provision_new_case_mode_rejects_existing_case(client_with_temp_db) -> None:
     _login_admin(client_with_temp_db)
     conn = db.get_connection()
@@ -514,7 +579,7 @@ def test_admin_slot_provision_new_case_mode_rejects_existing_case(client_with_te
             "action": "preview",
             "provision_mode": "new",
             "new_case_number": "case-exists",
-            "slot_identifiers": "2",
+            "slot_count": "2",
         },
     )
 


### PR DESCRIPTION
## Summary
Simplifies new-case provisioning by generating initial slots from a case capacity value.

## Related Issue
Closes #1175

## Changes
- Adds slot_count to new-case provisioning
- Generates initial slots deterministically as 1..N
- Preserves existing preview, confirmation, transaction, and insert paths
- Preserves manual slot entry for existing cases

## Verification
- [x] Focused tests: 73 passed
- [x] git diff --check
- [x] Docker rebuild
- [x] Incognito new-case workflow verified
- [x] Generated slots verified as exactly 1..N
- [x] Invalid slot count rejected
- [x] Existing-case provisioning regression verified
- [x] Container restart persistence verified

## Notes
No schema, migration, dependency, authentication, custody, or event-history changes.