### PR TITLE
Issue 31-38: Generate printable asset custody and accountability PDF

### DIFF
--- a/assettrack/custody_accountability.py
+++ b/assettrack/custody_accountability.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from assettrack.audit import ACTIVE_EVENTS_WHERE
+from assettrack.event_types import normalize_event_type
+from scripts.verify_accountability import verify_accountability
+
+
+CUSTODY_EVENT_TYPES = {"ISSUE", "RETURN"}
+
+
+@dataclass(frozen=True)
+class HolderSummary:
+    holder_id: int | None
+    name: str
+    organization: str
+
+    @property
+    def label(self) -> str:
+        if self.name and self.organization and self.organization != self.name:
+            return f"{self.name} ({self.organization})"
+        if self.name:
+            return self.name
+        if self.organization:
+            return self.organization
+        if self.holder_id is not None:
+            return f"holder_id {self.holder_id}"
+        return ""
+
+
+@dataclass(frozen=True)
+class CustodyEvent:
+    id: int
+    asset_id: int
+    asset_tag: str
+    event_type: str
+    event_at: datetime
+    holder: HolderSummary
+    home_slot_id: int | None
+    from_building_room: str
+    to_building_room: str
+
+
+@dataclass(frozen=True)
+class CustodyInterval:
+    issue_event_id: int
+    issue_timestamp: datetime
+    holder: HolderSummary
+    return_event_id: int | None
+    return_timestamp: datetime | None
+    elapsed: timedelta
+    outstanding: bool
+
+
+@dataclass(frozen=True)
+class AssetCustodyReport:
+    asset_id: int
+    asset_tag: str
+    serial_number: str
+    equipment_type: str
+    current_accountability_state: str
+    current_holder: HolderSummary
+    current_storage_location: str
+    intervals: tuple[CustodyInterval, ...]
+    issue_count: int
+    total_custody_duration: timedelta
+    longest_custody_interval: timedelta
+    exceptions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HolderCustodyReport:
+    holder: HolderSummary
+    unique_asset_tags: tuple[str, ...]
+    issue_transaction_count: int
+    total_custody_time: timedelta
+    longest_custody_interval: timedelta
+    currently_outstanding_count: int
+    outstanding_asset_tags: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CustodyAccountabilityReport:
+    generated_at: datetime
+    assets: tuple[AssetCustodyReport, ...]
+    holders: tuple[HolderCustodyReport, ...]
+    active_assets: int
+    checked_in: int
+    checked_out: int
+    unresolved: int
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    raw = _text(value)
+    if not raw:
+        return None
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _payload_dict(value: object) -> dict[str, object]:
+    try:
+        parsed = json.loads(str(value or "{}"))
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _holder_from_row(row: sqlite3.Row, *, prefix: str = "") -> HolderSummary:
+    holder_id = _optional_int(row[f"{prefix}holder_id"])
+    return HolderSummary(
+        holder_id=holder_id,
+        name=_text(row[f"{prefix}holder_name"]),
+        organization=_text(row[f"{prefix}holder_organization"]),
+    )
+
+
+def _storage_location(row: sqlite3.Row) -> str:
+    case_name = _text(row["home_case_name"])
+    slot_position = row["home_slot_position"]
+    if case_name and slot_position is not None:
+        return f"{case_name} / Slot {slot_position}"
+    return _text(row["building_room"])
+
+
+def _active_asset_rows(conn: sqlite3.Connection) -> tuple[sqlite3.Row, ...]:
+    return tuple(
+        conn.execute(
+            """
+            SELECT
+                a.id,
+                a.asset_tag,
+                COALESCE(a.serial_number, '') AS serial_number,
+                COALESCE(a.equipment_type, '') AS equipment_type,
+                COALESCE(a.location_type, '') AS location_type,
+                a.current_holder_id AS holder_id,
+                COALESCE(h.name, '') AS holder_name,
+                COALESCE(h.organization, '') AS holder_organization,
+                COALESCE(a.building_room, '') AS building_room,
+                s.case_name AS home_case_name,
+                s.slot_position AS home_slot_position
+            FROM assets a
+            LEFT JOIN holders h
+              ON h.id = a.current_holder_id
+            LEFT JOIN slots s
+              ON s.id = a.home_slot_id
+            WHERE COALESCE(a.location_type, '') NOT IN ('DISPOSED', 'RETIRED')
+            ORDER BY a.asset_tag COLLATE NOCASE ASC, a.id ASC;
+            """
+        ).fetchall()
+    )
+
+
+def _event_rows(conn: sqlite3.Connection) -> tuple[CustodyEvent, ...]:
+    active_events_where = ACTIVE_EVENTS_WHERE.replace("id NOT IN", "e.id NOT IN", 1)
+    rows = conn.execute(
+        f"""
+        SELECT
+            a.id AS asset_id,
+            a.asset_tag AS canonical_asset_tag,
+            e.id AS event_id,
+            e.asset_tag,
+            e.event_type,
+            e.event_date,
+            e.holder_id,
+            COALESCE(h.name, '') AS holder_name,
+            COALESCE(h.organization, '') AS holder_organization,
+            e.payload
+        FROM assets a
+        JOIN asset_events e
+          ON UPPER(e.asset_tag) = UPPER(a.asset_tag)
+        LEFT JOIN holders h
+          ON h.id = e.holder_id
+        WHERE COALESCE(a.location_type, '') NOT IN ('DISPOSED', 'RETIRED')
+          AND {active_events_where}
+        ORDER BY a.asset_tag COLLATE NOCASE ASC, e.event_date ASC, e.id ASC;
+        """
+    ).fetchall()
+
+    events: list[CustodyEvent] = []
+    for row in rows:
+        event_type = normalize_event_type(row["event_type"])
+        if event_type not in CUSTODY_EVENT_TYPES:
+            continue
+        event_at = _parse_timestamp(row["event_date"])
+        if event_at is None:
+            continue
+        payload = _payload_dict(row["payload"])
+        events.append(
+            CustodyEvent(
+                id=int(row["event_id"]),
+                asset_id=int(row["asset_id"]),
+                asset_tag=_text(row["canonical_asset_tag"]) or _text(row["asset_tag"]),
+                event_type=event_type,
+                event_at=event_at,
+                holder=_holder_from_row(row),
+                home_slot_id=_optional_int(payload.get("home_slot_id")),
+                from_building_room=_text(payload.get("from_building_room")),
+                to_building_room=_text(payload.get("to_building_room")),
+            )
+        )
+    return tuple(events)
+
+
+def _classifications_by_asset(conn: sqlite3.Connection) -> dict[int, str]:
+    result = verify_accountability(conn)
+    return {row.asset.id: row.classification for row in result.rows}
+
+
+def _pair_asset_events(
+    events: tuple[CustodyEvent, ...],
+    *,
+    generated_at: datetime,
+) -> tuple[tuple[CustodyInterval, ...], tuple[str, ...]]:
+    intervals: list[CustodyInterval] = []
+    exceptions: list[str] = []
+    open_issue: CustodyEvent | None = None
+
+    for event in events:
+        if event.event_type == "ISSUE":
+            if open_issue is not None:
+                exceptions.append(f"ISSUE event {event.id} occurred before RETURN for ISSUE event {open_issue.id}.")
+            open_issue = event
+            continue
+
+        if event.event_type == "RETURN":
+            if open_issue is None:
+                exceptions.append(f"RETURN event {event.id} has no preceding open ISSUE event.")
+                continue
+            if event.event_at < open_issue.event_at:
+                exceptions.append(f"RETURN event {event.id} is earlier than ISSUE event {open_issue.id}.")
+                open_issue = None
+                continue
+            intervals.append(
+                CustodyInterval(
+                    issue_event_id=open_issue.id,
+                    issue_timestamp=open_issue.event_at,
+                    holder=open_issue.holder,
+                    return_event_id=event.id,
+                    return_timestamp=event.event_at,
+                    elapsed=event.event_at - open_issue.event_at,
+                    outstanding=False,
+                )
+            )
+            open_issue = None
+
+    if open_issue is not None:
+        if generated_at < open_issue.event_at:
+            exceptions.append(f"Open ISSUE event {open_issue.id} is later than report timestamp.")
+        else:
+            intervals.append(
+                CustodyInterval(
+                    issue_event_id=open_issue.id,
+                    issue_timestamp=open_issue.event_at,
+                    holder=open_issue.holder,
+                    return_event_id=None,
+                    return_timestamp=None,
+                    elapsed=generated_at - open_issue.event_at,
+                    outstanding=True,
+                )
+            )
+
+    return tuple(intervals), tuple(exceptions)
+
+
+def _holder_key(holder: HolderSummary) -> tuple[int, str, str]:
+    return (-1 if holder.holder_id is None else holder.holder_id, holder.name, holder.organization)
+
+
+def _holder_reports(asset_reports: tuple[AssetCustodyReport, ...]) -> tuple[HolderCustodyReport, ...]:
+    grouped: dict[tuple[int, str, str], list[tuple[str, CustodyInterval]]] = {}
+    holder_lookup: dict[tuple[int, str, str], HolderSummary] = {}
+    for asset in asset_reports:
+        for interval in asset.intervals:
+            key = _holder_key(interval.holder)
+            grouped.setdefault(key, []).append((asset.asset_tag, interval))
+            holder_lookup[key] = interval.holder
+
+    reports: list[HolderCustodyReport] = []
+    for key in sorted(grouped, key=lambda item: (item[1].upper(), item[2].upper(), item[0])):
+        rows = grouped[key]
+        durations = [interval.elapsed for _asset_tag, interval in rows]
+        outstanding_asset_tags = sorted(
+            {asset_tag for asset_tag, interval in rows if interval.outstanding},
+            key=str.upper,
+        )
+        reports.append(
+            HolderCustodyReport(
+                holder=holder_lookup[key],
+                unique_asset_tags=tuple(sorted({asset_tag for asset_tag, _interval in rows}, key=str.upper)),
+                issue_transaction_count=len(rows),
+                total_custody_time=sum(durations, timedelta()),
+                longest_custody_interval=max(durations, default=timedelta()),
+                currently_outstanding_count=len(outstanding_asset_tags),
+                outstanding_asset_tags=tuple(outstanding_asset_tags),
+            )
+        )
+    return tuple(reports)
+
+
+def build_custody_accountability_report(
+    conn: sqlite3.Connection,
+    *,
+    generated_at: datetime,
+) -> CustodyAccountabilityReport:
+    generated = generated_at.astimezone(timezone.utc) if generated_at.tzinfo else generated_at.replace(tzinfo=timezone.utc)
+    event_groups: dict[int, list[CustodyEvent]] = {}
+    for event in _event_rows(conn):
+        event_groups.setdefault(event.asset_id, []).append(event)
+
+    classifications = _classifications_by_asset(conn)
+    asset_reports: list[AssetCustodyReport] = []
+    for row in _active_asset_rows(conn):
+        asset_id = int(row["id"])
+        intervals, exceptions = _pair_asset_events(tuple(event_groups.get(asset_id, [])), generated_at=generated)
+        durations = [interval.elapsed for interval in intervals]
+        classification = classifications.get(asset_id, "unresolved")
+        if classification == "unresolved" and "current accountability state is unresolved" not in exceptions:
+            exceptions = tuple(exceptions) + ("current accountability state is unresolved",)
+        asset_reports.append(
+            AssetCustodyReport(
+                asset_id=asset_id,
+                asset_tag=_text(row["asset_tag"]),
+                serial_number=_text(row["serial_number"]),
+                equipment_type=_text(row["equipment_type"]),
+                current_accountability_state=classification,
+                current_holder=_holder_from_row(row),
+                current_storage_location=_storage_location(row),
+                intervals=intervals,
+                issue_count=sum(1 for event in event_groups.get(asset_id, []) if event.event_type == "ISSUE"),
+                total_custody_duration=sum(durations, timedelta()),
+                longest_custody_interval=max(durations, default=timedelta()),
+                exceptions=exceptions,
+            )
+        )
+
+    checked_in = sum(1 for asset in asset_reports if asset.current_accountability_state == "confirmed_checked_in")
+    checked_out = sum(1 for asset in asset_reports if asset.current_accountability_state == "not_checked_in")
+    unresolved = sum(1 for asset in asset_reports if asset.current_accountability_state == "unresolved" or asset.exceptions)
+    return CustodyAccountabilityReport(
+        generated_at=generated,
+        assets=tuple(asset_reports),
+        holders=_holder_reports(tuple(asset_reports)),
+        active_assets=len(asset_reports),
+        checked_in=checked_in,
+        checked_out=checked_out,
+        unresolved=unresolved,
+    )

