### PR TITLE
Issue 31-37: Verify all assets are checked in and accounted for

### DIFF
--- a/docs/operator/accountability-verification.md
+++ b/docs/operator/accountability-verification.md
@@ -1,0 +1,15 @@
+# Accountability Verification
+
+Run this check before handoff, audit review, or any operational moment where every active asset must be confirmed checked in.
+
+Command:
+
+```bash
+.venv/bin/python scripts/verify_accountability.py --db data/assettrack.db
+```
+
+`PASS` means every active, non-retired asset is confirmed checked in: current state is `STORAGE`, no current holder is attached, and custody events do not contradict that state.
+
+`FAIL` means at least one active asset is issued or cannot be proven checked in from current state and active custody events. Read each exception line for the asset tag, serial number, asset type, current holder when present, storage location when present, and latest custody event.
+
+The script is read-only. It does not create Return events, repair records, or change custody state.

--- a/scripts/verify_accountability.py
+++ b/scripts/verify_accountability.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from assettrack.audit import ACTIVE_EVENTS_WHERE
+from assettrack.db import DB_PATH
+from assettrack.event_types import normalize_event_type
+
+
+TERMINAL_LOCATION_TYPES = {"DISPOSED", "RETIRED"}
+CUSTODY_EVENT_TYPES = {"ISSUE", "RETURN"}
+
+
+@dataclass(frozen=True)
+class LatestCustodyEvent:
+    id: int
+    event_type: str
+    event_date: str
+
+
+@dataclass(frozen=True)
+class AccountabilityAsset:
+    id: int
+    asset_tag: str
+    serial_number: str
+    equipment_type: str
+    location_type: str
+    current_holder_id: int | None
+    holder_name: str
+    holder_organization: str
+    current_location: str
+    home_slot: str
+    has_active_event: bool
+    latest_custody_event: LatestCustodyEvent | None
+
+
+@dataclass(frozen=True)
+class ClassifiedAsset:
+    asset: AccountabilityAsset
+    classification: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class AccountabilityResult:
+    rows: tuple[ClassifiedAsset, ...]
+
+    @property
+    def total_active_assets(self) -> int:
+        return len(self.rows)
+
+    @property
+    def confirmed_checked_in(self) -> tuple[ClassifiedAsset, ...]:
+        return tuple(row for row in self.rows if row.classification == "confirmed_checked_in")
+
+    @property
+    def not_checked_in(self) -> tuple[ClassifiedAsset, ...]:
+        return tuple(row for row in self.rows if row.classification == "not_checked_in")
+
+    @property
+    def unresolved(self) -> tuple[ClassifiedAsset, ...]:
+        return tuple(row for row in self.rows if row.classification == "unresolved")
+
+    @property
+    def passes(self) -> bool:
+        return not self.not_checked_in and not self.unresolved
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _storage_label(case_name: object, slot_position: object, building_room: object) -> str:
+    case_text = _text(case_name)
+    if case_text and slot_position is not None:
+        return f"{case_text} / Slot {slot_position}"
+    return _text(building_room)
+
+
+def _latest_custody_events(conn: sqlite3.Connection) -> dict[int, LatestCustodyEvent]:
+    active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
+    rows = conn.execute(
+        f"""
+        SELECT
+            a.id AS asset_id,
+            e.id AS event_id,
+            e.event_type,
+            e.event_date
+        FROM assets a
+        JOIN asset_events e
+          ON UPPER(e.asset_tag) = UPPER(a.asset_tag)
+        WHERE {active_events_where}
+        ORDER BY a.id ASC, e.id DESC;
+        """
+    ).fetchall()
+
+    latest: dict[int, LatestCustodyEvent] = {}
+    for row in rows:
+        asset_id = int(row["asset_id"])
+        if asset_id in latest:
+            continue
+        event_type = normalize_event_type(row["event_type"])
+        if event_type not in CUSTODY_EVENT_TYPES:
+            continue
+        latest[asset_id] = LatestCustodyEvent(
+            id=int(row["event_id"]),
+            event_type=event_type,
+            event_date=_text(row["event_date"]),
+        )
+    return latest
+
+
+def _asset_ids_with_active_events(conn: sqlite3.Connection) -> set[int]:
+    active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
+    rows = conn.execute(
+        f"""
+        SELECT DISTINCT a.id AS asset_id
+        FROM assets a
+        JOIN asset_events e
+          ON UPPER(e.asset_tag) = UPPER(a.asset_tag)
+        WHERE {active_events_where};
+        """
+    ).fetchall()
+    return {int(row["asset_id"]) for row in rows}
+
+
+def _active_assets(conn: sqlite3.Connection) -> tuple[AccountabilityAsset, ...]:
+    latest_events = _latest_custody_events(conn)
+    asset_ids_with_active_events = _asset_ids_with_active_events(conn)
+    rows = conn.execute(
+        """
+        SELECT
+            a.id,
+            a.asset_tag,
+            COALESCE(a.serial_number, '') AS serial_number,
+            COALESCE(a.equipment_type, '') AS equipment_type,
+            COALESCE(a.location_type, '') AS location_type,
+            a.current_holder_id,
+            COALESCE(h.name, '') AS holder_name,
+            COALESCE(h.organization, '') AS holder_organization,
+            COALESCE(a.building_room, '') AS building_room,
+            s.case_name AS home_case_name,
+            s.slot_position AS home_slot_position
+        FROM assets a
+        LEFT JOIN holders h
+          ON h.id = a.current_holder_id
+        LEFT JOIN slots s
+          ON s.id = a.home_slot_id
+        WHERE COALESCE(a.location_type, '') NOT IN ('DISPOSED', 'RETIRED')
+        ORDER BY a.asset_tag COLLATE NOCASE ASC, a.id ASC;
+        """
+    ).fetchall()
+
+    assets: list[AccountabilityAsset] = []
+    for row in rows:
+        asset_id = int(row["id"])
+        current_location = _storage_label(row["home_case_name"], row["home_slot_position"], row["building_room"])
+        assets.append(
+            AccountabilityAsset(
+                id=asset_id,
+                asset_tag=_text(row["asset_tag"]),
+                serial_number=_text(row["serial_number"]),
+                equipment_type=_text(row["equipment_type"]),
+                location_type=_text(row["location_type"]).upper(),
+                current_holder_id=None if row["current_holder_id"] is None else int(row["current_holder_id"]),
+                holder_name=_text(row["holder_name"]),
+                holder_organization=_text(row["holder_organization"]),
+                current_location=current_location,
+                home_slot=current_location,
+                has_active_event=asset_id in asset_ids_with_active_events,
+                latest_custody_event=latest_events.get(asset_id),
+            )
+        )
+    return tuple(assets)
+
+
+def classify_asset(asset: AccountabilityAsset) -> ClassifiedAsset:
+    event_type = "" if asset.latest_custody_event is None else asset.latest_custody_event.event_type
+
+    if asset.location_type == "STORAGE":
+        if asset.current_holder_id is not None:
+            return ClassifiedAsset(asset, "unresolved", "STORAGE asset still has current_holder_id")
+        if event_type == "RETURN":
+            return ClassifiedAsset(asset, "confirmed_checked_in", "state is STORAGE and custody events agree")
+        if event_type == "" and asset.has_active_event:
+            return ClassifiedAsset(asset, "confirmed_checked_in", "never-issued asset has active event history and is STORAGE")
+        if event_type == "":
+            return ClassifiedAsset(asset, "unresolved", "state is STORAGE without active event proof")
+        return ClassifiedAsset(asset, "unresolved", "state is STORAGE but latest custody event is ISSUE")
+
+    if asset.location_type == "IN_CUSTODY":
+        if event_type == "ISSUE":
+            return ClassifiedAsset(asset, "not_checked_in", "latest custody event is ISSUE")
+        if event_type == "RETURN":
+            return ClassifiedAsset(asset, "unresolved", "state is IN_CUSTODY but latest custody event is RETURN")
+        return ClassifiedAsset(asset, "unresolved", "state is IN_CUSTODY without custody event proof")
+
+    return ClassifiedAsset(asset, "unresolved", f"unsupported active location_type {asset.location_type or 'blank'}")
+
+
+def verify_accountability(conn: sqlite3.Connection) -> AccountabilityResult:
+    return AccountabilityResult(tuple(classify_asset(asset) for asset in _active_assets(conn)))
+
+
+def _event_label(event: LatestCustodyEvent | None) -> str:
+    if event is None:
+        return "none"
+    return f"#{event.id} {event.event_type} {event.event_date}".strip()
+
+
+def _holder_label(asset: AccountabilityAsset) -> str:
+    if asset.current_holder_id is None:
+        return ""
+    holder = asset.holder_name
+    if asset.holder_organization and asset.holder_organization != holder:
+        holder = f"{holder} ({asset.holder_organization})" if holder else asset.holder_organization
+    return holder or f"holder_id {asset.current_holder_id}"
+
+
+def _exception_line(row: ClassifiedAsset) -> str:
+    asset = row.asset
+    parts = [
+        f"{asset.asset_tag}",
+        f"classification={row.classification}",
+        f"reason={row.reason}",
+        f"serial={asset.serial_number or 'blank'}",
+        f"type={asset.equipment_type or 'blank'}",
+        f"location_type={asset.location_type or 'blank'}",
+    ]
+    holder = _holder_label(asset)
+    if holder:
+        parts.append(f"holder={holder}")
+    if asset.current_location:
+        parts.append(f"storage={asset.current_location}")
+    parts.append(f"latest_custody_event={_event_label(asset.latest_custody_event)}")
+    return "  - " + "; ".join(parts)
+
+
+def format_accountability_result(result: AccountabilityResult) -> str:
+    lines = ["Asset Accountability Verification", ""]
+    lines.extend(
+        [
+            f"Total active assets evaluated: {result.total_active_assets}",
+            f"Confirmed checked in: {len(result.confirmed_checked_in)}",
+            f"Not checked in: {len(result.not_checked_in)}",
+            f"Unresolved/inconsistent: {len(result.unresolved)}",
+            "",
+        ]
+    )
+    if result.passes:
+        lines.append(f"PASS: All {result.total_active_assets} active assets are checked in and accounted for.")
+        return "\n".join(lines)
+
+    failed_count = len(result.not_checked_in) + len(result.unresolved)
+    lines.append(f"FAIL: {failed_count} of {result.total_active_assets} active assets are not confirmed checked in.")
+    lines.extend(["", "Exceptions"])
+    for row in tuple(result.not_checked_in) + tuple(result.unresolved):
+        lines.append(_exception_line(row))
+    return "\n".join(lines)
+
+
+def _open_readonly_database(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(f"file:{path.resolve()}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON;")
+    return conn
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Read-only verification that active AssetTrack assets are checked in.")
+    parser.add_argument("--db", default=str(DB_PATH), help="Path to the AssetTrack SQLite database.")
+    args = parser.parse_args(argv)
+
+    try:
+        conn = _open_readonly_database(Path(args.db))
+    except sqlite3.Error as exc:
+        print(f"Could not open database read-only: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = verify_accountability(conn)
+    except sqlite3.Error as exc:
+        print(f"Accountability verification failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    print(format_accountability_result(result))
+    return 0 if result.passes else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_verify_accountability.py
+++ b/tests/test_verify_accountability.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+import assettrack.db as db
+from scripts import verify_accountability
+
+
+class VerifyAccountabilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        db._create_schema(self.conn)
+        self.conn.commit()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _insert_holder(self, holder_id: int, name: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO holders (
+                id, holder_type, name, identifier, email, contact_info, created_at, updated_at
+            )
+            VALUES (?, 'PERSON', ?, ?, '', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (holder_id, name, f"H-{holder_id}"),
+        )
+        self.conn.commit()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, NULL);
+            """,
+            (slot_id, case_name, slot_position),
+        )
+        self.conn.commit()
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        serial_number: str = "SER",
+        equipment_type: str = "laptop",
+        location_type: str = "STORAGE",
+        current_holder_id: int | None = None,
+        home_slot_id: int | None = None,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?);
+            """,
+            (asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id),
+        )
+        self.conn.commit()
+
+    def _insert_event(
+        self,
+        asset_tag: str,
+        event_type: str,
+        *,
+        event_date: str = "2026-01-01T00:00:00Z",
+        holder_id: int | None = None,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES (?, ?, ?, 'test', NULL, NULL, ?);
+            """,
+            (asset_tag, event_type, event_date, holder_id),
+        )
+        self.conn.commit()
+
+    def _run_main(self) -> tuple[int, str]:
+        output = StringIO()
+        with redirect_stdout(output):
+            exit_code = verify_accountability.main(["--db", str(self.db_path)])
+        return exit_code, output.getvalue()
+
+    def _db_digest(self) -> str:
+        return hashlib.sha256(self.db_path.read_bytes()).hexdigest()
+
+    def test_all_active_assets_checked_in_passes_with_zero_exit(self) -> None:
+        self._insert_asset("CHECKED-1", serial_number="SER-1", equipment_type="laptop")
+        self._insert_asset("CHECKED-2", serial_number="SER-2", equipment_type="router")
+        self._insert_event("CHECKED-1", "ASSET_CREATED")
+        self._insert_event("CHECKED-2", "RETURN")
+
+        exit_code, output = self._run_main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Total active assets evaluated: 2", output)
+        self.assertIn("Confirmed checked in: 2", output)
+        self.assertIn("PASS: All 2 active assets are checked in and accounted for.", output)
+
+    def test_one_issued_asset_is_identified_with_nonzero_exit(self) -> None:
+        self._insert_holder(7, "Issued Holder")
+        self._insert_asset("ISSUED-1", serial_number="SER-I", location_type="IN_CUSTODY", current_holder_id=7)
+        self._insert_event("ISSUED-1", "ISSUE", holder_id=7)
+
+        exit_code, output = self._run_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Not checked in: 1", output)
+        self.assertIn("FAIL: 1 of 1 active assets are not confirmed checked in.", output)
+        self.assertIn("ISSUED-1; classification=not_checked_in", output)
+        self.assertIn("serial=SER-I", output)
+        self.assertIn("holder=Issued Holder", output)
+
+    def test_multiple_issued_assets_have_deterministic_totals_and_order(self) -> None:
+        self._insert_holder(7, "Issued Holder")
+        self._insert_asset("ZZ-ISSUED", location_type="IN_CUSTODY", current_holder_id=7)
+        self._insert_asset("AA-ISSUED", location_type="IN_CUSTODY", current_holder_id=7)
+        self._insert_asset("MM-CHECKED", location_type="STORAGE")
+        self._insert_event("ZZ-ISSUED", "ISSUE", event_date="2026-01-02T00:00:00Z", holder_id=7)
+        self._insert_event("AA-ISSUED", "ISSUE", event_date="2026-01-03T00:00:00Z", holder_id=7)
+        self._insert_event("MM-CHECKED", "ASSET_CREATED")
+
+        first_exit, first_output = self._run_main()
+        second_exit, second_output = self._run_main()
+
+        self.assertEqual(first_exit, 1)
+        self.assertEqual(second_exit, 1)
+        self.assertEqual(first_output, second_output)
+        self.assertIn("Total active assets evaluated: 3", first_output)
+        self.assertIn("Confirmed checked in: 1", first_output)
+        self.assertIn("Not checked in: 2", first_output)
+        self.assertLess(first_output.index("AA-ISSUED"), first_output.index("ZZ-ISSUED"))
+
+    def test_returned_asset_is_checked_in(self) -> None:
+        self._insert_asset("RETURNED-1", location_type="STORAGE")
+        self._insert_event("RETURNED-1", "ISSUE", event_date="2026-01-01T00:00:00Z")
+        self._insert_event("RETURNED-1", "RETURN", event_date="2026-01-02T00:00:00Z")
+
+        result = verify_accountability.verify_accountability(self.conn)
+
+        self.assertTrue(result.passes)
+        self.assertEqual(len(result.confirmed_checked_in), 1)
+
+    def test_inconsistent_custody_event_state_is_unresolved(self) -> None:
+        self._insert_asset("BAD-STATE", location_type="STORAGE")
+        self._insert_event("BAD-STATE", "ISSUE")
+
+        exit_code, output = self._run_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("Unresolved/inconsistent: 1", output)
+        self.assertIn("BAD-STATE; classification=unresolved", output)
+        self.assertIn("state is STORAGE but latest custody event is ISSUE", output)
+
+    def test_asset_without_active_event_proof_is_unresolved(self) -> None:
+        self._insert_asset("NO-EVENT", location_type="STORAGE")
+
+        exit_code, output = self._run_main()
+
+        self.assertEqual(exit_code, 1)
+        self.assertIn("NO-EVENT; classification=unresolved", output)
+        self.assertIn("state is STORAGE without active event proof", output)
+
+    def test_retired_and_disposed_assets_are_excluded(self) -> None:
+        self._insert_asset("ACTIVE-1", location_type="STORAGE")
+        self._insert_asset("RET-1", location_type="RETIRED")
+        self._insert_asset("DISP-1", location_type="DISPOSED")
+        self._insert_event("ACTIVE-1", "ASSET_CREATED")
+
+        exit_code, output = self._run_main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("Total active assets evaluated: 1", output)
+        self.assertNotIn("RET-1", output)
+        self.assertNotIn("DISP-1", output)
+
+    def test_database_remains_unchanged_readonly(self) -> None:
+        self._insert_slot(10, "CASE-1", 1)
+        self._insert_holder(7, "Read Only Holder")
+        self._insert_asset("READONLY-1", location_type="STORAGE", current_holder_id=7, home_slot_id=10)
+        self._insert_event("READONLY-1", "ASSET_CREATED")
+        before_digest = self._db_digest()
+        before_counts = {
+            table: int(self.conn.execute(f"SELECT COUNT(*) FROM {table};").fetchone()[0])
+            for table in ("assets", "asset_events", "slots", "holders")
+        }
+
+        exit_code, output = self._run_main()
+
+        after_counts = {
+            table: int(self.conn.execute(f"SELECT COUNT(*) FROM {table};").fetchone()[0])
+            for table in ("assets", "asset_events", "slots", "holders")
+        }
+        self.assertEqual(exit_code, 1)
+        self.assertIn("storage=CASE-1 / Slot 1", output)
+        self.assertEqual(before_counts, after_counts)
+        self.assertEqual(before_digest, self._db_digest())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds an offline, read-only operational accountability gate for active AssetTrack assets.

## Related Issue
Closes #1166

## Changes
- Adds read-only accountability verification CLI
- Derives checked-in state from existing custody state and active event history
- Distinguishes checked in, issued, and unresolved/inconsistent assets
- Returns non-zero when accountability cannot be confirmed
- Adds operator documentation and focused regression coverage

## Verification
- [x] Focused tests: 8 passed
- [x] git diff --check
- [x] Baseline verification established
- [x] Normal Issue workflow changed asset to not checked in
- [x] Normal Return workflow restored exact baseline
- [x] Existing unresolved development records remained unresolved rather than silently passing
- [x] Repeated verification output deterministic
- [x] Verification operates read-only

## Notes
Development database baseline contains three pre-existing smoke-test records without active event proof. The verifier correctly reports them as unresolved. No database repair was performed.

No schema, migration, dependency, authentication, custody-workflow, or event-history changes.