### PR TITLE
Issue 31-36: Improve case selector ordering and dropdown usability

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -1332,10 +1332,8 @@ def _list_slot_options(conn, *, empty_only: bool = False) -> list[dict]:
 
 
 def _slot_case_options(slot_options: list[dict]) -> list[str]:
-    return sorted(
-        {str(row["case_name"]) for row in slot_options if str(row["case_name"]).strip()},
-        key=natural_identifier_sort_key,
-    )
+    case_names = {str(row["case_name"]) for row in slot_options if str(row["case_name"]).strip()}
+    return sorted(case_names, key=natural_identifier_sort_key)
 
 def _resolve_slot_selection(
     conn: sqlite3.Connection,

--- a/assettrack/intake/templates/index.html
+++ b/assettrack/intake/templates/index.html
@@ -158,7 +158,7 @@
           <div class="grid">
             <div class="row">
               <label for="case_name"><strong>Case</strong> (optional)</label><br />
-              <select id="case_name" name="case_name" data-timeout-lock-target>
+              <select id="case_name" name="case_name" autocomplete="off" data-timeout-lock-target>
                 <option value="">Unassigned</option>
                 {% for case_name in case_options %}
                   <option value="{{ case_name }}">{{ case_name }}</option>

--- a/tests/test_admin_add_asset_ui.py
+++ b/tests/test_admin_add_asset_ui.py
@@ -149,6 +149,66 @@ class AdminAddAssetUiTests(unittest.TestCase):
         self.assertNotIn(b"How to use:", response.data)
         self.assertNotIn(b"Add to database", response.data)
 
+    def test_shared_case_options_sort_naturally_without_reformatting_names(self) -> None:
+        slot_options = [
+            {"case_name": "Storage Case"},
+            {"case_name": "CASE-10"},
+            {"case_name": "CASE-2"},
+            {"case_name": "CASE-11"},
+            {"case_name": "CASE-3"},
+            {"case_name": "Network Case"},
+            {"case_name": "CASE-9"},
+            {"case_name": "White Case"},
+            {"case_name": "CASE-1"},
+            {"case_name": "storage-alpha"},
+            {"case_name": "CASE-2"},
+        ]
+
+        options = intake_app._slot_case_options(slot_options)
+
+        self.assertEqual(
+            options,
+            [
+                "CASE-1",
+                "CASE-2",
+                "CASE-3",
+                "CASE-9",
+                "CASE-10",
+                "CASE-11",
+                "Network Case",
+                "Storage Case",
+                "storage-alpha",
+                "White Case",
+            ],
+        )
+
+    def test_add_assets_case_selector_uses_natural_order_and_native_dropdown_hint(self) -> None:
+        self._insert_slot(121, "CASE-10", 1)
+        self._insert_slot(122, "CASE-2", 1)
+        self._insert_slot(123, "CASE-11", 1)
+        self._insert_slot(124, "CASE-1", 1)
+
+        response = self.client.get("/add-assets")
+
+        self.assertEqual(response.status_code, 200)
+        html = response.data.decode("utf-8")
+        self.assertIn(
+            '<select id="case_name" name="case_name" autocomplete="off" data-timeout-lock-target>',
+            html,
+        )
+        self.assertLess(
+            html.index('<option value="CASE-1">CASE-1</option>'),
+            html.index('<option value="CASE-2">CASE-2</option>'),
+        )
+        self.assertLess(
+            html.index('<option value="CASE-2">CASE-2</option>'),
+            html.index('<option value="CASE-10">CASE-10</option>'),
+        )
+        self.assertLess(
+            html.index('<option value="CASE-10">CASE-10</option>'),
+            html.index('<option value="CASE-11">CASE-11</option>'),
+        )
+
     def test_add_assets_empty_scan_submission_shows_validation_message(self) -> None:
         intake_app.SCAN_QUEUE.clear()
 


### PR DESCRIPTION
## Summary
Improves case selector usability and locks in natural case ordering.

## Related Issue
Closes #1165

## Changes
- Keeps case ordering centralized through the existing natural identifier sort path
- Adds regression coverage for CASE-2 before CASE-10 and deterministic non-numbered ordering
- Preserves stored case formatting
- Adds autocomplete="off" to the field-laptop case selector

## Verification
- [x] Focused tests: 24 passed
- [x] git diff --check
- [x] Docker rebuild
- [x] Incognito case-selector ordering verified
- [x] Field-laptop dropdown verified

## Notes
No schema, migration, persistence, authentication, custody, event, Issue, Return, or Assign Slots behavior changes.