--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -29,7 +29,7 @@ from datetime import datetime, timezone, date, timedelta
 
 from flask import Flask, abort, flash, jsonify, make_response, redirect, render_template, request, send_file, session, url_for
 from reportlab.lib import colors
-from reportlab.lib.pagesizes import letter
+from reportlab.lib.pagesizes import landscape, letter
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
 from reportlab.lib.units import inch
 from reportlab.pdfgen import canvas
@@ -48,6 +48,11 @@ from assettrack.assets import (
 )
 from assettrack.barcodes import barcode_lookup_key
 from assettrack.cases import CASE_SIZE_OPTIONS, save_case_size
+from assettrack.custody_accountability import (
+    CustodyAccountabilityReport,
+    HolderSummary,
+    build_custody_accountability_report,
+)
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import bootstrap_db, get_connection
 from assettrack.drilldowns import (
@@ -9577,6 +9582,253 @@ def admin_network_asset_import_template():
     )
 
 
+def _duration_label(value: timedelta) -> str:
+    total_seconds = max(0, int(value.total_seconds()))
+    days, remainder = divmod(total_seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes, _seconds = divmod(remainder, 60)
+    parts: list[str] = []
+    if days:
+        parts.append(f"{days}d")
+    if hours:
+        parts.append(f"{hours}h")
+    if minutes or not parts:
+        parts.append(f"{minutes}m")
+    return " ".join(parts)
+
+
+def _timestamp_label(value: datetime | None) -> str:
+    if value is None:
+        return "OUTSTANDING"
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _holder_summary_label(holder: HolderSummary) -> str:
+    return holder.label or "Unknown holder"
+
+
+def _holder_identifier_label(holder: HolderSummary) -> str:
+    return "No holder ID" if holder.holder_id is None else str(holder.holder_id)
+
+
+def _accountability_state_label(value: object) -> str:
+    labels = {
+        "confirmed_checked_in": "Checked in",
+        "not_checked_in": "Checked out",
+        "unresolved": "Unresolved / inconsistent",
+    }
+    return labels.get(str(value or "").strip(), str(value or "").strip() or "Unknown")
+
+
+def _custody_outstanding_rows(report: CustodyAccountabilityReport) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for asset in report.assets:
+        for interval in asset.intervals:
+            if interval.outstanding:
+                rows.append({"asset": asset, "interval": interval})
+    return sorted(rows, key=lambda row: str(row["asset"].asset_tag).upper())
+
+
+def _custody_interval_rows(report: CustodyAccountabilityReport) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for asset in report.assets:
+        for interval in asset.intervals:
+            rows.append({"asset": asset, "interval": interval})
+    return sorted(
+        rows,
+        key=lambda row: (
+            str(row["asset"].asset_tag).upper(),
+            row["interval"].issue_timestamp,
+            row["interval"].issue_event_id,
+        ),
+    )
+
+
+def _custody_exception_rows(report: CustodyAccountabilityReport) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for asset in report.assets:
+        for exception in asset.exceptions:
+            rows.append({"asset": asset, "exception": exception})
+    return sorted(rows, key=lambda row: str(row["asset"].asset_tag).upper())
+
+
+def _load_custody_accountability_report(resolved_db_path: Path, generated_at: datetime) -> CustodyAccountabilityReport:
+    conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only = ON;")
+    try:
+        return build_custody_accountability_report(conn, generated_at=generated_at)
+    finally:
+        conn.close()
+
+
+def _build_custody_accountability_pdf(report: CustodyAccountabilityReport) -> bytes:
+    styles = getSampleStyleSheet()
+    body = ParagraphStyle(
+        "CustodyPdfBody",
+        parent=styles["BodyText"],
+        fontSize=8,
+        leading=9.5,
+        splitLongWords=False,
+        wordWrap="LTR",
+    )
+    title = styles["Title"]
+    heading = styles["Heading2"]
+    table_header_style = ParagraphStyle("CustodyPdfHeader", parent=body, fontName="Helvetica-Bold")
+
+    def _text(value: object) -> str:
+        return str(value or "").replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+    def _p(value: object, style: ParagraphStyle = body) -> Paragraph:
+        return Paragraph(_text(value), style)
+
+    def _table(headers: list[str], rows: list[list[object]], widths: list[float]) -> Table:
+        data = [[_p(header, table_header_style) for header in headers]]
+        data.extend([[_p(value) for value in row] for row in rows])
+        if len(data) == 1:
+            data.append([_p("None")] + [_p("") for _ in headers[1:]])
+        table = Table(data, colWidths=widths, repeatRows=1)
+        table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8eef5")),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.black),
+                    ("GRID", (0, 0), (-1, -1), 0.4, colors.HexColor("#b8c4d0")),
+                    ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                    ("LEFTPADDING", (0, 0), (-1, -1), 4),
+                    ("RIGHTPADDING", (0, 0), (-1, -1), 4),
+                    ("TOPPADDING", (0, 0), (-1, -1), 4),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+                ]
+            )
+        )
+        return table
+
+    def _page_number(canvas_obj, doc):
+        canvas_obj.saveState()
+        canvas_obj.setFont("Helvetica", 8)
+        canvas_obj.drawRightString(doc.pagesize[0] - 0.45 * inch, 0.28 * inch, f"Page {doc.page}")
+        canvas_obj.restoreState()
+
+    status_text = (
+        "ALL ACTIVE ASSETS ACCOUNTED FOR"
+        if report.checked_out == 0 and report.unresolved == 0
+        else "OUTSTANDING ASSETS REQUIRE ATTENTION"
+    )
+    story: list[object] = [
+        Paragraph("Asset Custody / Accountability", title),
+        Spacer(1, 0.08 * inch),
+        Paragraph(f"Generated: {_timestamp_label(report.generated_at)}", body),
+        Paragraph(
+            "Historical holder evidence is the holder ID stored on the ISSUE event. Names and organizations are current lookups for that ID.",
+            body,
+        ),
+        Paragraph(
+            "Historical storage labels are not invented; current storage comes from current slot/building-room records.",
+            body,
+        ),
+        Spacer(1, 0.1 * inch),
+        Paragraph(status_text, heading),
+        _table(
+            ["Active", "Checked In", "Checked Out", "Unresolved"],
+            [[report.active_assets, report.checked_in, report.checked_out, report.unresolved]],
+            [0.9 * inch, 1.0 * inch, 1.0 * inch, 1.0 * inch],
+        ),
+        Spacer(1, 0.18 * inch),
+        Paragraph("Holder / MA Accountability", heading),
+        _table(
+            ["Holder ID", "Current Name / Org", "Unique Assets", "Issues", "Total Time", "Longest", "Outstanding", "Outstanding Tags"],
+            [
+                [
+                    _holder_identifier_label(row.holder),
+                    _holder_summary_label(row.holder),
+                    len(row.unique_asset_tags),
+                    row.issue_transaction_count,
+                    _duration_label(row.total_custody_time),
+                    _duration_label(row.longest_custody_interval),
+                    row.currently_outstanding_count,
+                    ", ".join(row.outstanding_asset_tags),
+                ]
+                for row in report.holders
+            ],
+            [0.6 * inch, 1.45 * inch, 0.65 * inch, 0.55 * inch, 0.8 * inch, 0.8 * inch, 0.7 * inch, 2.35 * inch],
+        ),
+        Spacer(1, 0.18 * inch),
+        Paragraph("Outstanding Assets", heading),
+        _table(
+            ["Asset", "Holder", "Checkout", "Elapsed", "Storage Evidence"],
+            [
+                [
+                    row["asset"].asset_tag,
+                    _holder_summary_label(row["interval"].holder),
+                    _timestamp_label(row["interval"].issue_timestamp),
+                    _duration_label(row["interval"].elapsed),
+                    row["asset"].current_storage_location,
+                ]
+                for row in _custody_outstanding_rows(report)
+            ],
+            [1.15 * inch, 1.6 * inch, 1.35 * inch, 0.85 * inch, 2.8 * inch],
+        ),
+        Spacer(1, 0.18 * inch),
+        Paragraph("Asset Custody / Accountability Details", heading),
+        _table(
+            ["Asset", "Serial", "Type", "State", "Current Holder", "Storage Evidence", "Issues", "Total", "Longest"],
+            [
+                [
+                    asset.asset_tag,
+                    asset.serial_number,
+                    asset.equipment_type,
+                    _accountability_state_label(asset.current_accountability_state),
+                    _holder_summary_label(asset.current_holder) if asset.current_holder.holder_id is not None else "",
+                    asset.current_storage_location,
+                    asset.issue_count,
+                    _duration_label(asset.total_custody_duration),
+                    _duration_label(asset.longest_custody_interval),
+                ]
+                for asset in report.assets
+            ],
+            [0.95 * inch, 0.95 * inch, 0.7 * inch, 1.0 * inch, 1.2 * inch, 1.45 * inch, 0.45 * inch, 0.6 * inch, 0.6 * inch],
+        ),
+        Spacer(1, 0.18 * inch),
+        Paragraph("Custody Intervals", heading),
+        _table(
+            ["Asset", "Issue", "Holder ID / Current Label", "Return", "Elapsed"],
+            [
+                [
+                    row["asset"].asset_tag,
+                    _timestamp_label(row["interval"].issue_timestamp),
+                    f"{_holder_identifier_label(row['interval'].holder)} / {_holder_summary_label(row['interval'].holder)}",
+                    _timestamp_label(row["interval"].return_timestamp),
+                    _duration_label(row["interval"].elapsed),
+                ]
+                for row in _custody_interval_rows(report)
+            ],
+            [1.05 * inch, 1.35 * inch, 2.15 * inch, 1.35 * inch, 0.75 * inch],
+        ),
+        Spacer(1, 0.18 * inch),
+        Paragraph("Exceptions", heading),
+        _table(
+            ["Asset", "Exception"],
+            [[row["asset"].asset_tag, row["exception"]] for row in _custody_exception_rows(report)],
+            [1.25 * inch, 6.4 * inch],
+        ),
+    ]
+
+    buffer = BytesIO()
+    doc = SimpleDocTemplate(
+        buffer,
+        pagesize=landscape(letter),
+        leftMargin=0.4 * inch,
+        rightMargin=0.4 * inch,
+        topMargin=0.45 * inch,
+        bottomMargin=0.45 * inch,
+        title="AssetTrack Custody Accountability",
+        author="AssetTrack",
+    )
+    doc.build(story, onFirstPage=_page_number, onLaterPages=_page_number)
+    return buffer.getvalue()
+
+
 def _load_admin_human_report_data(resolved_db_path: Path, *, include_retired_assets: bool = True) -> dict:
     recent_events_limit = 10
     conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
