### PR TITLE
Issue 31-39B: Add custody analytics dashboard and printable charts

### DIFF
--- a/assettrack/intake/app.py
+++ b/assettrack/intake/app.py
@@ -53,6 +53,11 @@ from assettrack.custody_accountability import (
     HolderSummary,
     build_custody_accountability_report,
 )
+from assettrack.custody_analytics import (
+    AnalyticsDataset,
+    SUPPORTED_ANALYTICS,
+    build_analytics_dataset,
+)
 from assettrack.dashboard import build_dashboard_data, get_custody_days_threshold
 from assettrack.db import bootstrap_db, get_connection
 from assettrack.drilldowns import (
@@ -9652,6 +9657,118 @@ def _custody_exception_rows(report: CustodyAccountabilityReport) -> list[dict[st
     return sorted(rows, key=lambda row: str(row["asset"].asset_tag).upper())
 
 
+ANALYTICS_CHART_TYPES: dict[tuple[str, str], tuple[tuple[str, str], ...]] = {
+    ("total_time_checked_out", "holder"): (("bar", "Bar"),),
+    ("checkout_transactions", "holder"): (("bar", "Bar"),),
+    ("number_of_assets", "asset_type"): (("bar", "Bar"),),
+    ("checkout_duration", "duration_range"): (("histogram", "Histogram"),),
+    ("current_accountability", "accountability_state"): (("bar", "Bar"),),
+    ("checkout_transactions", "checkout_date"): (("line", "Line"),),
+}
+
+ANALYTICS_MEASURE_LABELS: dict[str, str] = {
+    "total_time_checked_out": "Total Time Checked Out",
+    "checkout_transactions": "Checkout Transactions",
+    "number_of_assets": "Number of Assets",
+    "checkout_duration": "Checkout Duration",
+    "current_accountability": "Current Accountability",
+}
+
+ANALYTICS_GROUPING_LABELS: dict[str, str] = {
+    "holder": "MA / Holder",
+    "asset_type": "Asset Type",
+    "duration_range": "Duration Range",
+    "accountability_state": "Accountability State",
+    "checkout_date": "Checkout Date",
+}
+
+
+def _analytics_unique_options(values: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    seen: set[str] = set()
+    options: list[tuple[str, str]] = []
+    for value, label in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        options.append((value, label))
+    return options
+
+
+def _analytics_measure_options() -> list[tuple[str, str]]:
+    return _analytics_unique_options(
+        [(selection.measure, ANALYTICS_MEASURE_LABELS[selection.measure]) for selection in SUPPORTED_ANALYTICS]
+    )
+
+
+def _analytics_grouping_options() -> list[tuple[str, str]]:
+    return _analytics_unique_options(
+        [(selection.grouping, ANALYTICS_GROUPING_LABELS[selection.grouping]) for selection in SUPPORTED_ANALYTICS]
+    )
+
+
+def _analytics_supported_pairs() -> list[dict[str, str]]:
+    return [
+        {
+            "measure": selection.measure,
+            "grouping": selection.grouping,
+            "label": selection.label,
+        }
+        for selection in SUPPORTED_ANALYTICS
+    ]
+
+
+def _analytics_selector_mapping() -> list[dict[str, object]]:
+    return [
+        {
+            "measure": selection.measure,
+            "measure_label": ANALYTICS_MEASURE_LABELS[selection.measure],
+            "grouping": selection.grouping,
+            "grouping_label": ANALYTICS_GROUPING_LABELS[selection.grouping],
+            "charts": [
+                {"value": value, "label": label}
+                for value, label in _analytics_chart_types(selection.measure, selection.grouping)
+            ],
+        }
+        for selection in SUPPORTED_ANALYTICS
+    ]
+
+
+def _analytics_chart_types(measure: str, grouping: str) -> tuple[tuple[str, str], ...]:
+    return ANALYTICS_CHART_TYPES.get((measure, grouping), ())
+
+
+def _analytics_value_label(row, dataset: AnalyticsDataset) -> str:
+    if dataset.selection.measure == "total_time_checked_out":
+        return _duration_label(timedelta(seconds=row.value))
+    return str(row.value)
+
+
+def _analytics_chart_rows(dataset: AnalyticsDataset) -> list[dict[str, object]]:
+    max_value = max((row.value for row in dataset.rows), default=0)
+    row_count = len(dataset.rows)
+    chart_rows: list[dict[str, object]] = []
+    for index, row in enumerate(dataset.rows):
+        percent = 0 if max_value <= 0 else max(2, round((row.value / max_value) * 100))
+        x = 40 if row_count <= 1 else 40 + round((index / (row_count - 1)) * 440)
+        chart_rows.append(
+            {
+                "index": index,
+                "key": row.key,
+                "label": row.label,
+                "value": row.value,
+                "value_label": _analytics_value_label(row, dataset),
+                "percent": percent,
+                "x": x,
+                "y": 180 - (0 if max_value <= 0 else round((row.value / max_value) * 140)),
+            }
+        )
+    return chart_rows
+
+
+def _analytics_line_points(chart_rows: list[dict[str, object]]) -> str:
+    return " ".join(f"{row['x']},{row['y']}" for row in chart_rows)
+
+
 def _load_custody_accountability_report(resolved_db_path: Path, generated_at: datetime) -> CustodyAccountabilityReport:
     conn = sqlite3.connect(f"file:{resolved_db_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
@@ -10735,6 +10852,60 @@ def custody_accountability_pdf():
         download_name=download_name,
         mimetype="application/pdf",
         conditional=False,
+    )
+
+
+@app.get("/report/custody-analytics")
+@require_login
+def custody_analytics_dashboard():
+    default_selection = SUPPORTED_ANALYTICS[0]
+    measure = str(request.args.get("measure") or default_selection.measure).strip()
+    grouping = str(request.args.get("grouping") or default_selection.grouping).strip()
+    chart_types = _analytics_chart_types(measure, grouping)
+    chart_type = str(request.args.get("chart_type") or (chart_types[0][0] if chart_types else "")).strip()
+    should_generate = request.args.get("generate") == "1"
+    error_message: str | None = None
+    status_code = 200
+    dataset: AnalyticsDataset | None = None
+    chart_rows: list[dict[str, object]] = []
+
+    if not chart_types:
+        error_message = "Unsupported Measure and Group By combination."
+        status_code = 400
+    elif chart_type not in {value for value, _label in chart_types}:
+        error_message = "Unsupported chart type for the selected analytics dataset."
+        status_code = 400
+    elif should_generate:
+        generated_at = datetime.now(timezone.utc)
+        try:
+            report = _load_custody_accountability_report(_resolved_runtime_db_path(), generated_at)
+            dataset = build_analytics_dataset(report, measure=measure, grouping=grouping)
+            chart_rows = _analytics_chart_rows(dataset)
+        except ValueError as exc:
+            error_message = str(exc)
+            status_code = 400
+        except sqlite3.Error as exc:
+            error_message = f"Could not read custody analytics data: {exc}"
+            status_code = 500
+
+    return (
+        render_template(
+            "custody_analytics.html",
+            supported_pairs=_analytics_supported_pairs(),
+            selector_mapping=_analytics_selector_mapping(),
+            measure_options=_analytics_measure_options(),
+            grouping_options=_analytics_grouping_options(),
+            chart_types=chart_types,
+            selected_measure=measure,
+            selected_grouping=grouping,
+            selected_chart_type=chart_type,
+            dataset=dataset,
+            chart_rows=chart_rows,
+            line_points=_analytics_line_points(chart_rows),
+            should_generate=should_generate,
+            error_message=error_message,
+        ),
+        status_code,
     )
 
 

--- a/assettrack/intake/templates/custody_analytics.html
+++ b/assettrack/intake/templates/custody_analytics.html
@@ -1,0 +1,244 @@
+{% extends "base.html" %}
+
+{% block title %}Custody Analytics{% endblock %}
+{% block page_heading %}Custody Analytics{% endblock %}
+{% block page_class %} report-page custody-analytics-page{% endblock %}
+
+{% block extra_head %}
+  <style>
+    .analytics-controls {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      gap: 0.9rem;
+      align-items: end;
+    }
+    .analytics-controls label {
+      display: grid;
+      gap: 0.35rem;
+      font-weight: 700;
+    }
+    .analytics-controls select,
+    .analytics-controls button {
+      min-height: 2.85rem;
+      font-size: 1rem;
+    }
+    .analytics-supported {
+      margin-top: 0.8rem;
+      color: var(--color-text-muted);
+      font-size: 0.92rem;
+    }
+    .analytics-chart {
+      display: grid;
+      gap: 0.85rem;
+      margin-top: 1rem;
+    }
+    .analytics-bar-row {
+      display: grid;
+      grid-template-columns: minmax(8rem, 1.2fr) minmax(12rem, 3fr) minmax(4rem, auto);
+      gap: 0.7rem;
+      align-items: center;
+      break-inside: avoid;
+    }
+    .analytics-bar-track {
+      min-height: 1.8rem;
+      border: 1px solid var(--color-text);
+      background: repeating-linear-gradient(
+        45deg,
+        var(--color-surface-bg),
+        var(--color-surface-bg) 6px,
+        var(--color-surface-soft) 6px,
+        var(--color-surface-soft) 12px
+      );
+    }
+    .analytics-bar-fill {
+      min-height: 1.8rem;
+      background: var(--color-text);
+    }
+    .analytics-line-chart {
+      width: 100%;
+      max-width: 780px;
+      height: auto;
+      border: 1px solid var(--color-surface);
+      background: var(--color-surface-bg);
+    }
+    .analytics-line-labels {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.55rem 1rem;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      font-size: 0.92rem;
+    }
+    @media print {
+      .analytics-controls,
+      .analytics-supported {
+        display: none !important;
+      }
+      .analytics-chart {
+        break-inside: avoid;
+      }
+      .analytics-line-chart {
+        max-width: 100%;
+      }
+    }
+  </style>
+{% endblock %}
+
+{% block content %}
+  <nav class="actions report-actions" aria-label="Report navigation">
+    <a class="nav-link" href="{{ url_for('human_report') }}">Back to Reports</a>
+    <a class="nav-link" href="{{ url_for('custody_accountability_preview') }}">Asset Custody / Accountability</a>
+  </nav>
+
+  {% if error_message %}
+    <div class="flash error">{{ error_message }}</div>
+  {% endif %}
+
+  <form class="card analytics-controls" method="get" action="{{ url_for('custody_analytics_dashboard') }}">
+    <input type="hidden" name="generate" value="1">
+    <label>
+      Measure
+      <select name="measure" id="analytics-measure">
+        {% for value, label in measure_options %}
+          <option value="{{ value }}"{% if value == selected_measure %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>
+      Group By
+      <select name="grouping" id="analytics-grouping">
+        {% for value, label in grouping_options %}
+          <option value="{{ value }}"{% if value == selected_grouping %} selected{% endif %}>{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>
+      Chart Type
+      <select name="chart_type" id="analytics-chart-type">
+        {% for value, label in chart_types %}
+          <option value="{{ value }}"{% if value == selected_chart_type %} selected{% endif %}>{{ label }}</option>
+        {% else %}
+          <option value="">No valid chart</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit">Generate</button>
+  </form>
+
+  <p class="analytics-supported">
+    Approved selections:
+    {% for pair in supported_pairs %}
+      <code data-measure="{{ pair.measure }}" data-grouping="{{ pair.grouping }}">{{ pair.label }}</code>{% if not loop.last %}; {% endif %}
+    {% endfor %}
+  </p>
+
+  {% if dataset %}
+    <section class="card">
+      <h2>{{ dataset.selection.label }}</h2>
+      {% if chart_rows %}
+        <div class="analytics-chart" role="img" aria-label="{{ dataset.selection.label }} {{ selected_chart_type }} chart">
+          {% if selected_chart_type in ["bar", "histogram"] %}
+            {% for row in chart_rows %}
+              <div class="analytics-bar-row">
+                <strong>{{ row.label }}</strong>
+                <div class="analytics-bar-track" aria-hidden="true">
+                  <div class="analytics-bar-fill" style="width: {{ row.percent }}%;"></div>
+                </div>
+                <span>{{ row.value_label }}</span>
+              </div>
+            {% endfor %}
+          {% elif selected_chart_type == "line" %}
+            <svg class="analytics-line-chart" viewBox="0 0 520 220" role="img" aria-label="{{ dataset.selection.label }}">
+              <line x1="30" y1="180" x2="500" y2="180" stroke="currentColor" stroke-width="1"></line>
+              <line x1="30" y1="30" x2="30" y2="180" stroke="currentColor" stroke-width="1"></line>
+              {% if chart_rows|length == 1 %}
+                <circle cx="{{ chart_rows[0].x }}" cy="{{ chart_rows[0].y }}" r="5" fill="currentColor"></circle>
+              {% else %}
+                <polyline points="{{ line_points }}" fill="none" stroke="currentColor" stroke-width="3"></polyline>
+                {% for row in chart_rows %}
+                  <circle cx="{{ row.x }}" cy="{{ row.y }}" r="4" fill="currentColor"></circle>
+                {% endfor %}
+              {% endif %}
+            </svg>
+            <ul class="analytics-line-labels">
+              {% for row in chart_rows %}
+                <li><strong>{{ row.label }}</strong>: {{ row.value_label }}</li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </div>
+      {% else %}
+        <p class="muted">No analytics results for this selection.</p>
+      {% endif %}
+    </section>
+  {% elif not should_generate %}
+    <div class="card">
+      <h2>Generate a Custody Analytics View</h2>
+      <p class="muted">Choose one approved Measure and Group By combination, then generate the chart.</p>
+    </div>
+  {% endif %}
+
+  <script id="analytics-selector-map" type="application/json">{{ selector_mapping|tojson }}</script>
+  <script>
+    (() => {
+      const mapNode = document.getElementById("analytics-selector-map");
+      const measureSelect = document.getElementById("analytics-measure");
+      const groupingSelect = document.getElementById("analytics-grouping");
+      const chartSelect = document.getElementById("analytics-chart-type");
+      if (!mapNode || !measureSelect || !groupingSelect || !chartSelect) {
+        return;
+      }
+
+      const selectorMap = JSON.parse(mapNode.textContent || "[]");
+      const option = (value, label) => {
+        const node = document.createElement("option");
+        node.value = value;
+        node.textContent = label;
+        return node;
+      };
+
+      const replaceOptions = (select, options, preferredValue) => {
+        select.replaceChildren();
+        options.forEach((item) => select.appendChild(option(item.value, item.label)));
+        if (options.some((item) => item.value === preferredValue)) {
+          select.value = preferredValue;
+        } else if (options.length > 0) {
+          select.value = options[0].value;
+        }
+      };
+
+      const validGroupsForMeasure = (measure) => {
+        const seen = new Set();
+        const groups = [];
+        selectorMap
+          .filter((item) => item.measure === measure)
+          .forEach((item) => {
+            if (!seen.has(item.grouping)) {
+              seen.add(item.grouping);
+              groups.push({ value: item.grouping, label: item.grouping_label });
+            }
+          });
+        return groups;
+      };
+
+      const chartsForSelection = (measure, grouping) => {
+        const selected = selectorMap.find((item) => item.measure === measure && item.grouping === grouping);
+        return selected ? selected.charts : [];
+      };
+
+      const refreshCharts = () => {
+        replaceOptions(chartSelect, chartsForSelection(measureSelect.value, groupingSelect.value), chartSelect.value);
+      };
+
+      const refreshGroups = () => {
+        replaceOptions(groupingSelect, validGroupsForMeasure(measureSelect.value), groupingSelect.value);
+        refreshCharts();
+      };
+
+      measureSelect.addEventListener("change", refreshGroups);
+      groupingSelect.addEventListener("change", refreshCharts);
+      refreshGroups();
+    })();
+  </script>
+{% endblock %}

--- a/assettrack/intake/templates/report_readonly.html
+++ b/assettrack/intake/templates/report_readonly.html
@@ -64,6 +64,7 @@
     <div class="report-actions report-utility-links" aria-label="Report utilities">
       <span class="report-utility-label">Report utilities</span>
       <a class="nav-link" href="{{ url_for('custody_accountability_preview') }}">Asset Custody / Accountability</a>
+      <a class="nav-link" href="{{ url_for('custody_analytics_dashboard') }}">Custody Analytics</a>
       <a class="nav-link" href="{{ url_for('case_inventory') }}">Case inventory</a>
       <a class="nav-link" href="{{ url_for('receipts_list', return_to=report_return_to) }}">Search receipts</a>
       <a class="nav-link" href="{{ url_for('inventory_reconciliation') }}">Inventory Reconciliation</a>

--- a/docs/operator/custody-analytics-dashboard.md
+++ b/docs/operator/custody-analytics-dashboard.md
@@ -1,0 +1,68 @@
+# Custody Analytics Dashboard
+
+Use this dashboard when operators need a quick printable chart from AssetTrack custody history.
+
+## Where to find it
+
+1. Log in.
+2. Open `Reports`.
+3. Select `Custody Analytics`.
+
+## Generate a chart
+
+Choose:
+
+1. `Measure`
+2. `Group By`
+3. `Chart Type`
+4. `Generate`
+
+Only approved Measure and Group By combinations are available for reporting.
+
+## Measures
+
+- `Total Time Checked Out`
+- `Checkout Transactions`
+- `Number of Assets`
+- `Checkout Duration`
+- `Current Accountability`
+
+## Group By choices
+
+- `MA / Holder`
+- `Asset Type`
+- `Duration Range`
+- `Accountability State`
+- `Checkout Date`
+
+## Chart types
+
+- `Bar` for holder, asset type, and current accountability comparisons
+- `Histogram` for checkout duration ranges
+- `Line` for checkout transactions by checkout date
+
+## Duration buckets
+
+Checkout duration uses these fixed buckets:
+
+- `< 8 hours`
+- `8 to <24 hours`
+- `1 to <3 days`
+- `3 to <7 days`
+- `7+ days`
+
+## Source of truth
+
+Custody Analytics uses the same custody-accountability calculation as the `Asset Custody / Accountability` report.
+
+Custody history derives from AssetTrack append-only event history.
+
+The holder ID stored on the Issue event is historical evidence. Holder name and organization are current lookups for that stored holder ID.
+
+Historical case or slot labels are not invented when events do not preserve them.
+
+## Printing
+
+Use the browser print command from the dashboard page.
+
+The dashboard uses browser-print styling only. It does not add charts to the custody accountability PDF.

--- a/tests/test_custody_analytics_routes.py
+++ b/tests/test_custody_analytics_routes.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+import assettrack.db as db
+from assettrack.custody_analytics import SUPPORTED_ANALYTICS
+from assettrack.intake import app as intake_app
+from tests.auth_test_utils import create_test_user, login_session
+
+
+@pytest.fixture
+def client_with_temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(db, "DB_PATH", tmp_path / "assettrack.db")
+    conn = db.get_connection()
+    conn.close()
+    intake_app.app.testing = True
+    return intake_app.app.test_client()
+
+
+def _login_operator(client) -> None:
+    operator_id = create_test_user(username="custody-analytics-operator", password="op-pass", role="operator")
+    login_session(client, operator_id)
+
+
+def _snapshot(conn: sqlite3.Connection) -> dict[str, list[dict]]:
+    return {
+        "assets": [dict(row) for row in conn.execute("SELECT * FROM assets ORDER BY id;").fetchall()],
+        "asset_events": [dict(row) for row in conn.execute("SELECT * FROM asset_events ORDER BY id;").fetchall()],
+        "holders": [dict(row) for row in conn.execute("SELECT * FROM holders ORDER BY id;").fetchall()],
+        "slots": [dict(row) for row in conn.execute("SELECT * FROM slots ORDER BY id;").fetchall()],
+    }
+
+
+def _insert_holder(conn: sqlite3.Connection, holder_id: int, name: str, organization: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO holders (
+            id, holder_type, name, organization, identifier, email, contact_info, created_at, updated_at
+        )
+        VALUES (?, 'PERSON', ?, ?, ?, '', NULL, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+        """,
+        (holder_id, name, organization, f"H-{holder_id}"),
+    )
+
+
+def _insert_asset(
+    conn: sqlite3.Connection,
+    asset_tag: str,
+    *,
+    equipment_type: str = "laptop",
+    location_type: str = "STORAGE",
+    current_holder_id: int | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO assets (
+            asset_tag, serial_number, equipment_type, location_type, current_holder_id
+        )
+        VALUES (?, ?, ?, ?, ?);
+        """,
+        (asset_tag, f"SER-{asset_tag}", equipment_type, location_type, current_holder_id),
+    )
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    asset_tag: str,
+    event_type: str,
+    event_date: str,
+    *,
+    holder_id: int | None = None,
+) -> None:
+    conn.execute(
+        """
+        INSERT INTO asset_events (asset_tag, event_type, event_date, actor, notes, payload, holder_id)
+        VALUES (?, ?, ?, 'test', NULL, '{}', ?);
+        """,
+        (asset_tag, event_type, event_date, holder_id),
+    )
+
+
+def _seed_holder_totals() -> None:
+    conn = db.get_connection()
+    try:
+        _insert_holder(conn, 1, "Alice Holder", "Mission A")
+        _insert_holder(conn, 2, "Bob Holder", "Mission B")
+        _insert_asset(conn, "ALICE-1", equipment_type="laptop")
+        _insert_asset(conn, "ALICE-2", equipment_type="router")
+        _insert_asset(conn, "BOB-1", equipment_type="router")
+        _insert_event(conn, "ALICE-1", "ISSUE", "2026-01-01T00:00:00Z", holder_id=1)
+        _insert_event(conn, "ALICE-1", "RETURN", "2026-01-03T06:00:00Z")
+        _insert_event(conn, "ALICE-2", "ISSUE", "2026-01-03T00:00:00Z", holder_id=1)
+        _insert_event(conn, "ALICE-2", "RETURN", "2026-01-03T12:00:00Z")
+        _insert_event(conn, "BOB-1", "ISSUE", "2026-01-04T00:00:00Z", holder_id=2)
+        _insert_event(conn, "BOB-1", "RETURN", "2026-01-04T01:00:00Z")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _seed_accountability() -> None:
+    conn = db.get_connection()
+    try:
+        _insert_holder(conn, 1, "Alice Holder", "Mission A")
+        _insert_asset(conn, "IN-1", location_type="STORAGE")
+        _insert_event(conn, "IN-1", "ASSET_CREATED", "2026-01-01T00:00:00Z")
+        _insert_asset(conn, "OUT-1", location_type="IN_CUSTODY", current_holder_id=1)
+        _insert_event(conn, "OUT-1", "ISSUE", "2026-01-02T00:00:00Z", holder_id=1)
+        _insert_asset(conn, "BAD-1", location_type="STORAGE", current_holder_id=1)
+        _insert_event(conn, "BAD-1", "RETURN", "2026-01-03T00:00:00Z")
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _analytics_url(measure: str, grouping: str, chart_type: str) -> str:
+    return f"/report/custody-analytics?generate=1&measure={measure}&grouping={grouping}&chart_type={chart_type}"
+
+
+def _selector_mapping(response) -> list[dict]:
+    body = response.data.decode()
+    match = re.search(
+        r'<script id="analytics-selector-map" type="application/json">(.+?)</script>',
+        body,
+        flags=re.DOTALL,
+    )
+    assert match is not None
+    return json.loads(match.group(1))
+
+
+def _chart_select_html(response) -> str:
+    body = response.data.decode()
+    match = re.search(r'<select name="chart_type" id="analytics-chart-type">(.+?)</select>', body, flags=re.DOTALL)
+    assert match is not None
+    return match.group(1)
+
+
+def test_reports_exposes_custody_analytics(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    response = client_with_temp_db.get("/report")
+
+    assert response.status_code == 200
+    assert b'href="/report/custody-analytics"' in response.data
+    assert b"Custody Analytics" in response.data
+
+
+def test_dashboard_route_renders_and_lists_31_39a_selections(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    response = client_with_temp_db.get("/report/custody-analytics")
+
+    assert response.status_code == 200
+    assert b"Measure" in response.data
+    assert b"Group By" in response.data
+    assert b"Chart Type" in response.data
+    for selection in SUPPORTED_ANALYTICS:
+        assert selection.label.encode() in response.data
+
+
+def test_dashboard_exposes_authoritative_selector_mapping(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    response = client_with_temp_db.get("/report/custody-analytics")
+    mapping = _selector_mapping(response)
+
+    assert response.status_code == 200
+    assert {(item["measure"], item["grouping"]) for item in mapping} == {
+        (selection.measure, selection.grouping) for selection in SUPPORTED_ANALYTICS
+    }
+    assert b"analytics-measure" in response.data
+    assert b"analytics-grouping" in response.data
+    assert b"analytics-chart-type" in response.data
+
+
+def test_selector_mapping_has_expected_chart_types(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    mapping = {
+        (item["measure"], item["grouping"]): item["charts"]
+        for item in _selector_mapping(client_with_temp_db.get("/report/custody-analytics"))
+    }
+
+    assert mapping[("checkout_transactions", "checkout_date")] == [{"label": "Line", "value": "line"}]
+    assert mapping[("checkout_duration", "duration_range")] == [{"label": "Histogram", "value": "histogram"}]
+
+
+def test_valid_selection_does_not_render_stale_chart_type(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    response = client_with_temp_db.get("/report/custody-analytics?measure=checkout_transactions&grouping=checkout_date")
+    chart_select = _chart_select_html(response)
+
+    assert response.status_code == 200
+    assert 'value="line" selected' in chart_select
+    assert "Histogram" not in chart_select
+
+
+def test_total_checkout_time_by_holder_renders(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_holder_totals()
+
+    response = client_with_temp_db.get(_analytics_url("total_time_checked_out", "holder", "bar"))
+
+    assert response.status_code == 200
+    assert b"Total Time Checked Out + MA / Holder" in response.data
+    assert b"Alice Holder (Mission A)" in response.data
+    assert b"2d 18h" in response.data
+    assert b"Bob Holder (Mission B)" in response.data
+    assert b"1h" in response.data
+
+
+def test_duration_distribution_renders_31_39a_buckets(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_holder_totals()
+
+    response = client_with_temp_db.get(_analytics_url("checkout_duration", "duration_range", "histogram"))
+
+    assert response.status_code == 200
+    for label in (b"&lt; 8 hours", b"8 to &lt;24 hours", b"1 to &lt;3 days", b"3 to &lt;7 days", b"7+ days"):
+        assert label in response.data
+    assert b"Histogram" in response.data
+
+
+def test_current_accountability_renders_31_39a_totals(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_accountability()
+
+    response = client_with_temp_db.get(_analytics_url("current_accountability", "accountability_state", "bar"))
+
+    assert response.status_code == 200
+    assert b"Current Accountability + Accountability State" in response.data
+    assert b"Checked In" in response.data
+    assert b"Checked Out" in response.data
+    assert b"Exceptions / Unresolved" in response.data
+
+
+def test_checkout_activity_by_day_is_chronological(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_holder_totals()
+
+    response = client_with_temp_db.get(_analytics_url("checkout_transactions", "checkout_date", "line"))
+
+    assert response.status_code == 200
+    body = response.data.decode()
+    assert "Line" in body
+    assert body.index("2026-01-01") < body.index("2026-01-03") < body.index("2026-01-04")
+
+
+def test_unsupported_measure_grouping_and_chart_requests_are_rejected(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    unsupported_combo = client_with_temp_db.get(_analytics_url("total_time_checked_out", "asset_type", "bar"))
+    unsupported_chart = client_with_temp_db.get(_analytics_url("checkout_transactions", "checkout_date", "bar"))
+
+    assert unsupported_combo.status_code == 400
+    assert b"Unsupported Measure and Group By combination." in unsupported_combo.data
+    assert unsupported_chart.status_code == 400
+    assert b"Unsupported chart type" in unsupported_chart.data
+
+
+def test_zero_result_dataset_displays_cleanly(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+
+    response = client_with_temp_db.get(_analytics_url("total_time_checked_out", "holder", "bar"))
+
+    assert response.status_code == 200
+    assert b"No analytics results for this selection." in response.data
+
+
+def test_rendering_does_not_modify_assettrack_state(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_holder_totals()
+    conn = db.get_connection()
+    before = _snapshot(conn)
+    conn.close()
+
+    response = client_with_temp_db.get(_analytics_url("total_time_checked_out", "holder", "bar"))
+
+    conn = db.get_connection()
+    after = _snapshot(conn)
+    conn.close()
+    assert response.status_code == 200
+    assert before == after
+
+
+def test_existing_custody_accountability_report_still_renders(client_with_temp_db) -> None:
+    _login_operator(client_with_temp_db)
+    _seed_holder_totals()
+
+    response = client_with_temp_db.get("/report/custody-accountability")
+
+    assert response.status_code == 200
+    assert b"Asset Custody / Accountability" in response.data
+    assert b"Holder / MA Accountability" in response.data


### PR DESCRIPTION
## Summary
Adds a lightweight offline custody analytics dashboard using the trusted 31-39A analytics layer.

## Related Issue
Closes #1182

## Changes
- Adds Reports → Custody Analytics
- Adds Measure, Group By, and Chart Type workflow
- Adds dependency-free bar, histogram, accountability, and line visualizations
- Adds synchronized dependent selectors
- Rejects unsupported combinations server-side
- Adds browser-print styling and operator documentation

## Verification
- [x] Dashboard route tests pass
- [x] Custody analytics/report regression tests pass
- [x] Selector synchronization regression tests pass
- [x] Unsupported combinations return HTTP 400
- [x] Docker rebuild completed
- [x] Incognito operator workflow verified
- [x] Browser print preview verified
- [x] git diff --check

## Notes
31-39A remains the single analytics source. No schema, dependency, event, custody, persistence, PDF embedding, external service, or internet requirement was added.