@@ -10439,6 +10691,50 @@ def human_report():
         report_error=report_error,
         include_retired_assets=include_retired_assets,
         **report_data,
+    )
+
+
+@app.get("/report/custody-accountability")
+@require_login
+def custody_accountability_preview():
+    generated_at = datetime.now(timezone.utc)
+    try:
+        report = _load_custody_accountability_report(_resolved_runtime_db_path(), generated_at)
+    except sqlite3.Error as exc:
+        return f"Could not read custody accountability report: {exc}", 500
+
+    return render_template(
+        "custody_accountability.html",
+        report=report,
+        generated_at=generated_at,
+        outstanding_rows=_custody_outstanding_rows(report),
+        interval_rows=_custody_interval_rows(report),
+        exception_rows=_custody_exception_rows(report),
+        duration_label=_duration_label,
+        timestamp_label=_timestamp_label,
+        holder_summary_label=_holder_summary_label,
+        holder_identifier_label=_holder_identifier_label,
+        accountability_state_label=_accountability_state_label,
+    )
+
+
+@app.get("/report/custody-accountability/pdf")
+@require_login
+def custody_accountability_pdf():
+    generated_at = datetime.now(timezone.utc)
+    try:
+        report = _load_custody_accountability_report(_resolved_runtime_db_path(), generated_at)
+        pdf_bytes = _build_custody_accountability_pdf(report)
+    except sqlite3.Error as exc:
+        return f"Could not build custody accountability PDF: {exc}", 500
+
+    download_name = f"assettrack-custody-accountability-{generated_at.strftime('%Y%m%d-%H%M%S')}.pdf"
+    return send_file(
+        BytesIO(pdf_bytes),
+        as_attachment=True,
+        download_name=download_name,
+        mimetype="application/pdf",
+        conditional=False,
     )
 
 

--- a/assettrack/intake/templates/custody_accountability.html
+++ b/assettrack/intake/templates/custody_accountability.html
@@ -1,0 +1,192 @@
+{% extends "base.html" %}
+
+{% block title %}Asset Custody / Accountability{% endblock %}
+{% block page_heading %}Asset Custody / Accountability{% endblock %}
+{% block page_class %} report-page{% endblock %}
+
+{% block content %}
+  <nav class="actions" aria-label="Report navigation">
+    <a class="nav-link" href="{{ url_for('human_report') }}">Back to Reports</a>
+    <a class="action-secondary" href="{{ url_for('custody_accountability_pdf') }}">Generate PDF</a>
+  </nav>
+
+  <div class="card">
+    <h2>Summary</h2>
+    <p class="muted">Generated {{ timestamp_label(report.generated_at) }}. Preview is read-only.</p>
+    <p class="{% if report.checked_out == 0 and report.unresolved == 0 %}flash success{% else %}flash warning{% endif %}">
+      {% if report.checked_out == 0 and report.unresolved == 0 %}
+        ALL ACTIVE ASSETS ACCOUNTED FOR
+      {% else %}
+        OUTSTANDING ASSETS REQUIRE ATTENTION
+      {% endif %}
+    </p>
+    <div class="report-grid">
+      <div class="report-stat">Total active assets<strong>{{ report.active_assets }}</strong></div>
+      <div class="report-stat">Checked in<strong>{{ report.checked_in }}</strong></div>
+      <div class="report-stat">Checked out<strong>{{ report.checked_out }}</strong></div>
+      <div class="report-stat">Unresolved / inconsistent<strong>{{ report.unresolved }}</strong></div>
+    </div>
+    <p class="muted">
+      Holder ID on the ISSUE event is historical evidence. Holder names and organizations shown here are current lookups for that stored ID.
+      Storage evidence is current slot/building-room data; historical case/slot labels are not invented.
+    </p>
+  </div>
+
+  <section class="report-section">
+    <h2>Holder / MA Accountability</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Holder ID</th>
+            <th>Current Name / Organization</th>
+            <th>Unique Assets Issued</th>
+            <th>Issue Transactions</th>
+            <th>Total Custody Time</th>
+            <th>Longest Interval</th>
+            <th>Outstanding</th>
+            <th>Outstanding Asset Tags</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in report.holders %}
+            <tr>
+              <td><code>{{ holder_identifier_label(row.holder) }}</code></td>
+              <td>{{ holder_summary_label(row.holder) }}</td>
+              <td>{{ row.unique_asset_tags|length }}</td>
+              <td>{{ row.issue_transaction_count }}</td>
+              <td>{{ duration_label(row.total_custody_time) }}</td>
+              <td>{{ duration_label(row.longest_custody_interval) }}</td>
+              <td>{{ row.currently_outstanding_count }}</td>
+              <td>{% if row.outstanding_asset_tags %}<code>{{ row.outstanding_asset_tags|join(', ') }}</code>{% endif %}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="8">No custody intervals found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="report-section">
+    <h2>Asset Accountability</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Asset</th>
+            <th>Serial</th>
+            <th>Type</th>
+            <th>Current State</th>
+            <th>Current Holder</th>
+            <th>Current Storage / Location Evidence</th>
+            <th>Issues</th>
+            <th>Total Custody</th>
+            <th>Longest</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for asset in report.assets %}
+            <tr>
+              <td><code>{{ asset.asset_tag }}</code></td>
+              <td>{{ asset.serial_number }}</td>
+              <td>{{ asset.equipment_type }}</td>
+              <td>{{ accountability_state_label(asset.current_accountability_state) }}</td>
+              <td>{% if asset.current_holder.holder_id is not none %}{{ holder_summary_label(asset.current_holder) }}{% endif %}</td>
+              <td>{{ asset.current_storage_location }}</td>
+              <td>{{ asset.issue_count }}</td>
+              <td>{{ duration_label(asset.total_custody_duration) }}</td>
+              <td>{{ duration_label(asset.longest_custody_interval) }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="9">No active assets found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="report-section">
+    <h2>Outstanding Assets</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Asset</th>
+            <th>Holder</th>
+            <th>Checkout Timestamp</th>
+            <th>Elapsed</th>
+            <th>Available Storage / Location Evidence</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in outstanding_rows %}
+            <tr>
+              <td><code>{{ row.asset.asset_tag }}</code></td>
+              <td>{{ holder_summary_label(row.interval.holder) }}</td>
+              <td>{{ timestamp_label(row.interval.issue_timestamp) }}</td>
+              <td>{{ duration_label(row.interval.elapsed) }}</td>
+              <td>{{ row.asset.current_storage_location }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5">No outstanding assets.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="report-section">
+    <h2>Custody Intervals</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Asset</th>
+            <th>Issue Timestamp</th>
+            <th>Holder ID / Current Label</th>
+            <th>Return Timestamp</th>
+            <th>Elapsed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in interval_rows %}
+            <tr>
+              <td><code>{{ row.asset.asset_tag }}</code></td>
+              <td>{{ timestamp_label(row.interval.issue_timestamp) }}</td>
+              <td><code>{{ holder_identifier_label(row.interval.holder) }}</code> / {{ holder_summary_label(row.interval.holder) }}</td>
+              <td>{{ timestamp_label(row.interval.return_timestamp) }}</td>
+              <td>{{ duration_label(row.interval.elapsed) }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="5">No Issue/Return intervals found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="report-section">
+    <h2>Exceptions</h2>
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Asset</th>
+            <th>Exception</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in exception_rows %}
+            <tr>
+              <td><code>{{ row.asset.asset_tag }}</code></td>
+              <td>{{ row.exception }}</td>
+            </tr>
+          {% else %}
+            <tr><td colspan="2">No inconsistent histories found.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+{% endblock %}

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -63,6 +63,7 @@
     </div>
     <div class="report-actions report-utility-links" aria-label="Report utilities">
       <span class="report-utility-label">Report utilities</span>
+      <a class="nav-link" href="{{ url_for('custody_accountability_preview') }}">Asset Custody / Accountability</a>
       <a class="nav-link" href="{{ url_for('case_inventory') }}">Case inventory</a>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Search receipts</a>
       <a class="nav-link" href="{{ url_for('inventory_reconciliation') }}">Inventory Reconciliation</a>

--- a/docs/operator/custody-accountability-report.md
+++ b/docs/operator/custody-accountability-report.md
@@ -1,0 +1,51 @@
+# Asset Custody / Accountability Report
+
+Use this report when operators need a printable custody accountability view from AssetTrack.
+
+## Where to find it
+
+1. Log in.
+2. Open `Reports`.
+3. Select `Asset Custody / Accountability`.
+
+## Preview
+
+The preview opens in the browser before any PDF is generated.
+
+Use it to review:
+
+- active asset totals
+- holder / MA accountability
+- asset accountability
+- outstanding assets
+- exceptions or unresolved records
+
+## PDF
+
+Select `Generate PDF` from the preview page.
+
+Expected result:
+
+- the browser downloads a printable PDF version of the same accountability report
+
+Print the downloaded PDF using the browser or PDF viewer print command.
+
+## How to read it
+
+`Custody duration` is the elapsed time between an Issue event and its matching Return event.
+
+For an outstanding issue, custody duration is measured from the Issue event timestamp to the report generation timestamp.
+
+`OUTSTANDING` means the asset has an Issue event that has not been paired with a later Return event.
+
+An exception or unresolved record means AssetTrack could not safely reconstruct or confirm custody from the event history and current reconciliation data. Review the listed asset before treating the report as complete.
+
+## Historical evidence
+
+Custody history derives from AssetTrack append-only event history.
+
+The holder ID stored on the Issue event is historical evidence.
+
+Holder name and organization are current lookups for that stored holder ID, not historical snapshots.
+
+Historical case or slot labels are not invented when events do not preserve them. Storage evidence may show current slot or building-room information when available.

--- a/tests/test_custody_accountability.py
+++ b/tests/test_custody_accountability.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import assettrack.db as db
+from assettrack.custody_accountability import build_custody_accountability_report
+
+
+GENERATED_AT = datetime(2026, 1, 10, 12, 0, tzinfo=timezone.utc)
+
+
+class CustodyAccountabilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "assettrack.db"
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.row_factory = sqlite3.Row
+        db._create_schema(self.conn)
+        self.conn.commit()
+
+    def tearDown(self) -> None:
+        self.conn.close()
+        self.temp_dir.cleanup()
+
+    def _digest(self) -> str:
+        return hashlib.sha256(self.db_path.read_bytes()).hexdigest()
+
+    def _insert_holder(self, holder_id: int, name: str, organization: str) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO holders (
+                id, holder_type, name, organization, identifier, email, contact_info, created_at, updated_at
+            )
+            VALUES (?, 'PERSON', ?, ?, ?, '', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+            """,
+            (holder_id, name, organization, f"H-{holder_id}"),
+        )
+        self.conn.commit()
+
+    def _insert_slot(self, slot_id: int, case_name: str, slot_position: int) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+            VALUES (?, ?, ?, NULL);
+            """,
+            (slot_id, case_name, slot_position),
+        )
+        self.conn.commit()
+
+    def _insert_asset(
+        self,
+        asset_tag: str,
+        *,
+        serial_number: str = "SER",
+        equipment_type: str = "laptop",
+        location_type: str = "STORAGE",
+        current_holder_id: int | None = None,
+        home_slot_id: int | None = None,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO assets (
+                asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?);
+            """,
+            (asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id),
+        )
+        self.conn.commit()
+
+    def _insert_event(
+        self,
+        asset_tag: str,
+        event_type: str,
+        event_date: str,
+        *,
+        holder_id: int | None = None,
+    ) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+            VALUES (?, ?, ?, 'test', NULL, '{}', ?);
+            """,
+            (asset_tag, event_type, event_date, holder_id),
+        )
+        self.conn.commit()
+
+    def _report(self):
+        return build_custody_accountability_report(self.conn, generated_at=GENERATED_AT)
+
+    def test_single_issue_return_interval(self) -> None:
+        self._insert_holder(1, "Alice Holder", "Mission A")
+        self._insert_asset("AT-1", serial_number="SER-1", equipment_type="laptop")
+        self._insert_event("AT-1", "ISSUE", "2026-01-01T00:00:00Z", holder_id=1)
+        self._insert_event("AT-1", "RETURN", "2026-01-03T06:00:00Z")
+
+        report = self._report()
+        asset = report.assets[0]
+
+        self.assertEqual(report.active_assets, 1)
+        self.assertEqual(report.checked_in, 1)
+        self.assertEqual(asset.asset_tag, "AT-1")
+        self.assertEqual(asset.serial_number, "SER-1")
+        self.assertEqual(asset.equipment_type, "laptop")
+        self.assertEqual(asset.issue_count, 1)
+        self.assertEqual(len(asset.intervals), 1)
+        self.assertEqual(asset.intervals[0].holder.holder_id, 1)
+        self.assertEqual(asset.intervals[0].holder.organization, "Mission A")
+        self.assertEqual(asset.intervals[0].elapsed, timedelta(days=2, hours=6))
+        self.assertFalse(asset.intervals[0].outstanding)
+
+    def test_multiple_intervals_total_and_longest(self) -> None:
+        self._insert_holder(1, "Alice Holder", "Mission A")
+        self._insert_asset("AT-2")
+        self._insert_event("AT-2", "ISSUE", "2026-01-01T00:00:00Z", holder_id=1)
+        self._insert_event("AT-2", "RETURN", "2026-01-02T00:00:00Z")
+        self._insert_event("AT-2", "ISSUE", "2026-01-05T00:00:00Z", holder_id=1)
+        self._insert_event("AT-2", "RETURN", "2026-01-08T12:00:00Z")
+
+        asset = self._report().assets[0]
+
+        self.assertEqual(asset.issue_count, 2)
+        self.assertEqual(len(asset.intervals), 2)
+        self.assertEqual(asset.total_custody_duration, timedelta(days=4, hours=12))
+        self.assertEqual(asset.longest_custody_interval, timedelta(days=3, hours=12))
+
+    def test_outstanding_interval_uses_fixed_generation_timestamp(self) -> None:
+        self._insert_holder(2, "Bob Holder", "Mission B")
+        self._insert_asset("AT-3", location_type="IN_CUSTODY", current_holder_id=2)
+        self._insert_event("AT-3", "ISSUE", "2026-01-09T12:00:00Z", holder_id=2)
+
+        first = self._report()
+        second = self._report()
+        asset = first.assets[0]
+
+        self.assertEqual(first, second)
+        self.assertEqual(first.checked_out, 1)
+        self.assertEqual(asset.current_accountability_state, "not_checked_in")
+        self.assertEqual(asset.intervals[0].elapsed, timedelta(days=1))
+        self.assertTrue(asset.intervals[0].outstanding)
+
+    def test_holder_summary_multiple_holders(self) -> None:
+        self._insert_holder(1, "Alice Holder", "Mission A")
+        self._insert_holder(2, "Bob Holder", "Mission B")
+        self._insert_asset("AT-4")
+        self._insert_asset("AT-5")
+        self._insert_event("AT-4", "ISSUE", "2026-01-01T00:00:00Z", holder_id=1)
+        self._insert_event("AT-4", "RETURN", "2026-01-02T00:00:00Z")
+        self._insert_event("AT-4", "ISSUE", "2026-01-03T00:00:00Z", holder_id=2)
+        self._insert_event("AT-4", "RETURN", "2026-01-04T12:00:00Z")
+        self._insert_event("AT-5", "ISSUE", "2026-01-05T00:00:00Z", holder_id=2)
+        self._insert_event("AT-5", "RETURN", "2026-01-06T00:00:00Z")
+
+        holders = {summary.holder.holder_id: summary for summary in self._report().holders}
+
+        self.assertEqual(holders[1].unique_asset_tags, ("AT-4",))
+        self.assertEqual(holders[1].issue_transaction_count, 1)
+        self.assertEqual(holders[1].total_custody_time, timedelta(days=1))
+        self.assertEqual(holders[2].unique_asset_tags, ("AT-4", "AT-5"))
+        self.assertEqual(holders[2].issue_transaction_count, 2)
+        self.assertEqual(holders[2].total_custody_time, timedelta(days=2, hours=12))
+        self.assertEqual(holders[2].longest_custody_interval, timedelta(days=1, hours=12))
+
+    def test_unpairable_history_surfaces_exception(self) -> None:
+        self._insert_asset("AT-BAD")
+        self._insert_event("AT-BAD", "RETURN", "2026-01-02T00:00:00Z")
+
+        report = self._report()
+        asset = report.assets[0]
+
+        self.assertEqual(report.unresolved, 1)
+        self.assertIn("RETURN event", asset.exceptions[0])
+        self.assertIn("no preceding open ISSUE", asset.exceptions[0])
+
+    def test_retired_and_disposed_assets_are_excluded(self) -> None:
+        self._insert_asset("ACTIVE-1")
+        self._insert_asset("RET-1", location_type="RETIRED")
+        self._insert_asset("DISP-1", location_type="DISPOSED")
+        self._insert_event("ACTIVE-1", "ASSET_CREATED", "2026-01-01T00:00:00Z")
+
+        report = self._report()
+
+        self.assertEqual(report.active_assets, 1)
+        self.assertEqual([asset.asset_tag for asset in report.assets], ["ACTIVE-1"])
+
+    def test_current_storage_location_uses_home_slot_when_supported(self) -> None:
+        self._insert_slot(10, "CASE-1", 7)
+        self._insert_asset("AT-SLOT", home_slot_id=10)
+        self._insert_event("AT-SLOT", "ASSET_CREATED", "2026-01-01T00:00:00Z")
+
+        asset = self._report().assets[0]
+
+        self.assertEqual(asset.current_storage_location, "CASE-1 / Slot 7")
+
+    def test_calculation_is_read_only(self) -> None:
+        self._insert_asset("READONLY-1")
+        self._insert_event("READONLY-1", "ASSET_CREATED", "2026-01-01T00:00:00Z")
+        before_digest = self._digest()
+        before_counts = {
+            table: int(self.conn.execute(f"SELECT COUNT(*) FROM {table};").fetchone()[0])
+            for table in ("assets", "asset_events", "slots", "holders")
+        }
+
+        report = self._report()
+
+        after_counts = {
+            table: int(self.conn.execute(f"SELECT COUNT(*) FROM {table};").fetchone()[0])
+            for table in ("assets", "asset_events", "slots", "holders")
+        }
+        self.assertEqual(report.checked_in, 1)
+        self.assertEqual(before_counts, after_counts)
+        self.assertEqual(before_digest, self._digest())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_custody_accountability_routes.py
+++ b/tests/test_custody_accountability_routes.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import sqlite3
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from pypdf import PdfReader
+
+import assettrack.db as db
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_operator(client) -> None:
+    operator_id = create_test_user(username="custody-report-operator", password="op-pass", role="operator")
+    login_session(client, operator_id)
+
+
+def _counts(conn: sqlite3.Connection) -> dict[str, int]:
+    return {
+        table: int(conn.execute(f"SELECT COUNT(*) FROM {table};").fetchone()[0])
+        for table in ("assets", "asset_events", "holders", "slots")
+    }
+
+
+def _snapshot(conn: sqlite3.Connection) -> dict[str, list[dict]]:
+    return {
+        "assets": [dict(row) for row in conn.execute("SELECT * FROM assets ORDER BY id;").fetchall()],
+        "asset_events": [dict(row) for row in conn.execute("SELECT * FROM asset_events ORDER BY id;").fetchall()],
+        "holders": [dict(row) for row in conn.execute("SELECT * FROM holders ORDER BY id;").fetchall()],
+        "slots": [dict(row) for row in conn.execute("SELECT * FROM slots ORDER BY id;").fetchall()],
+    }
+
+
+def _insert_holder(conn: sqlite3.Connection, holder_id: int, name: str, organization: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO holders (
+            id, holder_type, name, organization, identifier, email, contact_info, created_at, updated_at
+        )
+        VALUES (?, 'PERSON', ?, ?, ?, '', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """,
+        (holder_id, name, organization, f"H-{holder_id}"),
+    )
+
+
+def _insert_slot(conn: sqlite3.Connection, slot_id: int, case_name: str, slot_position: int) -> None:
+    conn.execute(
+        """
+        INSERT INTO slots (id, case_name, slot_position, current_asset_tag)
+        VALUES (?, ?, ?, NULL);
+        """,
+        (slot_id, case_name, slot_position),
+    )
+
+
+def _insert_asset(
+    conn: sqlite3.Connection,
+    asset_tag: str,
+    *,
+    serial_number: str = "SER",
+    equipment_type: str = "laptop",
+    location_type: str = "STORAGE",
+    current_holder_id: int | None = None,
+    home_slot_id: int | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id
+        )
+        VALUES (?, ?, ?, ?, ?, ?);
+        """,
+        (asset_tag, serial_number, equipment_type, location_type, current_holder_id, home_slot_id),
+    )
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    asset_tag: str,
+    event_type: str,
+    event_date: str,
+    *,
+    holder_id: int | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (?, ?, ?, 'test', NULL, '{}', ?);
+        """,
+        (asset_tag, event_type, event_date, holder_id),
+    )
+
+
+def _seed_custody_fixture() -> None:
+    conn = db.get_connection()
+    try:
+        _insert_holder(conn, 1, "Alice Holder", "Mission A")
+        _insert_holder(conn, 2, "Bob Holder", "Mission B")
+        _insert_slot(conn, 10, "CASE-1", 4)
+        _insert_slot(conn, 11, "CASE-2", 7)
+        _insert_asset(conn, "RETURNED-1", serial_number="SER-R", equipment_type="laptop", home_slot_id=10)
+        _insert_asset(
+            conn,
+            "OUT-1",
+            serial_number="SER-O",
+            equipment_type="router",
+            location_type="IN_CUSTODY",
+            current_holder_id=2,
+            home_slot_id=11,
+        )
+        _insert_asset(conn, "BAD-1", serial_number="SER-B")
+        _insert_event(conn, "RETURNED-1", "ISSUE", "2026-01-01T00:00:00Z", holder_id=1)
+        _insert_event(conn, "RETURNED-1", "RETURN", "2026-01-03T06:00:00Z")
+        _insert_event(conn, "OUT-1", "ISSUE", "2026-01-05T00:00:00Z", holder_id=2)
+        _insert_event(conn, "BAD-1", "RETURN", "2026-01-06T00:00:00Z")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _pdf_text(pdf_bytes: bytes) -> str:
+    reader = PdfReader(BytesIO(pdf_bytes))
+    return "\n".join(page.extract_text() or "" for page in reader.pages)
+
+
+def test_preview_route_renders_model_sections_and_known_interval(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_custody_fixture()
+
+    response = client_with_temp_db.get("/report/custody-accountability")
+
+    assert response.status_code == 200
+    assert b"Asset Custody / Accountability" in response.data
+    assert b"OUTSTANDING ASSETS REQUIRE ATTENTION" in response.data
+    assert b"Total active assets" in response.data
+    assert b"RETURNED-1" in response.data
+    assert b"2026-01-01 00:00 UTC" in response.data
+    assert b"2026-01-03 06:00 UTC" in response.data
+    assert b"2d 6h" in response.data
+
+
+def test_preview_is_read_only_and_shows_holder_outstanding_and_exception(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_custody_fixture()
+    conn = db.get_connection()
+    before_counts = _counts(conn)
+    before_snapshot = _snapshot(conn)
+    conn.close()
+
+    response = client_with_temp_db.get("/report/custody-accountability")
+
+    conn = db.get_connection()
+    after_counts = _counts(conn)
+    after_snapshot = _snapshot(conn)
+    conn.close()
+    assert response.status_code == 200
+    assert b"Bob Holder (Mission B)" in response.data
+    assert b"OUT-1" in response.data
+    assert b"OUTSTANDING" in response.data
+    assert b"BAD-1" in response.data
+    assert b"no preceding open ISSUE" in response.data
+    assert before_counts == after_counts
+    assert before_snapshot == after_snapshot
+
+
+def test_reports_page_links_to_custody_accountability_preview(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    response = client_with_temp_db.get("/report")
+
+    assert response.status_code == 200
+    assert b'href="/report/custody-accountability"' in response.data
+    assert b"Asset Custody / Accountability" in response.data
+
+
+def test_pdf_response_and_representative_content(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_custody_fixture()
+
+    response = client_with_temp_db.get("/report/custody-accountability/pdf")
+
+    assert response.status_code == 200
+    assert response.mimetype == "application/pdf"
+    assert response.data.startswith(b"%PDF-")
+    disposition = response.headers.get("Content-Disposition") or ""
+    assert "attachment;" in disposition
+    assert "assettrack-custody-accountability-" in disposition
+    pdf_text = _pdf_text(response.data)
+    assert "Asset Custody / Accountability" in pdf_text
+    assert "RETURNED-1" in pdf_text
+    assert "OUT-1" in pdf_text
+    assert "Bob Holder" in pdf_text
+    assert "OUTSTANDING" in pdf_text
+    assert "BAD-1" in pdf_text
+
+
+def test_pdf_generation_is_read_only(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_custody_fixture()
+    conn = db.get_connection()
+    before_counts = _counts(conn)
+    before_snapshot = _snapshot(conn)
+    conn.close()
+
+    response = client_with_temp_db.get("/report/custody-accountability/pdf")
+
+    conn = db.get_connection()
+    after_counts = _counts(conn)
+    after_snapshot = _snapshot(conn)
+    conn.close()
+    assert response.status_code == 200
+    assert before_counts == after_counts
+    assert before_snapshot == after_snapshot
+
+
+def test_multi_page_pdf_generation(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    conn = db.get_connection()
+    try:
+        _insert_holder(conn, 3, "Large Holder", "Mission Large")
+        for index in range(60):
+            asset_tag = f"MP-{index:03d}"
+            _insert_asset(conn, asset_tag, serial_number=f"SER-{index:03d}", location_type="IN_CUSTODY", current_holder_id=3)
+            _insert_event(conn, asset_tag, "ISSUE", "2026-01-01T00:00:00Z", holder_id=3)
+        conn.commit()
+    finally:
+        conn.close()
+
+    response = client_with_temp_db.get("/report/custody-accountability/pdf")
+    reader = PdfReader(BytesIO(response.data))
+
+    assert response.status_code == 200
+    assert len(reader.pages) > 1
+    pdf_text = "\n".join(page.extract_text() or "" for page in reader.pages)
+    assert "MP-000" in pdf_text
+    assert "MP-059" in pdf_text


### PR DESCRIPTION
## Summary
Adds a printable custody and accountability report derived from AssetTrack append-only event history.

## Related Issue
Closes #1167

## Changes
- Adds reusable read-only custody-accountability calculations
- Reconstructs Issue/Return custody intervals and holder accountability
- Adds Reports → Asset Custody / Accountability preview
- Adds downloadable US Letter landscape PDF
- Surfaces outstanding and inconsistent custody histories
- Adds operator documentation

## Verification
- [x] Custody model tests: 8 passed
- [x] Combined focused/regression tests: 23 passed
- [x] git diff --check
- [x] Docker rebuild
- [x] Incognito report preview verified
- [x] PDF generation verified
- [x] US Letter landscape print preview verified
- [x] Multi-page layout, headers, margins, and page numbers verified
- [x] Known Issue/Return history spot-checked
- [x] Read-only behavior verified

## Notes
Historical custody derives from append-only AssetTrack events. ISSUE holder IDs are historical evidence; displayed holder names/organizations are current lookups. Historical case/slot labels are not invented when the event history does not preserve them.

No schema, migration, dependency, authentication, Issue/Return, custody-event, or persistence changes.